### PR TITLE
Add pds-core development dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,39 @@ Development priorities:
 
 ## Local Setup
 
+`pds-core` is required for local Paper Data Suite development. Check out
+`pds-core` and `pds-quillan` as sibling repositories; the parent directory name
+and location can vary:
+
+```text
+Paper-Data-Suite/
+  pds-core/
+  pds-quillan/
+```
+
 Create and activate a virtual environment:
 
 ```powershell
 py -m venv .venv
 .\.venv\Scripts\Activate.ps1
-````
+```
 
-Install the project with development dependencies:
+From inside `pds-quillan`, install the project, development tools, and the
+editable sibling checkout of `pds-core`:
 
 ```powershell
 python -m pip install --upgrade pip
-pip install -e ".[dev]"
+python -m pip install -r requirements-dev.txt
 ```
+
+Installing only Quillan's ordinary third-party dependencies is not sufficient
+for Paper Data Suite development because Quillan depends on shared
+infrastructure from `pds-core`.
+
+Later Quillan work will use `pds-core` for identifier validation, shared
+workspace-root behavior, route conventions, and QR payload construction and
+parsing. The shared PDS workspace root is owned by `pds-core`; this issue does
+not yet route Quillan data through it.
 
 ## Running Quillan
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,4 @@ target-version = "py311"
 python_version = "3.11"
 strict = true
 explicit_package_bases = true
+mypy_path = "../pds-core"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-e ../pds-core
+-e .[dev]

--- a/tests/test_pds_core_dependency.py
+++ b/tests/test_pds_core_dependency.py
@@ -1,0 +1,13 @@
+"""Smoke tests for the local pds-core development dependency."""
+
+from pds_core.identifiers import validate_identifier
+from pds_core.pds1 import build_pds1_payload
+from pds_core.qr_payload import QrPayload
+from pds_core.workspace import resolve_workspace_root
+
+
+def test_pds_core_dependency_is_available() -> None:
+    assert validate_identifier("english12_p4") == "english12_p4"
+    assert QrPayload.__module__ == "pds_core.qr_payload"
+    assert callable(resolve_workspace_root)
+    assert callable(build_pds1_payload)


### PR DESCRIPTION
## Summary

Adds local `pds-core` dependency support for Quillan development.

This prepares Quillan to use shared Paper Data Suite infrastructure for identifiers, workspace behavior, route/path conventions, and future QR payload work.

## Changes

* Added sibling editable `pds-core` dependency through `requirements-dev.txt`
* Added Quillan editable development install support through `-e .[dev]`
* Updated README setup documentation for the sibling repository layout
* Updated mypy configuration to see the sibling `pds-core` checkout
* Added a minimal `pds-core` dependency smoke test

## Notes

The current `pds-core` QR APIs are exposed through `pds_core.pds1` and `pds_core.qr_payload`, not `pds_core.qr`.

This PR does not implement Quillan QR generation, PDF generation, writing submission routing, paper workflows, AI tagging/scoring, CLI commands, menu workflows, or workspace UI.

## Validation

* `python -m pip install -r requirements-dev.txt`
* `python -m pytest` — 23 passed
* `python -m ruff check .`
* `python -m mypy ...` / configured mypy command — passed
* `git diff --check`

## Closes

Closes #1
