### PR TITLE
Align assignment paths with pds-core routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,15 @@ Installing only Quillan's ordinary third-party dependencies is not sufficient
 for Paper Data Suite development because Quillan depends on shared
 infrastructure from `pds-core`.
 
-Later Quillan work will use `pds-core` for identifier validation, shared
-workspace-root behavior, route conventions, and QR payload construction and
-parsing. The shared PDS workspace root is owned by `pds-core`; this issue does
-not yet route Quillan data through it.
+Quillan uses `pds-core` route helpers for assignment-local storage beneath the
+shared PDS workspace root:
+
+```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/
+```
+
+This alignment establishes the shared path convention only. Workspace settings,
+scan routing, QR workflows, and paper/PDF workflows are not yet implemented.
 
 ## Running Quillan
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -106,7 +106,7 @@ An assignment defines what students wrote, which class or classes are connected,
 Suggested path:
 
 ```text
-quillan_data/assignments/<assignment_id>/assignment.json
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
 ```
 
 Required fields:
@@ -165,7 +165,7 @@ MVP submissions are plain-text files.
 Suggested path:
 
 ```text
-quillan_data/assignments/<assignment_id>/submissions/<student_id>/submission.txt
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.txt
 ```
 
 A future metadata file may describe source type, import time, OCR status, or original file references.
@@ -173,7 +173,7 @@ A future metadata file may describe source type, import time, OCR status, or ori
 Example path:
 
 ```text
-quillan_data/assignments/villainy_final_essay_synthetic/submissions/stu_0001/submission.txt
+<PDS workspace root>/classes/english12_period3_synthetic/assignments/villainy_final_essay_synthetic/submissions/stu_0001/submission.txt
 ```
 
 ## Requirements Check
@@ -183,7 +183,7 @@ A requirements check records whether the submission met basic assignment require
 Suggested path:
 
 ```text
-quillan_data/assignments/<assignment_id>/submissions/<student_id>/requirements.json
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/requirements.json
 ```
 
 Requirement status values:
@@ -228,7 +228,7 @@ A tag record connects a specific observation to a location in the writing, a sta
 Suggested path:
 
 ```text
-quillan_data/assignments/<assignment_id>/submissions/<student_id>/tags.json
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/tags.json
 ```
 
 Required fields:
@@ -300,7 +300,7 @@ Scores are informed by tags but are not automatically determined by tags.
 Suggested path:
 
 ```text
-quillan_data/assignments/<assignment_id>/submissions/<student_id>/scores.json
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/scores.json
 ```
 
 Example:
@@ -331,7 +331,7 @@ A feedback file stores student-readable feedback.
 Suggested path:
 
 ```text
-quillan_data/assignments/<assignment_id>/submissions/<student_id>/feedback.md
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/feedback.md
 ```
 
 Example:
@@ -361,7 +361,7 @@ A standards summary aggregates tag data by standard.
 Suggested path:
 
 ```text
-quillan_data/assignments/<assignment_id>/reports/standards_summary.csv
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/reports/standards_summary.csv
 ```
 
 Required MVP columns:
@@ -384,7 +384,7 @@ A class summary aggregates submission-level results.
 Suggested path:
 
 ```text
-quillan_data/assignments/<assignment_id>/reports/class_summary.csv
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/reports/class_summary.csv
 ```
 
 Required MVP columns:

