### PR TITLE
Add workspace status command

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen Severino
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ shared PDS workspace root:
 ```
 
 Quillan also uses `pds-core` to build canonical PDS1 payload strings for
-writing-response pages. QR image generation, workspace settings, scan routing,
-and paper/PDF workflows are not yet implemented.
+writing-response pages. QR image generation, scan routing, and paper/PDF
+workflows are not yet implemented.
 
 Quillan consumes class rosters through the shared `pds-core` roster contract.
 Synthetic roster fixtures use the canonical columns `class_id`, `student_id`,
@@ -122,6 +122,16 @@ Show CLI help:
 ```powershell
 quillan --help
 ```
+
+Inspect the shared Paper Data Suite workspace root:
+
+```powershell
+quillan workspace show
+```
+
+This read-only command reports the resolved root, resolution source, config
+path, default root, and basic filesystem status using the shared `pds-core`
+workspace status API.
 
 Validate a standards profile:
 

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -5,26 +5,36 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from pds_core.workspace import (
+    WorkspaceRootError,
+    WorkspaceStatus,
+    inspect_workspace_root,
+)
+
 from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.standards import StandardsProfileError, load_standards_profile
 
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: list[str] | None = None) -> int:
     """Run the Quillan command-line interface."""
     parser = _build_parser()
     args = parser.parse_args(argv)
 
     if args.command == "validate-standards":
         _handle_validate_standards(args.path)
-        return
+        return 0
 
     if args.command == "validate-assignment":
         _handle_validate_assignment(args.path)
-        return
+        return 0
+
+    if args.command == "workspace" and args.workspace_command == "show":
+        return _handle_workspace_show()
 
     parser.print_help()
+    return 0
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -52,6 +62,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to the assignment config JSON file.",
     )
 
+    workspace_parser = subparsers.add_parser(
+        "workspace",
+        help="Inspect the shared PDS workspace with 'quillan workspace show'.",
+    )
+    workspace_subparsers = workspace_parser.add_subparsers(
+        dest="workspace_command"
+    )
+    workspace_subparsers.add_parser(
+        "show",
+        help="Show the active Paper Data Suite workspace status.",
+    )
+
     return parser
 
 
@@ -73,3 +95,37 @@ def _handle_validate_assignment(path: Path) -> None:
         raise SystemExit(f"Invalid assignment config: {error}") from error
 
     print(f"Valid assignment config: {assignment['assignment_id']}")
+
+
+def _handle_workspace_show() -> int:
+    """Print the shared Paper Data Suite workspace status."""
+    try:
+        status = inspect_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return 1
+
+    _print_workspace_status(status)
+    return 0
+
+
+def _print_workspace_status(status: WorkspaceStatus) -> None:
+    """Print a stable, user-facing workspace status summary."""
+    print("Current PDS workspace root:")
+    print(status.root)
+    print("\nSource:")
+    print(status.source)
+    print("\nExists:")
+    print(_format_bool(status.exists))
+    print("\nDirectory:")
+    print(_format_bool(status.is_dir))
+    print("\nWritable:")
+    print(_format_bool(status.is_writable))
+    print("\nConfig file:")
+    print(status.config_path)
+    print("\nDefault workspace root:")
+    print(status.default_root)
+
+
+def _format_bool(value: bool) -> str:
+    return "yes" if value else "no"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from pds_core.workspace import WorkspaceRootError, WorkspaceStatus
 import pytest
 
+import quillan.cli
 from quillan.cli import main
 
 
@@ -19,6 +21,15 @@ def test_cli_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
     assert error.value.code == 0
     assert "Quillan: standards-based writing evidence capture" in captured.out
     assert "validate-standards" in captured.out
+    assert "workspace" in captured.out
+
+    with pytest.raises(SystemExit) as workspace_error:
+        main(["workspace", "--help"])
+
+    workspace_help = capsys.readouterr()
+
+    assert workspace_error.value.code == 0
+    assert "show" in workspace_help.out
 
 
 def test_cli_validates_standards_profile(
@@ -109,3 +120,94 @@ def test_cli_reports_invalid_assignment_config(tmp_path: Path) -> None:
         main(["validate-assignment", str(assignment_path)])
 
     assert "Invalid assignment config" in str(error.value)
+
+
+def test_workspace_show_uses_pds_core_status(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = WorkspaceStatus(
+        root=tmp_path / "active-workspace",
+        source="saved_config",
+        exists=True,
+        is_dir=True,
+        is_writable=True,
+        config_path=tmp_path / "config.json",
+        default_root=tmp_path / "default-workspace",
+    )
+    calls = 0
+
+    def inspect_workspace_root() -> WorkspaceStatus:
+        nonlocal calls
+        calls += 1
+        return status
+
+    monkeypatch.setattr(quillan.cli, "inspect_workspace_root", inspect_workspace_root)
+
+    result = main(["workspace", "show"])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert calls == 1
+    assert str(status.root) in captured.out
+    assert status.source in captured.out
+    assert str(status.config_path) in captured.out
+    assert str(status.default_root) in captured.out
+
+
+def test_workspace_show_reports_status_fields(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = WorkspaceStatus(
+        root=tmp_path / "workspace",
+        source="default",
+        exists=False,
+        is_dir=False,
+        is_writable=True,
+        config_path=tmp_path / "config.json",
+        default_root=tmp_path / "workspace",
+    )
+    monkeypatch.setattr(
+        quillan.cli,
+        "inspect_workspace_root",
+        lambda: status,
+    )
+
+    assert main(["workspace", "show"]) == 0
+    output = capsys.readouterr().out
+
+    assert "Exists:\nno" in output
+    assert "Directory:\nno" in output
+    assert "Writable:\nyes" in output
+
+
+def test_workspace_show_rejects_extra_arguments(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["workspace", "show", "extra"])
+
+    captured = capsys.readouterr()
+
+    assert error.value.code != 0
+    assert "usage:" in captured.err
+
+
+def test_workspace_show_reports_workspace_error(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_workspace_error() -> WorkspaceStatus:
+        raise WorkspaceRootError("bad workspace")
+
+    monkeypatch.setattr(
+        quillan.cli,
+        "inspect_workspace_root",
+        raise_workspace_error,
+    )
+
+    assert main(["workspace", "show"]) != 0
+    assert "Error: bad workspace" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Adds a read-only Quillan workspace status command using the shared `pds-core` workspace status API.

This gives Quillan CLI users a way to inspect the active Paper Data Suite workspace root without adding workspace mutation commands.

## Changes

* Added `quillan workspace show`
* Used `pds_core.workspace.inspect_workspace_root(...)`
* Printed shared `WorkspaceStatus` fields:

  * resolved root
  * source
  * exists
  * directory
  * writable
  * config file
  * default workspace root
* Added CLI tests for workspace status behavior
* Updated README documentation for the new command
* Added MIT license text to the existing `LICENSE` file

## Workspace Behavior

The new command is read-only.

It does not:

* create workspace folders
* save workspace configuration
* reset workspace configuration
* validate workspace contents
* move, copy, or delete files

This PR intentionally adds only status/show behavior.

## Error Handling

Workspace errors from `pds-core` are reported cleanly with nonzero CLI return behavior.

Extra arguments to `quillan workspace show` are rejected through the existing `argparse` behavior.

## Tests

Added or updated tests covering:

* top-level help includes the workspace command
* workspace help includes `show`
* `quillan workspace show` calls the shared `pds-core` status helper
* output includes root, source, config path, and default root
* output includes exists/directory/writable status fields
* extra arguments are rejected
* workspace errors are reported cleanly

## Behavior Preserved

This PR does not add:

* `quillan workspace set`
* `quillan workspace reset`
* `quillan workspace validate`
* interactive menus
* workspace migration behavior
* class setup commands
* roster commands

This PR does not change:

* standards behavior
* assignment schema behavior
* printable response generation
* report generation
* sibling repositories

## Validation

* `.\run_tests.ps1` — passed
* `python -m pytest` — 163 passed
* `python -m ruff check .` — passed
* `python -m mypy .` — passed
* `git diff --check` — passed

Closes #31
