### PR TITLE
Document Quillan teacher review model

### DIFF
--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -7,6 +7,10 @@ These contracts describe the expected MVP file formats for standards profiles, a
 For the expected workspace layout and file lifecycle of these records, see
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
 
+For the teacher-controlled relationship among evidence, review artifacts,
+scores, feedback, and reports, see
+[`teacher_review_model.md`](teacher_review_model.md).
+
 All examples must use synthetic data only. No real student names, writing, rosters, scores, or personally identifiable student information should be committed to the repository.
 
 ## Design Principles
@@ -304,7 +308,11 @@ forms, and scan routing are outside the current implementation.
 
 ## Requirements Check
 
-A requirements check records whether the submission met basic assignment requirements.
+A requirements check records structural or compliance information about basic
+assignment conditions. It may be manually entered, teacher-confirmed, or
+eventually computed for low-risk facts such as word count or paragraph count.
+It remains separate from writing-quality scoring and does not determine a
+score or feedback decision.
 
 Suggested path:
 
@@ -349,7 +357,11 @@ Example:
 
 ## Tag Record
 
-A tag record connects a specific observation to a location in the writing, a standard, and a structured comment.
+A tag record connects a teacher-created or teacher-confirmed observation to a
+location in the writing, a standard, and a structured comment. A tag is not an
+automatic mark, a score, or proof that a standard was met or missed. Tags can
+support review consistency and reporting, but they do not mechanically
+determine scores.
 
 Suggested path:
 
@@ -419,9 +431,10 @@ Example:
 
 ## Score Record
 
-A score record stores the teacher's final scoring decision.
-
-Scores are informed by tags but are not automatically determined by tags.
+A score record stores a teacher-entered or teacher-confirmed scoring decision.
+Scores may be informed by source evidence, rubric criteria, requirements
+checks, tags, and teacher notes, but they are not automatically generated or
+determined by those records.
 
 Suggested path:
 
@@ -452,7 +465,10 @@ Example:
 
 ## Feedback File
 
-A feedback file stores student-readable feedback.
+A feedback file stores student-readable teacher communication. It may draw on
+teacher-reviewed tags, notes, score records, requirements checks, and
+teacher-approved standards profile comments. Any future drafting or formatting
+support must remain teacher-reviewed and teacher-controlled.
 
 Suggested path:
 
@@ -482,7 +498,9 @@ The essay has a clear central claim and relevant evidence, but several body para
 
 ## Standards Summary Report
 
-A standards summary aggregates tag data by standard.
+A standards summary aggregates teacher-reviewed tag data by standard. It is a
+derived report rather than independent evidence and should remain traceable to
+its underlying review records.
 
 Suggested path:
 
@@ -505,7 +523,9 @@ villainy_final_essay_synthetic,english12_period3_synthetic,W.AW.11-12.1,12,18,6,
 
 ## Class Summary Report
 
