### PR TITLE
Add Quillan workspace settings menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a full Workspace Settings menu and matching direct commands for
+  showing, setting, validating/creating, and resetting the shared Paper Data
+  Suite workspace root through `pds-core`.
 - Added a root security policy covering private classroom data, synthetic
   repository fixtures, local artifacts, concern reporting, and dependency
   updates.

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ quillan
 
 The menu currently provides honest placeholders for assignment management,
 roster management, and printable response pages. Its Workspace Settings
-section can show the same read-only workspace status as
-`quillan workspace show`, and its help summarizes Quillan's teacher-controlled
-purpose and safe-data expectations.
+section can show, set, validate/create, and reset the shared Paper Data Suite
+workspace root. Its help summarizes Quillan's teacher-controlled purpose and
+safe-data expectations.
 
 Show direct CLI help:
 
@@ -182,6 +182,21 @@ quillan workspace show
 This read-only command reports the resolved root, resolution source, config
 path, default root, and basic filesystem status using the shared `pds-core`
 workspace status API.
+
+The same shared workspace operations are also available directly:
+
+```powershell
+quillan workspace set <folder>
+quillan workspace validate
+quillan workspace reset
+```
+
+Quillan uses the shared `pds-core` workspace configuration; it does not create
+a Quillan-specific workspace config. Setting a root validates/creates it and
+saves the shared preference, but does not move or migrate existing files.
+Resetting clears only the saved preference and does not delete workspace
+files. In both cases, `PDS_WORKSPACE_ROOT` still takes precedence over the
+saved preference when it is set.
 
 Validate a standards profile:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -48,13 +48,17 @@ quillan --help
 quillan validate-standards <path>
 quillan validate-assignment <path>
 quillan workspace show
+quillan workspace set <path>
+quillan workspace validate
+quillan workspace reset
 quillan workspace --help
 quillan menu
 ```
 
 Running `quillan` without a command launches the initial teacher-facing
-terminal menu. Running `quillan workspace` without `show` prints top-level
-help and exits successfully; it does not inspect or modify the workspace.
+terminal menu. Running `quillan workspace` without a subcommand prints
+top-level help and exits successfully; it does not inspect or modify the
+workspace.
 
 The teacher-facing menu may also be launched explicitly:
 
@@ -122,6 +126,42 @@ This command reports status only. It does not create, select, repair, or
 change a workspace. A reported `no` value is status information and does not
 by itself make the command fail.
 
+### `workspace set`
+
+```powershell
+quillan workspace set <path>
+```
+
+Uses shared `pds-core` behavior to validate/create the supplied workspace root
+and save it as the Paper Data Suite workspace preference. This operation does
+not move, copy, migrate, delete, archive, or reorganize existing Quillan or
+Paper Data Suite files. If `PDS_WORKSPACE_ROOT` is set, the environment value
+still takes precedence over the saved preference.
+
+### `workspace validate`
+
+```powershell
+quillan workspace validate
+```
+
+Resolves the active root using the shared precedence rules, creates the
+workspace and shared metadata if needed, and verifies that it is writable. It
+does not prompt for a different root or change the saved preference.
+
+### `workspace reset`
+
+```powershell
+quillan workspace reset
+```
+
+Clears only the saved Paper Data Suite workspace-root preference. It does not
+delete workspace directories or files. The command reports the newly resolved
+root after reset; `PDS_WORKSPACE_ROOT`, when set, still takes precedence.
+
+All workspace commands use shared `pds-core` APIs and configuration. Quillan
+does not maintain a separate workspace config. Expected workspace errors are
+reported as `Error: ...` without a traceback and return a nonzero status.
+
 ## Direct CLI and Menu Boundary
 
 Direct CLI commands and the interactive menu serve different use cases.
@@ -163,16 +203,27 @@ a Python API but has no teacher-facing menu workflow yet. These sections do not
 prompt for files or create, edit, generate, route, review, score, or report
 data.
 
-Workspace Settings currently provides only:
+Workspace Settings provides:
 
 ```text
 1. Show current workspace
