### PR TITLE
Add Quillan assignment management menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a teacher-facing Assignment Management menu for creating validated
+  one-class writing assignment configs at the canonical shared assignment
+  route and viewing/validating existing configs without rewriting them.
+- Added exact overwrite confirmation for existing assignment configs and
+  roster-gated class selection for assignment creation.
 - Added a teacher-facing Roster Management menu for creating, viewing, staged
   editing, and validating canonical shared `pds-core` class rosters.
 - Added preservation of leading-zero student IDs and existing optional roster

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Quillan currently supports:
   records and display-name helpers;
 - teacher-facing class roster creation, viewing, staged editing, and validation
   through the Roster Management menu;
+- teacher-facing writing assignment config creation and read-only validation
+  through the Assignment Management menu;
 - shared Paper Data Suite workspace status reporting;
 - assignment-local storage paths based on shared `pds-core` route helpers; and
 - synthetic examples and fixtures for safe testing and documentation.
@@ -155,6 +157,19 @@ only the active roster and does not delete assignments, submissions,
 printable PDFs, scans, reports, tags, scores, feedback, or historical
 evidence.
 
+The Assignment Management menu creates validated writing assignment configs
+from prompts and can view/validate an explicit existing assignment JSON file.
+Creation requires an existing canonical class roster and saves to:
+
+```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+```
+
+Generated configs use Quillan's existing assignment validation contract. This
+menu does not edit, delete, import, score, tag, check requirements, generate
+feedback or reports, route scans, perform OCR or AI work, or generate printable
+response packets.
+
 Quillan also consumes the shared PDS1 payload conventions and helpers from
 `pds-core`. Each generated response page embeds a QR code containing a
 canonical payload such as:
@@ -176,11 +191,12 @@ quillan
 
 `quillan menu` launches the same menu as an explicit alias.
 
-The menu provides class roster creation, viewing, staged editing, and
-validation through Roster Management. Assignment Management and Printable
-Response Pages remain honest placeholders. Workspace Settings can show, set,
-validate/create, and reset the shared Paper Data Suite workspace root. Help
-summarizes Quillan's teacher-controlled purpose and safe-data expectations.
+The menu provides writing assignment config creation and validation through
+Assignment Management, plus class roster creation, viewing, staged editing,
+and validation through Roster Management. Printable Response Pages remains an
+honest placeholder. Workspace Settings can show, set, validate/create, and
+reset the shared Paper Data Suite workspace root. Help summarizes Quillan's
+teacher-controlled purpose and safe-data expectations.
 
 Show direct CLI help:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -220,7 +220,24 @@ active-roster removal do not write immediately. Saving requires typing
 removal never deletes assignments, submissions, printable PDFs, scans,
 reports, tags, scores, feedback, or historical evidence.
 
-Assignment Management states that its workflow is not implemented yet.
+Assignment Management provides:
+
+```text
+1. Create writing assignment
+2. View/validate assignment
+3. Back
+```
+
+Creation selects one class with an existing canonical roster, prompts for the
+fields in the existing assignment config contract, and writes
+`<workspace_root>/classes/<class_id>/assignments/<assignment_id>/assignment.json`.
+An existing config is replaced only after exact `OVERWRITE` confirmation.
+View/validate accepts an explicit JSON path, uses the existing assignment
+loader and validator, prints a concise summary, and does not rewrite the file.
+These workflows do not add assignment editing, deletion, import, scoring,
+feedback, tagging execution, requirements checking, reports, scan routing,
+OCR, AI, or printable packet generation.
+
 Printable Response Pages states that PDF generation exists as a Python API but
 has no teacher-facing menu workflow yet.
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -19,6 +19,7 @@ Quillan currently has:
 * initial CLI support;
 * teacher-facing shared-roster creation, viewing, staged editing, and
   validation;
+* teacher-facing writing assignment config creation and read-only validation;
 * automated tests for standards validation and CLI behavior;
 * configured development checks using `pytest`, `ruff`, and `mypy`.
 
@@ -143,12 +144,19 @@ contracts plus Quillan's `roster_workflows.py` menu orchestration:
 
 ### `assignments.py`
 
-Planned responsibility:
+Current responsibility:
 
