### PR TITLE
Audit Quillan documentation for stale foundation language

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ particular, Quillan does not currently provide:
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
+- assignment creation and roster management workflows;
 - implemented requirements-checking, tagging, scoring, feedback, or
   production reporting workflows;
 - AI tagging, AI scoring, or AI feedback;
 - automatic grading; or
-- full teacher-facing terminal menu workflows.
+- full teacher-facing terminal menu workflows or a dedicated
+  printable-response command.
 
 The intended scan-routing rules and failure behavior are documented in
 [`docs/scan_routing_design.md`](docs/scan_routing_design.md), but that document

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -1,8 +1,16 @@
-# Quillan MVP Data Contracts
+# Quillan Data Contracts
 
 Quillan stores structured evidence about student writing using local files.
 
-These contracts describe the expected MVP file formats for standards profiles, assignments, submissions, requirements checks, tags, scores, feedback, and reports.
+These contracts describe the expected file formats for standards profiles,
+assignments, submissions, requirements checks, tags, scores, feedback, and
+reports.
+
+Standards profiles, assignment configurations, and submission metadata have
+implemented Python validation support. The writing-response payload contract
+is also implemented and used by printable PDF generation. Requirements,
+tagging, scoring, feedback, and reporting records remain contracts for
+teacher-controlled workflows that are not yet implemented end to end.
 
 For the expected workspace layout and file lifecycle of these records, see
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
@@ -25,7 +33,7 @@ Quillan data should be:
 * human-readable where practical;
 * structured enough for validation and reporting;
 * subject-agnostic;
-* compatible with future Paper Data Suite shared data structures;
+* compatible with shared Paper Data Suite data structures;
 * auditable by a teacher.
 
 ## Standards Profile
@@ -302,8 +310,11 @@ The page number is a positive integer. Class, assignment, and student
 identifiers follow shared `pds-core` identifier validation.
 
 Printable response generation consumes validated `pds-core` roster records.
-Roster student IDs remain strings, including leading zeros, and visible names
-use the shared student display helper.
+The shared roster fields are `class_id`, `student_id`, `last_name`,
+`first_name`, and `period`. Roster student IDs remain strings, including
+leading zeros, and visible names use the shared student display helper.
+Quillan consumes these records for generation; it does not yet provide a
+teacher-facing roster management workflow.
 
 Example:
 
@@ -311,10 +322,13 @@ Example:
 PDS1|module=quillan|class=english12_p4|aid=personal_narrative|sid=1001|page=1|doc=response
 ```
 
-This contract identifies response documents only; QR image generation, paper
-forms, and scan routing are outside the current implementation. The printable
-page structure, identity fields, writing area, and future output location are
-defined in
+This contract identifies response documents only. The implemented printable
+generator embeds the payload in a QR code on each response page and writes the
+batch PDF to the assignment-local `templates/` directory. Student display
+names are printed for handling but are not included in the payload. QR
+extraction from later scans, scan routing, and OCR remain unimplemented. The
+printable page structure, identity fields, writing area, and output location
+are defined in
 [`printable_response_template.md`](printable_response_template.md).
 
 ## Requirements Check

--- a/docs/printable_response_template.md
+++ b/docs/printable_response_template.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines the MVP contract for one generic printable Quillan
+This document defines the current contract for one generic printable Quillan
 writing-response page. It describes the information and page structure that the
 PDF generator produces so teachers can distribute identifiable
 paper writing surfaces and later connect captured pages to local Quillan
@@ -44,7 +44,7 @@ and page number.
 
 ## Page Format
 
-The MVP page format is:
+The current page format is:
 
 * US Letter;
 * 8.5 by 11 inches; and
@@ -55,7 +55,7 @@ printers. The identity area, QR code, writing area, and footer must not overlap
 or depend on edge-to-edge printing.
 
 Future contracts may add other paper sizes or orientations. Such options do
-not change the MVP default and are not layout modes defined here.
+not change the current default and are not layout modes defined here.
 
 ## Required Page Elements
 
@@ -126,9 +126,9 @@ for an already-decoded payload is defined in
 
 The QR code must be visually separate from the writing lines, printed with
 sufficient contrast, and given unobstructed whitespace so the page remains
-usable for future scanning. Exact QR sizing, rendering, error-correction
-settings, image generation, decoding, and scan routing belong to later
-implementation work.
+usable for future scanning. QR image generation and embedding are implemented
+by the current PDF generator. QR extraction or decoding from later scans and
+scan routing belong to future implementation work.
 
 Synthetic example:
 
@@ -147,12 +147,13 @@ page. It must:
 * avoid header, footer, or decorative elements that obscure writing lines.
 
 This contract does not require an exact line count, line spacing, margin
-width, or header height. Those measurements should be established and tested
-when PDF generation is implemented.
+width, or header height. The implementation chooses and tests practical
+measurements while this contract intentionally avoids making drawing
+coordinates public data contracts.
 
-The MVP has one writing-area layout. Cornell notes, graphic organizers,
-short-answer boxes, rubric grids, teacher scoring areas, and other specialized
-layouts are not variants of this contract.
+The current generator has one writing-area layout. Cornell notes, graphic
+organizers, short-answer boxes, rubric grids, teacher scoring areas, and other
+specialized layouts are not variants of this contract.
 
 ## Page Numbering
 
@@ -180,7 +181,7 @@ template directory:
 ```
 
 This location keeps teacher-distributed materials with the applicable local
