### PR TITLE
Add canonical synthetic roster fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Quillan also uses `pds-core` to build canonical PDS1 payload strings for
 writing-response pages. QR image generation, workspace settings, scan routing,
 and paper/PDF workflows are not yet implemented.
 
+Quillan consumes class rosters through the shared `pds-core` roster contract.
+Synthetic roster fixtures use the canonical columns `class_id`, `student_id`,
+`last_name`, `first_name`, and `period`. Student IDs remain strings, including
+leading zeros.
+
 ## Running Quillan
 
 Show CLI help:

--- a/examples/rosters/english12_p3_synthetic.csv
+++ b/examples/rosters/english12_p3_synthetic.csv
@@ -1,0 +1,4 @@
+class_id,student_id,last_name,first_name,period
+english12_p3,01001,Doe,Jane,3
+english12_p3,01002,Smith,Marcus,3
+english12_p3,01003,Brown,Alyssa,3

--- a/tests/test_roster_fixture.py
+++ b/tests/test_roster_fixture.py
@@ -1,0 +1,60 @@
+"""Tests for the canonical synthetic roster example."""
+
+from pathlib import Path
+
+from pds_core.rosters import (
+    load_roster,
+    student_display_name,
+    student_sort_name,
+)
+
+ROSTER_PATH = (
+    Path(__file__).parent.parent
+    / "examples"
+    / "rosters"
+    / "english12_p3_synthetic.csv"
+)
+REQUIRED_COLUMNS = (
+    "class_id",
+    "student_id",
+    "last_name",
+    "first_name",
+    "period",
+)
+
+
+def test_synthetic_roster_fixture_loads_with_pds_core() -> None:
+    roster = load_roster(ROSTER_PATH)
+
+    assert roster.class_id == "english12_p3"
+    assert len(roster.students) == 3
+    assert roster.columns == REQUIRED_COLUMNS
+    for student in roster.students:
+        assert student.class_id == roster.class_id
+        assert all(
+            isinstance(getattr(student, field), str) and getattr(student, field)
+            for field in REQUIRED_COLUMNS
+        )
+
+
+def test_synthetic_roster_preserves_student_ids_as_strings() -> None:
+    roster = load_roster(ROSTER_PATH)
+
+    assert [student.student_id for student in roster.students] == [
+        "01001",
+        "01002",
+        "01003",
+    ]
+    assert all(isinstance(student.student_id, str) for student in roster.students)
+
+
+def test_synthetic_roster_uses_shared_student_display_helper() -> None:
+    roster = load_roster(ROSTER_PATH)
+
+    assert student_display_name(roster.students[0]) == "Jane Doe"
+
+
+def test_synthetic_roster_uses_shared_student_sort_helper() -> None:
+    roster = load_roster(ROSTER_PATH)
+
+    assert student_sort_name(roster.students[0]) == "Doe, Jane"


### PR DESCRIPTION
## Summary

Adds a canonical synthetic roster fixture to `pds-quillan` using the shared `pds-core` roster contract.

This establishes a small Quillan-side integration point for shared Paper Data Suite roster data before printable response generation is refactored to consume shared roster/student records.

## Changes

* Added synthetic roster fixture:

  * `examples/rosters/english12_p3_synthetic.csv`
* Added focused roster fixture tests:

  * `tests/test_roster_fixture.py`
* Updated `README.md` to note that Quillan consumes class rosters through the shared `pds-core` roster contract

## Fixture Details

The fixture uses the canonical shared roster columns:

```csv
class_id,student_id,last_name,first_name,period
```

Fixture class:

```text
english12_p3
```

Synthetic student IDs:

```text
01001
01002
01003
```

The leading-zero IDs are intentional and verify that student identifiers are preserved as strings.

## pds-core APIs Used

The new tests verify Quillan can consume the fixture through shared `pds-core` roster APIs:

* `load_roster`
* `student_display_name`
* `student_sort_name`

## Tests Added

The new tests verify:

* the fixture loads through `pds_core.rosters.load_roster`
* the expected `class_id` is present
* the expected student count is present
* required student fields are populated
* student IDs remain strings
* leading-zero student IDs are preserved
* shared student display helper works
* shared student sort helper works

## Behavior Preserved

This PR does not change:

* printable response PDF behavior
* assignment schema behavior
* standards profile behavior
* tag behavior
* scoring behavior
* report generation
* workspace behavior
* sibling repositories

No Quillan-specific roster model was added.

## Documentation

Updated `README.md` to state that Quillan consumes class rosters through the shared `pds-core` roster contract and that synthetic roster fixtures use the canonical shared columns.

## Validation

* `pytest` — 156 passed
* `ruff check .` — passed
* `mypy .` — passed
* `git diff --check` — passed

Closes #27
