### PR TITLE
Add Quillan terminal menu skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Quillan is part of the broader Paper Data Suite concept, alongside ScoreForm.
 
 ## Current Status
 
-Quillan is an early pre-1.0 foundation. It is developer- and CLI-oriented
-rather than a complete teacher-facing application.
+Quillan is an early pre-1.0 foundation. It provides direct CLI commands and
+an initial teacher-facing terminal menu skeleton, but it is not yet a complete
+teacher-facing application.
 
 Quillan currently supports:
 
@@ -28,8 +29,8 @@ Quillan currently supports:
 - synthetic examples and fixtures for safe testing and documentation.
 
 Printable response generation is implemented as a Python API in
-`quillan.printable_response`; it is not yet exposed as a complete teacher
-menu or dedicated CLI command.
+`quillan.printable_response`; it is not yet exposed as a teacher-facing menu
+workflow or dedicated CLI command.
 
 ## Core Principle
 
@@ -54,8 +55,9 @@ particular, Quillan does not currently provide:
   production reporting workflows;
 - AI tagging, AI scoring, or AI feedback;
 - automatic grading; or
-- full teacher-facing terminal menu workflows or a dedicated
-  printable-response command.
+- complete teacher-facing assignment, roster, printable-response, or review
+  workflows; or
+- a dedicated printable-response command.
 
 The intended scan-routing rules and failure behavior are documented in
 [`docs/scan_routing_design.md`](docs/scan_routing_design.md), but that document
@@ -151,6 +153,21 @@ routing the scan, and performing OCR are not.
 
 ## Running Quillan
 
+Launch the initial teacher-facing menu skeleton:
+
+```powershell
+quillan menu
+```
+
+The menu currently provides honest placeholders for assignment management,
+roster management, and printable response pages. Its Workspace Settings
+section can show the same read-only workspace status as
+`quillan workspace show`, and its help summarizes Quillan's teacher-controlled
+purpose and safe-data expectations.
+
+Running bare `quillan` continues to print top-level CLI help; it does not launch
+the menu.
+
 Show CLI help:
 
 ```powershell
@@ -192,6 +209,7 @@ quillan --help
 quillan validate-standards <standards-profile.json>
 quillan validate-assignment <assignment.json>
 quillan workspace show
+quillan menu
 ```
 
 Submission metadata validation and printable response generation currently

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -6,16 +6,16 @@ This document defines Quillan's command-line contract during pre-1.0
 development. It records:
 
 * the command surface that is implemented now;
-* the boundary between direct commands and a future interactive menu;
+* the boundary between direct commands and the initial interactive menu;
 * conventions for help, errors, paths, output, and exit status; and
 * the compatibility expectations contributors should use when changing the
   CLI.
 
-The CLI is currently a developer-oriented and scriptable interface, not a
-complete teacher-facing application. This contract describes implemented
-behavior separately from future design. A command documented elsewhere as
-planned is not part of the current CLI until it is implemented, tested, and
-added here.
+The CLI includes a developer-oriented, scriptable command layer and an initial
+teacher-facing menu skeleton. It is not a complete teacher-facing application.
+This contract describes implemented behavior separately from future design. A
+command or workflow documented elsewhere as planned is not part of the current
+CLI until it is implemented, tested, and added here.
 
 Quillan is pre-1.0. Command names, output, and conventions may evolve, but
 changes should be intentional, documented, and covered by tests.
@@ -48,12 +48,22 @@ quillan validate-standards <path>
 quillan validate-assignment <path>
 quillan workspace show
 quillan workspace --help
