### PR TITLE
Add Quillan roster management menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a teacher-facing Roster Management menu for creating, viewing, staged
+  editing, and validating canonical shared `pds-core` class rosters.
+- Added preservation of leading-zero student IDs and existing optional roster
+  columns, with explicit `SAVE`, `DISCARD`, `REMOVE`, and overwrite
+  confirmations.
 - Added a full Workspace Settings menu and matching direct commands for
   showing, setting, validating/creating, and resetting the shared Paper Data
   Suite workspace root through `pds-core`.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Quillan currently supports:
   response pages;
 - roster-aware printable response generation using shared `pds-core` roster
   records and display-name helpers;
+- teacher-facing class roster creation, viewing, staged editing, and validation
+  through the Roster Management menu;
 - shared Paper Data Suite workspace status reporting;
 - assignment-local storage paths based on shared `pds-core` route helpers; and
 - synthetic examples and fixtures for safe testing and documentation.
@@ -50,12 +52,12 @@ particular, Quillan does not currently provide:
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
-- assignment creation and roster management workflows;
+- assignment creation workflows;
 - implemented requirements-checking, tagging, scoring, feedback, or
   production reporting workflows;
 - AI tagging, AI scoring, or AI feedback;
 - automatic grading; or
-- complete teacher-facing assignment, roster, printable-response, or review
+- complete teacher-facing assignment, printable-response, or review
   workflows; or
 - a dedicated printable-response command.
 
@@ -140,6 +142,19 @@ helpers. Canonical roster columns are `class_id`, `student_id`, `last_name`,
 `first_name`, and `period`; student IDs remain strings so leading zeros are
 preserved.
 
+The Roster Management menu creates and reads canonical shared rosters at:
+
+```text
+<PDS workspace root>/classes/<class_id>/roster.csv
+```
+
+Existing optional columns are displayed and preserved when students are
+added, edited, or removed. Edits remain in memory until the teacher types
+`SAVE`; canceling changed data requires `DISCARD`. Removing a student changes
+only the active roster and does not delete assignments, submissions,
+printable PDFs, scans, reports, tags, scores, feedback, or historical
+evidence.
+
 Quillan also consumes the shared PDS1 payload conventions and helpers from
 `pds-core`. Each generated response page embeds a QR code containing a
 canonical payload such as:
@@ -161,11 +176,11 @@ quillan
 
 `quillan menu` launches the same menu as an explicit alias.
 
-The menu currently provides honest placeholders for assignment management,
-roster management, and printable response pages. Its Workspace Settings
-section can show, set, validate/create, and reset the shared Paper Data Suite
-workspace root. Its help summarizes Quillan's teacher-controlled purpose and
-safe-data expectations.
+The menu provides class roster creation, viewing, staged editing, and
+validation through Roster Management. Assignment Management and Printable
+Response Pages remain honest placeholders. Workspace Settings can show, set,
+validate/create, and reset the shared Paper Data Suite workspace root. Help
+summarizes Quillan's teacher-controlled purpose and safe-data expectations.
 
 Show direct CLI help:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -12,7 +12,8 @@ development. It records:
   CLI.
 
 The CLI includes a developer-oriented, scriptable command layer and an initial
-teacher-facing menu skeleton. It is not a complete teacher-facing application.
+teacher-facing menu with shared-roster management. It is not a complete
+teacher-facing application.
 This contract describes implemented behavior separately from future design. A
 command or workflow documented elsewhere as planned is not part of the current
 CLI until it is implemented, tested, and added here.