-* define assignment configuration;
-* validate assignment requirements;
+* load and validate the existing assignment configuration contract;
 * connect assignments to standards profiles;
-* support writing type, focus standards, tagging mode, and rubric configuration.
+* support writing type, focus standards, tagging mode, and rubric configuration;
+* create one-class writing assignment configs from teacher prompts at the
+  canonical shared route; and
+* view and validate existing assignment configs without rewriting them.
+
+The menu workflow requires an existing class roster and protects existing
+configs with exact `OVERWRITE` confirmation. Assignment editing, deletion,
+import, scoring, feedback, tagging execution, requirements checking, reports,
+scan routing, OCR, AI, and printable packet generation remain out of scope.
 
 ### `submissions.py`
 

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -89,6 +89,21 @@ The teacher-created assignment configuration. It defines the task, writing
 type, connected class IDs, standards profile reference, focus standards,
 basic requirements, tagging mode, and rubric reference.
 
+Quillan's Assignment Management menu can create this file from prompts after
+the teacher selects a class with an existing canonical roster. It uses the
+existing assignment validation contract and the shared assignment route:
+
+```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+```
+
+The menu can also load, validate, and summarize an explicit assignment JSON
+path without rewriting it. Existing configs require exact `OVERWRITE`
+confirmation before replacement. This workflow does not edit or delete
+assignments and does not perform scoring, feedback, tagging execution,
+requirements checking, reporting, scan routing, OCR, AI, or printable packet
+generation.
+
 ### `templates/`
 
 A shared assignment-local directory for generated or teacher-facing printable

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -1,0 +1,337 @@
+"""Teacher-facing workflows for Quillan writing assignment configs."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pds_core.classes import ClassFolder, list_class_folders
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.assignments import (
+    ALLOWED_TAGGING_MODES,
+    AssignmentConfigError,
+    load_assignment_config,
+    validate_assignment_config,
+)
+from quillan.storage import assignment_config_path
+
+_NUMERIC_REQUIREMENTS = (
+    "paragraphs_min",
+    "paragraphs_max",
+    "word_count_min",
+    "word_count_max",
+)
+
+
+def suggest_assignment_id(title: str) -> str:
+    """Suggest a conservative shared identifier from an assignment title."""
+    normalized = unicodedata.normalize("NFKD", title)
+    ascii_title = normalized.encode("ascii", "ignore").decode("ascii")
+    suggestion = re.sub(r"[^A-Za-z0-9_-]+", "_", ascii_title.strip())
+    return suggestion.strip("_-").lower()
+
+
+def parse_comma_separated_values(value: str) -> list[str]:
+    """Return trimmed, nonblank values from comma-separated teacher input."""
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def parse_optional_nonnegative_int(
+    value: str,
+    field_name: str,
+) -> int | None:
+    """Parse an optional nonnegative integer requirement."""
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        parsed = int(stripped)
+    except ValueError as error:
+        raise ValueError(f"{field_name} must be a non-negative integer.") from error
+    if parsed < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer.")
+    return parsed
+
+
+def build_assignment_config(
+    *,
+    assignment_id: str,
+    title: str,
+    class_id: str,
+    writing_type: str,
+    standards_profile_id: str,
+    tagging_mode: str,
+    focus_standards: Sequence[str],
+    basic_requirements: Mapping[str, Any],
+    rubric_id: str,
+) -> dict[str, Any]:
+    """Build and validate an assignment config using the existing contract."""
+    assignment: dict[str, Any] = {
+        "assignment_id": assignment_id,
+        "title": title,
+        "class_ids": [class_id],
+        "writing_type": writing_type,
+        "standards_profile_id": standards_profile_id,
+        "tagging_mode": tagging_mode,
+        "focus_standards": list(focus_standards),
+        "basic_requirements": dict(basic_requirements),
+        "rubric_id": rubric_id,
+    }
+    validate_assignment_config(assignment)
+    return assignment
+
+
+def write_assignment_config(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Write a validated assignment config to its canonical shared path."""
+    assignment_data = dict(assignment)
+    validate_assignment_config(assignment_data)
+    if assignment_data["class_ids"] != [class_id]:
+        raise AssignmentConfigError(
+            "Assignment class_ids must match the selected class_id."
+        )
+    assignment_id = str(assignment_data["assignment_id"])
+    path = assignment_config_path(workspace_root, class_id, assignment_id)
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"Assignment config already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(assignment_data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def format_assignment_summary(
+    assignment: Mapping[str, Any],
+    assignment_path: str | Path,
+) -> str:
+    """Return a concise human-readable assignment summary."""
+    class_ids = ", ".join(str(value) for value in assignment["class_ids"])
+    focus_standards = [str(value) for value in assignment["focus_standards"]]
+    focus_text = ", ".join(focus_standards) if focus_standards else "(none)"
+    return "\n".join(
+        [
+            f"Assignment path: {Path(assignment_path)}",
+            f"Assignment ID: {assignment['assignment_id']}",
+            f"Title: {assignment['title']}",
+            f"Class IDs: {class_ids}",
+            f"Writing type: {assignment['writing_type']}",
+            f"Standards profile ID: {assignment['standards_profile_id']}",
+            f"Tagging mode: {assignment['tagging_mode']}",
+            f"Focus standards ({len(focus_standards)}): {focus_text}",
+            f"Rubric ID: {assignment['rubric_id']}",
+        ]
+    )
+
+
+def _workspace_root() -> Path | None:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return None
+
+
+def _available_class_folders(workspace_root: Path) -> tuple[ClassFolder, ...]:
+    return list_class_folders(workspace_root, require_roster=True)
+
+
+def _prompt_class_folder(workspace_root: Path) -> ClassFolder | None:
+    folders = _available_class_folders(workspace_root)
+    if not folders:
+        print("No class rosters found. Create a class roster first.")
+        return None
+
+    print("Available classes:")
+    for index, folder in enumerate(folders, start=1):
+        print(f"{index}. {folder.class_id}")
+    print()
+    selection = input("Select class for assignment: ").strip()
+    if selection.isdigit() and 1 <= int(selection) <= len(folders):
+        return folders[int(selection) - 1]
+    for folder in folders:
+        if folder.class_id == selection:
+            return folder
+    print(f"Error: Class not found: {selection}")
+    return None
+
+
+def _required_input(prompt: str, field_name: str) -> str:
+    value = input(prompt).strip()
+    if not value:
+        raise ValueError(f"{field_name} is required.")
+    return value
+
+
+def _prompt_basic_requirements() -> dict[str, Any]:
+    requirements: dict[str, Any] = {}
+    print("Basic requirements (leave blank to omit):")
+    for field_name in _NUMERIC_REQUIREMENTS:
+        parsed = parse_optional_nonnegative_int(
+            input(f"  {field_name}: "),
+            field_name,
+        )
+        if parsed is not None:
+            requirements[field_name] = parsed
+    required_elements = parse_comma_separated_values(
+        input("  required_elements, comma-separated: ")
+    )
+    if required_elements:
+        requirements["required_elements"] = required_elements
+    return requirements
+
+
+def prompt_create_assignment() -> int:
+    """Prompt for and write one validated writing assignment config."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Create Writing Assignment")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    class_folder = _prompt_class_folder(workspace_root)
+    if class_folder is None:
+        return 1
+
+    try:
+        title = _required_input("Assignment title: ", "Assignment title")
+        suggestion = suggest_assignment_id(title)
+        print(f"Suggested assignment_id: {suggestion}")
+        assignment_id = input(
+            "Press Enter to accept, or type a different assignment_id: "
+        ).strip()
+        if not assignment_id:
+            assignment_id = suggestion
+        validate_identifier(assignment_id, "assignment_id")
+
+        writing_type = _required_input("Writing type: ", "Writing type")
+        standards_profile_id = _required_input(
+            "Standards profile ID: ",
+            "Standards profile ID",
+        )
+        tagging_mode = input(
+            "Tagging mode [focus/focus_plus_past/benchmark/custom] "
+            "(default: focus): "
+        ).strip()
+        if not tagging_mode:
+            tagging_mode = "focus"
+        if tagging_mode not in ALLOWED_TAGGING_MODES:
+            allowed = "/".join(sorted(ALLOWED_TAGGING_MODES))
+            raise ValueError(f"Tagging mode must be one of: {allowed}.")
+        focus_standards = parse_comma_separated_values(
+            input("Focus standards, comma-separated: ")
+        )
+        basic_requirements = _prompt_basic_requirements()
+        rubric_id = _required_input("Rubric ID: ", "Rubric ID")
+        assignment = build_assignment_config(
+            assignment_id=assignment_id,
+            title=title,
+            class_id=class_folder.class_id,
+            writing_type=writing_type,
+            standards_profile_id=standards_profile_id,
+            tagging_mode=tagging_mode,
+            focus_standards=focus_standards,
+            basic_requirements=basic_requirements,
+            rubric_id=rubric_id,
+        )
+    except (AssignmentConfigError, IdentifierValidationError, ValueError) as error:
+        print(f"Error: {error}")
+        return 1
+
+    path = assignment_config_path(
+        workspace_root,
+        class_folder.class_id,
+        assignment_id,
+    )
+    overwrite = False
+    if path.exists():
+        confirmation = input("Type OVERWRITE to replace it: ").strip()
+        if confirmation != "OVERWRITE":
+            print("Canceled: existing assignment config was not changed.")
+            return 1
+        overwrite = True
+
+    try:
+        saved_path = write_assignment_config(
+            workspace_root,
+            class_folder.class_id,
+            assignment,
+            overwrite=overwrite,
+        )
+    except (AssignmentConfigError, OSError) as error:
+        print(f"Error: {error}")
+        return 1
+    print(f"Saved assignment config: {saved_path}")
+    return 0
+
+
+def _normalize_path_input(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in "'\"":
+        return stripped[1:-1]
+    return stripped
+
+
+def prompt_view_validate_assignment() -> int:
+    """Load, validate, and summarize an explicit assignment JSON path."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("View/Validate Assignment")
+    assignment_path = _normalize_path_input(input("Assignment JSON path: "))
+    if not assignment_path:
+        print("Error: assignment JSON path is required.")
+        return 1
+    try:
+        assignment = load_assignment_config(assignment_path)
+    except (AssignmentConfigError, OSError) as error:
+        print(f"Error: {error}")
+        return 1
+    print("Assignment config is valid.")
+    print(format_assignment_summary(assignment, assignment_path))
+    return 0
+
+
+def launch_assignment_menu() -> int:
+    """Launch the teacher-facing assignment management submenu."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Assignment Management")
+            print("1. Create writing assignment")
+            print("2. View/validate assignment")
+            print("3. Back")
+            print()
+            choice = input("Select an option: ").strip()
+            print()
+
+            if choice == "3":
+                return 0
+            workflows = {
+                "1": prompt_create_assignment,
+                "2": prompt_view_validate_assignment,
+            }
+            workflow = workflows.get(choice)
+            if workflow is None:
+                print("Invalid selection. Please enter a number from 1 to 3.")
+            else:
+                clear_screen()
+                workflow()
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting assignment menu.")
+        return 0

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -61,14 +61,10 @@ def print_menu_help() -> None:
 
 
 def launch_assignment_menu() -> None:
-    """Display the current assignment-management boundary."""
-    clear_screen()
-    print_menu_header("Assignment Management")
-    print("Assignment management workflows are not implemented yet.")
-    print("Current direct CLI support:")
-    print("  quillan validate-assignment <assignment.json>")
-    print()
-    pause_for_user()
+    """Launch writing-assignment config workflows."""
+    from quillan.assignment_workflows import launch_assignment_menu as launch
+
+    launch()
 
 
 def launch_roster_menu() -> None:

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -1,0 +1,403 @@
+"""Tests for Quillan's teacher-facing assignment config workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+from pathlib import Path
+
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+import pytest
+
+import quillan.assignment_workflows as workflows
+from quillan.assignments import (
+    AssignmentConfigError,
+    load_assignment_config,
+    validate_assignment_config,
+)
+
+
+def _assignment(
+    *,
+    assignment_id: str = "literary_analysis_essay",
+    class_id: str = "english_12_p3",
+) -> dict[str, object]:
+    return workflows.build_assignment_config(
+        assignment_id=assignment_id,
+        title="Literary Analysis Essay",
+        class_id=class_id,
+        writing_type="literary_analysis",
+        standards_profile_id="synthetic_ela_11_12",
+        tagging_mode="focus",
+        focus_standards=["W.AW.11-12.1", "L.KL.11-12.2"],
+        basic_requirements={
+            "paragraphs_min": 4,
+            "word_count_min": 500,
+            "required_elements": ["claim", "textual evidence"],
+        },
+        rubric_id="synthetic_argument_v1",
+    )
+
+
+def _write_roster(workspace_root: Path, class_id: str = "english_12_p3") -> None:
+    roster = create_roster(
+        class_id,
+        [
+            {
+                "student_id": "0001",
+                "last_name": "Synthetic",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        ],
+    )
+    write_class_roster(workspace_root, roster)
+
+
+def _inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[str],
+) -> list[str]:
+    response_iterator: Iterator[str] = iter(responses)
+    prompts: list[str] = []
+
+    def fake_input(prompt: str = "") -> str:
+        prompts.append(prompt)
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError("Workflow requested unexpected input.") from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    return prompts
+
+
+def _creation_responses(
+    *,
+    selection: str = "1",
+    assignment_id: str = "",
+    paragraphs_min: str = "4",
+    overwrite: str | None = None,
+) -> list[str]:
+    responses = [
+        selection,
+        "Literary Analysis Essay",
+        assignment_id,
+        "literary_analysis",
+        "synthetic_ela_11_12",
+        "",
+        " W.AW.11-12.1, L.KL.11-12.2, ",
+        paragraphs_min,
+        "",
+        "500",
+        "",
+        "claim, textual evidence",
+        "synthetic_argument_v1",
+    ]
+    if overwrite is not None:
+        responses.append(overwrite)
+    return responses
+
+
+def test_build_assignment_config_has_required_fields_and_validates() -> None:
+    assignment = _assignment()
+
+    assert list(assignment) == [
+        "assignment_id",
+        "title",
+        "class_ids",
+        "writing_type",
+        "standards_profile_id",
+        "tagging_mode",
+        "focus_standards",
+        "basic_requirements",
+        "rubric_id",
+    ]
+    validate_assignment_config(assignment)
+
+
+def test_write_assignment_config_uses_canonical_path(tmp_path: Path) -> None:
+    assignment = _assignment()
+
+    path = workflows.write_assignment_config(
+        tmp_path,
+        "english_12_p3",
+        assignment,
+    )
+
+    assert path == (
+        tmp_path
+        / "classes"
+        / "english_12_p3"
+        / "assignments"
+        / "literary_analysis_essay"
+        / "assignment.json"
+    )
+    assert load_assignment_config(path) == assignment
+    assert path.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_write_assignment_config_rejects_class_path_mismatch(
+    tmp_path: Path,
+) -> None:
+    assignment = _assignment(class_id="english_12_p3")
+
+    with pytest.raises(AssignmentConfigError, match="class_ids"):
+        workflows.write_assignment_config(
+            tmp_path,
+            "english_12_p4",
+            assignment,
+        )
+
+    assert not list(tmp_path.rglob("assignment.json"))
+
+
+def test_assignment_parsing_helpers() -> None:
+    assert workflows.suggest_assignment_id("  Café Literary Analysis!  ") == (
+        "cafe_literary_analysis"
+    )
+    assert workflows.parse_comma_separated_values(" A, B ,, C ") == [
+        "A",
+        "B",
+        "C",
+    ]
+    assert workflows.parse_comma_separated_values("") == []
+    assert workflows.parse_optional_nonnegative_int("", "paragraphs_min") is None
+    assert workflows.parse_optional_nonnegative_int(" 0 ", "paragraphs_min") == 0
+    assert workflows.parse_optional_nonnegative_int("12", "word_count_min") == 12
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        workflows.parse_optional_nonnegative_int("-1", "paragraphs_min")
+    with pytest.raises(ValueError, match="non-negative integer"):
+        workflows.parse_optional_nonnegative_int("many", "paragraphs_min")
+
+
+def test_prompt_create_assignment_selects_roster_class_and_writes_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, _creation_responses())
+
+    assert workflows.prompt_create_assignment() == 0
+    path = (
+        tmp_path
+        / "classes"
+        / "english_12_p3"
+        / "assignments"
+        / "literary_analysis_essay"
+        / "assignment.json"
+    )
+    assignment = load_assignment_config(path)
+    assert assignment["class_ids"] == ["english_12_p3"]
+    assert assignment["focus_standards"] == [
+        "W.AW.11-12.1",
+        "L.KL.11-12.2",
+    ]
+    assert assignment["basic_requirements"] == {
+        "paragraphs_min": 4,
+        "word_count_min": 500,
+        "required_elements": ["claim", "textual evidence"],
+    }
+    assert "Saved assignment config:" in capsys.readouterr().out
+
+
+def test_prompt_create_assignment_accepts_exact_class_id_and_blank_options(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_roster(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    responses = _creation_responses(
+        selection="english_12_p3",
+        assignment_id="custom_assignment",
+        paragraphs_min="",
+    )
+    responses[9] = ""
+    responses[11] = ""
+    _inputs(monkeypatch, responses)
+
+    assert workflows.prompt_create_assignment() == 0
+    assignment = load_assignment_config(
+        tmp_path
+        / "classes"
+        / "english_12_p3"
+        / "assignments"
+        / "custom_assignment"
+        / "assignment.json"
+    )
+    assert assignment["focus_standards"] == [
+        "W.AW.11-12.1",
+        "L.KL.11-12.2",
+    ]
+    assert assignment["basic_requirements"] == {}
+
+
+def test_prompt_create_assignment_requires_existing_roster(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+
+    assert workflows.prompt_create_assignment() == 1
+    assert "No class rosters found" in capsys.readouterr().out
+    assert not (tmp_path / "classes").exists()
+
+
+def test_prompt_create_assignment_rejects_invalid_teacher_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        ["1", "Synthetic Assignment", "invalid assignment id"],
+    )
+
+    assert workflows.prompt_create_assignment() == 1
+    assert "Error:" in capsys.readouterr().out
+    assert not list(tmp_path.rglob("assignment.json"))
+
+
+def test_prompt_create_assignment_rejects_invalid_numeric_requirement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        _creation_responses(paragraphs_min="-1")[:8],
+    )
+
+    assert workflows.prompt_create_assignment() == 1
+    assert "paragraphs_min must be a non-negative integer" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("confirmation", "expected_title"),
+    [
+        ("no", "Original Synthetic Assignment"),
+        ("OVERWRITE", "Literary Analysis Essay"),
+    ],
+)
+def test_prompt_create_assignment_overwrite_requires_exact_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    confirmation: str,
+    expected_title: str,
+) -> None:
+    _write_roster(tmp_path)
+    existing = _assignment()
+    existing["title"] = "Original Synthetic Assignment"
+    path = workflows.write_assignment_config(
+        tmp_path,
+        "english_12_p3",
+        existing,
+    )
+    original_text = path.read_text(encoding="utf-8")
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, _creation_responses(overwrite=confirmation))
+
+    result = workflows.prompt_create_assignment()
+    assert result == (0 if confirmation == "OVERWRITE" else 1)
+    assert load_assignment_config(path)["title"] == expected_title
+    if confirmation != "OVERWRITE":
+        assert path.read_text(encoding="utf-8") == original_text
+
+
+def test_view_validate_assignment_prints_summary_without_rewriting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = workflows.write_assignment_config(
+        tmp_path,
+        "english_12_p3",
+        _assignment(),
+    )
+    original_bytes = path.read_bytes()
+    _inputs(monkeypatch, [f'"{path}"'])
+
+    assert workflows.prompt_view_validate_assignment() == 0
+    output = capsys.readouterr().out
+    assert "Assignment config is valid." in output
+    assert "Assignment ID: literary_analysis_essay" in output
+    assert "Title: Literary Analysis Essay" in output
+    assert "Class IDs: english_12_p3" in output
+    assert "Writing type: literary_analysis" in output
+    assert "Standards profile ID: synthetic_ela_11_12" in output
+    assert "Tagging mode: focus" in output
+    assert "Focus standards (2)" in output
+    assert "Rubric ID: synthetic_argument_v1" in output
+    assert path.read_bytes() == original_bytes
+
+
+def test_view_validate_assignment_reports_error_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "invalid.json"
+    path.write_text(json.dumps({"assignment_id": "incomplete"}), encoding="utf-8")
+    original_bytes = path.read_bytes()
+    _inputs(monkeypatch, [str(path)])
+
+    assert workflows.prompt_view_validate_assignment() == 1
+    output = capsys.readouterr().out
+    assert "Error:" in output
+    assert "Traceback" not in output
+    assert path.read_bytes() == original_bytes
+
+
+def test_assignment_menu_displays_options_and_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[str] = []
+
+    def record(name: str) -> int:
+        calls.append(name)
+        return 0
+
+    monkeypatch.setattr(
+        workflows,
+        "prompt_create_assignment",
+        lambda: record("create"),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "prompt_view_validate_assignment",
+        lambda: record("view"),
+    )
+    _inputs(monkeypatch, ["1", "", "2", "", "3"])
+
+    assert workflows.launch_assignment_menu() == 0
+    output = capsys.readouterr().out
+    assert calls == ["create", "view"]
+    assert "Create writing assignment" in output
+    assert "View/validate assignment" in output
+    assert "Back" in output
+
+
+def test_assignment_menu_invalid_selection_and_keyboard_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _inputs(monkeypatch, ["bad", "", "3"])
+    assert workflows.launch_assignment_menu() == 0
+    assert "Invalid selection" in capsys.readouterr().out
+
+    def interrupt(_prompt: str = "") -> str:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", interrupt)
+    assert workflows.launch_assignment_menu() == 0
+    assert "Exiting assignment menu." in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -428,7 +428,6 @@ def test_menu_help_explains_teacher_control_and_safe_data(
 @pytest.mark.parametrize(
     ("selection", "expected_message"),
     [
-        ("1", "Assignment management workflows are not implemented yet."),
         (
             "3",
             "teacher-facing menu workflow is not implemented yet.",
@@ -445,6 +444,21 @@ def test_unsupported_menu_sections_are_honest_placeholders(
 
     assert main(["menu"]) == 0
     assert expected_message in capsys.readouterr().out
+
+
+def test_main_menu_opens_assignment_management_submenu(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["1", "3", "6"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Assignment Management" in output
+    assert "Create writing assignment" in output
+    assert "View/validate assignment" in output
+    assert "Back" in output
+    assert "Goodbye." in output
 
 
 def test_main_menu_opens_roster_management_submenu(


### PR DESCRIPTION
## Summary

- Added an Assignment Management submenu with create writing assignment, view/validate assignment, and back options.
- Added prompt-driven writing assignment creation using existing class rosters for class selection.
- Generated assignment configs with the existing Quillan assignment schema and validation contract.
- Saved assignment configs to the canonical `classes/<class_id>/assignments/<assignment_id>/assignment.json` path.
- Added write-time protection against class/path mismatches.
- Added exact `OVERWRITE` protection for existing assignment configs.
- Added read-only view/validate assignment summaries.
- Added workflow and focused menu tests for assignment creation, validation, canonical storage, overwrite protection, class/path mismatch protection, and dispatch.
- Updated documentation and changelog for the new assignment-management menu capability.

Closes #41.

## Validation

- [x] `python -m pytest` — 214 tests passed
- [x] `python -m ruff check .`
- [x] `python -m mypy .`
- [x] `git diff --check`
- [x] `.\run_tests.ps1`

## Notes

- Existing `quillan validate-assignment <path>` behavior unchanged.
- No direct assignment creation command added.
- No assignment editing, deletion, duplication, import, or archival workflow added.
- No scoring, feedback, tagging execution, requirements checking engine, reports, scan routing, OCR, AI, or printable-response menu generation added.
- No schemas changed.
- No PDS1 payload behavior changed.
- No workspace behavior changed.
- No roster contracts changed.
- No printable response generation behavior changed.
- No scan/report behavior changed.
- No generated PDFs, scans, real assignments, real rosters, private files, classroom artifacts, or real student data committed.
- No sibling repositories modified.