-A class summary aggregates submission-level results.
+A class summary aggregates teacher-reviewed submission-level results. It is a
+derived report for review and instructional planning, not a replacement for
+reading student work or consulting the underlying records.
 
 Suggested path:
 

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -1,0 +1,169 @@
+# Quillan Teacher-Review Model
+
+## Overview
+
+Quillan's review model is teacher-controlled. Quillan preserves student
+writing, organizes teacher-review artifacts, and reduces clerical friction,
+but it does not replace the teacher's professional judgment.
+
+The model keeps source evidence, teacher-review artifacts, and derived reports
+distinct. Software may validate records, organize observations, format
+teacher-approved language, and summarize confirmed records. It must not
+present an unconfirmed software judgment as a teacher evaluation or encourage
+review without reading the student's work.
+
+## Source Evidence
+
+Source evidence is the student-produced writing and the metadata needed to
+identify and preserve it:
+
+* `submission.txt`
+* `submission.json`
+
+The writing is the student's work. The metadata records its identity,
+provenance, capture time, lifecycle status, and version. Source evidence does
+not contain teacher tags, scores, feedback, or reports.
+
+Keeping source evidence separate allows a teacher to compare later review
+artifacts with the writing that was actually submitted.
+
+## Teacher-Review Artifacts
+
+Teacher-review artifacts are records created by the teacher or confirmed
+through teacher review:
+
+* `requirements.json`
+* `tags.json`
+* `scores.json`
+* `feedback.md`
+
+These records describe structural checks, observations, decisions, and
+communication associated with a submission. They remain connected to, but
+separate from, the source evidence so teacher judgment does not alter the
+student's original work.
+
+## Derived Reports
+
+Derived reports are aggregations generated from teacher-reviewed records:
+
+* `reports/standards_summary.csv`
+* `reports/class_summary.csv`
+
+Reports are not independent evidence. They summarize existing
+teacher-confirmed observations and decisions and should remain traceable to
+the records from which they were derived.
+
+## Tag Philosophy
+
+A tag is a teacher-created or teacher-confirmed observation attached to
+student writing evidence. A tag may connect:
+
+* a location in the student writing;
+* a standard;
+* a reusable teacher-defined comment;
+* a polarity;
+* an optional severity; and
+* an optional teacher note.
+
+A tag is not an AI-detected issue, an automatic mark, a software-generated
+judgment, a score, or proof that a standard was met or missed. Hotwords and
+subskills may help a teacher find or organize possible areas for review, but
+they do not establish a tag without teacher confirmation.
+
+Tags can support review consistency and reporting, but they do not
+mechanically determine scores.
+
+## Evidence Philosophy
+
+In Quillan, evidence means preserved student work and teacher-confirmed
+records about that work. Depending on the workflow, evidence may include:
+
+* the student's submitted writing;
+* submission metadata;
+* teacher tags and notes;
+* requirements-check records;
+* teacher-entered scores; and
+* teacher-confirmed feedback records.
+
+Evidence should remain local-first, auditable, and traceable to the applicable
+submission. It is not a conclusion produced by an AI evaluator. Source
+evidence establishes what the student submitted; teacher-review artifacts
+record how the teacher understood and evaluated it.
+
+## Requirements Check Philosophy
+
+A requirements check records structural or compliance information about a
+submission. Examples include:
+
+* word count;
+* paragraph count;
+* required elements;
+* presence of a title;
+* number of lines or stanzas; and
+* required sections.
+
+These checks help a teacher see whether basic assignment conditions were met.
+They do not measure writing quality and must not be treated as a
+writing-quality score.
+
+Requirements results may be entered manually, confirmed by the teacher, or
+eventually computed for low-risk structural facts. A computed result remains
+distinct from scoring and feedback, and the teacher retains responsibility
+for interpreting it in context.
+
+## Score Philosophy
+
+A score record is a teacher-entered or teacher-confirmed scoring decision. A
+teacher may consider:
+
+* source evidence;
+* teacher tags;
+* rubric criteria;
+* requirements checks; and
+* teacher notes.
+
+Tags and requirements results may inform a score, but they do not calculate
+or compel one. Quillan must not automatically determine or generate scores. A
+score record represents teacher judgment, not software judgment.
+
+## Feedback Philosophy
+
+Feedback is student-readable teacher communication. It may draw on:
+
+* teacher tags;
+* teacher notes;
+* score records;
+* requirements checks; and
+* standards profile comments.
+
+Feedback remains teacher-controlled. Future tooling may help select
+teacher-approved language, draft text, or format a feedback file, but the
+teacher must review and confirm the communication before it is treated as a
+teacher-review artifact. Quillan must not present authoritative AI-generated
+feedback.
+
+## Report Philosophy
+
+Reports summarize teacher-reviewed records. They may help teachers identify:
+
+* common strengths;
+* common areas for growth;
+* standards-level patterns;
+* class-level needs; and
+* individual student review summaries.
+
+Reports must be derived from teacher-confirmed artifacts rather than
+unconfirmed software judgments. They support instructional planning and
+clerical organization, but they do not replace reading student work or
+reviewing the underlying records.
+
+## Relationship to Existing Documentation
+
+[`data_contracts.md`](data_contracts.md) defines the fields and formats of
+individual Quillan records. This document defines the review philosophy and
+the conceptual relationships among those records.
+
+[`workspace_lifecycle.md`](workspace_lifecycle.md) defines where records live
+in the shared PDS workspace and how active records relate over time. It does
+not change the meaning of teacher review defined here.
+

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -244,3 +244,7 @@ expectations for individual JSON, text, Markdown, and CSV records. This
 document defines where those records belong in the shared PDS workspace and
 how they relate to one another over time.
 
+[`teacher_review_model.md`](teacher_review_model.md) defines what source
+evidence, teacher-review artifacts, scores, feedback, and derived reports mean
+within Quillan's teacher-controlled review process.
+


### PR DESCRIPTION
## Summary

Documents Quillan’s teacher-review model and clarifies the relationship between student writing evidence, teacher-review artifacts, and derived reports.

This PR reinforces Quillan’s teacher-controlled purpose: software may organize evidence and reduce clerical friction, but professional judgment remains with the teacher.

## Changes

* Adds `docs/teacher_review_model.md`
* Defines source evidence as student-produced writing and identifying metadata
* Defines teacher-review artifacts as records created by or confirmed through teacher review
* Defines derived reports as summaries generated from teacher-reviewed records
* Clarifies tag philosophy:

  * tags are teacher-created or teacher-confirmed observations
  * tags may support consistency and reporting
  * tags do not mechanically determine scores
* Clarifies requirements-check philosophy:

  * requirements checks describe structural or compliance facts
  * requirements checks are not writing-quality scores
* Clarifies score philosophy:

  * score records represent teacher-entered or teacher-confirmed scoring decisions
  * scores are not automatically generated from tags
* Clarifies feedback and report philosophy
* Updates `docs/data_contracts.md` terminology and cross-reference
* Updates `docs/workspace_lifecycle.md` with a teacher-review model cross-reference

## Notes

This is a documentation/model clarification PR only.

It does not change runtime behavior, schemas, examples, generated artifacts, tagging workflows, scoring workflows, feedback generation, report generation, printable templates, PDF generation, QR generation, OCR, scan routing, CLI workflows, workspace behavior, or AI behavior.

## Validation

* `python -m pytest` — passed, 138 tests
* `python -m ruff check .` — passed
* `python -m ruff format --check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed

## Closes

Closes #10