+quillan menu
 ```
 
 Running `quillan` without a command currently prints top-level help and exits
 successfully. Running `quillan workspace` without `show` also prints
 top-level help and exits successfully. These no-operation forms do not
 validate data, inspect the workspace, or modify files.
+
+The canonical teacher-facing menu invocation is:
+
+```powershell
+quillan menu
+```
+
+The explicit `menu` command is interactive. Direct commands remain
+non-interactive.
 
 ### `validate-standards`
 
@@ -111,9 +121,9 @@ This command reports status only. It does not create, select, repair, or
 change a workspace. A reported `no` value is status information and does not
 by itself make the command fail.
 
-## Direct CLI and Future Menu Boundary
+## Direct CLI and Menu Boundary
 
-Direct CLI commands and a future interactive menu serve different use cases.
+Direct CLI commands and the interactive menu serve different use cases.
 They may call the same application services, but neither should implement
 business rules independently.
 
@@ -129,28 +139,56 @@ A direct command should be preferred when the operation:
 
 Validation, status inspection, import/export, and other discrete operations
 are natural direct-command candidates. Direct commands should remain usable
-without the future menu.
+without the menu.
 
-### Future interactive menu
+### Interactive menu
 
-A future menu may guide teachers through multi-step work such as selecting a
-class and assignment, reviewing submissions, entering tags or scores, and
-confirming output. It may improve discoverability and preserve session
-context, but it should orchestrate reusable application functions rather than
-becoming the only route to core operations.
+The current menu is a small discovery and navigation shell. It provides:
 
-The menu is not currently implemented. In particular:
+```text
+1. Assignment Management
+2. Roster Management
+3. Printable Response Pages
+4. Workspace Settings
+5. Help
+6. Exit
+```
 
-* running `quillan` does not launch a menu;
-* no current command should prompt for missing required arguments;
-* documentation must not present planned menu workflows as available; and
-* adding a menu must not silently change an existing direct command into an
-  interactive workflow.
+Assignment Management and Roster Management state that their workflows are not
+implemented yet. Printable Response Pages states that PDF generation exists as
+a Python API but has no teacher-facing menu workflow yet. These sections do not
+prompt for files or create, edit, generate, route, review, score, or report
+data.
+
+Workspace Settings currently provides only:
+
+```text
+1. Show current workspace
+2. Back
+```
+
+Showing the workspace calls the same status behavior as
+`quillan workspace show`. It does not set, create, validate, reset, repair, or
+clean a workspace.
+
+Menu help describes Quillan as a local-first, teacher-controlled
+writing-evidence tool; keeps teacher judgment primary; states that Quillan is
+not automated grading software; identifies currently unsupported AI, OCR,
+scan-routing, and review workflows; and summarizes repository safe-data
+expectations and current direct commands.
+
+The menu clears the screen only when both standard input and standard output
+are interactive terminals. A normal exit or `KeyboardInterrupt` returns status
+`0`.
+
+A future menu may guide teachers through additional multi-step work after
+those workflows are actually implemented. It should orchestrate reusable
+application functions rather than becoming the only route to core operations.
 
 CLI parsing and presentation belong in `quillan/cli.py`. Validation, storage,
 workspace resolution, and other domain behavior belong in their relevant
 modules or in shared `pds-core` services. This separation allows direct
-commands and a future menu to share behavior and tests.
+commands and the menu to share behavior and tests.
 
 ## Help and Discoverability
 
@@ -294,7 +332,8 @@ explicitly outside the current end-to-end foundation:
 * requirements checking, tagging, scoring, feedback, and reporting
   workflows;
 * AI grading, scoring, tagging, or feedback; and
-* a teacher-facing interactive terminal menu.
+* complete teacher-facing assignment, roster, printable-response, submission
+  review, tagging, scoring, feedback, or reporting workflows.
 
 Their presence in design documents or Python modules does not add them to the
 CLI contract.

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -217,11 +217,12 @@ Responsible for:
 
 * teacher-facing terminal commands;
 * direct CLI workflows;
-* future menu workflows.
+* the initial menu shell and future menu workflows.
 
 Current status:
 
 * implemented `validate-standards`;
+* implemented the initial `quillan menu` skeleton;
 * covered by tests.
 
 ## Development Sequence
@@ -283,6 +284,7 @@ Completed work:
 
 * Add argparse-based CLI structure.
 * Add `validate-standards` command.
+* Add the initial `quillan menu` entry point and navigation skeleton.
 * Add CLI tests.
 
 Remaining possible work:
@@ -290,7 +292,7 @@ Remaining possible work:
 * Add version/status command.
 * Improve user-facing error formatting.
 * Add examples to CLI help text.
-* Add future menu entry point.
+* Expand menu workflows only as supported application behavior is implemented.
 
 ### Phase 5 — Assignments
 

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -15,8 +15,9 @@ review without reading the student's work.
 This document defines the review model and data boundaries. Quillan currently
 validates relevant data contracts and can prepare printable writing-response
 pages, but it does not yet implement complete requirements-checking, tagging,
-scoring, feedback, reporting, or teacher-facing menu workflows. AI tagging,
-AI scoring, AI feedback, and automatic grading are not implemented.
+scoring, feedback, reporting, or teacher-facing review workflows. Its initial
+terminal menu is a navigation skeleton rather than a review implementation.
+AI tagging, AI scoring, AI feedback, and automatic grading are not implemented.
 
 ## Source Evidence
 

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -12,6 +12,7 @@ from pds_core.workspace import (
 )
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.menu import launch_menu
 from quillan.standards import StandardsProfileError, load_standards_profile
 
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
@@ -32,6 +33,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "workspace" and args.workspace_command == "show":
         return _handle_workspace_show()
+
+    if args.command == "menu":
+        return launch_menu(_handle_workspace_show)
 
     parser.print_help()
     return 0
@@ -72,6 +76,11 @@ def _build_parser() -> argparse.ArgumentParser:
     workspace_subparsers.add_parser(
         "show",
         help="Show the active Paper Data Suite workspace status.",
+    )
+
+    subparsers.add_parser(
+        "menu",
+        help="Launch the teacher-facing interactive menu.",
     )
 
     return parser

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -1,0 +1,157 @@
+"""Teacher-facing interactive menu for Quillan."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+
+WorkspaceShowHandler = Callable[[], int]
+
+
+def clear_screen() -> None:
+    """Clear an interactive terminal without affecting captured output."""
+    try:
+        is_interactive = sys.stdin.isatty() and sys.stdout.isatty()
+    except (AttributeError, OSError):
+        is_interactive = False
+
+    if is_interactive:
+        os.system("cls" if os.name == "nt" else "clear")
+
+
+def pause_for_user() -> None:
+    """Wait for the teacher before returning to a menu."""
+    input("Press Enter to continue...")
+
+
+def print_menu_header(title: str | None = None) -> None:
+    """Print the Quillan identity and an optional section title."""
+    print("Quillan")
+    if title:
+        print(title)
+    print()
+
+
+def print_menu_help() -> None:
+    """Print concise teacher-facing purpose, safety, and CLI help."""
+    print_menu_header("Help")
+    print("Quillan is a local-first, teacher-controlled writing-evidence tool.")
+    print("It helps teachers organize and validate writing evidence.")
+    print("Teacher judgment remains primary; Quillan is not automated grading software.")
+    print()
+    print("Quillan does not currently implement AI tagging, AI scoring,")
+    print("AI feedback, OCR, scan routing, or full teacher-facing review workflows.")
+    print()
+    print("Use synthetic data only in repository examples and tests.")
+    print("Do not commit or post real student data, rosters, scans, writing, grades,")
+    print("feedback, reports, screenshots, or workspace artifacts publicly.")
+    print()
+    print("Current direct CLI commands:")
+    print("  quillan --help")
+    print("  quillan validate-standards <standards-profile.json>")
+    print("  quillan validate-assignment <assignment.json>")
+    print("  quillan workspace show")
+    print("  quillan menu")
+
+
+def launch_assignment_menu() -> None:
+    """Display the current assignment-management boundary."""
+    clear_screen()
+    print_menu_header("Assignment Management")
+    print("Assignment management workflows are not implemented yet.")
+    print("Current direct CLI support:")
+    print("  quillan validate-assignment <assignment.json>")
+    print()
+    pause_for_user()
+
+
+def launch_roster_menu() -> None:
+    """Display the current roster-management boundary."""
+    clear_screen()
+    print_menu_header("Roster Management")
+    print("Roster management workflows are not implemented yet.")
+    print("Quillan currently consumes shared pds-core roster records for printable")
+    print("response generation, but it does not provide roster management.")
+    print()
+    pause_for_user()
+
+
+def launch_printable_response_menu() -> None:
+    """Display the current printable-response workflow boundary."""
+    clear_screen()
+    print_menu_header("Printable Response Pages")
+    print("Printable response PDF generation exists as a Python API, but the")
+    print("teacher-facing menu workflow is not implemented yet.")
+    print("Generated pages use PDS1 Quillan response payloads and shared pds-core")
+    print("roster records.")
+    print()
+    pause_for_user()
+
+
+def launch_workspace_menu(workspace_show: WorkspaceShowHandler) -> None:
+    """Launch the read-only workspace settings submenu."""
+    while True:
+        clear_screen()
+        print_menu_header("Workspace Settings")
+        print("1. Show current workspace")
+        print("2. Back")
+        print()
+
+        choice = input("Select an option: ").strip()
+        print()
+
+        if choice == "1":
+            clear_screen()
+            print_menu_header("Current Workspace")
+            workspace_show()
+            print()
+            pause_for_user()
+        elif choice == "2":
+            return
+        else:
+            print("Invalid selection. Please enter 1 or 2.")
+            print()
+            pause_for_user()
+
+
+def launch_menu(workspace_show: WorkspaceShowHandler) -> int:
+    """Launch the Quillan teacher-facing menu skeleton."""
+    try:
+        while True:
+            clear_screen()
+            print_menu_header()
+            print("1. Assignment Management")
+            print("2. Roster Management")
+            print("3. Printable Response Pages")
+            print("4. Workspace Settings")
+            print("5. Help")
+            print("6. Exit")
+            print()
+
+            choice = input("Select an option: ").strip()
+            print()
+
+            if choice == "1":
+                launch_assignment_menu()
+            elif choice == "2":
+                launch_roster_menu()
+            elif choice == "3":
+                launch_printable_response_menu()
+            elif choice == "4":
+                launch_workspace_menu(workspace_show)
+            elif choice == "5":
+                clear_screen()
+                print_menu_help()
+                print()
+                pause_for_user()
+            elif choice == "6":
+                print("Goodbye.")
+                return 0
+            else:
+                print("Invalid selection. Please enter a number from 1 to 6.")
+                print()
+                pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting Quillan.")
+        return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 import json
 from pathlib import Path
 
@@ -10,6 +11,23 @@ import pytest
 
 import quillan.cli
 from quillan.cli import main
+
+
+def _menu_input(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[str],
+) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError(
+                "Menu requested more input than the test provided."
+            ) from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
 
 
 def test_cli_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
@@ -22,6 +40,7 @@ def test_cli_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
     assert "Quillan: standards-based writing evidence capture" in captured.out
     assert "validate-standards" in captured.out
     assert "workspace" in captured.out
+    assert "menu" in captured.out
 
     with pytest.raises(SystemExit) as workspace_error:
         main(["workspace", "--help"])
@@ -30,6 +49,16 @@ def test_cli_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
 
     assert workspace_error.value.code == 0
     assert "show" in workspace_help.out
+
+
+def test_cli_without_command_preserves_help_only_behavior(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main([]) == 0
+
+    output = capsys.readouterr().out
+    assert "Quillan: standards-based writing evidence capture" in output
+    assert "Launch the teacher-facing interactive menu" in output
 
 
 def test_cli_validates_standards_profile(
@@ -211,3 +240,100 @@ def test_workspace_show_reports_workspace_error(
 
     assert main(["workspace", "show"]) != 0
     assert "Error: bad workspace" in capsys.readouterr().out
+
+
+def test_menu_dispatch_displays_options_and_exits(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["6"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+
+    assert "Quillan" in output
+    assert "Assignment Management" in output
+    assert "Roster Management" in output
+    assert "Printable Response Pages" in output
+    assert "Workspace Settings" in output
+    assert "Help" in output
+    assert "Exit" in output
+    assert "Goodbye." in output
+
+
+def test_menu_help_explains_teacher_control_and_safe_data(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["5", "", "6"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+
+    assert "local-first, teacher-controlled" in output
+    assert "Teacher judgment remains primary" in output
+    assert "not automated grading software" in output
+    assert "synthetic data only" in output
+    assert "Do not commit or post real student data" in output
+    assert "quillan validate-standards" in output
+    assert "quillan menu" in output
+
+
+@pytest.mark.parametrize(
+    ("selection", "expected_message"),
+    [
+        ("1", "Assignment management workflows are not implemented yet."),
+        ("2", "Roster management workflows are not implemented yet."),
+        (
+            "3",
+            "teacher-facing menu workflow is not implemented yet.",
+        ),
+    ],
+)
+def test_unsupported_menu_sections_are_honest_placeholders(
+    selection: str,
+    expected_message: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, [selection, "", "6"])
+
+    assert main(["menu"]) == 0
+    assert expected_message in capsys.readouterr().out
+
+
+def test_workspace_menu_reuses_workspace_show_handler(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def handle_workspace_show() -> int:
+        nonlocal calls
+        calls += 1
+        print("Synthetic workspace status")
+        return 0
+
+    monkeypatch.setattr(quillan.cli, "_handle_workspace_show", handle_workspace_show)
+    _menu_input(monkeypatch, ["4", "1", "", "2", "6"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+
+    assert calls == 1
+    assert "Workspace Settings" in output
+    assert "Show current workspace" in output
+    assert "Synthetic workspace status" in output
+
+
+def test_menu_handles_keyboard_interrupt(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def interrupt(_prompt: str = "") -> str:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", interrupt)
+
+    assert main(["menu"]) == 0
+    assert "Exiting Quillan." in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Added `quillan menu` as the canonical teacher-facing menu entry point.
- Preserved bare `quillan` as help-only behavior.
- Added a Quillan menu skeleton with Assignment Management, Roster Management, Printable Response Pages, Workspace Settings, Help, and Exit.
- Added honest placeholder screens for unsupported assignment, roster, and printable-response menu workflows.
- Reused existing workspace status behavior from the Workspace Settings menu.
- Added menu help covering Quillan’s teacher-controlled evidence boundary and safe-data expectations.
- Added tests for menu dispatch, help, placeholders, workspace-status reuse, keyboard interrupt handling, and direct CLI preservation.

Closes #38.

## Validation

- [x] `python -m pytest` — 172 tests passed
- [x] `python -m ruff check .`
- [x] `python -m mypy .`
- [x] `git diff --check`
- [x] `.\run_tests.ps1`

## Notes

- Menu skeleton only.
- No assignment creation workflow added.
- No roster management workflow added.
- No printable-response packet-generation wizard added.
- No scan routing, QR extraction from scans, OCR, AI, grading, feedback, or reporting workflow added.
- No schemas changed.
- No PDS1 payload behavior changed.
- No printable response generation behavior changed.
- No generated PDFs, scans, workspace files, private files, or classroom artifacts committed.
- No sibling repositories modified.