### PR TITLE
Define standards hotwords and subskills model

### DIFF
--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -19,7 +19,14 @@ Quillan data should be:
 
 ## Standards Profile
 
-A standards profile defines the standards and comments available for tagging.
+A standards profile is a teacher- or department-defined collection of
+instructional targets and reusable review language. Profiles can be reused
+across assignments to make teacher review, evidence organization, and
+reporting more consistent.
+
+A profile describes the review vocabulary available to a teacher. It does not
+discover standards, inspect writing automatically, determine whether a
+standard was met, generate authoritative feedback, or calculate a score.
 
 Suggested Paper Data Suite path:
 
@@ -47,11 +54,27 @@ Each standard requires:
 * `description`
 * `comments`
 
+A standard is an instructional target or teacher-defined evaluation category.
+It may represent a published standard, a course skill, a local performance
+expectation, or a writing criterion used in another subject. Standard `code`
+values must be unique within a standards profile.
+
+The `comments` field is a list and may be empty when a teacher has not defined
+reusable comments for that standard. A standard with no comments is available
+for alignment and reporting only until teacher-review comments are added.
+
 Each comment requires:
 
 * `comment_id`
 * `label`
 * `polarity`
+
+A comment is reusable teacher-approved language connected to a standard. It
+supports consistent teacher tagging and feedback, but its presence in a
+profile is not a judgment about any student work. Each `comment_id` must be
+unique within its standard. The same `comment_id` may be reused under a
+different standard; records that refer to a comment use both `standard_code`
+and `comment_id` to identify it.
 
 Allowed polarity values:
 
@@ -59,11 +82,31 @@ Allowed polarity values:
 * `developing`
 * `negative`
 
+Polarity organizes teacher observations as strengths, developing skills, or
+problems. It has no numeric scoring semantics and does not determine a grade.
+
 Optional comment fields:
 
 * `severity_default`
 * `feedback_template`
 * `subskills`
+* `hotwords`
+
+`severity_default`, when present, is a non-negative integer. It is a suggested
+organizational default for a teacher-entered observation, not a score.
+`feedback_template` is optional teacher-approved wording.
+
+Subskills are smaller teacher-defined components of a standard or comment,
+such as `claim`, `reasoning`, `evidence_integration`, `imagery`, or
+`line_breaks`. Hotwords are teacher-defined text cues, such as `because`,
+`however`, or `this shows`, that may help a teacher search for or organize
+evidence. Both fields are optional lists of non-empty strings, and either list
+may be empty.
+
+Hotwords and subskills are support metadata only. A hotword match is not proof
+that a standard was met or missed, and neither field defines an automated
+detection, feedback, grading, or scoring rule. Scores and final judgments
+remain teacher decisions based on teacher-reviewed evidence.
 
 Example:
 