-2. Back
+2. Set workspace folder
+3. Validate/create current workspace
+4. Reset saved workspace preference
+5. Back
 ```
 
 Showing the workspace calls the same status behavior as
-`quillan workspace show`. It does not set, create, validate, reset, repair, or
-clean a workspace.
+`quillan workspace show` and remains read-only. Setting prompts for a folder;
+blank input cancels without changing the saved preference. Nonblank input
+validates/creates the folder and saves it through shared `pds-core`
+configuration. Validate/create operates on the currently resolved root.
+Reset clears only the saved preference and then reports the current resolved
+root. The menu warns that setting does not migrate files, resetting does not
+delete files, and `PDS_WORKSPACE_ROOT` still takes precedence.
+
+The workspace submenu does not include school-year settings. The overall menu
+remains a guided shell rather than a complete teacher-facing application.
 
 Menu help describes Quillan as a local-first, teacher-controlled
 writing-evidence tool; keeps teacher judgment primary; states that Quillan is

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -25,10 +25,12 @@ the Quillan source checkout, the Python virtual environment used for
 development, and the location where the Quillan package is installed. None of
 those code or environment locations should be treated as the workspace root.
 
-Quillan currently inspects the resolved workspace through the shared
-`pds-core` workspace status API, exposed read-only by `quillan workspace show`.
-That command reports status; it does not create, select, repair, or populate a
-workspace.
+Quillan uses shared `pds-core` APIs to show, set, validate/create, and reset the
+Paper Data Suite workspace root through its Workspace Settings menu and
+matching direct commands. It does not maintain Quillan-specific workspace
+configuration. Setting a root does not migrate existing files, and resetting
+the saved preference does not delete workspace files. `PDS_WORKSPACE_ROOT`
+continues to take precedence over the saved preference when set.
 
 ## Core Directory Layout
 

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from pds_core.workspace import (
     WorkspaceRootError,
     WorkspaceStatus,
+    clear_saved_workspace_root,
+    ensure_workspace_root,
     inspect_workspace_root,
+    resolve_workspace_root,
+    save_workspace_root,
 )
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
@@ -34,8 +38,22 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "workspace" and args.workspace_command == "show":
         return _handle_workspace_show()
 
+    if args.command == "workspace" and args.workspace_command == "set":
+        return _handle_workspace_set(args.path)
+
+    if args.command == "workspace" and args.workspace_command == "validate":
+        return _handle_workspace_validate()
+
+    if args.command == "workspace" and args.workspace_command == "reset":
+        return _handle_workspace_reset()
+
     if args.command is None or args.command == "menu":
-        return launch_menu(_handle_workspace_show)
+        return launch_menu(
+            _handle_workspace_show,
+            _handle_workspace_set,
+            _handle_workspace_validate,
+            _handle_workspace_reset,
+        )
 
     parser.print_help()
     return 0
@@ -68,7 +86,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     workspace_parser = subparsers.add_parser(
         "workspace",
-        help="Inspect the shared PDS workspace with 'quillan workspace show'.",
+        help="Manage the shared Paper Data Suite workspace.",
     )
     workspace_subparsers = workspace_parser.add_subparsers(
         dest="workspace_command"
@@ -76,6 +94,23 @@ def _build_parser() -> argparse.ArgumentParser:
     workspace_subparsers.add_parser(
         "show",
         help="Show the active Paper Data Suite workspace status.",
+    )
+    workspace_set_parser = workspace_subparsers.add_parser(
+        "set",
+        help="Validate, create, and save a shared workspace root.",
+    )
+    workspace_set_parser.add_argument(
+        "path",
+        type=Path,
+        help="Folder to use as the shared Paper Data Suite workspace.",
+    )
+    workspace_subparsers.add_parser(
+        "validate",
+        help="Validate or create the currently resolved workspace root.",
+    )
+    workspace_subparsers.add_parser(
+        "reset",
+        help="Clear the saved workspace preference without deleting files.",
     )
 
     subparsers.add_parser(
@@ -115,6 +150,62 @@ def _handle_workspace_show() -> int:
         return 1
 
     _print_workspace_status(status)
+    return 0
+
+
+def _handle_workspace_set(path: str | Path) -> int:
+    """Validate, create, and save the shared workspace root."""
+    try:
+        workspace_root = ensure_workspace_root(path)
+        saved_root = save_workspace_root(workspace_root)
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return 1
+
+    print("Saved PDS workspace root:")
+    print(saved_root)
+    print()
+    print("This does not move existing Quillan or Paper Data Suite files.")
+    print(
+        "If PDS_WORKSPACE_ROOT is set, it still takes precedence over "
+        "the saved preference."
+    )
+    return 0
+
+
+def _handle_workspace_validate() -> int:
+    """Validate or create the currently resolved shared workspace root."""
+    try:
+        workspace_root = resolve_workspace_root()
+        validated_root = ensure_workspace_root(workspace_root)
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return 1
+
+    print("Workspace validated successfully:")
+    print(validated_root)
+    return 0
+
+
+def _handle_workspace_reset() -> int:
+    """Clear the saved shared workspace preference without deleting files."""
+    try:
+        was_cleared = clear_saved_workspace_root()
+        workspace_root = resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return 1
+
+    if was_cleared:
+        print("Saved PDS workspace preference cleared.")
+    else:
+        print("No saved PDS workspace preference was set.")
+    print("No workspace files were deleted.")
+    print()
+    print("Current resolved PDS workspace root:")
+    print(workspace_root)
+    print()
+    print("If PDS_WORKSPACE_ROOT is set, it still takes precedence.")
     return 0
 
 

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -7,6 +7,8 @@ import sys
 from collections.abc import Callable
 
 WorkspaceShowHandler = Callable[[], int]
+WorkspaceSetHandler = Callable[[str], int]
+WorkspaceActionHandler = Callable[[], int]
 
 
 def clear_screen() -> None:
@@ -52,6 +54,9 @@ def print_menu_help() -> None:
     print("  quillan validate-standards <standards-profile.json>")
     print("  quillan validate-assignment <assignment.json>")
     print("  quillan workspace show")
+    print("  quillan workspace set <folder>")
+    print("  quillan workspace validate")
+    print("  quillan workspace reset")
     print("  quillan menu")
 
 
@@ -89,13 +94,21 @@ def launch_printable_response_menu() -> None:
     pause_for_user()
 
 
-def launch_workspace_menu(workspace_show: WorkspaceShowHandler) -> None:
-    """Launch the read-only workspace settings submenu."""
+def launch_workspace_menu(
+    workspace_show: WorkspaceShowHandler,
+    workspace_set: WorkspaceSetHandler,
+    workspace_validate: WorkspaceActionHandler,
+    workspace_reset: WorkspaceActionHandler,
+) -> None:
+    """Launch the shared Paper Data Suite workspace settings submenu."""
     while True:
         clear_screen()
         print_menu_header("Workspace Settings")
         print("1. Show current workspace")
-        print("2. Back")
+        print("2. Set workspace folder")
+        print("3. Validate/create current workspace")
+        print("4. Reset saved workspace preference")
+        print("5. Back")
         print()
 
         choice = input("Select an option: ").strip()
@@ -108,14 +121,44 @@ def launch_workspace_menu(workspace_show: WorkspaceShowHandler) -> None:
             print()
             pause_for_user()
         elif choice == "2":
+            clear_screen()
+            print_menu_header("Set Workspace Folder")
+            path = input(
+                "Workspace folder (leave blank to cancel): "
+            ).strip()
+            print()
+            if path:
+                workspace_set(path)
+            else:
+                print("Workspace selection canceled. No preference was changed.")
+            print()
+            pause_for_user()
+        elif choice == "3":
+            clear_screen()
+            print_menu_header("Validate Current Workspace")
+            workspace_validate()
+            print()
+            pause_for_user()
+        elif choice == "4":
+            clear_screen()
+            print_menu_header("Reset Workspace Preference")
+            workspace_reset()
+            print()
+            pause_for_user()
+        elif choice == "5":
             return
         else:
-            print("Invalid selection. Please enter 1 or 2.")
+            print("Invalid selection. Please enter a number from 1 to 5.")
             print()
             pause_for_user()
 
 
-def launch_menu(workspace_show: WorkspaceShowHandler) -> int:
+def launch_menu(
+    workspace_show: WorkspaceShowHandler,
+    workspace_set: WorkspaceSetHandler,
+    workspace_validate: WorkspaceActionHandler,
+    workspace_reset: WorkspaceActionHandler,
+) -> int:
     """Launch the Quillan teacher-facing menu skeleton."""
     try:
         while True:
@@ -139,7 +182,12 @@ def launch_menu(workspace_show: WorkspaceShowHandler) -> int:
             elif choice == "3":
                 launch_printable_response_menu()
             elif choice == "4":
-                launch_workspace_menu(workspace_show)
+                launch_workspace_menu(
+                    workspace_show,
+                    workspace_set,
+                    workspace_validate,
+                    workspace_reset,
+                )
             elif choice == "5":
                 clear_screen()
                 print_menu_help()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,9 @@ def test_cli_prints_help(
 
     assert workspace_error.value.code == 0
     assert "show" in workspace_help.out
+    assert "set" in workspace_help.out
+    assert "validate" in workspace_help.out
+    assert "reset" in workspace_help.out
 
 
 def test_cli_without_command_displays_menu_options_and_exits(
@@ -255,6 +258,136 @@ def test_workspace_show_reports_workspace_error(
     assert "Error: bad workspace" in capsys.readouterr().out
 
 
+def test_workspace_set_validates_and_saves_shared_root(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_root = tmp_path / "requested-workspace"
+    calls: list[tuple[str, Path]] = []
+
+    def ensure(path: str | Path) -> Path:
+        root = Path(path)
+        root.mkdir(parents=True)
+        calls.append(("ensure", root))
+        return root
+
+    def save(path: str | Path) -> Path:
+        root = Path(path)
+        calls.append(("save", root))
+        return root
+
+    monkeypatch.setattr(quillan.cli, "ensure_workspace_root", ensure)
+    monkeypatch.setattr(quillan.cli, "save_workspace_root", save)
+
+    assert main(["workspace", "set", str(requested_root)]) == 0
+    output = capsys.readouterr().out
+
+    assert calls == [("ensure", requested_root), ("save", requested_root)]
+    assert requested_root.is_dir()
+    assert str(requested_root) in output
+    assert "does not move existing Quillan or Paper Data Suite files" in output
+    assert "PDS_WORKSPACE_ROOT" in output
+    assert "takes precedence" in output
+
+
+def test_workspace_validate_uses_current_resolved_root(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved_root = tmp_path / "active-workspace"
+    calls: list[Path] = []
+
+    monkeypatch.setattr(
+        quillan.cli,
+        "resolve_workspace_root",
+        lambda: resolved_root,
+    )
+
+    def ensure(path: str | Path) -> Path:
+        root = Path(path)
+        root.mkdir(parents=True)
+        calls.append(root)
+        return root
+
+    monkeypatch.setattr(quillan.cli, "ensure_workspace_root", ensure)
+
+    assert main(["workspace", "validate"]) == 0
+    output = capsys.readouterr().out
+
+    assert calls == [resolved_root]
+    assert resolved_root.is_dir()
+    assert "Workspace validated successfully" in output
+    assert str(resolved_root) in output
+
+
+@pytest.mark.parametrize(
+    ("was_cleared", "expected_message"),
+    [
+        (True, "Saved PDS workspace preference cleared."),
+        (False, "No saved PDS workspace preference was set."),
+    ],
+)
+def test_workspace_reset_clears_only_saved_preference(
+    was_cleared: bool,
+    expected_message: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved_root = tmp_path / "resolved-after-reset"
+    existing_file = tmp_path / "workspace-file.txt"
+    existing_file.write_text("keep me", encoding="utf-8")
+    calls = 0
+
+    def clear() -> bool:
+        nonlocal calls
+        calls += 1
+        return was_cleared
+
+    monkeypatch.setattr(quillan.cli, "clear_saved_workspace_root", clear)
+    monkeypatch.setattr(
+        quillan.cli,
+        "resolve_workspace_root",
+        lambda: resolved_root,
+    )
+
+    assert main(["workspace", "reset"]) == 0
+    output = capsys.readouterr().out
+
+    assert calls == 1
+    assert existing_file.read_text(encoding="utf-8") == "keep me"
+    assert expected_message in output
+    assert "No workspace files were deleted." in output
+    assert str(resolved_root) in output
+    assert "PDS_WORKSPACE_ROOT" in output
+    assert "takes precedence" in output
+
+
+@pytest.mark.parametrize(
+    ("command", "patched_name"),
+    [
+        (["workspace", "set", "bad-root"], "ensure_workspace_root"),
+        (["workspace", "validate"], "resolve_workspace_root"),
+        (["workspace", "reset"], "clear_saved_workspace_root"),
+    ],
+)
+def test_workspace_commands_report_workspace_errors(
+    command: list[str],
+    patched_name: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail(*_args: object) -> object:
+        raise WorkspaceRootError("bad workspace")
+
+    monkeypatch.setattr(quillan.cli, patched_name, fail)
+
+    assert main(command) != 0
+    assert "Error: bad workspace" in capsys.readouterr().out
+
+
 def test_menu_dispatch_displays_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -328,7 +461,7 @@ def test_workspace_menu_reuses_workspace_show_handler(
         return 0
 
     monkeypatch.setattr(quillan.cli, "_handle_workspace_show", handle_workspace_show)
-    _menu_input(monkeypatch, ["4", "1", "", "2", "6"])
+    _menu_input(monkeypatch, ["4", "1", "", "5", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -336,7 +469,116 @@ def test_workspace_menu_reuses_workspace_show_handler(
     assert calls == 1
     assert "Workspace Settings" in output
     assert "Show current workspace" in output
+    assert "Set workspace folder" in output
+    assert "Validate/create current workspace" in output
+    assert "Reset saved workspace preference" in output
+    assert "Back" in output
     assert "Synthetic workspace status" in output
+
+
+def test_workspace_menu_sets_workspace_folder(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "menu-workspace"
+    calls: list[str] = []
+
+    def handle_workspace_set(path: str | Path) -> int:
+        calls.append(str(path))
+        print(f"Saved PDS workspace root:\n{path}")
+        print("This does not move existing Quillan or Paper Data Suite files.")
+        print("PDS_WORKSPACE_ROOT still takes precedence.")
+        return 0
+
+    monkeypatch.setattr(quillan.cli, "_handle_workspace_set", handle_workspace_set)
+    _menu_input(monkeypatch, ["4", "2", str(workspace_root), "", "5", "6"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+
+    assert calls == [str(workspace_root)]
+    assert str(workspace_root) in output
+    assert "does not move existing Quillan or Paper Data Suite files" in output
+    assert "PDS_WORKSPACE_ROOT" in output
+    assert "takes precedence" in output
+
+
+def test_workspace_menu_blank_set_cancels_without_change(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def handle_workspace_set(_path: str | Path) -> int:
+        nonlocal calls
+        calls += 1
+        return 0
+
+    monkeypatch.setattr(quillan.cli, "_handle_workspace_set", handle_workspace_set)
+    _menu_input(monkeypatch, ["4", "2", "  ", "", "5", "6"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+
+    assert calls == 0
+    assert "canceled" in output
+    assert "No preference was changed" in output
+
+
+def test_workspace_menu_validates_current_workspace(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def handle_workspace_validate() -> int:
+        nonlocal calls
+        calls += 1
+        print("Workspace validated successfully")
+        return 0
+
+    monkeypatch.setattr(
+        quillan.cli,
+        "_handle_workspace_validate",
+        handle_workspace_validate,
+    )
+    _menu_input(monkeypatch, ["4", "3", "", "5", "6"])
+
+    assert main(["menu"]) == 0
+    assert calls == 1
+    assert "Workspace validated successfully" in capsys.readouterr().out
+
+
+def test_workspace_menu_resets_saved_preference(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def handle_workspace_reset() -> int:
+        nonlocal calls
+        calls += 1
+        print("Saved PDS workspace preference cleared.")
+        print("No workspace files were deleted.")
+        print("Current resolved PDS workspace root: synthetic")
+        print("PDS_WORKSPACE_ROOT still takes precedence.")
+        return 0
+
+    monkeypatch.setattr(
+        quillan.cli,
+        "_handle_workspace_reset",
+        handle_workspace_reset,
+    )
+    _menu_input(monkeypatch, ["4", "4", "", "5", "6"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+
+    assert calls == 1
+    assert "No workspace files were deleted" in output
+    assert "Current resolved PDS workspace root" in output
+    assert "PDS_WORKSPACE_ROOT" in output
 
 
 def test_menu_handles_keyboard_interrupt(


### PR DESCRIPTION
## Summary

- Added Workspace Settings menu support for showing, setting, validating/creating, and resetting the shared PDS workspace root.
- Added direct workspace commands for `show`, `set`, `validate`, and `reset`.
- Used shared `pds-core` workspace APIs without introducing Quillan-specific workspace configuration.
- Added teacher-facing warnings that setting a workspace does not migrate files and resetting a saved preference does not delete files.
- Documented that `PDS_WORKSPACE_ROOT` still takes precedence over saved workspace preferences.
- Updated tests for workspace set, validate/create, reset, and menu behavior.

Closes #39.

## Validation

- [x] `python -m pytest` — 184 tests passed
- [x] `python -m ruff check .`
- [x] `python -m mypy .`
- [x] `git diff --check`
- [x] `.\run_tests.ps1`

## Notes

- Uses shared `pds-core` workspace behavior.
- No Quillan-specific workspace config added.
- No school-year settings added.
- No assignment, roster, printable-response, scan, OCR, AI, grading, feedback, or reporting workflow added.
- No schemas changed.
- No data contracts changed.
- No PDS1 payload behavior changed.
- No printable response generation behavior changed.
- No generated PDFs, scans, real user config files, private files, or classroom artifacts committed.
- No sibling repositories modified.