### PR TITLE
Generate printable responses from roster records

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ and paper/PDF workflows are not yet implemented.
 Quillan consumes class rosters through the shared `pds-core` roster contract.
 Synthetic roster fixtures use the canonical columns `class_id`, `student_id`,
 `last_name`, `first_name`, and `period`. Student IDs remain strings, including
-leading zeros.
+leading zeros. Printable response generation loads roster CSVs with
+`pds_core.rosters.load_roster()` and uses shared student display names.
 
 ## Running Quillan
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -301,6 +301,10 @@ PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<
 The page number is a positive integer. Class, assignment, and student
 identifiers follow shared `pds-core` identifier validation.
 
+Printable response generation consumes validated `pds-core` roster records.
+Roster student IDs remain strings, including leading zeros, and visible names
+use the shared student display helper.
+
 Example:
 
 ```text

--- a/quillan/printable_response.py
+++ b/quillan/printable_response.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import Final, Mapping, Sequence
+from typing import Final, Mapping, Sequence, TypeAlias, cast
 
+from pds_core.rosters import StudentRecord, load_roster, student_display_name
 import qrcode
 from qrcode.constants import ERROR_CORRECT_M
 from qrcode.image.pil import PilImage
@@ -17,10 +18,12 @@ from reportlab.lib.utils import ImageReader
 from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.pdfgen.canvas import Canvas
 
+from quillan.assignments import load_assignment_config
 from quillan.payloads import build_response_payload
 from quillan.storage import assignment_templates_dir
 
 PRINTABLE_RESPONSE_FILENAME: Final = "printable_response_pages.pdf"
+StudentInput: TypeAlias = StudentRecord | Mapping[str, str]
 
 
 @dataclass(frozen=True)
@@ -77,7 +80,7 @@ def generate_printable_response_pdf(
     *,
     class_id: str,
     assignment_id: str,
-    students: Sequence[Mapping[str, str]],
+    students: Sequence[StudentInput],
     pages_per_student: int = 1,
     assignment_title: str | None = None,
     class_label: str | None = None,
@@ -93,8 +96,8 @@ def generate_printable_response_pdf(
             assignment_id=assignment_id,
             assignment_title=assignment_title,
             class_label=class_label,
-            student_id=_student_field(student, "student_id"),
-            student_display_name=_student_field(student, "student_display_name"),
+            student_id=_student_id(student),
+            student_display_name=_student_name(student),
             page_number=page_number,
         )
         for student in students
@@ -113,6 +116,36 @@ def generate_printable_response_pdf(
     pdf.save()
 
     return output_path
+
+
+def generate_printable_responses_for_roster(
+    workspace_root: str | Path,
+    *,
+    assignment_path: str | Path,
+    roster_path: str | Path,
+    pages_per_student: int = 1,
+    class_label: str | None = None,
+) -> Path:
+    """Generate printable response pages from validated shared roster records."""
+    assignment = load_assignment_config(assignment_path)
+    roster = load_roster(roster_path)
+    assignment_class_ids = cast(list[str], assignment["class_ids"])
+
+    if roster.class_id not in assignment_class_ids:
+        raise ValueError(
+            f"Roster class_id '{roster.class_id}' is not included in assignment "
+            f"class_ids: {', '.join(assignment_class_ids)}."
+        )
+
+    return generate_printable_response_pdf(
+        workspace_root,
+        class_id=roster.class_id,
+        assignment_id=cast(str, assignment["assignment_id"]),
+        assignment_title=cast(str, assignment["title"]),
+        class_label=class_label,
+        students=roster.students,
+        pages_per_student=pages_per_student,
+    )
 
 
 def _draw_response_page(
@@ -228,6 +261,20 @@ def _fit_text(text: str, font_name: str, font_size: int, max_width: float) -> st
     ):
         candidate = candidate[:-1]
     return candidate + ellipsis
+
+
+def _student_id(student: StudentInput) -> str:
+    if isinstance(student, StudentRecord):
+        return _require_display_text(student.student_id, "student_id")
+    return _student_field(student, "student_id")
+
+
+def _student_name(student: StudentInput) -> str:
+    if isinstance(student, StudentRecord):
+        return _require_display_text(
+            student_display_name(student), "student_display_name"
+        )
+    return _student_field(student, "student_display_name")
 
 
 def _student_field(student: Mapping[str, str], field: str) -> str:

--- a/tests/test_printable_response_pdf.py
+++ b/tests/test_printable_response_pdf.py
@@ -14,9 +14,15 @@ from quillan.printable_response import (
     PRINTABLE_RESPONSE_FILENAME,
     build_response_page_context,
     generate_printable_response_pdf,
+    generate_printable_responses_for_roster,
 )
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "paper_workflow"
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+ROSTER_PATH = EXAMPLES_DIR / "rosters" / "english12_p3_synthetic.csv"
+ASSIGNMENT_PATH = (
+    EXAMPLES_DIR / "assignments" / "villainy_final_essay_synthetic.json"
+)
 
 
 def _load_assignment() -> dict[str, Any]:
@@ -32,6 +38,15 @@ def _load_students() -> list[dict[str, str]]:
     assert isinstance(students, list)
     assert all(isinstance(student, dict) for student in students)
     return cast(list[dict[str, str]], students)
+
+
+def _write_roster_assignment(tmp_path: Path) -> Path:
+    assignment = json.loads(ASSIGNMENT_PATH.read_text(encoding="utf-8"))
+    assert isinstance(assignment, dict)
+    assignment["class_ids"] = ["english12_p3"]
+    assignment_path = tmp_path / "assignment.json"
+    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
+    return assignment_path
 
 
 def test_build_response_page_context_uses_fixture_identity() -> None:
@@ -110,6 +125,46 @@ def test_generate_printable_response_pdf_supports_multiple_students_and_pages(
 
     reader = PdfReader(str(output_path))
     assert len(reader.pages) == 4
+
+
+def test_printable_response_generation_accepts_pds_core_roster_fixture(
+    tmp_path: Path,
+) -> None:
+    output_path = generate_printable_responses_for_roster(
+        tmp_path,
+        assignment_path=_write_roster_assignment(tmp_path),
+        roster_path=ROSTER_PATH,
+    )
+
+    reader = PdfReader(str(output_path))
+    assert output_path.is_file()
+    assert len(reader.pages) == 3
+
+
+def test_printable_response_generation_preserves_roster_identity(
+    tmp_path: Path,
+) -> None:
+    output_path = generate_printable_responses_for_roster(
+        tmp_path,
+        assignment_path=_write_roster_assignment(tmp_path),
+        roster_path=ROSTER_PATH,
+    )
+
+    first_page_text = PdfReader(str(output_path)).pages[0].extract_text()
+    assert "Student: Jane Doe" in first_page_text
+    assert "Student ID: 01001" in first_page_text
+    assert "Student ID: 1001" not in first_page_text
+
+
+def test_printable_response_generation_rejects_roster_assignment_class_mismatch(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="english12_p3.*class_ids"):
+        generate_printable_responses_for_roster(
+            tmp_path,
+            assignment_path=ASSIGNMENT_PATH,
+            roster_path=ROSTER_PATH,
+        )
 
 
 @pytest.mark.parametrize("pages_per_student", [0, -1, True, 1.5, "1"])


### PR DESCRIPTION
## Summary

Updates Quillan printable response generation to consume shared `pds-core` roster records.

This builds on the canonical roster fixture added in #27 and makes printable response generation work with validated `pds-core` `Roster` / `StudentRecord` data.

## Changes

* Added `generate_printable_responses_for_roster(...)`
* Updated printable response generation to accept both:

  * shared `pds-core` `StudentRecord` objects
  * existing legacy student mappings
* Loaded roster CSVs through `pds_core.rosters.load_roster(...)`
* Used the shared `student_display_name(...)` helper for `StudentRecord` display names
* Added assignment/roster class mismatch validation
* Added focused printable response tests using the canonical synthetic roster fixture
* Updated printable-response data contract documentation

## Roster Integration

The new roster-aware helper loads a roster CSV through `pds-core`:

```python
load_roster(roster_path)
```

It then delegates to the existing printable response PDF generation path using the loaded roster’s student records.

The canonical fixture used in tests is:

```text
examples/rosters/english12_p3_synthetic.csv
```

## Student Identity Behavior

Student IDs remain strings throughout printable generation.

The tests verify that leading-zero IDs such as:

```text
01001
```

are preserved in generated PDF text and are not converted to:

```text
1001
```

## Display Name Behavior

For shared `StudentRecord` values, printable generation uses:

```python
student_display_name(student)
```

Existing mapping-based student inputs remain supported for compatibility.

## Class Consistency

Roster-backed printable generation now rejects assignment/roster class mismatches when the roster `class_id` is not present in the assignment’s `class_ids`.

This uses the existing Quillan assignment shape and does not redesign the assignment schema.

## Tests

Added or updated tests covering:

* existing mapping-based printable response behavior
* roster-backed printable response generation
* PDF creation from the canonical synthetic roster fixture
* one generated page per roster student
* preservation of leading-zero student IDs
* shared display-name behavior in generated PDF text
* assignment/roster class mismatch rejection
* existing invalid page-count and empty-student behavior

## Documentation

Updated `docs/data_contracts.md` to state that printable response generation consumes validated `pds-core` roster records, preserves roster student IDs as strings, and uses the shared student display helper for visible names.

## Behavior Preserved

This PR does not change:

* PDF layout
* assignment schema
* standards behavior
* standards profiles
* tag behavior
* scoring behavior
* feedback behavior
* report generation
* workspace behavior
* sibling repositories

No Quillan-specific roster model was added.

## Validation

* `python -m pytest` — 159 passed
* `python -m ruff check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed

Closes #29
