### PR TITLE
Default new roster students to shared period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ planning and do not by themselves represent releases.
 
 ## Unreleased
 
+### Changed
+
+- Adding a student to an existing single-period roster now offers that shared
+  period as the default while preserving explicit entry for mixed rosters.
+
 ### Added
 
 - Added a teacher-facing Roster Management menu for creating, viewing, staged

--- a/quillan/roster_workflows.py
+++ b/quillan/roster_workflows.py
@@ -39,6 +39,15 @@ def optional_roster_columns(roster: Roster) -> tuple[str, ...]:
     )
 
 
+def shared_roster_period(roster: Roster) -> str | None:
+    """Return the shared nonblank student period when it is unambiguous."""
+    periods = [student.period.strip() for student in roster.students]
+    if not periods or any(not period for period in periods):
+        return None
+    unique_periods = set(periods)
+    return next(iter(unique_periods)) if len(unique_periods) == 1 else None
+
+
 def format_roster_for_display(roster: Roster, roster_path: str | Path) -> str:
     """Return a readable roster summary including all roster columns."""
     columns = tuple(
@@ -209,7 +218,12 @@ def prompt_add_student_to_roster(roster: Roster) -> Roster:
     values = {
         field: _prompt_required(field)
         for field in _REQUIRED_STUDENT_FIELDS
+        if field != "period"
     }
+    values["period"] = _prompt_required(
+        "period",
+        default=shared_roster_period(roster),
+    )
     for column in optional_roster_columns(roster):
         values[column] = input(f"  {column} (optional): ").strip()
     student = student_record_from_values(roster, values["student_id"], values)

--- a/tests/test_roster_workflows.py
+++ b/tests/test_roster_workflows.py
@@ -47,16 +47,19 @@ def _roster(class_id: str = "synthetic_class") -> Roster:
 def _inputs(
     monkeypatch: pytest.MonkeyPatch,
     responses: list[str],
-) -> None:
+) -> list[str]:
     response_iterator: Iterator[str] = iter(responses)
+    prompts: list[str] = []
 
-    def fake_input(_prompt: str = "") -> str:
+    def fake_input(prompt: str = "") -> str:
+        prompts.append(prompt)
         try:
             return next(response_iterator)
         except StopIteration as error:
             raise AssertionError("Workflow requested unexpected input.") from error
 
     monkeypatch.setattr("builtins.input", fake_input)
+    return prompts
 
 
 def test_create_class_roster_uses_canonical_path_and_preserves_zero_id(
@@ -187,6 +190,69 @@ def test_add_and_edit_student_preserve_optional_schema_and_values() -> None:
     }
     assert edited.students[0].extra_fields == roster.students[0].extra_fields
     assert edited.students[0].period == "4"
+
+
+def test_add_student_accepts_shared_period_default_and_preserves_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    roster = _roster()
+    prompts = _inputs(
+        monkeypatch,
+        ["0099", "Person", "Taylor", "", "Tay", ""],
+    )
+
+    updated = workflows.prompt_add_student_to_roster(roster)
+
+    added = updated.students[-1]
+    assert "  period [3]: " in prompts
+    assert added.student_id == "0099"
+    assert isinstance(added.student_id, str)
+    assert added.period == "3"
+    assert added.extra_fields == {
+        "preferred_name": "Tay",
+        "notes": "",
+    }
+
+
+def test_add_student_can_override_shared_period_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _inputs(monkeypatch, ["0099", "Person", "Taylor", "4", "Tay", ""])
+
+    updated = workflows.prompt_add_student_to_roster(_roster())
+
+    assert updated.students[-1].period == "4"
+
+
+def test_add_student_requires_period_when_existing_periods_are_mixed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = _roster()
+    roster = replace_student_record(
+        original,
+        workflows.student_record_from_values(
+            original,
+            "0042",
+            {
+                "last_name": "Sample",
+                "first_name": "Morgan",
+                "period": "4",
+                "preferred_name": "",
+                "notes": "",
+            },
+        ),
+    )
+    prompts = _inputs(
+        monkeypatch,
+        ["0099", "Person", "Taylor", "5", "Tay", ""],
+    )
+
+    updated = workflows.prompt_add_student_to_roster(roster)
+
+    assert workflows.shared_roster_period(roster) is None
+    assert "  period: " in prompts
+    assert not any(prompt.startswith("  period [") for prompt in prompts)
+    assert updated.students[-1].period == "5"
 
 
 def test_remove_is_in_memory_only_and_does_not_touch_evidence(


### PR DESCRIPTION
## Summary

- Added shared-period inference for adding students to an existing roster.
- Updated add-student prompts to show a default period when the roster has one reliable shared period.
- Allowed Enter to accept the inferred default period.
- Preserved typed period overrides.
- Kept mixed, blank, and empty roster period cases on explicit period entry.
- Added tests for default period acceptance, typed override, mixed-period fallback, prompt text, optional-column preservation, and leading-zero student IDs.
- Recorded the UX improvement in the changelog.

Closes #58.

## Validation

- [x] `python -m pytest` — 199 tests passed
- [x] `python -m ruff check .`
- [x] `python -m mypy .`
- [x] `git diff --check`
- [x] `.\run_tests.ps1`

## Notes

- Create-roster blank-ID-to-finish behavior unchanged.
- Staged save, discard, and remove semantics unchanged.
- No schemas changed.
- No `pds-core` behavior changed.
- No `pds-scoreform` behavior changed.
- No canonical paths changed.
- No PDS1 payload behavior changed.
- No workspace behavior changed.
- No assignment, printable, scan, report, or historical-evidence behavior changed.
- No generated PDFs, scans, real rosters, private files, classroom artifacts, or real student data committed.
- No sibling repositories modified.