-assignment. The MVP generator writes one batch PDF named
+assignment. The current generator writes one batch PDF named
 `printable_response_pages.pdf`, containing each requested page for each
 student.
 
@@ -191,6 +192,11 @@ Letter portrait pages with ReportLab and embeds QR codes with `qrcode[pil]`.
 `build_response_page_context()` exposes the validated human-readable identity
 and canonical PDS1 payload for one page so contract behavior can be tested
 without inspecting PDF drawing coordinates.
+
+`generate_printable_responses_for_roster()` loads shared `pds-core` roster
+records with `class_id`, `student_id`, `last_name`, `first_name`, and `period`.
+Student IDs remain strings so leading zeros are preserved. This API support
+does not provide a teacher-facing roster management workflow.
 
 ## Privacy and Synthetic Data
 
@@ -217,8 +223,8 @@ identifiers should follow the same validation rules as production identifiers.
 
 The synthetic paper-workflow fixtures in
 `tests/fixtures/paper_workflow/` provide repository-safe assignment,
-standards, student display, and submission data for future response-page
-generation tests. They include:
+standards, student display, and submission data for response-page tests. They
+include:
 
 * a valid `class_id`;
 * a valid `assignment_id`;
@@ -246,7 +252,9 @@ This contract does not implement or define:
 * assignment, submission, or standards model redesign;
 * requirements checking, tagging, scoring, feedback, or reporting;
 * AI tagging, scoring, feedback, or automatic grading; or
-* CLI, menu, or workspace-settings workflows.
+* a dedicated printable-response CLI or menu workflow;
+* assignment creation or roster management workflows; or
+* workspace configuration workflows.
 
 The field-level PDS1 contract remains documented in
 [`data_contracts.md`](data_contracts.md), and the intended assignment-local

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -6,6 +6,11 @@ This design describes how a future Quillan scan router should accept a scanned
 writing-response page with an already-decoded PDS1 payload, validate its page
 identity, and select a safe location in the Paper Data Suite workspace.
 
+Quillan currently generates printable response PDFs and embeds canonical PDS1
+Quillan response payloads in QR codes on those pages. That implemented output
+is the upstream artifact assumed by this design; Quillan does not yet extract
+those QR payloads from scanned PDFs or images.
+
 The PDS1 payload is the machine-readable source of class, assignment, student,
 and page identity. A successfully routed file is preserved as raw source
 evidence in the assignment-level `scans/` directory. Routing does not make the
@@ -132,11 +137,12 @@ Validation should happen before filesystem writes and in the following order.
    verify that it remains inside the resolved workspace root. Reject any path
    that escapes the root, including through traversal or filesystem links.
 
