### PR TITLE
Implement printable response PDF generation

### DIFF
--- a/docs/printable_response_template.md
+++ b/docs/printable_response_template.md
@@ -3,8 +3,8 @@
 ## Overview
 
 This document defines the MVP contract for one generic printable Quillan
-writing-response page. It describes the information and page structure that a
-future PDF generator must produce so teachers can distribute identifiable
+writing-response page. It describes the information and page structure that the
+PDF generator produces so teachers can distribute identifiable
 paper writing surfaces and later connect captured pages to local Quillan
 records.
 
@@ -37,7 +37,7 @@ One physical response page represents exactly:
 * one positive integer `page_number`; and
 * one lined student writing surface.
 
-A future generator may produce `N` response pages for a student by repeating
+The generator may produce `N` response pages for a student by repeating
 this contract with a different `page_number` on each page. The human-readable
 identity and PDS1 payload must describe the same class, assignment, student,
 and page number.
@@ -168,7 +168,7 @@ global page identifier.
 
 ## Output Location
 
-Future generated printable response PDFs belong under the assignment-local
+Generated printable response PDFs belong under the assignment-local
 template directory:
 
 ```text
@@ -176,8 +176,17 @@ template directory:
 ```
 
 This location keeps teacher-distributed materials with the applicable local
-assignment. This contract does not define a filename, create the directory,
-generate a PDF, or move any files.
+assignment. The MVP generator writes one batch PDF named
+`printable_response_pages.pdf`, containing each requested page for each
+student.
+
+## Implemented Generator
+
+`quillan.printable_response.generate_printable_response_pdf()` renders US
+Letter portrait pages with ReportLab and embeds QR codes with `qrcode[pil]`.
+`build_response_page_context()` exposes the validated human-readable identity
+and canonical PDS1 payload for one page so contract behavior can be tested
+without inspecting PDF drawing coordinates.
 
 ## Privacy and Synthetic Data
 
@@ -217,7 +226,7 @@ generation tests. They include:
 
 The fixture consistency tests verify that the assignment, standards profile,
 student display record, and submission refer to the same synthetic workflow.
-Future response-page tests can combine those fixture identities with a
+Response-page tests combine those fixture identities with a
 positive page number. The fixture layout is test data, not a production roster
 or workspace schema.
 
@@ -225,7 +234,6 @@ or workspace schema.
 
 This contract does not implement or define:
 
-* PDF or QR image generation;
 * scan decoding, routing, filing, or OCR;
 * complete printable assignment packets;
 * prompt, rubric, standards-summary, or graphic-organizer pages;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,19 @@ license = { text = "MIT" }
 authors = [
     { name = "Stephen Severino" }
 ]
-dependencies = []
+dependencies = [
+    "qrcode[pil]",
+    "reportlab",
+]
 
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pypdf",
     "ruff",
-    "mypy"
+    "mypy",
+    "types-qrcode",
+    "types-reportlab",
 ]
 
 [project.scripts]