@@ -197,11 +198,31 @@ The menu provides:
 6. Exit
 ```
 
-Assignment Management and Roster Management state that their workflows are not
-implemented yet. Printable Response Pages states that PDF generation exists as
-a Python API but has no teacher-facing menu workflow yet. These sections do not
-prompt for files or create, edit, generate, route, review, score, or report
-data.
+Roster Management provides:
+
+```text
+1. Create class roster
+2. View class roster
+3. Edit class roster
+4. Validate class roster
+5. Back
+```
+
+These menu-only workflows use shared `pds-core` class and roster APIs.
+Canonical rosters are stored at
+`<workspace_root>/classes/<class_id>/roster.csv`. Student IDs remain strings,
+including leading zeros, and existing optional columns remain in their
+original order. Viewing and validation are read-only.
+
+Editing stages shared immutable roster mutations in memory. Add, edit, and
+active-roster removal do not write immediately. Saving requires typing
+`SAVE`; canceling staged changes requires typing `DISCARD`. Active-roster
+removal never deletes assignments, submissions, printable PDFs, scans,
+reports, tags, scores, feedback, or historical evidence.
+
+Assignment Management states that its workflow is not implemented yet.
+Printable Response Pages states that PDF generation exists as a Python API but
+has no teacher-facing menu workflow yet.
 
 Workspace Settings provides:
 
@@ -386,7 +407,7 @@ explicitly outside the current end-to-end foundation:
 * requirements checking, tagging, scoring, feedback, and reporting
   workflows;
 * AI grading, scoring, tagging, or feedback; and
-* complete teacher-facing assignment, roster, printable-response, submission
+* complete teacher-facing assignment, printable-response, submission
   review, tagging, scoring, feedback, or reporting workflows.
 
 Their presence in design documents or Python modules does not add them to the

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -313,8 +313,9 @@ Printable response generation consumes validated `pds-core` roster records.
 The shared roster fields are `class_id`, `student_id`, `last_name`,
 `first_name`, and `period`. Roster student IDs remain strings, including
 leading zeros, and visible names use the shared student display helper.
-Quillan consumes these records for generation; it does not yet provide a
-teacher-facing roster management workflow.
+Quillan consumes these records for generation and provides teacher-facing
+creation, viewing, staged editing, and validation through the Roster
+Management menu.
 
 Example:
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -17,6 +17,8 @@ Quillan currently has:
 * synthetic example files;
 * standards profile loading and validation;
 * initial CLI support;
+* teacher-facing shared-roster creation, viewing, staged editing, and
+  validation;
 * automated tests for standards validation and CLI behavior;
 * configured development checks using `pytest`, `ruff`, and `mypy`.
 
@@ -131,11 +133,13 @@ Current status:
 
 ### `classes.py`
 
-Planned responsibility:
+Shared responsibility is implemented through `pds-core` class and roster
+contracts plus Quillan's `roster_workflows.py` menu orchestration:
 
-* load class metadata;
-* connect class IDs to rosters;
-* eventually integrate with shared Paper Data Suite class structures.
+* discover canonical class folders;
+* create, load, edit, and validate `classes/<class_id>/roster.csv`;
+* preserve leading-zero IDs and optional columns; and
+* stage edits until explicit save without deleting historical evidence.
 
 ### `assignments.py`
 
@@ -286,6 +290,7 @@ Completed work:
 * Add `validate-standards` command.
 * Add the initial bare `quillan` menu entry point, explicit `quillan menu`
   alias, and navigation skeleton.
+* Add the Roster Management submenu using shared `pds-core` contracts.
 * Add CLI tests.
 
 Remaining possible work:

--- a/docs/printable_response_template.md
+++ b/docs/printable_response_template.md
@@ -196,7 +196,7 @@ without inspecting PDF drawing coordinates.
 `generate_printable_responses_for_roster()` loads shared `pds-core` roster
 records with `class_id`, `student_id`, `last_name`, `first_name`, and `period`.
 Student IDs remain strings so leading zeros are preserved. This API support
-does not provide a teacher-facing roster management workflow.
+is complemented by a teacher-facing Roster Management menu.
 
 ## Privacy and Synthetic Data
 
@@ -253,7 +253,7 @@ This contract does not implement or define:
 * requirements checking, tagging, scoring, feedback, or reporting;
 * AI tagging, scoring, feedback, or automatic grading; or
 * a dedicated printable-response CLI or menu workflow;
-* assignment creation or roster management workflows; or
+* assignment creation workflows; or
 * workspace configuration workflows.
 
 The field-level PDS1 contract remains documented in

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -138,9 +138,9 @@ Validation should happen before filesystem writes and in the following order.
    that escapes the root, including through traversal or filesystem links.
 
 Student roster membership is not an initial routing prerequisite. Quillan
-already consumes shared `pds-core` roster records for printable generation,
-but it does not provide a production teacher-facing roster management
-workflow. A future roster-aware routing phase may flag an unknown student for
+consumes and manages shared `pds-core` roster records, but roster membership
+does not alter the routing contract described here. A future roster-aware
+routing phase may flag an unknown student for
 review, but it must preserve the source evidence rather than infer a different
 identity. The student identifier must still be valid.
 

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -41,6 +41,7 @@ The expected current and reserved layout is:
   routing_review/
   classes/
     <class_id>/
+      roster.csv
       assignments/
         <assignment_id>/
           assignment.json
@@ -68,6 +69,19 @@ reserved locations for future workflows. A directory does not need to exist
 until a workflow has a reason to create it.
 
 ## File Responsibilities
+
+### `roster.csv`
+
+The canonical active class roster uses the shared `pds-core` roster contract.
+Quillan's Roster Management menu can create, view, edit, and validate this
+file. Required columns are `class_id`, `student_id`, `last_name`,
+`first_name`, and `period`; optional columns are preserved. Leading-zero
+student IDs remain strings. Menu edits are staged until explicit `SAVE`, and
+discarded edits are not written.
+
+Removing a student from this active roster does not delete or modify
+assignments, submissions, printable PDFs, scans, reports, tags, scores,
+feedback, or historical evidence.
 
 ### `assignment.json`
 

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -72,14 +72,10 @@ def launch_assignment_menu() -> None:
 
 
 def launch_roster_menu() -> None:
-    """Display the current roster-management boundary."""
-    clear_screen()
-    print_menu_header("Roster Management")
-    print("Roster management workflows are not implemented yet.")
-    print("Quillan currently consumes shared pds-core roster records for printable")
-    print("response generation, but it does not provide roster management.")
-    print()
-    pause_for_user()
+    """Launch shared-roster teacher workflows."""
+    from quillan.roster_workflows import launch_roster_menu as launch
+
+    launch()
 
 
 def launch_printable_response_menu() -> None:

--- a/quillan/roster_workflows.py
+++ b/quillan/roster_workflows.py
@@ -1,0 +1,519 @@
+"""Teacher-facing workflows for shared Paper Data Suite class rosters."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from pds_core.classes import (
+    ClassFolder,
+    list_class_folders,
+    load_class_roster,
+    write_class_roster,
+)
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.rosters import (
+    ROSTER_REQUIRED_COLUMNS,
+    Roster,
+    RosterError,
+    RosterValidationError,
+    StudentRecord,
+    add_student_record,
+    create_roster,
+    load_roster,
+    remove_student_record,
+    replace_student_record,
+)
+from pds_core.routes import class_roster_path
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+_REQUIRED_STUDENT_FIELDS = ("student_id", "last_name", "first_name", "period")
+
+
+def optional_roster_columns(roster: Roster) -> tuple[str, ...]:
+    """Return existing optional columns in their shared-roster order."""
+    return tuple(
+        column for column in roster.columns if column not in ROSTER_REQUIRED_COLUMNS
+    )
+
+
+def format_roster_for_display(roster: Roster, roster_path: str | Path) -> str:
+    """Return a readable roster summary including all roster columns."""
+    columns = tuple(
+        column for column in roster.columns if column != "class_id"
+    )
+    rows = [
+        {
+            "student_id": student.student_id,
+            "last_name": student.last_name,
+            "first_name": student.first_name,
+            "period": student.period,
+            **student.extra_fields,
+        }
+        for student in roster.students
+    ]
+    widths = {
+        column: max(
+            len(column),
+            *(len(row.get(column, "")) for row in rows),
+        )
+        for column in columns
+    }
+    lines = [
+        f"Class ID: {roster.class_id}",
+        f"Roster path: {Path(roster_path)}",
+        f"Student count: {len(roster.students)}",
+        "",
+        "  ".join(column.ljust(widths[column]) for column in columns),
+    ]
+    lines.extend(
+        "  ".join(row.get(column, "").ljust(widths[column]) for column in columns)
+        for row in rows
+    )
+    return "\n".join(lines)
+
+
+def student_record_from_values(
+    roster: Roster,
+    student_id: str,
+    values: Mapping[str, str],
+) -> StudentRecord:
+    """Build a student record while preserving the roster's optional schema."""
+    return StudentRecord(
+        class_id=roster.class_id,
+        student_id=student_id.strip(),
+        last_name=values["last_name"].strip(),
+        first_name=values["first_name"].strip(),
+        period=values["period"].strip(),
+        extra_fields={
+            column: values.get(column, "").strip()
+            for column in optional_roster_columns(roster)
+        },
+    )
+
+
+def create_class_roster(
+    workspace_root: str | Path,
+    class_id: str,
+    students: Sequence[Mapping[str, str]],
+    *,
+    overwrite: bool = False,
+) -> tuple[Roster, Path]:
+    """Create and write a validated roster at its canonical shared path."""
+    roster = create_roster(class_id, students)
+    path = write_class_roster(workspace_root, roster, overwrite=overwrite)
+    return roster, path
+
+
+def validate_roster_file(path: str | Path) -> Roster:
+    """Load an explicit roster path through shared validation without writing."""
+    return load_roster(path)
+
+
+def print_roster_validation_error(error: Exception) -> None:
+    """Print expected shared roster errors without a traceback."""
+    print(f"Error: {error}")
+    if isinstance(error, RosterValidationError):
+        for issue in error.issues:
+            location: list[str] = []
+            if issue.row_number is not None:
+                location.append(f"row {issue.row_number}")
+            if issue.column:
+                location.append(f"column {issue.column}")
+            prefix = f"  {' / '.join(location)}: " if location else "  "
+            print(f"{prefix}[{issue.code}] {issue.message}")
+
+
+def suggest_class_id(class_label: str) -> str:
+    """Suggest a conservative shared identifier from a teacher-facing label."""
+    normalized = unicodedata.normalize("NFKD", class_label)
+    ascii_label = normalized.encode("ascii", "ignore").decode("ascii")
+    suggestion = re.sub(r"[^A-Za-z0-9_-]+", "_", ascii_label.strip())
+    return suggestion.strip("_-").lower()
+
+
+def _workspace_root() -> Path | None:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return None
+
+
+def _available_class_folders(workspace_root: Path) -> tuple[ClassFolder, ...]:
+    return list_class_folders(workspace_root, require_roster=True)
+
+
+def _prompt_class_folder(
+    workspace_root: Path,
+    action: str,
+) -> ClassFolder | None:
+    folders = _available_class_folders(workspace_root)
+    if not folders:
+        print("No class rosters found.")
+        print("Create a class roster first, then return to this option.")
+        return None
+
+    print("Available classes:")
+    for index, folder in enumerate(folders, start=1):
+        print(f"{index}. {folder.class_id}")
+    print()
+    selection = input(f"Select class to {action}: ").strip()
+    if selection.isdigit() and 1 <= int(selection) <= len(folders):
+        return folders[int(selection) - 1]
+    for folder in folders:
+        if folder.class_id == selection:
+            return folder
+    print(f"Error: Class not found: {selection}")
+    return None
+
+
+def _prompt_required(field_name: str, *, default: str | None = None) -> str:
+    while True:
+        suffix = f" [{default}]" if default is not None else ""
+        value = input(f"  {field_name}{suffix}: ").strip()
+        if value:
+            return value
+        if default is not None:
+            return default
+        print(f"  Error: {field_name} is required.")
+
+
+def _print_student_choices(roster: Roster) -> None:
+    for index, student in enumerate(roster.students, start=1):
+        print(
+            f"{index}. {student.student_id} - "
+            f"{student.last_name}, {student.first_name} "
+            f"(period {student.period})"
+        )
+
+
+def prompt_student_selection(roster: Roster, prompt: str) -> StudentRecord:
+    """Select a student by visible number or exact string student ID."""
+    selection = input(prompt).strip()
+    if selection.isdigit():
+        index = int(selection)
+        if 1 <= index <= len(roster.students):
+            return roster.students[index - 1]
+    for student in roster.students:
+        if student.student_id == selection:
+            return student
+    raise ValueError(f"Student not found: {selection}")
+
+
+def prompt_add_student_to_roster(roster: Roster) -> Roster:
+    """Prompt for and stage one shared roster addition."""
+    print("Add student")
+    values = {
+        field: _prompt_required(field)
+        for field in _REQUIRED_STUDENT_FIELDS
+    }
+    for column in optional_roster_columns(roster):
+        values[column] = input(f"  {column} (optional): ").strip()
+    student = student_record_from_values(roster, values["student_id"], values)
+    return add_student_record(roster, student)
+
+
+def prompt_edit_student_in_roster(roster: Roster) -> Roster:
+    """Prompt for and stage replacement of one stable student identity."""
+    print("Edit student")
+    _print_student_choices(roster)
+    student = prompt_student_selection(
+        roster,
+        "Select student by number or student_id: ",
+    )
+    print(f"student_id: {student.student_id} (cannot be changed)")
+    print("Press Enter to keep the current value.")
+    values = {
+        "last_name": _prompt_required("last_name", default=student.last_name),
+        "first_name": _prompt_required("first_name", default=student.first_name),
+        "period": _prompt_required("period", default=student.period),
+    }
+    for column in optional_roster_columns(roster):
+        current = student.extra_fields.get(column, "")
+        entered = input(f"  {column} [{current}]: ").strip()
+        values[column] = entered or current
+    replacement = student_record_from_values(roster, student.student_id, values)
+    return replace_student_record(roster, replacement)
+
+
+def prompt_remove_student_from_roster(roster: Roster) -> Roster:
+    """Prompt for and stage active-roster removal only."""
+    print("Remove student from active roster")
+    _print_student_choices(roster)
+    student = prompt_student_selection(
+        roster,
+        "Select student by number or student_id: ",
+    )
+    print(
+        f"Selected: {student.student_id} - "
+        f"{student.last_name}, {student.first_name} "
+        f"(period {student.period})"
+    )
+    print(
+        "Removing a student from the active roster does not delete assignments, "
+        "submissions, printable PDFs, scans, reports, tags, scores, feedback, "
+        "or historical evidence."
+    )
+    confirmation = input("Type REMOVE to remove from active roster: ").strip()
+    if confirmation != "REMOVE":
+        print("Canceled: removal not confirmed.")
+        return roster
+    return remove_student_record(roster, student.student_id)
+
+
+def prompt_create_roster() -> int:
+    """Create a canonical shared class roster from teacher prompts."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Create Class Roster")
+    class_label = input("Class name or label: ").strip()
+    if not class_label:
+        print("Error: class name or label is required.")
+        return 1
+
+    suggestion = suggest_class_id(class_label)
+    if suggestion:
+        print(f"Suggested class_id: {suggestion}")
+        class_id = input(
+            "Press Enter to accept, or type a different class_id: "
+        ).strip() or suggestion
+    else:
+        class_id = input("Enter class_id: ").strip()
+
+    try:
+        validate_identifier(class_id, "class_id")
+    except IdentifierValidationError as error:
+        print(f"Error: {error}")
+        return 1
+
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    output_path = class_roster_path(workspace_root, class_id)
+    overwrite = False
+    if output_path.exists():
+        print(f"Roster already exists for class '{class_id}':")
+        print(output_path)
+        confirmation = input("Type OVERWRITE to replace it: ").strip()
+        if confirmation != "OVERWRITE":
+            print("Canceled: existing roster was not changed.")
+            return 1
+        overwrite = True
+
+    period = _prompt_required("period")
+    students: list[dict[str, str]] = []
+    print()
+    print("Enter students one at a time.")
+    while True:
+        print(f"Student #{len(students) + 1}:")
+        student_id = input("  student_id (blank when finished): ").strip()
+        if not student_id:
+            if not students:
+                print("  Error: at least one student is required.")
+                continue
+            break
+        last_name = _prompt_required("last_name")
+        first_name = _prompt_required("first_name")
+        students.append(
+            {
+                "student_id": student_id,
+                "last_name": last_name,
+                "first_name": first_name,
+                "period": period,
+            }
+        )
+        print(f"  Staged: {student_id} - {last_name}, {first_name}")
+
+    try:
+        roster, saved_path = create_class_roster(
+            workspace_root,
+            class_id,
+            students,
+            overwrite=overwrite,
+        )
+    except RosterError as error:
+        print_roster_validation_error(error)
+        return 1
+    print(f"Created roster with {len(roster.students)} students:")
+    print(saved_path)
+    return 0
+
+
+def prompt_view_roster() -> int:
+    """Display one canonical class roster without modifying it."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("View Class Roster")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    folder = _prompt_class_folder(workspace_root, "view")
+    if folder is None:
+        return 1
+    try:
+        roster = load_class_roster(workspace_root, folder.class_id)
+    except RosterError as error:
+        print_roster_validation_error(error)
+        return 1
+    print()
+    print(format_roster_for_display(roster, folder.roster_path))
+    return 0
+
+
+def prompt_edit_class_roster() -> int:
+    """Stage roster mutations and write only after explicit SAVE."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Edit Class Roster")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    folder = _prompt_class_folder(workspace_root, "edit")
+    if folder is None:
+        return 1
+    try:
+        staged_roster = load_class_roster(workspace_root, folder.class_id)
+    except RosterError as error:
+        print_roster_validation_error(error)
+        return 1
+
+    dirty = False
+    print()
+    print(format_roster_for_display(staged_roster, folder.roster_path))
+    while True:
+        print()
+        print("Edit menu")
+        print("1. Add student")
+        print("2. Edit student")
+        print("3. Remove student from active roster")
+        print("4. View current roster")
+        print("5. Save changes")
+        print("6. Cancel without saving")
+        print()
+        choice = input("Select an option: ").strip()
+        print()
+
+        try:
+            if choice == "1":
+                staged_roster = prompt_add_student_to_roster(staged_roster)
+                dirty = True
+                print("Staged: student added.")
+            elif choice == "2":
+                staged_roster = prompt_edit_student_in_roster(staged_roster)
+                dirty = True
+                print("Staged: student updated.")
+            elif choice == "3":
+                updated = prompt_remove_student_from_roster(staged_roster)
+                if updated is not staged_roster:
+                    staged_roster = updated
+                    dirty = True
+                    print("Staged: student removed from active roster.")
+            elif choice == "4":
+                print(format_roster_for_display(staged_roster, folder.roster_path))
+                if dirty:
+                    print("\nUnsaved staged changes are shown above.")
+            elif choice == "5":
+                if not dirty:
+                    print("No changes to save.")
+                    return 0
+                confirmation = input(
+                    "Type SAVE to write staged changes: "
+                ).strip()
+                if confirmation != "SAVE":
+                    print("Canceled: save not confirmed.")
+                    continue
+                saved_path = write_class_roster(
+                    workspace_root,
+                    staged_roster,
+                    overwrite=True,
+                )
+                print(f"Saved roster: {saved_path}")
+                return 0
+            elif choice == "6":
+                if dirty:
+                    confirmation = input(
+                        "Type DISCARD to discard staged changes: "
+                    ).strip()
+                    if confirmation != "DISCARD":
+                        print("Canceled: staged changes were not discarded.")
+                        continue
+                print("Canceled: no roster changes were saved.")
+                return 0
+            else:
+                print("Invalid selection. Please enter a number from 1 to 6.")
+        except (RosterError, ValueError) as error:
+            print_roster_validation_error(error)
+
+
+def _normalize_path_input(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in "'\"":
+        return stripped[1:-1]
+    return stripped
+
+
+def prompt_validate_roster() -> int:
+    """Validate an explicit roster CSV without rewriting it."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Validate Class Roster")
+    roster_path = _normalize_path_input(input("Roster CSV path: "))
+    if not roster_path:
+        print("Error: roster CSV path is required.")
+        return 1
+    try:
+        roster = validate_roster_file(roster_path)
+    except RosterError as error:
+        print_roster_validation_error(error)
+        return 1
+    print("Roster file is valid.")
+    print(f"Class ID: {roster.class_id}")
+    print(f"Student count: {len(roster.students)}")
+    print("First students:")
+    for student in roster.students[:5]:
+        print(
+            f"  {student.student_id}: "
+            f"{student.last_name}, {student.first_name}"
+        )
+    return 0
+
+
+def launch_roster_menu() -> int:
+    """Launch the teacher-facing roster management submenu."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Roster Management")
+            print("1. Create class roster")
+            print("2. View class roster")
+            print("3. Edit class roster")
+            print("4. Validate class roster")
+            print("5. Back")
+            print()
+            choice = input("Select an option: ").strip()
+            print()
+
+            if choice == "5":
+                return 0
+            workflows = {
+                "1": prompt_create_roster,
+                "2": prompt_view_roster,
+                "3": prompt_edit_class_roster,
+                "4": prompt_validate_roster,
+            }
+            workflow = workflows.get(choice)
+            if workflow is None:
+                print("Invalid selection. Please enter a number from 1 to 5.")
+            else:
+                clear_screen()
+                workflow()
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting roster menu.")
+        return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -429,7 +429,6 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     ("selection", "expected_message"),
     [
         ("1", "Assignment management workflows are not implemented yet."),
-        ("2", "Roster management workflows are not implemented yet."),
         (
             "3",
             "teacher-facing menu workflow is not implemented yet.",
@@ -446,6 +445,23 @@ def test_unsupported_menu_sections_are_honest_placeholders(
 
     assert main(["menu"]) == 0
     assert expected_message in capsys.readouterr().out
+
+
+def test_main_menu_opens_roster_management_submenu(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["2", "5", "6"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Roster Management" in output
+    assert "Create class roster" in output
+    assert "View class roster" in output
+    assert "Edit class roster" in output
+    assert "Validate class roster" in output
+    assert "Back" in output
+    assert "Goodbye." in output
 
 
 def test_workspace_menu_reuses_workspace_show_handler(

--- a/tests/test_roster_workflows.py
+++ b/tests/test_roster_workflows.py
@@ -1,0 +1,372 @@
+"""Tests for Quillan's shared-roster teacher workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from pds_core.classes import load_class_roster, write_class_roster
+from pds_core.rosters import (
+    Roster,
+    RosterValidationError,
+    StudentRecord,
+    add_student_record,
+    create_roster,
+    remove_student_record,
+    replace_student_record,
+)
+import pytest
+
+import quillan.roster_workflows as workflows
+
+
+def _roster(class_id: str = "synthetic_class") -> Roster:
+    return create_roster(
+        class_id,
+        [
+            {
+                "student_id": "0012",
+                "last_name": "Example",
+                "first_name": "Avery",
+                "period": "3",
+                "preferred_name": "Ari",
+                "notes": "synthetic",
+            },
+            {
+                "student_id": "0042",
+                "last_name": "Sample",
+                "first_name": "Morgan",
+                "period": "3",
+                "preferred_name": "",
+                "notes": "",
+            },
+        ],
+    )
+
+
+def _inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[str],
+) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError("Workflow requested unexpected input.") from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def test_create_class_roster_uses_canonical_path_and_preserves_zero_id(
+    tmp_path: Path,
+) -> None:
+    roster, path = workflows.create_class_roster(
+        tmp_path,
+        "english_12_p3",
+        [
+            {
+                "student_id": "0007",
+                "last_name": "Synthetic",
+                "first_name": "Jordan",
+                "period": "3",
+            }
+        ],
+    )
+
+    assert path == tmp_path / "classes" / "english_12_p3" / "roster.csv"
+    assert roster.students[0].student_id == "0007"
+    assert load_class_roster(tmp_path, "english_12_p3").students[0].student_id == "0007"
+
+
+def test_prompt_create_roster_writes_canonical_roster_and_preserves_zero_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "English 10 Period 2",
+            "",
+            "2",
+            "0008",
+            "Synthetic",
+            "Riley",
+            "",
+        ],
+    )
+
+    assert workflows.prompt_create_roster() == 0
+
+    class_id = "english_10_period_2"
+    roster_path = tmp_path / "classes" / class_id / "roster.csv"
+    assert roster_path.is_file()
+
+    roster = load_class_roster(tmp_path, class_id)
+    assert roster.class_id == class_id
+    assert len(roster.students) == 1
+    assert roster.students[0].student_id == "0008"
+    assert roster.students[0].last_name == "Synthetic"
+    assert roster.students[0].first_name == "Riley"
+    assert roster.students[0].period == "2"
+
+
+def test_prompt_create_roster_does_not_overwrite_without_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_class_roster(tmp_path, _roster())
+    original = load_class_roster(tmp_path, "synthetic_class")
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "Synthetic Class",
+            "",
+            "no",
+        ],
+    )
+
+    assert workflows.prompt_create_roster() == 1
+    assert load_class_roster(tmp_path, "synthetic_class") == original
+
+
+def test_format_roster_includes_required_and_optional_columns() -> None:
+    output = workflows.format_roster_for_display(
+        _roster(),
+        Path("classes/synthetic_class/roster.csv"),
+    )
+
+    assert "Student count: 2" in output
+    assert "student_id" in output
+    assert "last_name" in output
+    assert "first_name" in output
+    assert "period" in output
+    assert "preferred_name" in output
+    assert "notes" in output
+    assert "0012" in output
+
+
+def test_add_and_edit_student_preserve_optional_schema_and_values() -> None:
+    roster = _roster()
+    added = add_student_record(
+        roster,
+        workflows.student_record_from_values(
+            roster,
+            "0099",
+            {
+                "last_name": "Person",
+                "first_name": "Taylor",
+                "period": "3",
+                "preferred_name": "Tay",
+                "notes": "",
+            },
+        ),
+    )
+    edited = replace_student_record(
+        added,
+        workflows.student_record_from_values(
+            added,
+            "0012",
+            {
+                "last_name": "Example",
+                "first_name": "Avery",
+                "period": "4",
+                "preferred_name": "Ari",
+                "notes": "synthetic",
+            },
+        ),
+    )
+
+    assert edited.columns == roster.columns
+    assert edited.students[-1].extra_fields == {
+        "preferred_name": "Tay",
+        "notes": "",
+    }
+    assert edited.students[0].extra_fields == roster.students[0].extra_fields
+    assert edited.students[0].period == "4"
+
+
+def test_remove_is_in_memory_only_and_does_not_touch_evidence(
+    tmp_path: Path,
+) -> None:
+    roster = _roster()
+    evidence = (
+        tmp_path
+        / "classes"
+        / roster.class_id
+        / "assignments"
+        / "essay"
+        / "submissions"
+        / "0012"
+        / "feedback.md"
+    )
+    evidence.parent.mkdir(parents=True)
+    evidence.write_text("keep historical evidence", encoding="utf-8")
+
+    staged = remove_student_record(roster, "0012")
+
+    assert [student.student_id for student in staged.students] == ["0042"]
+    assert len(roster.students) == 2
+    assert evidence.read_text(encoding="utf-8") == "keep historical evidence"
+
+
+def test_edit_cancel_discard_does_not_write_staged_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_class_roster(tmp_path, _roster())
+    original = load_class_roster(tmp_path, "synthetic_class")
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "1",
+            "1",
+            "0099",
+            "Person",
+            "Taylor",
+            "3",
+            "Tay",
+            "",
+            "6",
+            "DISCARD",
+        ],
+    )
+
+    assert workflows.prompt_edit_class_roster() == 0
+    saved = load_class_roster(tmp_path, "synthetic_class")
+    assert saved == original
+
+
+def test_edit_save_requires_confirmation_then_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_class_roster(tmp_path, _roster())
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "1",
+            "2",
+            "1",
+            "",
+            "",
+            "4",
+            "",
+            "",
+            "5",
+            "no",
+            "5",
+            "SAVE",
+        ],
+    )
+
+    assert workflows.prompt_edit_class_roster() == 0
+    saved = load_class_roster(tmp_path, "synthetic_class")
+    assert saved.students[0].period == "4"
+    assert saved.students[0].student_id == "0012"
+    assert saved.students[0].extra_fields["preferred_name"] == "Ari"
+
+
+def test_validate_roster_summary_and_structured_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    valid_path = write_class_roster(tmp_path, _roster())
+    _inputs(monkeypatch, [str(valid_path)])
+    assert workflows.prompt_validate_roster() == 0
+    valid_output = capsys.readouterr().out
+    assert "Roster file is valid." in valid_output
+    assert "Student count: 2" in valid_output
+    assert "0012" in valid_output
+
+    invalid_path = tmp_path / "invalid.csv"
+    invalid_path.write_text(
+        "class_id,student_id,last_name,first_name,period\n"
+        "synthetic_class,0001,Example,,3\n",
+        encoding="utf-8",
+    )
+    _inputs(monkeypatch, [str(invalid_path)])
+    assert workflows.prompt_validate_roster() == 1
+    invalid_output = capsys.readouterr().out
+    assert "[blank_required_value]" in invalid_output
+    assert "row 2" in invalid_output
+    assert "column first_name" in invalid_output
+
+
+def test_shared_validation_rejects_duplicate_student_id() -> None:
+    roster = _roster()
+    duplicate = StudentRecord(
+        class_id=roster.class_id,
+        student_id="0012",
+        last_name="Duplicate",
+        first_name="Synthetic",
+        period="3",
+        extra_fields={"preferred_name": "", "notes": ""},
+    )
+
+    with pytest.raises(RosterValidationError):
+        add_student_record(roster, duplicate)
+
+
+def test_roster_menu_displays_options_and_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[str] = []
+
+    def record(name: str) -> int:
+        calls.append(name)
+        return 0
+
+    monkeypatch.setattr(
+        workflows,
+        "prompt_create_roster",
+        lambda: record("create"),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "prompt_view_roster",
+        lambda: record("view"),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "prompt_edit_class_roster",
+        lambda: record("edit"),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "prompt_validate_roster",
+        lambda: record("validate"),
+    )
+    _inputs(monkeypatch, ["1", "", "2", "", "3", "", "4", "", "5"])
+
+    assert workflows.launch_roster_menu() == 0
+    output = capsys.readouterr().out
+    assert calls == ["create", "view", "edit", "validate"]
+    assert "Create class roster" in output
+    assert "View class roster" in output
+    assert "Edit class roster" in output
+    assert "Validate class roster" in output
+    assert "Back" in output
+
+
+def test_roster_menu_invalid_selection_and_keyboard_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _inputs(monkeypatch, ["bad", "", "5"])
+    assert workflows.launch_roster_menu() == 0
+    assert "Invalid selection" in capsys.readouterr().out
+
+    def interrupt(_prompt: str = "") -> str:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", interrupt)
+    assert workflows.launch_roster_menu() == 0
+    assert "Exiting roster menu." in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Added a Quillan Roster Management menu with create, view, edit, validate, and back options.
- Added roster workflow helpers using shared `pds-core` class, roster, identifier, workspace, and route APIs.
- Stored class rosters at the canonical `classes/<class_id>/roster.csv` path.
- Preserved leading-zero student IDs and existing optional roster columns.
- Added staged edit behavior with explicit `SAVE` and `DISCARD` confirmation.
- Added active-roster removal with explicit `REMOVE` confirmation and historical-evidence safety warnings.
- Added workflow and focused menu tests for roster creation, viewing, editing, removal, save/cancel, validation, overwrite cancellation, and menu dispatch.
- Updated documentation and changelog for the new roster-management menu capability.

Closes #40.

## Validation

- [x] `python -m pytest` — 196 tests passed
- [x] `python -m ruff check .`
- [x] `python -m mypy .`
- [x] `git diff --check`
- [x] `.\run_tests.ps1`

## Notes

- Uses shared `pds-core` roster and class contracts.
- No direct roster CLI commands added.
- No Quillan-specific roster schema added.
- No assignments, submissions, printable PDFs, scans, reports, tags, scores, feedback, or historical evidence are deleted by roster removal.
- No assignment workflow added.
- No printable-response menu generation workflow added.
- No scan routing, QR extraction from scans, OCR, AI, grading, feedback, or reporting workflow added.
- No schemas changed.
- No PDS1 payload behavior changed.
- No printable response generation behavior changed.
- No workspace behavior changed.
- No generated PDFs, scans, real rosters, private files, classroom artifacts, or real student data committed.
- No sibling repositories modified.