--- a/quillan/storage.py
+++ b/quillan/storage.py
@@ -1,0 +1,122 @@
+"""Storage paths for Quillan assignment data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.routes import (
+    assignment_config_path as pds_assignment_config_path,
+    assignment_dir as pds_assignment_dir,
+    assignment_submissions_dir as pds_assignment_submissions_dir,
+    student_submission_dir as pds_student_submission_dir,
+)
+
+
+def assignment_dir(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return the shared PDS directory for a Quillan assignment."""
+    return pds_assignment_dir(root, class_id, assignment_id)
+
+
+def assignment_config_path(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return the shared PDS assignment configuration path."""
+    return pds_assignment_config_path(root, class_id, assignment_id)
+
+
+def assignment_submissions_dir(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return the shared PDS submissions directory for an assignment."""
+    return pds_assignment_submissions_dir(root, class_id, assignment_id)
+
+
+def student_submission_dir(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the shared PDS directory for a student's submission."""
+    return pds_student_submission_dir(root, class_id, assignment_id, student_id)
+
+
+def submission_text_path(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the plain-text submission path for a student."""
+    return (
+        student_submission_dir(root, class_id, assignment_id, student_id)
+        / "submission.txt"
+    )
+
+
+def requirements_path(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the requirements-check path for a student submission."""
+    return (
+        student_submission_dir(root, class_id, assignment_id, student_id)
+        / "requirements.json"
+    )
+
+
+def tags_path(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the evidence-tags path for a student submission."""
+    return (
+        student_submission_dir(root, class_id, assignment_id, student_id) / "tags.json"
+    )
+
+
+def scores_path(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the scores path for a student submission."""
+    return (
+        student_submission_dir(root, class_id, assignment_id, student_id)
+        / "scores.json"
+    )
+
+
+def feedback_path(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the feedback path for a student submission."""
+    return (
+        student_submission_dir(root, class_id, assignment_id, student_id)
+        / "feedback.md"
+    )
+
+
+def reports_dir(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return Quillan's assignment-local reports directory."""
+    return assignment_dir(root, class_id, assignment_id) / "reports"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,84 @@
+"""Tests for shared PDS assignment storage paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.routes import (
+    assignment_config_path as pds_assignment_config_path,
+    assignment_dir as pds_assignment_dir,
+    assignment_submissions_dir as pds_assignment_submissions_dir,
+    student_submission_dir as pds_student_submission_dir,
+)
+
+from quillan.storage import (
+    assignment_config_path,
+    assignment_dir,
+    assignment_submissions_dir,
+    feedback_path,
+    reports_dir,
+    requirements_path,
+    scores_path,
+    student_submission_dir,
+    submission_text_path,
+    tags_path,
+)
+
+CLASS_ID = "english12_period3_synthetic"
+ASSIGNMENT_ID = "villainy_final_essay_synthetic"
+STUDENT_ID = "stu_0001"
+
+
+def test_assignment_paths_use_shared_pds_routes(tmp_path: Path) -> None:
+    expected_dir = tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+
+    assert assignment_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID) == expected_dir
+    assert assignment_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID) == pds_assignment_dir(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    assert assignment_config_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    ) == pds_assignment_config_path(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    assert assignment_submissions_dir(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    ) == pds_assignment_submissions_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+
+def test_quillan_assignment_files_remain_assignment_local(tmp_path: Path) -> None:
+    expected_dir = pds_assignment_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+    assert reports_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID) == expected_dir / "reports"
+
+
+def test_student_files_remain_submission_local(tmp_path: Path) -> None:
+    expected_dir = pds_student_submission_dir(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+
+    assert (
+        student_submission_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+        == expected_dir
+    )
+    assert (
+        submission_text_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+        == expected_dir / "submission.txt"
+    )
+    assert (
+        requirements_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+        == expected_dir / "requirements.json"
+    )
+    assert (
+        tags_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+        == expected_dir / "tags.json"
+    )
+    assert (
+        scores_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+        == expected_dir / "scores.json"
+    )
+    assert (
+        feedback_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+        == expected_dir / "feedback.md"
+    )


### PR DESCRIPTION
## Summary

Aligns Quillan assignment storage paths with shared `pds-core` route helpers.

This prepares Quillan for future assignment-local submission, scan, report, and QR-based routing work while preserving the existing Quillan data model.

## Changes

* Added Quillan storage/path helpers in `quillan/storage.py`
* Used shared `pds-core` route helpers for assignment and submission paths
* Added temporary-workspace storage route tests
* Updated README documentation for the shared assignment layout
* Updated `docs/data_contracts.md` to replace old `quillan_data/assignments` path references

## pds-core Helpers Used

* `assignment_dir`
* `assignment_config_path`
* `assignment_submissions_dir`
* `student_submission_dir`

## Notes

No existing Quillan helper was replaced because `quillan/storage.py` was previously empty.

This PR does not implement scan routing, QR workflows, PDF generation, AI tagging/scoring, or data-model redesign.

`ruff format --check .` still reports unrelated pre-existing formatting issues in six files. The new/changed files in this PR are formatted.

## Validation

* `python -m pytest` — 26 passed
* `python -m ruff check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed

## Closes

Closes #2
