### PR TITLE
Tighten paper workflow fixture tests

### DIFF
--- a/docs/printable_response_template.md
+++ b/docs/printable_response_template.md
@@ -200,25 +200,26 @@ use synthetic data only. Do not commit:
 Synthetic display names should be obviously fictional, and synthetic
 identifiers should follow the same validation rules as production identifiers.
 
-## Relationship to Future Fixtures
+## Relationship to Test Fixtures
 
-This contract is the source of page-template expectations for the synthetic
-paper-workflow fixtures planned in issue `#22`. Those fixtures should provide
-enough synthetic data to construct and verify a response page, including:
+The synthetic paper-workflow fixtures in
+`tests/fixtures/paper_workflow/` provide repository-safe assignment,
+standards, student display, and submission data for future response-page
+generation tests. They include:
 
 * a valid `class_id`;
-* a class display label when the scenario exercises friendly labels;
 * a valid `assignment_id`;
 * an assignment title;
 * a valid `student_id`;
 * a synthetic student display name;
-* a positive integer page number; and
-* a standards profile reference if required by the assignment fixture.
+* a standards profile reference; and
+* valid submission metadata and synthetic submission text.
 
-Fixtures should make it possible to verify that human-readable fields agree
-with the PDS1 identity fields without introducing real student information.
-This document does not create or prescribe the storage schema for those
-fixtures.
+The fixture consistency tests verify that the assignment, standards profile,
+student display record, and submission refer to the same synthetic workflow.
+Future response-page tests can combine those fixture identities with a
+positive page number. The fixture layout is test data, not a production roster
+or workspace schema.
 
 ## Out of Scope
 
@@ -230,7 +231,6 @@ This contract does not implement or define:
 * prompt, rubric, standards-summary, or graphic-organizer pages;
 * multiple response-layout modes;
 * teacher scoring areas;
-* synthetic fixture files;
 * assignment, submission, or standards model redesign;
 * requirements checking, tagging, scoring, feedback, or reporting;
 * AI tagging, scoring, feedback, or automatic grading; or

--- a/tests/fixtures/paper_workflow/assignment.json
+++ b/tests/fixtures/paper_workflow/assignment.json
@@ -1,0 +1,21 @@
+{
+  "assignment_id": "literary_argument_synthetic",
+  "title": "Literary Argument Response",
+  "class_ids": ["english12_p4_synthetic"],
+  "writing_type": "literary argument essay",
+  "standards_profile_id": "english_12_njsls_synthetic",
+  "tagging_mode": "focus",
+  "focus_standards": [
+    "W.AW.11-12.1"
+  ],
+  "basic_requirements": {
+    "paragraphs_min": 3,
+    "word_count_min": 300,
+    "required_elements": [
+      "claim",
+      "textual evidence",
+      "reasoning"
+    ]
+  },
+  "rubric_id": "argument_essay_4pt_synthetic"
+}