--- a/quillan/printable_response.py
+++ b/quillan/printable_response.py
@@ -1,0 +1,263 @@
+"""Printable PDF generation for Quillan writing-response pages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Final, Mapping, Sequence
+
+import qrcode
+from qrcode.constants import ERROR_CORRECT_M
+from qrcode.image.pil import PilImage
+from reportlab.lib.colors import HexColor
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.units import inch
+from reportlab.lib.utils import ImageReader
+from reportlab.pdfbase.pdfmetrics import stringWidth
+from reportlab.pdfgen.canvas import Canvas
+
+from quillan.payloads import build_response_payload
+from quillan.storage import assignment_templates_dir
+
+PRINTABLE_RESPONSE_FILENAME: Final = "printable_response_pages.pdf"
+
+
+@dataclass(frozen=True)
+class ResponsePageContext:
+    """Validated identity and payload data for one printable response page."""
+
+    class_id: str
+    class_label: str
+    assignment_id: str
+    assignment_title: str
+    student_id: str
+    student_display_name: str
+    page_number: int
+    payload: str
+
+
+def build_response_page_context(
+    *,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    student_display_name: str,
+    page_number: int,
+    assignment_title: str | None = None,
+    class_label: str | None = None,
+) -> ResponsePageContext:
+    """Build validated display and routing data for one response page."""
+    display_name = _require_display_text(student_display_name, "student_display_name")
+    resolved_assignment_title = _optional_display_text(
+        assignment_title, assignment_id, "assignment_title"
+    )
+    resolved_class_label = _optional_display_text(class_label, class_id, "class_label")
+    payload = build_response_payload(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        page=page_number,
+    )
+
+    return ResponsePageContext(
+        class_id=class_id,
+        class_label=resolved_class_label,
+        assignment_id=assignment_id,
+        assignment_title=resolved_assignment_title,
+        student_id=student_id,
+        student_display_name=display_name,
+        page_number=page_number,
+        payload=payload,
+    )
+
+
+def generate_printable_response_pdf(
+    workspace_root: str | Path,
+    *,
+    class_id: str,
+    assignment_id: str,
+    students: Sequence[Mapping[str, str]],
+    pages_per_student: int = 1,
+    assignment_title: str | None = None,
+    class_label: str | None = None,
+) -> Path:
+    """Generate one assignment PDF containing student-specific response pages."""
+    _validate_page_count(pages_per_student)
+    if not students:
+        raise ValueError("students must contain at least one student.")
+
+    page_contexts = [
+        build_response_page_context(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            assignment_title=assignment_title,
+            class_label=class_label,
+            student_id=_student_field(student, "student_id"),
+            student_display_name=_student_field(student, "student_display_name"),
+            page_number=page_number,
+        )
+        for student in students
+        for page_number in range(1, pages_per_student + 1)
+    ]
+
+    output_dir = assignment_templates_dir(workspace_root, class_id, assignment_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / PRINTABLE_RESPONSE_FILENAME
+
+    pdf = Canvas(str(output_path), pagesize=letter)
+    pdf.setTitle("Quillan Printable Writing Response Pages")
+    for context in page_contexts:
+        _draw_response_page(pdf, context, pages_per_student)
+        pdf.showPage()
+    pdf.save()
+
+    return output_path
+
+
+def _draw_response_page(
+    pdf: Canvas,
+    context: ResponsePageContext,
+    pages_per_student: int,
+) -> None:
+    page_width, page_height = letter
+    margin = 0.5 * inch
+    qr_size = 1.0 * inch
+    qr_x = page_width - margin - qr_size
+    qr_y = page_height - margin - qr_size
+    text_width = qr_x - margin - 0.2 * inch
+
+    pdf.setFillColor(HexColor("#111111"))
+    pdf.setFont("Helvetica-Bold", 14)
+    pdf.drawString(
+        margin,
+        page_height - margin - 14,
+        _fit_text(context.assignment_title, "Helvetica-Bold", 14, text_width),
+    )
+
+    identity_lines = (
+        f"Student: {context.student_display_name}",
+        f"Student ID: {context.student_id}",
+        f"Class: {context.class_label} ({context.class_id})"
+        if context.class_label != context.class_id
+        else f"Class: {context.class_id}",
+        f"Assignment ID: {context.assignment_id}",
+    )
+    pdf.setFont("Helvetica", 9)
+    line_y = page_height - margin - 31
+    for identity_line in identity_lines:
+        pdf.drawString(
+            margin,
+            line_y,
+            _fit_text(identity_line, "Helvetica", 9, text_width),
+        )
+        line_y -= 12
+
+    pdf.drawImage(
+        _make_qr_image(context.payload),
+        qr_x,
+        qr_y,
+        width=qr_size,
+        height=qr_size,
+        preserveAspectRatio=True,
+        mask="auto",
+    )
+
+    header_bottom = page_height - margin - qr_size - 0.2 * inch
+    pdf.setStrokeColor(HexColor("#555555"))
+    pdf.setLineWidth(0.8)
+    pdf.line(margin, header_bottom, page_width - margin, header_bottom)
+
+    writing_top = header_bottom - 0.3 * inch
+    writing_bottom = margin + 0.35 * inch
+    writing_left = margin + 0.2 * inch
+    writing_right = page_width - margin
+
+    pdf.setStrokeColor(HexColor("#C8C8C8"))
+    pdf.setLineWidth(0.35)
+    line_y = writing_top
+    while line_y >= writing_bottom:
+        pdf.line(writing_left, line_y, writing_right, line_y)
+        line_y -= 0.32 * inch
+
+    pdf.setStrokeColor(HexColor("#C98888"))
+    pdf.setLineWidth(0.5)
+    pdf.line(writing_left, writing_bottom, writing_left, writing_top)
+
+    pdf.setFillColor(HexColor("#333333"))
+    pdf.setFont("Helvetica", 8)
+    pdf.drawString(
+        margin,
+        margin - 6,
+        "Quillan writing response",
+    )
+    pdf.drawRightString(
+        page_width - margin,
+        margin - 6,
+        f"Page {context.page_number} of {pages_per_student}",
+    )
+
+
+def _make_qr_image(payload: str) -> ImageReader:
+    qr = qrcode.QRCode[PilImage](
+        version=None,
+        error_correction=ERROR_CORRECT_M,
+        box_size=8,
+        border=4,
+        image_factory=PilImage,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+
+    image = qr.make_image(fill_color="black", back_color="white")
+    image_data = BytesIO()
+    image.save(image_data, format="PNG")
+    image_data.seek(0)
+    return ImageReader(image_data)
+
+
+def _fit_text(text: str, font_name: str, font_size: int, max_width: float) -> str:
+    if stringWidth(text, font_name, font_size) <= max_width:
+        return text
+
+    ellipsis = "..."
+    candidate = text
+    while (
+        candidate
+        and stringWidth(candidate + ellipsis, font_name, font_size) > max_width
+    ):
+        candidate = candidate[:-1]
+    return candidate + ellipsis
+
+
+def _student_field(student: Mapping[str, str], field: str) -> str:
+    try:
+        value = student[field]
+    except KeyError as error:
+        raise ValueError(f"student is missing required field '{field}'.") from error
+    return _require_display_text(value, field)
+
+
+def _optional_display_text(
+    value: str | None,
+    fallback: str,
+    field: str,
+) -> str:
+    if value is None:
+        return fallback
+    return _require_display_text(value, field)
+
+
+def _require_display_text(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string.")
+    return value.strip()
+
+
+def _validate_page_count(pages_per_student: int) -> None:
+    if (
+        isinstance(pages_per_student, bool)
+        or not isinstance(pages_per_student, int)
+        or pages_per_student < 1
+    ):
+        raise ValueError("pages_per_student must be a positive integer.")

--- a/quillan/storage.py
+++ b/quillan/storage.py
@@ -8,6 +8,7 @@ from pds_core.routes import (
     assignment_config_path as pds_assignment_config_path,
     assignment_dir as pds_assignment_dir,
     assignment_submissions_dir as pds_assignment_submissions_dir,
+    assignment_templates_dir as pds_assignment_templates_dir,
     student_submission_dir as pds_student_submission_dir,
 )
 
@@ -37,6 +38,15 @@ def assignment_submissions_dir(
 ) -> Path:
     """Return the shared PDS submissions directory for an assignment."""
     return pds_assignment_submissions_dir(root, class_id, assignment_id)
+
+
+def assignment_templates_dir(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return the shared PDS templates directory for an assignment."""
+    return pds_assignment_templates_dir(root, class_id, assignment_id)
 
 
 def student_submission_dir(

--- a/tests/test_printable_response_pdf.py
+++ b/tests/test_printable_response_pdf.py
@@ -1,0 +1,145 @@
+"""Tests for printable Quillan writing-response PDFs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from pds_core.routes import assignment_templates_dir
+from pypdf import PdfReader
+
+from quillan.printable_response import (
+    PRINTABLE_RESPONSE_FILENAME,
+    build_response_page_context,
+    generate_printable_response_pdf,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "paper_workflow"
+
+
+def _load_assignment() -> dict[str, Any]:
+    assignment = json.loads(
+        (FIXTURE_DIR / "assignment.json").read_text(encoding="utf-8")
+    )
+    assert isinstance(assignment, dict)
+    return cast(dict[str, Any], assignment)
+
+
+def _load_students() -> list[dict[str, str]]:
+    students = json.loads((FIXTURE_DIR / "students.json").read_text(encoding="utf-8"))
+    assert isinstance(students, list)
+    assert all(isinstance(student, dict) for student in students)
+    return cast(list[dict[str, str]], students)
+
+
+def test_build_response_page_context_uses_fixture_identity() -> None:
+    assignment = _load_assignment()
+    student = _load_students()[0]
+
+    context = build_response_page_context(
+        class_id=student["class_id"],
+        assignment_id=cast(str, assignment["assignment_id"]),
+        assignment_title=cast(str, assignment["title"]),
+        student_id=student["student_id"],
+        student_display_name=student["student_display_name"],
+        page_number=2,
+    )
+
+    assert context.class_id == "english12_p4_synthetic"
+    assert context.class_label == "english12_p4_synthetic"
+    assert context.assignment_id == "literary_argument_synthetic"
+    assert context.assignment_title == "Literary Argument Response"
+    assert context.student_id == "stu_0001"
+    assert context.student_display_name == student["student_display_name"]
+    assert context.page_number == 2
+    assert context.payload == (
+        "PDS1|module=quillan|class=english12_p4_synthetic|"
+        "aid=literary_argument_synthetic|sid=stu_0001|page=2|doc=response"
+    )
+    assert context.student_display_name not in context.payload
+
+
+def test_generate_printable_response_pdf_uses_templates_route(
+    tmp_path: Path,
+) -> None:
+    assignment = _load_assignment()
+    students = _load_students()
+    class_id = students[0]["class_id"]
+    assignment_id = cast(str, assignment["assignment_id"])
+
+    output_path = generate_printable_response_pdf(
+        tmp_path,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        assignment_title=cast(str, assignment["title"]),
+        students=students,
+    )
+
+    assert output_path == (
+        assignment_templates_dir(tmp_path, class_id, assignment_id)
+        / PRINTABLE_RESPONSE_FILENAME
+    )
+    assert output_path.is_file()
+    assert output_path.stat().st_size > 1_000
+    assert output_path.read_bytes().startswith(b"%PDF")
+
+
+def test_generate_printable_response_pdf_supports_multiple_students_and_pages(
+    tmp_path: Path,
+) -> None:
+    assignment = _load_assignment()
+    students = _load_students()
+    students.append(
+        {
+            "student_id": "stu_0002",
+            "student_display_name": "Jordan Example",
+            "class_id": students[0]["class_id"],
+        }
+    )
+
+    output_path = generate_printable_response_pdf(
+        tmp_path,
+        class_id=students[0]["class_id"],
+        assignment_id=cast(str, assignment["assignment_id"]),
+        assignment_title=cast(str, assignment["title"]),
+        students=students,
+        pages_per_student=2,
+    )
+
+    reader = PdfReader(str(output_path))
+    assert len(reader.pages) == 4
+
+
+@pytest.mark.parametrize("pages_per_student", [0, -1, True, 1.5, "1"])
+def test_generate_printable_response_pdf_rejects_invalid_page_counts(
+    tmp_path: Path,
+    pages_per_student: object,
+) -> None:
+    assignment = _load_assignment()
+    students = _load_students()
+
+    with pytest.raises(
+        ValueError, match="pages_per_student must be a positive integer"
+    ):
+        generate_printable_response_pdf(
+            tmp_path,
+            class_id=students[0]["class_id"],
+            assignment_id=cast(str, assignment["assignment_id"]),
+            assignment_title=cast(str, assignment["title"]),
+            students=students,
+            pages_per_student=pages_per_student,  # type: ignore[arg-type]
+        )
+
+
+def test_generate_printable_response_pdf_rejects_empty_students(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="at least one student"):
+        generate_printable_response_pdf(
+            tmp_path,
+            class_id="english12_p4_synthetic",
+            assignment_id="literary_argument_synthetic",
+            students=[],
+        )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,6 +8,7 @@ from pds_core.routes import (
     assignment_config_path as pds_assignment_config_path,
     assignment_dir as pds_assignment_dir,
     assignment_submissions_dir as pds_assignment_submissions_dir,
+    assignment_templates_dir as pds_assignment_templates_dir,
     student_submission_dir as pds_student_submission_dir,
 )
 
@@ -15,6 +16,7 @@ from quillan.storage import (
     assignment_config_path,
     assignment_dir,
     assignment_submissions_dir,
+    assignment_templates_dir,
     feedback_path,
     reports_dir,
     requirements_path,
@@ -42,6 +44,9 @@ def test_assignment_paths_use_shared_pds_routes(tmp_path: Path) -> None:
     assert assignment_submissions_dir(
         tmp_path, CLASS_ID, ASSIGNMENT_ID
     ) == pds_assignment_submissions_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    assert assignment_templates_dir(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    ) == pds_assignment_templates_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
 
 
 def test_quillan_assignment_files_remain_assignment_local(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements initial printable Quillan writing-response PDF generation.

This PR adds a focused PDF-generation path for student-specific printable response pages using the documented printable response-page contract and the synthetic paper workflow fixtures. Generated pages include teacher-readable classroom distribution information, lined writing space, page numbering, and PDS1 QR codes for future scan-routing support.

## Changes

* Adds `quillan/printable_response.py`

* Adds `ResponsePageContext`

* Adds `build_response_page_context()`

* Adds `generate_printable_response_pdf()`

* Generates US Letter portrait response pages

* Includes required page elements:

  * student display name
  * student ID
  * class label or class ID
  * assignment title or assignment ID
  * human-readable page number
  * lined writing area
  * PDS1 QR payload

* Uses the existing Quillan response payload format:

  `PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page_number>|doc=response`

* Keeps student display names out of QR payloads

* Supports multiple students

* Supports multiple pages per student

* Rejects invalid page counts, including zero, negative values, booleans, and non-integers

* Writes generated PDFs through the shared `pds-core` assignment templates route

* Uses deterministic output filename:

  `printable_response_pages.pdf`

* Adds fixture-driven tests for:

  * response page context construction
  * payload construction
  * output routing
  * PDF creation
  * PDF page count
  * multiple students and pages
  * invalid page counts
  * empty student lists

* Uses `pypdf` in tests to avoid brittle PDF byte-count assertions

* Updates `docs/printable_response_template.md` with implemented MVP behavior

## Dependencies

Runtime dependencies added:

* `reportlab`
* `qrcode[pil]`

Development/test dependencies added:

* `types-reportlab`
* `types-qrcode`
* `pypdf`

## Notes

This PR does not implement scan routing, scan filing, OCR, prompt page generation, rubric page generation, standards summary page generation, printable assignment packets, production roster workflows, requirements checking, tagging, scoring, feedback generation, reporting, CLI workflows, menu workflows, AI behavior, or automatic grading.

No generated PDFs are committed.

## Validation

* `python -m pytest` — passed, 152 tests
* `python -m ruff check .` — passed
* `python -m ruff format --check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed
* `.\run_tests.ps1` — passed

## Closes

Closes #5
