### PR TITLE
Launch Quillan menu by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,10 @@ routing the scan, and performing OCR are not.
 Launch the initial teacher-facing menu skeleton:
 
 ```powershell
-quillan menu
+quillan
 ```
+
+`quillan menu` launches the same menu as an explicit alias.
 
 The menu currently provides honest placeholders for assignment management,
 roster management, and printable response pages. Its Workspace Settings
@@ -165,10 +167,7 @@ section can show the same read-only workspace status as
 `quillan workspace show`, and its help summarizes Quillan's teacher-controlled
 purpose and safe-data expectations.
 
-Running bare `quillan` continues to print top-level CLI help; it does not launch
-the menu.
-
-Show CLI help:
+Show direct CLI help:
 
 ```powershell
 quillan --help
@@ -205,6 +204,7 @@ quillan validate-assignment <assignment.json>
 The current command surface is:
 
 ```powershell
+quillan
 quillan --help
 quillan validate-standards <standards-profile.json>
 quillan validate-assignment <assignment.json>

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -43,6 +43,7 @@ separate public Python API contract.
 The implemented command surface currently exposed through argparse is:
 
 ```powershell
+quillan
 quillan --help
 quillan validate-standards <path>
 quillan validate-assignment <path>
@@ -51,18 +52,18 @@ quillan workspace --help
 quillan menu
 ```
 
-Running `quillan` without a command currently prints top-level help and exits
-successfully. Running `quillan workspace` without `show` also prints
-top-level help and exits successfully. These no-operation forms do not
-validate data, inspect the workspace, or modify files.
+Running `quillan` without a command launches the initial teacher-facing
+terminal menu. Running `quillan workspace` without `show` prints top-level
+help and exits successfully; it does not inspect or modify the workspace.
 
-The canonical teacher-facing menu invocation is:
+The teacher-facing menu may also be launched explicitly:
 
 ```powershell
 quillan menu
 ```
 
-The explicit `menu` command is interactive. Direct commands remain
+Bare `quillan` and the explicit `menu` command launch the same interactive
+menu skeleton. Direct validation and workspace-status commands remain
 non-interactive.
 
 ### `validate-standards`
@@ -143,7 +144,9 @@ without the menu.
 
 ### Interactive menu
 
-The current menu is a small discovery and navigation shell. It provides:
+Bare `quillan` launches the current menu, which is a small discovery and
+navigation shell. `quillan menu` is an explicit alias for the same behavior.
+The menu provides:
 
 ```text
 1. Assignment Management
@@ -211,9 +214,9 @@ Command summaries should describe effects accurately, especially whether an
 operation reads, writes, or modifies workspace data. Planned commands belong
 in design or roadmap documentation, not active help output.
 
-During the current pre-1.0 period, running a parser level without selecting an
-operation may continue to print help and return `0`. If that policy changes
-to require a command, the behavior and tests should change together.
+During the current pre-1.0 period, a command-specific parser level without a
+selected operation may continue to print help and return `0`. The top-level
+parser is different: bare `quillan` launches the teacher-facing menu.
 
 ## Paths and Filesystem Behavior
 
@@ -287,7 +290,7 @@ The process exit status is part of the CLI contract:
 
 | Status | Meaning |
 | --- | --- |
-| `0` | The requested operation completed successfully, or help was requested or printed for a no-operation parser level. |
+| `0` | The requested operation or menu session completed successfully, or help was requested or printed for a no-operation command-specific parser level. |
 | `1` | The command was understood, but validation or an operational action failed. |
 | `2` | Command-line usage was invalid, as reported by `argparse`. |
 | Other nonzero | An unexpected failure or a future explicitly documented category. |

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -222,7 +222,7 @@ Responsible for:
 Current status:
 
 * implemented `validate-standards`;
-* implemented the initial `quillan menu` skeleton;
+* implemented the initial bare `quillan` / `quillan menu` skeleton;
 * covered by tests.
 
 ## Development Sequence
@@ -284,7 +284,8 @@ Completed work:
 
 * Add argparse-based CLI structure.
 * Add `validate-standards` command.
-* Add the initial `quillan menu` entry point and navigation skeleton.
+* Add the initial bare `quillan` menu entry point, explicit `quillan menu`
+  alias, and navigation skeleton.
 * Add CLI tests.
 
 Remaining possible work:

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -34,7 +34,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "workspace" and args.workspace_command == "show":
         return _handle_workspace_show()
 
-    if args.command == "menu":
+    if args.command is None or args.command == "menu":
         return launch_menu(_handle_workspace_show)
 
     parser.print_help()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,9 +30,13 @@ def _menu_input(
     monkeypatch.setattr("builtins.input", fake_input)
 
 
-def test_cli_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
+@pytest.mark.parametrize("help_flag", ["--help", "-h"])
+def test_cli_prints_help(
+    help_flag: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     with pytest.raises(SystemExit) as error:
-        main(["--help"])
+        main([help_flag])
 
     captured = capsys.readouterr()
 
@@ -51,14 +55,23 @@ def test_cli_prints_help(capsys: pytest.CaptureFixture[str]) -> None:
     assert "show" in workspace_help.out
 
 
-def test_cli_without_command_preserves_help_only_behavior(
+def test_cli_without_command_displays_menu_options_and_exits(
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _menu_input(monkeypatch, ["6"])
+
     assert main([]) == 0
 
     output = capsys.readouterr().out
-    assert "Quillan: standards-based writing evidence capture" in output
-    assert "Launch the teacher-facing interactive menu" in output
+    assert "Quillan" in output
+    assert "Assignment Management" in output
+    assert "Roster Management" in output
+    assert "Printable Response Pages" in output
+    assert "Workspace Settings" in output
+    assert "Help" in output
+    assert "Exit" in output
+    assert "Goodbye." in output
 
 
 def test_cli_validates_standards_profile(


### PR DESCRIPTION
## Summary

- Changed bare `quillan` to launch the teacher-facing menu by default.
- Preserved `quillan menu` as an explicit menu alias.
- Preserved explicit CLI help through `quillan --help` and `quillan -h`.
- Updated tests for no-argument menu launch, explicit menu launch, and explicit help behavior.
- Updated documentation to describe menu-by-default behavior.

Closes #54.

## Validation

- [x] `.\run_tests.ps1` — 173 tests passed
- [x] `python -m ruff check .`
- [x] `python -m mypy .`
- [x] `git diff --check`

## Notes

- Entry-point behavior only.
- No menu workflows expanded.
- No assignment, roster, printable-response, scan, OCR, AI, grading, feedback, or reporting workflow added.
- No schemas changed.
- No data contracts changed.
- No PDS1 payload behavior changed.
- No printable response generation behavior changed.
- No workspace behavior changed.
- No generated PDFs, scans, private files, or classroom artifacts committed.
- No sibling repositories modified.