### PR TITLE
Define assignment and submission metadata validation

### DIFF
--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -101,7 +101,9 @@ Example:
 
 ## Assignment
 
-An assignment defines what students wrote, which class or classes are connected, which standards are active, and what basic requirements apply.
+An assignment defines what the teacher asked students to write, which class or
+classes are connected, which standards are active, and what basic requirements
+apply.
 
 Suggested path:
 
@@ -158,23 +160,74 @@ Example:
 
 ## Submission
 
-A submission stores or references a student's written work.
-
-MVP submissions are plain-text files.
-
-Suggested path:
+A submission preserves student-produced writing as evidence and records how
+that writing entered the teacher's review workflow. The writing and its
+metadata are stored separately:
 
 ```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.txt
 ```
 
-A future metadata file may describe source type, import time, OCR status, or original file references.
+`submission.txt` contains the student writing. `submission.json` organizes the
+artifact and its provenance without adding scores, feedback, or software-made
+judgments.
 
-Example path:
+Required submission metadata fields:
 
-```text
-<PDS workspace root>/classes/english12_period3_synthetic/assignments/villainy_final_essay_synthetic/submissions/stu_0001/submission.txt
+* `submission_id`
+* `assignment_id`
+* `class_id`
+* `student_id`
+* `source_type`
+* `text_file`
+* `captured_at`
+* `status`
+* `version`
+
+Allowed MVP `source_type` values:
+
+* `manual_entry`
+* `typed_text`
+* `pasted_text`
+* `file_import`
+* `paper_scan`
+* `ocr_scan`
+* `google_doc_export`
+
+Allowed MVP `status` values:
+
+* `captured`
+* `needs_review`
+* `reviewed`
+* `superseded`
+* `invalid`
+
+Example `submission.json`:
+
+```json
+{
+  "submission_id": "sub_stu_0001_v1",
+  "assignment_id": "villainy_final_essay_synthetic",
+  "class_id": "english12_period3_synthetic",
+  "student_id": "stu_0001",
+  "source_type": "manual_entry",
+  "text_file": "submission.txt",
+  "captured_at": "2026-06-07T12:00:00",
+  "status": "captured",
+  "version": 1
+}
 ```
+
+The metadata identifiers follow shared `pds-core` identifier validation.
+`text_file` must be a relative path contained within the submission record;
+absolute paths and parent-directory traversal are not allowed. `version` is a
+positive integer.
+
+Requirements checks, teacher tags, teacher notes, rubric scores entered or
+confirmed by the teacher, and feedback records remain separate artifacts.
+Software may organize and validate these records, but the student text remains
+the evidence and teacher review remains central.
 
 ## Writing-Response Payload
 

--- a/quillan/assignments.py
+++ b/quillan/assignments.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
 ALLOWED_TAGGING_MODES = {"focus", "focus_plus_past", "benchmark", "custom"}
 
 
@@ -56,10 +58,17 @@ def validate_assignment_config(assignment: dict[str, Any]) -> None:
     for field in required_fields:
         _require_field(assignment, field, "assignment config")
 
+    _validate_identifier(assignment["assignment_id"], "assignment_id")
+    _validate_non_empty_string(assignment["title"], "title")
     _validate_class_ids(assignment["class_ids"])
+    _validate_non_empty_string(assignment["writing_type"], "writing_type")
+    _validate_non_empty_string(
+        assignment["standards_profile_id"], "standards_profile_id"
+    )
     _validate_tagging_mode(assignment["tagging_mode"])
     _validate_focus_standards(assignment["focus_standards"])
     _validate_basic_requirements(assignment["basic_requirements"])
+    _validate_non_empty_string(assignment["rubric_id"], "rubric_id")
 
 
 def _validate_class_ids(class_ids: Any) -> None:
@@ -71,14 +80,14 @@ def _validate_class_ids(class_ids: Any) -> None:
         raise AssignmentConfigError("Field 'class_ids' must not be empty.")
 
     for class_id in class_ids:
-        if not isinstance(class_id, str) or not class_id:
-            raise AssignmentConfigError(
-                "Each value in 'class_ids' must be a non-empty string."
-            )
+        _validate_identifier(class_id, "class_id")
 
 
 def _validate_tagging_mode(tagging_mode: Any) -> None:
     """Validate assignment tagging mode."""
+    if not isinstance(tagging_mode, str):
+        raise AssignmentConfigError("Field 'tagging_mode' must be a string.")
+
     if tagging_mode not in ALLOWED_TAGGING_MODES:
         allowed = ", ".join(sorted(ALLOWED_TAGGING_MODES))
         raise AssignmentConfigError(
@@ -92,7 +101,7 @@ def _validate_focus_standards(focus_standards: Any) -> None:
         raise AssignmentConfigError("Field 'focus_standards' must be a list.")
 
     for standard_code in focus_standards:
-        if not isinstance(standard_code, str) or not standard_code:
+        if not isinstance(standard_code, str) or not standard_code.strip():
             raise AssignmentConfigError(
                 "Each value in 'focus_standards' must be a non-empty string."
             )
@@ -121,7 +130,7 @@ def _validate_basic_requirements(basic_requirements: Any) -> None:
             )
 
         for element in required_elements:
-            if not isinstance(element, str) or not element:
+            if not isinstance(element, str) or not element.strip():
                 raise AssignmentConfigError(
                     "Each value in 'required_elements' must be a non-empty string."
                 )
@@ -129,10 +138,24 @@ def _validate_basic_requirements(basic_requirements: Any) -> None:
 
 def _validate_non_negative_integer_requirement(key: str, value: Any) -> None:
     """Validate a non-negative integer requirement value."""
-    if not isinstance(value, int) or value < 0:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise AssignmentConfigError(
             f"Field '{key}' in 'basic_requirements' must be a non-negative integer."
         )
+
+
+def _validate_identifier(value: Any, field: str) -> None:
+    """Validate a shared Paper Data Suite identifier."""
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise AssignmentConfigError(str(error)) from error
+
+
+def _validate_non_empty_string(value: Any, field: str) -> None:
+    """Validate a required non-empty string field."""
+    if not isinstance(value, str) or not value.strip():
+        raise AssignmentConfigError(f"Field '{field}' must be a non-empty string.")
 
 
 def _require_field(data: dict[str, Any], field: str, context: str) -> None:

--- a/quillan/submissions.py
+++ b/quillan/submissions.py
@@ -1,0 +1,140 @@
+"""Submission metadata loading and validation for Quillan."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+ALLOWED_SOURCE_TYPES = {
+    "manual_entry",
+    "typed_text",
+    "pasted_text",
+    "file_import",
+    "paper_scan",
+    "ocr_scan",
+    "google_doc_export",
+}
+
+ALLOWED_SUBMISSION_STATUSES = {
+    "captured",
+    "needs_review",
+    "reviewed",
+    "superseded",
+    "invalid",
+}
+
+REQUIRED_SUBMISSION_FIELDS = [
+    "submission_id",
+    "assignment_id",
+    "class_id",
+    "student_id",
+    "source_type",
+    "text_file",
+    "captured_at",
+    "status",
+    "version",
+]
+
+
+class SubmissionMetadataError(ValueError):
+    """Raised when submission metadata is missing or invalid."""
+
+
+def load_submission_metadata(path: str | Path) -> dict[str, Any]:
+    """Load and validate submission metadata from a JSON file."""
+    metadata_path = Path(path)
+
+    try:
+        with metadata_path.open("r", encoding="utf-8") as file:
+            submission = json.load(file)
+    except FileNotFoundError as error:
+        raise SubmissionMetadataError(
+            f"Submission metadata not found: {metadata_path}"
+        ) from error
+    except json.JSONDecodeError as error:
+        raise SubmissionMetadataError(
+            f"Submission metadata is not valid JSON: {metadata_path}"
+        ) from error
+
+    if not isinstance(submission, dict):
+        raise SubmissionMetadataError(
+            f"Submission metadata must be a JSON object: {metadata_path}"
+        )
+
+    submission_dict = cast(dict[str, Any], submission)
+    validate_submission_metadata(submission_dict)
+    return submission_dict
+
+
+def validate_submission_metadata(submission: dict[str, Any]) -> None:
+    """Validate the structure of a submission metadata record."""
+    for field in REQUIRED_SUBMISSION_FIELDS:
+        if field not in submission:
+            raise SubmissionMetadataError(f"Missing required field '{field}'.")
+
+    for field in (
+        "submission_id",
+        "assignment_id",
+        "class_id",
+        "student_id",
+        "source_type",
+        "text_file",
+        "captured_at",
+        "status",
+    ):
+        _validate_non_empty_string(submission[field], field)
+
+    for field in ("submission_id", "assignment_id", "class_id", "student_id"):
+        _validate_identifier(submission[field], field)
+
+    _validate_allowed_value(
+        submission["source_type"], "source_type", ALLOWED_SOURCE_TYPES
+    )
+    _validate_text_file(submission["text_file"])
+    _validate_allowed_value(submission["status"], "status", ALLOWED_SUBMISSION_STATUSES)
+    _validate_version(submission["version"])
+
+
+def _validate_non_empty_string(value: Any, field: str) -> None:
+    """Validate a required non-empty string field."""
+    if not isinstance(value, str) or not value.strip():
+        raise SubmissionMetadataError(f"Field '{field}' must be a non-empty string.")
+
+
+def _validate_identifier(value: Any, field: str) -> None:
+    """Validate a shared Paper Data Suite identifier."""
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise SubmissionMetadataError(str(error)) from error
+
+
+def _validate_allowed_value(value: str, field: str, allowed_values: set[str]) -> None:
+    """Validate a string against an explicit set of allowed values."""
+    if value not in allowed_values:
+        allowed = ", ".join(sorted(allowed_values))
+        raise SubmissionMetadataError(
+            f"Invalid {field} '{value}'. Allowed values: {allowed}."
+        )
+
+
+def _validate_text_file(text_file: str) -> None:
+    """Validate that the text artifact path is relative and contained."""
+    path_variants = (PurePosixPath(text_file), PureWindowsPath(text_file))
+
+    if any(path.anchor for path in path_variants):
+        raise SubmissionMetadataError("Field 'text_file' must be a relative path.")
+
+    if any(".." in path.parts for path in path_variants):
+        raise SubmissionMetadataError(
+            "Field 'text_file' must not contain parent-directory traversal."
+        )
+
+
+def _validate_version(version: Any) -> None:
+    """Validate the positive integer submission version."""
+    if isinstance(version, bool) or not isinstance(version, int) or version < 1:
+        raise SubmissionMetadataError("Field 'version' must be a positive integer.")

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -69,6 +69,40 @@ def test_invalid_tagging_mode_raises_error(tmp_path: Path) -> None:
         load_assignment_config(assignment_path)
 
 
+def test_invalid_assignment_identifier_raises_error(tmp_path: Path) -> None:
+    assignment_path = tmp_path / "assignment.json"
+    assignment_data = _valid_assignment_config()
+    assignment_data["assignment_id"] = "../unsafe"
+    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+
+    with pytest.raises(AssignmentConfigError, match="assignment_id"):
+        load_assignment_config(assignment_path)
+
+
+def test_invalid_class_identifier_raises_error(tmp_path: Path) -> None:
+    assignment_path = tmp_path / "assignment.json"
+    assignment_data = _valid_assignment_config()
+    assignment_data["class_ids"] = ["English 12"]
+    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+
+    with pytest.raises(AssignmentConfigError, match="class_id"):
+        load_assignment_config(assignment_path)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["title", "writing_type", "standards_profile_id", "rubric_id"],
+)
+def test_required_string_field_must_be_string(tmp_path: Path, field: str) -> None:
+    assignment_path = tmp_path / "assignment.json"
+    assignment_data = _valid_assignment_config()
+    assignment_data[field] = 123
+    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+
+    with pytest.raises(AssignmentConfigError, match=field):
+        load_assignment_config(assignment_path)
+
+
 def test_empty_class_ids_raises_error(tmp_path: Path) -> None:
     assignment_path = tmp_path / "assignment.json"
     assignment_data = _valid_assignment_config()
@@ -86,6 +120,16 @@ def test_focus_standards_must_be_list(tmp_path: Path) -> None:
     assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
 
     with pytest.raises(AssignmentConfigError, match="focus_standards.*must be a list"):
+        load_assignment_config(assignment_path)
+
+
+def test_focus_standards_reject_whitespace_only_value(tmp_path: Path) -> None:
+    assignment_path = tmp_path / "assignment.json"
+    assignment_data = _valid_assignment_config()
+    assignment_data["focus_standards"] = ["   "]
+    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+
+    with pytest.raises(AssignmentConfigError, match="focus_standards"):
         load_assignment_config(assignment_path)
 
 
@@ -111,6 +155,18 @@ def test_negative_requirement_value_raises_error(tmp_path: Path) -> None:
         load_assignment_config(assignment_path)
 
 
+def test_boolean_requirement_value_raises_error(tmp_path: Path) -> None:
+    assignment_path = tmp_path / "assignment.json"
+    assignment_data = _valid_assignment_config()
+    assignment_data["basic_requirements"] = {
+        "paragraphs_min": True,
+    }
+    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+
+    with pytest.raises(AssignmentConfigError, match="paragraphs_min"):
+        load_assignment_config(assignment_path)
+
+
 def test_required_elements_must_be_list(tmp_path: Path) -> None:
     assignment_path = tmp_path / "assignment.json"
     assignment_data = _valid_assignment_config()
@@ -122,6 +178,18 @@ def test_required_elements_must_be_list(tmp_path: Path) -> None:
     with pytest.raises(
         AssignmentConfigError, match="required_elements.*must be a list"
     ):
+        load_assignment_config(assignment_path)
+
+
+def test_required_elements_reject_whitespace_only_value(tmp_path: Path) -> None:
+    assignment_path = tmp_path / "assignment.json"
+    assignment_data = _valid_assignment_config()
+    assignment_data["basic_requirements"] = {
+        "required_elements": ["   "],
+    }
+    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+
+    with pytest.raises(AssignmentConfigError, match="required_elements"):
         load_assignment_config(assignment_path)
 
 

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -1,0 +1,180 @@
+"""Tests for submission metadata loading and validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quillan.submissions import (
+    SubmissionMetadataError,
+    load_submission_metadata,
+)
+
+
+def _valid_submission_metadata() -> dict[str, object]:
+    """Return valid synthetic submission metadata."""
+    return {
+        "submission_id": "sub_stu_0001_v1",
+        "assignment_id": "villainy_final_essay_synthetic",
+        "class_id": "english12_period3_synthetic",
+        "student_id": "stu_0001",
+        "source_type": "manual_entry",
+        "text_file": "submission.txt",
+        "captured_at": "2026-06-07T12:00:00",
+        "status": "captured",
+        "version": 1,
+    }
+
+
+def _write_metadata(tmp_path: Path, metadata: object) -> Path:
+    """Write metadata to the test submission path."""
+    metadata_path = tmp_path / "submission.json"
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    return metadata_path
+
+
+def test_load_valid_submission_metadata(tmp_path: Path) -> None:
+    metadata = _valid_submission_metadata()
+
+    assert load_submission_metadata(_write_metadata(tmp_path, metadata)) == metadata
+
+
+def test_missing_required_field_raises_error(tmp_path: Path) -> None:
+    metadata = _valid_submission_metadata()
+    del metadata["captured_at"]
+
+    with pytest.raises(
+        SubmissionMetadataError, match="Missing required field 'captured_at'"
+    ):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+def test_invalid_json_raises_error(tmp_path: Path) -> None:
+    metadata_path = tmp_path / "submission.json"
+    metadata_path.write_text("{bad json", encoding="utf-8")
+
+    with pytest.raises(SubmissionMetadataError, match="not valid JSON"):
+        load_submission_metadata(metadata_path)
+
+
+def test_valid_json_that_is_not_object_raises_error(tmp_path: Path) -> None:
+    with pytest.raises(SubmissionMetadataError, match="must be a JSON object"):
+        load_submission_metadata(_write_metadata(tmp_path, []))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_type", "email"),
+        ("status", "auto_graded"),
+    ],
+)
+def test_invalid_allowed_value_raises_error(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    metadata = _valid_submission_metadata()
+    metadata[field] = value
+
+    with pytest.raises(SubmissionMetadataError, match=field):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["submission_id", "assignment_id", "class_id", "student_id"],
+)
+def test_invalid_identifier_raises_error(tmp_path: Path, field: str) -> None:
+    metadata = _valid_submission_metadata()
+    metadata[field] = "../unsafe"
+
+    with pytest.raises(SubmissionMetadataError, match=field):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "submission_id",
+        "assignment_id",
+        "class_id",
+        "student_id",
+        "source_type",
+        "text_file",
+        "captured_at",
+        "status",
+    ],
+)
+def test_empty_required_string_raises_error(tmp_path: Path, field: str) -> None:
+    metadata = _valid_submission_metadata()
+    metadata[field] = ""
+
+    with pytest.raises(SubmissionMetadataError, match=field):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+@pytest.mark.parametrize(
+    "text_file",
+    [
+        "/absolute/submission.txt",
+        r"C:\absolute\submission.txt",
+        r"C:drive-relative\submission.txt",
+        r"\root-relative\submission.txt",
+    ],
+)
+def test_absolute_text_file_raises_error(tmp_path: Path, text_file: str) -> None:
+    metadata = _valid_submission_metadata()
+    metadata["text_file"] = text_file
+
+    with pytest.raises(SubmissionMetadataError, match="relative path"):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+@pytest.mark.parametrize(
+    "text_file",
+    [
+        "../submission.txt",
+        "drafts/../../submission.txt",
+        r"..\submission.txt",
+    ],
+)
+def test_parent_traversal_in_text_file_raises_error(
+    tmp_path: Path, text_file: str
+) -> None:
+    metadata = _valid_submission_metadata()
+    metadata["text_file"] = text_file
+
+    with pytest.raises(SubmissionMetadataError, match="parent-directory traversal"):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+@pytest.mark.parametrize("version", [0, -1])
+def test_non_positive_version_raises_error(tmp_path: Path, version: int) -> None:
+    metadata = _valid_submission_metadata()
+    metadata["version"] = version
+
+    with pytest.raises(SubmissionMetadataError, match="positive integer"):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+@pytest.mark.parametrize("version", [1.5, "1", None])
+def test_non_integer_version_raises_error(tmp_path: Path, version: object) -> None:
+    metadata = _valid_submission_metadata()
+    metadata["version"] = version
+
+    with pytest.raises(SubmissionMetadataError, match="positive integer"):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+def test_boolean_version_raises_error(tmp_path: Path) -> None:
+    metadata = _valid_submission_metadata()
+    metadata["version"] = True
+
+    with pytest.raises(SubmissionMetadataError, match="positive integer"):
+        load_submission_metadata(_write_metadata(tmp_path, metadata))
+
+
+def test_missing_file_raises_error() -> None:
+    with pytest.raises(SubmissionMetadataError, match="Submission metadata not found"):
+        load_submission_metadata("missing_submission.json")


### PR DESCRIPTION
## Summary

Stabilizes Quillan’s assignment config validation and adds explicit submission metadata validation.

This PR keeps Quillan focused on preserving student writing as teacher-reviewed evidence, not on automated scoring or AI judgment.

## Changes

* Adds `pds-core` identifier validation to assignment configs
* Tightens assignment string and numeric requirement validation
* Adds submission metadata loading and validation in `quillan/submissions.py`
* Adds explicit allowed submission source types and workflow statuses
* Validates submission metadata identifiers through `pds-core`
* Rejects unsafe `text_file` paths, including absolute paths and parent-directory traversal
* Rejects invalid submission versions, including boolean values
* Adds submission metadata tests
* Updates assignment validation tests
* Updates `docs/data_contracts.md` with the MVP `submission.json` contract and teacher-review framing

## Notes

This PR defines assignment/submission data contracts only.

It does not add AI tagging, AI scoring, automatic grading, feedback generation, requirements checking, QR image generation, PDF generation, OCR, scan routing, report generation, CLI workflows, or workspace-setting changes.

## Validation

* `python -m pytest` — passed, 74 tests
* `python -m ruff check .` — passed
* `python -m ruff format --check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed

## Closes

Closes #17