-Student roster membership is not an initial routing prerequisite because a
-production roster workflow is outside this design and may not be available.
-The student identifier must still be valid. A future roster-aware phase may
-flag an unknown student for review, but it must preserve the source evidence
-rather than infer a different identity.
+Student roster membership is not an initial routing prerequisite. Quillan
+already consumes shared `pds-core` roster records for printable generation,
+but it does not provide a production teacher-facing roster management
+workflow. A future roster-aware routing phase may flag an unknown student for
+review, but it must preserve the source evidence rather than infer a different
+identity. The student identifier must still be valid.
 
 Validation should return stable, machine-readable failure codes in addition to
 human-readable reasons. It must not attempt to repair identifiers, guess a

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -12,6 +12,12 @@ teacher-approved language, and summarize confirmed records. It must not
 present an unconfirmed software judgment as a teacher evaluation or encourage
 review without reading the student's work.
 
+This document defines the review model and data boundaries. Quillan currently
+validates relevant data contracts and can prepare printable writing-response
+pages, but it does not yet implement complete requirements-checking, tagging,
+scoring, feedback, reporting, or teacher-facing menu workflows. AI tagging,
+AI scoring, AI feedback, and automatic grading are not implemented.
+
 ## Source Evidence
 
 Source evidence is the student-produced writing and the metadata needed to

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -18,9 +18,21 @@ organizes files without substituting software decisions for teacher judgment.
 The shared `pds-core` route helpers define the assignment and submission
 locations. Quillan-specific files remain inside those shared routes.
 
+## Workspace vs. Installation
+
+The PDS workspace root is teacher-controlled data storage. It is separate from
+the Quillan source checkout, the Python virtual environment used for
+development, and the location where the Quillan package is installed. None of
+those code or environment locations should be treated as the workspace root.
+
+Quillan currently inspects the resolved workspace through the shared
+`pds-core` workspace status API, exposed read-only by `quillan workspace show`.
+That command reports status; it does not create, select, repair, or populate a
+workspace.
+
 ## Core Directory Layout
 
-The expected MVP layout is:
+The expected current and reserved layout is:
 
 ```text
 <PDS workspace root>/
@@ -31,6 +43,7 @@ The expected MVP layout is:
         <assignment_id>/
           assignment.json
           templates/
+            printable_response_pages.pdf
           scans/
           submissions/
             <student_id>/
@@ -62,10 +75,12 @@ basic requirements, tagging mode, and rubric reference.
 
 ### `templates/`
 
-A reserved assignment-local directory for future generated or teacher-facing
-printable materials. Template or printable-material generation is not part of
-the current lifecycle implementation. The contract for future printable
-writing-response pages and their use of this directory is defined in
+A shared assignment-local directory for generated or teacher-facing printable
+materials. The implemented Python API creates
+`templates/printable_response_pages.pdf` for a generated batch of
+roster-aware writing-response pages. A dedicated printable-response CLI or
+teacher menu workflow is not yet implemented. The response-page contract is
+defined in
 [`printable_response_template.md`](printable_response_template.md).
 
 ### `scans/`
@@ -261,7 +276,8 @@ within Quillan's teacher-controlled review process.
 
 [`printable_response_template.md`](printable_response_template.md) defines the
 required structure, identity fields, PDS1 payload use, writing area, and
-intended `templates/` location for future printable writing-response pages.
+implemented `templates/printable_response_pages.pdf` output for printable
+writing-response pages.
 
 [`scan_routing_design.md`](scan_routing_design.md) defines how a future router
 should validate decoded response payloads, preserve scan evidence, and select


### PR DESCRIPTION
## Summary

- Audited Quillan documentation for stale foundation-era language.
- Updated docs to accurately distinguish implemented printable PDF, QR/PDS1, roster-aware generation, and shared workspace foundations from future scan intake/review workflows.
- Reconciled storage paths, roster expectations, string student IDs, and canonical PDS1 response payload language across the documentation set.
- Clarified that scan routing, scan QR extraction, OCR, AI workflows, automatic grading, and complete teacher-facing workflows are not implemented.
- Preserved the teacher-controlled evidence-system boundary.

Closes #37.

## Validation

- [x] `git diff --check`

## Notes

- Documentation-only change.
- No schemas changed.
- No tests changed.
- No production behavior changed.
- No dependency changes introduced.
- No generated PDFs, scans, workspace files, private files, or classroom artifacts committed.
- No sibling repositories modified.