--- a/tests/fixtures/paper_workflow/standards_profile.json
+++ b/tests/fixtures/paper_workflow/standards_profile.json
@@ -1,0 +1,25 @@
+{
+  "profile_id": "english_12_njsls_synthetic",
+  "subject": "English Language Arts (Synthetic)",
+  "course": "English 12 (Synthetic)",
+  "standards": [
+    {
+      "code": "W.AW.11-12.1",
+      "short_name": "Argument Writing",
+      "description": "Write arguments using claims, reasoning, and evidence.",
+      "comments": [
+        {
+          "comment_id": "evidence_needs_explanation",
+          "label": "Evidence needs more explanation",
+          "polarity": "developing",
+          "severity_default": 2,
+          "feedback_template": "Explain how the evidence supports the claim.",
+          "subskills": [
+            "reasoning",
+            "evidence_explanation"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/paper_workflow/students.json
+++ b/tests/fixtures/paper_workflow/students.json
@@ -1,0 +1,7 @@
+[
+  {
+    "student_id": "stu_0001",
+    "student_display_name": "Avery Example",
+    "class_id": "english12_p4_synthetic"
+  }
+]

--- a/tests/fixtures/paper_workflow/submissions/stu_0001/submission.json
+++ b/tests/fixtures/paper_workflow/submissions/stu_0001/submission.json
@@ -1,0 +1,11 @@
+{
+  "submission_id": "sub_stu_0001_literary_argument_v1",
+  "assignment_id": "literary_argument_synthetic",
+  "class_id": "english12_p4_synthetic",
+  "student_id": "stu_0001",
+  "source_type": "manual_entry",
+  "text_file": "submission.txt",
+  "captured_at": "2026-01-15T12:00:00Z",
+  "status": "captured",
+  "version": 1
+}

--- a/tests/fixtures/paper_workflow/submissions/stu_0001/submission.txt
+++ b/tests/fixtures/paper_workflow/submissions/stu_0001/submission.txt
@@ -1,0 +1,3 @@
+This is a short synthetic response for paper workflow tests.
+The example makes a fictional claim and refers to imaginary evidence.
+It is not real student writing.

--- a/tests/test_paper_workflow_fixtures.py
+++ b/tests/test_paper_workflow_fixtures.py
@@ -1,0 +1,81 @@
+"""Validation and consistency tests for synthetic paper workflow fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from quillan.assignments import load_assignment_config
+from quillan.standards import load_standards_profile
+from quillan.submissions import load_submission_metadata
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "paper_workflow"
+SUBMISSION_DIR = FIXTURE_DIR / "submissions" / "stu_0001"
+
+
+def _load_students() -> list[dict[str, Any]]:
+    """Load the minimal synthetic student display fixture."""
+    students = json.loads((FIXTURE_DIR / "students.json").read_text(encoding="utf-8"))
+    assert isinstance(students, list)
+    assert all(isinstance(student, dict) for student in students)
+    return cast(list[dict[str, Any]], students)
+
+
+def test_assignment_fixture_is_valid() -> None:
+    assignment = load_assignment_config(FIXTURE_DIR / "assignment.json")
+
+    assert assignment["assignment_id"] == "literary_argument_synthetic"
+
+
+def test_standards_profile_fixture_is_valid_and_has_review_comment() -> None:
+    profile = load_standards_profile(FIXTURE_DIR / "standards_profile.json")
+
+    assert profile["standards"]
+    assert any(standard["comments"] for standard in profile["standards"])
+
+
+def test_submission_fixture_is_valid_and_text_exists() -> None:
+    submission = load_submission_metadata(SUBMISSION_DIR / "submission.json")
+    text_path = SUBMISSION_DIR / cast(str, submission["text_file"])
+
+    assert text_path.is_file()
+    assert text_path.read_text(encoding="utf-8").strip()
+
+
+def test_students_fixture_has_synthetic_display_data() -> None:
+    students = _load_students()
+
+    assert students
+    for student in students:
+        assert isinstance(student.get("student_id"), str)
+        assert student["student_id"].strip()
+        assert isinstance(student.get("student_display_name"), str)
+        assert student["student_display_name"].strip()
+        assert isinstance(student.get("class_id"), str)
+        assert student["class_id"].strip()
+
+
+def test_fixture_ids_are_internally_consistent() -> None:
+    assignment = load_assignment_config(FIXTURE_DIR / "assignment.json")
+    profile = load_standards_profile(FIXTURE_DIR / "standards_profile.json")
+    submission = load_submission_metadata(SUBMISSION_DIR / "submission.json")
+    students = _load_students()
+    matching_students = [
+        student
+        for student in students
+        if student.get("student_id") == submission["student_id"]
+    ]
+
+    assert submission["assignment_id"] == assignment["assignment_id"]
+    assert submission["class_id"] in assignment["class_ids"]
+    assert assignment["standards_profile_id"] == profile["profile_id"]
+    assert matching_students
+    assert all(
+        isinstance(student.get("student_display_name"), str)
+        and student["student_display_name"].strip()
+        for student in matching_students
+    )
+    assert all(
+        student["class_id"] == submission["class_id"] for student in matching_students
+    )


### PR DESCRIPTION
## Summary

Adds stable synthetic Quillan paper-workflow fixtures for future printable response and scan-routing tests.

This PR creates a small, coherent fixture set representing one synthetic class, one assignment, one standards profile, one student display record, and one student submission. The fixtures are validated through Quillan’s existing assignment, standards, and submission loaders and checked for cross-file consistency.

## Changes

* Adds synthetic paper-workflow fixtures under `tests/fixtures/paper_workflow/`:

  * `assignment.json`
  * `standards_profile.json`
  * `students.json`
  * `submissions/stu_0001/submission.json`
  * `submissions/stu_0001/submission.txt`
* Adds `tests/test_paper_workflow_fixtures.py`
* Validates the assignment fixture with `load_assignment_config`
* Validates the standards profile fixture with `load_standards_profile`
* Validates the submission metadata fixture with `load_submission_metadata`
* Confirms submission text exists and is non-empty
* Confirms student display records include non-empty:

  * `student_id`
  * `student_display_name`
  * `class_id`
* Confirms fixture IDs are internally consistent:

  * submission assignment matches fixture assignment
  * submission class appears in assignment `class_ids`
  * assignment standards profile matches fixture standards profile
  * submission student has matching display data
  * submission student class matches the student display fixture
* Updates `docs/printable_response_template.md` with the fixture location and purpose

## Notes

All fixture data is synthetic and repository-safe.

This PR does not add PDF generation, QR image generation, scan routing, scan filing, OCR, production roster logic, generated artifacts, scoring, feedback generation, reporting, CLI workflows, or AI behavior.

## Validation

* `python -m pytest` — passed, 143 tests
* `python -m ruff check .` — passed
* `python -m ruff format --check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed
* `.\run_tests.ps1` — passed

## Closes

Closes #22
