### PR TITLE
Build Quillan response payloads with pds-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ shared PDS workspace root:
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/
 ```
 
-This alignment establishes the shared path convention only. Workspace settings,
-scan routing, QR workflows, and paper/PDF workflows are not yet implemented.
+Quillan also uses `pds-core` to build canonical PDS1 payload strings for
+writing-response pages. QR image generation, workspace settings, scan routing,
+and paper/PDF workflows are not yet implemented.
 
 ## Running Quillan
 
@@ -154,6 +155,12 @@ Before opening a pull request, all three should pass:
 pytest
 ruff check .
 mypy .
+```
+
+Run the complete validation sequence, including the diff whitespace check:
+
+```powershell
+.\run_tests.ps1
 ```
 
 ## Data Contracts

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -176,6 +176,27 @@ Example path:
 <PDS workspace root>/classes/english12_period3_synthetic/assignments/villainy_final_essay_synthetic/submissions/stu_0001/submission.txt
 ```
 
+## Writing-Response Payload
+
+Each Quillan writing-response page can be identified by a canonical PDS1
+payload built through `pds-core`:
+
+```text
+PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page_number>|doc=response
+```
+
+The page number is a positive integer. Class, assignment, and student
+identifiers follow shared `pds-core` identifier validation.
+
+Example:
+
+```text
+PDS1|module=quillan|class=english12_p4|aid=personal_narrative|sid=1001|page=1|doc=response
+```
+
+This contract identifies response documents only; QR image generation, paper
+forms, and scan routing are outside the current implementation.
+
 ## Requirements Check
 
 A requirements check records whether the submission met basic assignment requirements.

--- a/quillan/payloads.py
+++ b/quillan/payloads.py
@@ -1,0 +1,28 @@
+"""PDS1 payload helpers for Quillan documents."""
+
+from __future__ import annotations
+
+from pds_core.pds1 import PDS1_SCHEMA, build_pds1_payload
+from pds_core.qr_payload import QrPayload
+
+
+def build_response_payload(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    page: int,
+) -> str:
+    """Build a canonical PDS1 payload for a Quillan writing-response page."""
+    if isinstance(page, bool) or not isinstance(page, int) or page < 1:
+        raise ValueError("page must be a positive integer.")
+
+    payload = QrPayload(
+        schema=PDS1_SCHEMA,
+        module="quillan",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        page=page,
+        metadata={"doc": "response"},
+    )
+    return build_pds1_payload(payload)

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,0 +1,25 @@
+$ErrorActionPreference = "Stop"
+
+function Invoke-Check {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Label,
+
+        [Parameter(Mandatory)]
+        [scriptblock]$Command
+    )
+
+    Write-Host $Label
+    & $Command
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+Invoke-Check "Running pytest..." { python -m pytest }
+Invoke-Check "Running Ruff..." { python -m ruff check . }
+Invoke-Check "Running mypy..." { python -m mypy . }
+Invoke-Check "Checking diff whitespace..." { git diff --check }
+
+Write-Host "All checks passed."

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -1,0 +1,76 @@
+"""Tests for Quillan PDS1 response payloads."""
+
+from __future__ import annotations
+
+import pytest
+from pds_core.pds1 import PDS1_SCHEMA, parse_pds1_payload
+from pds_core.qr_payload import QrPayloadValidationError
+
+from quillan.payloads import build_response_payload
+
+
+def test_build_response_payload() -> None:
+    payload = build_response_payload(
+        class_id="english12_p4",
+        assignment_id="personal_narrative",
+        student_id="1001",
+        page=1,
+    )
+
+    assert payload == (
+        "PDS1|module=quillan|class=english12_p4|aid=personal_narrative|"
+        "sid=1001|page=1|doc=response"
+    )
+
+
+@pytest.mark.parametrize("page", [0, -1, True, 1.5, "1"])
+def test_build_response_payload_rejects_invalid_pages(page: object) -> None:
+    with pytest.raises(ValueError, match="page must be a positive integer"):
+        build_response_payload(
+            class_id="english12_p4",
+            assignment_id="personal_narrative",
+            student_id="1001",
+            page=page,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("class_id", "english 12"),
+        ("assignment_id", "personal/narrative"),
+        ("student_id", ""),
+    ],
+)
+def test_build_response_payload_delegates_identifier_validation(
+    field_name: str,
+    field_value: str,
+) -> None:
+    identifiers = {
+        "class_id": "english12_p4",
+        "assignment_id": "personal_narrative",
+        "student_id": "1001",
+    }
+    identifiers[field_name] = field_value
+
+    with pytest.raises(QrPayloadValidationError, match=field_name):
+        build_response_payload(**identifiers, page=1)
+
+
+def test_response_payload_round_trip() -> None:
+    payload_text = build_response_payload(
+        class_id="english12_p4",
+        assignment_id="personal_narrative",
+        student_id="1001",
+        page=2,
+    )
+
+    parsed = parse_pds1_payload(payload_text)
+
+    assert parsed.schema == PDS1_SCHEMA
+    assert parsed.module == "quillan"
+    assert parsed.class_id == "english12_p4"
+    assert parsed.assignment_id == "personal_narrative"
+    assert parsed.student_id == "1001"
+    assert parsed.page == 2
+    assert parsed.metadata == {"doc": "response"}


### PR DESCRIPTION
## Summary

Adds `pds-core`-backed PDS1 payload construction for Quillan writing-response documents.

This introduces a focused helper for building Quillan response payload strings with `module=quillan` and `doc=response`, without adding QR image generation, PDFs, scanning, or workflow behavior.

This PR also adds a small `run_tests.ps1` developer test runner to keep Quillan validation consistent with the broader Paper Data Suite workflow.

## Changes

* Added `build_response_payload` in `quillan/payloads.py`
* Used `pds-core` payload APIs:

  * `QrPayload`
  * `PDS1_SCHEMA`
  * `build_pds1_payload`
* Delegated identifier validation to `pds-core`
* Added validation for positive page numbers
* Added payload construction, validation, and parser round-trip tests in `tests/test_payloads.py`
* Added root-level `run_tests.ps1`
* Updated README documentation
* Updated `docs/data_contracts.md`

## Example Payload

```text id="d2w11v"
PDS1|module=quillan|class=english12_p4|aid=personal_narrative|sid=1001|page=1|doc=response
```

## Test Runner

`run_tests.ps1` runs:

```powershell id="2cnb6p"
python -m pytest
python -m ruff check .
python -m mypy .
git diff --check
```

`ruff format --check .` is intentionally excluded because it currently reports unrelated pre-existing formatting issues in six files.

## Notes

This PR does not implement QR image generation, PDF generation, paper response sheets, scan routing, OCR, AI tagging/scoring, CLI commands, menu workflows, or workspace settings.

## Validation

* `.\run_tests.ps1` — passed
* `python -m pytest` — 36 passed
* `python -m ruff check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed
* `ruff format --check .` — excluded from `run_tests.ps1`; six unrelated pre-existing files require formatting

## Closes

Closes #4