@@ -81,12 +124,18 @@ Example:
         {
           "comment_id": "clear_claim",
           "label": "Clear claim",
-          "polarity": "positive"
+          "polarity": "positive",
+          "subskills": ["claim"],
+          "hotwords": ["claim", "thesis", "argues"]
         },
         {
           "comment_id": "evidence_needs_explanation",
           "label": "Evidence needs more explanation",
-          "polarity": "developing"
+          "polarity": "developing",
+          "severity_default": 2,
+          "feedback_template": "The evidence is relevant, but the explanation needs to show more clearly how it supports the claim.",
+          "subskills": ["reasoning", "evidence_explanation"],
+          "hotwords": ["quote", "example", "this shows"]
         },
         {
           "comment_id": "unsupported_claim",

--- a/examples/standards/english_12_njsls_synthetic.json
+++ b/examples/standards/english_12_njsls_synthetic.json
@@ -11,7 +11,9 @@
         {
           "comment_id": "clear_claim",
           "label": "Clear claim",
-          "polarity": "positive"
+          "polarity": "positive",
+          "subskills": ["claim"],
+          "hotwords": ["claim", "thesis", "argues"]
         },
         {
           "comment_id": "relevant_evidence",
@@ -21,7 +23,11 @@
         {
           "comment_id": "evidence_needs_explanation",
           "label": "Evidence needs more explanation",
-          "polarity": "developing"
+          "polarity": "developing",
+          "severity_default": 2,
+          "feedback_template": "The evidence is relevant, but the explanation needs to show more clearly how it supports the claim.",
+          "subskills": ["reasoning", "evidence_explanation"],
+          "hotwords": ["quote", "example", "this shows"]
         },
         {
           "comment_id": "unsupported_claim",

--- a/quillan/standards.py
+++ b/quillan/standards.py
@@ -6,7 +6,12 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
 ALLOWED_POLARITIES = {"positive", "developing", "negative"}
+REQUIRED_PROFILE_FIELDS = ("profile_id", "subject", "course", "standards")
+REQUIRED_STANDARD_FIELDS = ("code", "short_name", "description", "comments")
+REQUIRED_COMMENT_FIELDS = ("comment_id", "label", "polarity")
 
 
 class StandardsProfileError(ValueError):
@@ -41,10 +46,12 @@ def load_standards_profile(path: str | Path) -> dict[str, Any]:
 
 def validate_standards_profile(profile: dict[str, Any]) -> None:
     """Validate the structure of a standards profile."""
-    required_top_level_fields = ["profile_id", "subject", "course", "standards"]
-
-    for field in required_top_level_fields:
+    for field in REQUIRED_PROFILE_FIELDS:
         _require_field(profile, field, "standards profile")
+
+    _validate_identifier(profile["profile_id"], "profile_id")
+    _validate_non_empty_string(profile["subject"], "subject")
+    _validate_non_empty_string(profile["course"], "course")
 
     if not isinstance(profile["standards"], list):
         raise StandardsProfileError("Field 'standards' must be a list.")
@@ -52,8 +59,15 @@ def validate_standards_profile(profile: dict[str, Any]) -> None:
     if not profile["standards"]:
         raise StandardsProfileError("Field 'standards' must not be empty.")
 
+    standard_codes: set[str] = set()
     for standard in profile["standards"]:
         _validate_standard(standard)
+        standard_code = standard["code"]
+        if standard_code in standard_codes:
+            raise StandardsProfileError(
+                f"Duplicate standard code '{standard_code}' in standards profile."
+            )
+        standard_codes.add(standard_code)
 
 
 def _validate_standard(standard: Any) -> None:
@@ -61,23 +75,27 @@ def _validate_standard(standard: Any) -> None:
     if not isinstance(standard, dict):
         raise StandardsProfileError("Each standard must be an object.")
 
-    required_standard_fields = ["code", "short_name", "description", "comments"]
-
-    for field in required_standard_fields:
+    for field in REQUIRED_STANDARD_FIELDS:
         _require_field(standard, field, "standard")
+
+    for field in ("code", "short_name", "description"):
+        _validate_non_empty_string(standard[field], field)
 
     if not isinstance(standard["comments"], list):
         raise StandardsProfileError(
             f"Comments for standard '{standard['code']}' must be a list."
         )
 
-    if not standard["comments"]:
-        raise StandardsProfileError(
-            f"Comments for standard '{standard['code']}' must not be empty."
-        )
-
+    comment_ids: set[str] = set()
     for comment in standard["comments"]:
         _validate_comment(comment, standard["code"])
+        comment_id = comment["comment_id"]
+        if comment_id in comment_ids:
+            raise StandardsProfileError(
+                f"Duplicate comment_id '{comment_id}' for standard "
+                f"'{standard['code']}'."
+            )
+        comment_ids.add(comment_id)
 
 
 def _validate_comment(comment: Any, standard_code: str) -> None:
@@ -87,10 +105,14 @@ def _validate_comment(comment: Any, standard_code: str) -> None:
             f"Each comment for standard '{standard_code}' must be an object."
         )
 
-    required_comment_fields = ["comment_id", "label", "polarity"]
-
-    for field in required_comment_fields:
+    for field in REQUIRED_COMMENT_FIELDS:
         _require_field(comment, field, f"comment for standard '{standard_code}'")
+
+    _validate_identifier(comment["comment_id"], "comment_id")
+    _validate_non_empty_string(comment["label"], "label")
+
+    if not isinstance(comment["polarity"], str):
+        raise StandardsProfileError("Field 'polarity' must be a string.")
 
     if comment["polarity"] not in ALLOWED_POLARITIES:
         allowed = ", ".join(sorted(ALLOWED_POLARITIES))
@@ -99,11 +121,48 @@ def _validate_comment(comment: Any, standard_code: str) -> None:
             f"'{comment['comment_id']}'. Allowed values: {allowed}."
         )
 
+    if "severity_default" in comment:
+        severity = comment["severity_default"]
+        if isinstance(severity, bool) or not isinstance(severity, int) or severity < 0:
+            raise StandardsProfileError(
+                "Field 'severity_default' must be a non-negative integer."
+            )
+
+    if "feedback_template" in comment:
+        _validate_non_empty_string(comment["feedback_template"], "feedback_template")
+
+    for field in ("subskills", "hotwords"):
+        if field in comment:
+            _validate_string_list(comment[field], field)
+
+
+def _validate_identifier(value: Any, field: str) -> None:
+    """Validate a shared Paper Data Suite identifier."""
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise StandardsProfileError(str(error)) from error
+
+
+def _validate_non_empty_string(value: Any, field: str) -> None:
+    """Validate a required non-empty string field."""
+    if not isinstance(value, str) or not value.strip():
+        raise StandardsProfileError(f"Field '{field}' must be a non-empty string.")
+
+
+def _validate_string_list(value: Any, field: str) -> None:
+    """Validate an optional list of non-empty teacher-defined strings."""
+    if not isinstance(value, list):
+        raise StandardsProfileError(f"Field '{field}' must be a list.")
+
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise StandardsProfileError(
+                f"Each value in '{field}' must be a non-empty string."
+            )
+
 
 def _require_field(data: dict[str, Any], field: str, context: str) -> None:
-    """Require a field to exist and contain a non-empty value."""
+    """Require a field to exist."""
     if field not in data:
         raise StandardsProfileError(f"Missing required field '{field}' in {context}.")
-
-    if data[field] in ("", None):
-        raise StandardsProfileError(f"Field '{field}' in {context} must not be empty.")

--- a/tests/test_standards.py
+++ b/tests/test_standards.py
@@ -4,92 +4,122 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from quillan.standards import StandardsProfileError, load_standards_profile
 
 
+def _valid_profile() -> dict[str, Any]:
+    """Return a valid synthetic standards profile."""
+    return {
+        "profile_id": "english_12_njsls_synthetic",
+        "subject": "English Language Arts",
+        "course": "English 12",
+        "standards": [
+            {
+                "code": "W.AW.11-12.1",
+                "short_name": "Argument Writing",
+                "description": "Write arguments using claims, reasoning, and evidence.",
+                "comments": [
+                    {
+                        "comment_id": "evidence_needs_explanation",
+                        "label": "Evidence needs more explanation",
+                        "polarity": "developing",
+                        "severity_default": 2,
+                        "feedback_template": (
+                            "Explain how the evidence supports the claim."
+                        ),
+                        "subskills": ["reasoning", "evidence_explanation"],
+                        "hotwords": ["because", "this shows"],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _write_profile(tmp_path: Path, profile: object) -> Path:
+    """Write a JSON value to a temporary standards profile."""
+    profile_path = tmp_path / "standards.json"
+    profile_path.write_text(json.dumps(profile), encoding="utf-8")
+    return profile_path
+
+
 def test_load_valid_standards_profile(tmp_path: Path) -> None:
-    profile_path = tmp_path / "standards.json"
-    profile_data = {
-        "profile_id": "english_12_njsls_synthetic",
-        "subject": "English Language Arts",
-        "course": "English 12",
-        "standards": [
-            {
-                "code": "W.AW.11-12.1",
-                "short_name": "Argument Writing",
-                "description": "Write arguments using claims, reasoning, and evidence.",
-                "comments": [
-                    {
-                        "comment_id": "clear_claim",
-                        "label": "Clear claim",
-                        "polarity": "positive",
-                    }
-                ],
-            }
-        ],
-    }
-    profile_path.write_text(json.dumps(profile_data), encoding="utf-8")
+    profile = _valid_profile()
 
-    loaded_profile = load_standards_profile(profile_path)
-
-    assert loaded_profile == profile_data
+    assert load_standards_profile(_write_profile(tmp_path, profile)) == profile
 
 
-def test_missing_top_level_field_raises_error(tmp_path: Path) -> None:
-    profile_path = tmp_path / "standards.json"
-    profile_data = {
-        "profile_id": "english_12_njsls_synthetic",
-        "subject": "English Language Arts",
-        "standards": [],
-    }
-    profile_path.write_text(json.dumps(profile_data), encoding="utf-8")
+def test_optional_lists_may_be_empty_or_omitted(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    comment = profile["standards"][0]["comments"][0]
+    comment.pop("severity_default")
+    comment.pop("feedback_template")
+    comment["subskills"] = []
+    comment["hotwords"] = []
 
-    with pytest.raises(StandardsProfileError, match="Missing required field 'course'"):
-        load_standards_profile(profile_path)
+    assert load_standards_profile(_write_profile(tmp_path, profile)) == profile
 
 
-def test_empty_standards_list_raises_error(tmp_path: Path) -> None:
-    profile_path = tmp_path / "standards.json"
-    profile_data = {
-        "profile_id": "english_12_njsls_synthetic",
-        "subject": "English Language Arts",
-        "course": "English 12",
-        "standards": [],
-    }
-    profile_path.write_text(json.dumps(profile_data), encoding="utf-8")
+def test_standard_comments_may_be_empty(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"] = []
 
-    with pytest.raises(StandardsProfileError, match="must not be empty"):
-        load_standards_profile(profile_path)
+    assert load_standards_profile(_write_profile(tmp_path, profile)) == profile
 
 
-def test_invalid_comment_polarity_raises_error(tmp_path: Path) -> None:
-    profile_path = tmp_path / "standards.json"
-    profile_data = {
-        "profile_id": "english_12_njsls_synthetic",
-        "subject": "English Language Arts",
-        "course": "English 12",
-        "standards": [
-            {
-                "code": "W.AW.11-12.1",
-                "short_name": "Argument Writing",
-                "description": "Write arguments using claims, reasoning, and evidence.",
-                "comments": [
-                    {
-                        "comment_id": "clear_claim",
-                        "label": "Clear claim",
-                        "polarity": "strong",
-                    }
-                ],
-            }
-        ],
-    }
-    profile_path.write_text(json.dumps(profile_data), encoding="utf-8")
+def test_duplicate_standard_codes_are_rejected(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"].append(
+        {
+            "code": "W.AW.11-12.1",
+            "short_name": "Argument Writing Duplicate",
+            "description": "Duplicate standard code.",
+            "comments": [],
+        }
+    )
 
-    with pytest.raises(StandardsProfileError, match="Invalid polarity"):
-        load_standards_profile(profile_path)
+    with pytest.raises(StandardsProfileError, match="Duplicate standard code"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_duplicate_comment_ids_within_standard_are_rejected(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"].append(
+        {
+            "comment_id": "evidence_needs_explanation",
+            "label": "Evidence needs more explanation duplicate",
+            "polarity": "developing",
+        }
+    )
+
+    with pytest.raises(StandardsProfileError, match="Duplicate comment_id"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_duplicate_comment_ids_under_different_standards_are_allowed(
+    tmp_path: Path,
+) -> None:
+    profile = _valid_profile()
+    profile["standards"].append(
+        {
+            "code": "W.WP.11-12.4",
+            "short_name": "Writing Process",
+            "description": "Develop and strengthen writing through revision.",
+            "comments": [
+                {
+                    "comment_id": "evidence_needs_explanation",
+                    "label": "Revision needs more explanation",
+                    "polarity": "developing",
+                }
+            ],
+        }
+    )
+
+    assert load_standards_profile(_write_profile(tmp_path, profile)) == profile
 
 
 def test_missing_file_raises_clear_error() -> None:
@@ -103,3 +133,172 @@ def test_invalid_json_raises_clear_error(tmp_path: Path) -> None:
 
     with pytest.raises(StandardsProfileError, match="not valid JSON"):
         load_standards_profile(profile_path)
+
+
+def test_valid_json_that_is_not_object_raises_error(tmp_path: Path) -> None:
+    with pytest.raises(StandardsProfileError, match="must be a JSON object"):
+        load_standards_profile(_write_profile(tmp_path, []))
+
+
+@pytest.mark.parametrize("field", ["profile_id", "subject", "course", "standards"])
+def test_missing_top_level_field_raises_error(tmp_path: Path, field: str) -> None:
+    profile = _valid_profile()
+    del profile[field]
+
+    with pytest.raises(StandardsProfileError, match=f"required field '{field}'"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_invalid_profile_identifier_raises_error(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["profile_id"] = "../unsafe"
+
+    with pytest.raises(StandardsProfileError, match="profile_id"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("field", ["subject", "course"])
+@pytest.mark.parametrize("value", ["", "   ", 123])
+def test_profile_string_must_be_non_empty(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    profile = _valid_profile()
+    profile[field] = value
+
+    with pytest.raises(StandardsProfileError, match=field):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("value", ["W.AW.11-12.1", {}, None])
+def test_standards_must_be_list(tmp_path: Path, value: object) -> None:
+    profile = _valid_profile()
+    profile["standards"] = value
+
+    with pytest.raises(StandardsProfileError, match="standards.*list"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_standards_must_not_be_empty(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"] = []
+
+    with pytest.raises(StandardsProfileError, match="standards.*not be empty"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_standard_must_be_object(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"] = ["W.AW.11-12.1"]
+
+    with pytest.raises(StandardsProfileError, match="standard must be an object"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("field", ["code", "short_name", "description", "comments"])
+def test_missing_standard_field_raises_error(tmp_path: Path, field: str) -> None:
+    profile = _valid_profile()
+    del profile["standards"][0][field]
+
+    with pytest.raises(StandardsProfileError, match=f"required field '{field}'"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("field", ["code", "short_name", "description"])
+@pytest.mark.parametrize("value", ["", "   ", 123])
+def test_standard_string_must_be_non_empty(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    profile = _valid_profile()
+    profile["standards"][0][field] = value
+
+    with pytest.raises(StandardsProfileError, match=field):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_comments_must_be_list(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"] = {}
+
+    with pytest.raises(StandardsProfileError, match="Comments.*must be a list"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_comment_must_be_object(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"] = ["clear_claim"]
+
+    with pytest.raises(StandardsProfileError, match="comment.*must be an object"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("field", ["comment_id", "label", "polarity"])
+def test_missing_comment_field_raises_error(tmp_path: Path, field: str) -> None:
+    profile = _valid_profile()
+    del profile["standards"][0]["comments"][0][field]
+
+    with pytest.raises(StandardsProfileError, match=f"required field '{field}'"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_invalid_comment_identifier_raises_error(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"][0]["comment_id"] = "Clear Claim"
+
+    with pytest.raises(StandardsProfileError, match="comment_id"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("value", ["", "   ", 123])
+def test_comment_label_must_be_non_empty(tmp_path: Path, value: object) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"][0]["label"] = value
+
+    with pytest.raises(StandardsProfileError, match="label"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("value", ["strong", "", 1, ["positive"]])
+def test_invalid_comment_polarity_raises_error(tmp_path: Path, value: object) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"][0]["polarity"] = value
+
+    with pytest.raises(StandardsProfileError, match="polarity"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("value", [-1, 1.5, "2", None])
+def test_invalid_severity_default_raises_error(tmp_path: Path, value: object) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"][0]["severity_default"] = value
+
+    with pytest.raises(StandardsProfileError, match="severity_default"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+def test_boolean_severity_default_raises_error(tmp_path: Path) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"][0]["severity_default"] = True
+
+    with pytest.raises(StandardsProfileError, match="severity_default"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("value", ["", "   ", 123])
+def test_feedback_template_must_be_non_empty(tmp_path: Path, value: object) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"][0]["feedback_template"] = value
+
+    with pytest.raises(StandardsProfileError, match="feedback_template"):
+        load_standards_profile(_write_profile(tmp_path, profile))
+
+
+@pytest.mark.parametrize("field", ["subskills", "hotwords"])
+@pytest.mark.parametrize("value", ["claim", [""], ["   "], [1]])
+def test_teacher_metadata_must_be_list_of_non_empty_strings(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    profile = _valid_profile()
+    profile["standards"][0]["comments"][0][field] = value
+
+    with pytest.raises(StandardsProfileError, match=field):
+        load_standards_profile(_write_profile(tmp_path, profile))


### PR DESCRIPTION
## Summary

Defines Quillan’s MVP standards profile model, including teacher-defined standards, reusable comments, polarity, hotwords, and subskills.

This PR keeps Quillan focused on teacher-controlled review of student writing evidence rather than automated scoring, AI feedback, or software-determined judgment.

## Changes

* Adds standards profile loading and validation in `quillan/standards.py`
* Adds `pds-core` identifier validation for `profile_id` and `comment_id`
* Defines allowed MVP polarity values:

  * `positive`
  * `developing`
  * `negative`
* Adds validation for required profile, standard, and comment fields
* Adds optional validation for:

  * `severity_default`
  * `feedback_template`
  * `subskills`
  * `hotwords`
* Rejects duplicate standard codes within a profile
* Rejects duplicate `comment_id` values within a single standard
* Allows the same `comment_id` under different standards
* Allows empty `comments` lists for alignment-only standards
* Adds standards profile tests covering valid and invalid cases
* Updates `docs/data_contracts.md` with standards, comments, polarity, hotwords, subskills, and teacher-controlled review semantics
* Updates synthetic standards example data

## Notes

This PR defines the standards/profile data contract only.

It does not add AI tagging, AI scoring, automatic grading, feedback generation, tag generation, score calculation, report generation, assignment/submission redesign, QR image generation, PDF generation, OCR, scan routing, CLI workflows, or workspace-setting changes.

## Validation

* `python -m pytest` — passed, 135 tests
* `python -m ruff check .` — passed
* `python -m ruff format --check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed

## Closes

Closes #9
