### PR TITLE
Add printable response packet menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a teacher-facing Printable Response Pages menu that generates one
+  combined class packet from an existing canonical roster and assignment
+  config using the existing roster-aware PDF generator.
+- Added positive pages-per-student validation, clear assignment validation and
+  class-mismatch errors, canonical output-path reporting, and exact
+  `OVERWRITE` protection for existing printable packets.
 - Added a teacher-facing Assignment Management menu for creating validated
   one-class writing assignment configs at the canonical shared assignment
   route and viewing/validating existing configs without rewriting them.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ Quillan currently supports:
   through the Roster Management menu;
 - teacher-facing writing assignment config creation and read-only validation
   through the Assignment Management menu;
+- teacher-facing generation of one combined printable response class packet
+  from an existing canonical roster and assignment config;
 - shared Paper Data Suite workspace status reporting;
 - assignment-local storage paths based on shared `pds-core` route helpers; and
 - synthetic examples and fixtures for safe testing and documentation.
 
-Printable response generation is implemented as a Python API in
-`quillan.printable_response`; it is not yet exposed as a teacher-facing menu
-workflow or dedicated CLI command.
+Printable response generation is exposed through the teacher-facing menu and
+the Python API in `quillan.printable_response`. It is not exposed as a
+dedicated direct CLI command.
 
 ## Core Principle
 
@@ -59,8 +61,7 @@ particular, Quillan does not currently provide:
   production reporting workflows;
 - AI tagging, AI scoring, or AI feedback;
 - automatic grading; or
-- complete teacher-facing assignment, printable-response, or review
-  workflows; or
+- complete teacher-facing assignment editing or review workflows; or
 - a dedicated printable-response command.
 
 The intended scan-routing rules and failure behavior are documented in
@@ -167,8 +168,19 @@ Creation requires an existing canonical class roster and saves to:
 
 Generated configs use Quillan's existing assignment validation contract. This
 menu does not edit, delete, import, score, tag, check requirements, generate
-feedback or reports, route scans, perform OCR or AI work, or generate printable
-response packets.
+feedback or reports, route scans, or perform OCR or AI work.
+
+The Printable Response Pages menu selects an existing canonical class roster
+and assignment config, prompts for a positive number of pages per student, and
+generates one combined class packet at:
+
+```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
+```
+
+Replacing an existing packet requires exact `OVERWRITE` confirmation.
+Generation does not alter the roster or assignment config. Generated PDFs are
+local workspace artifacts and should not be committed.
 
 Quillan also consumes the shared PDS1 payload conventions and helpers from
 `pds-core`. Each generated response page embeds a QR code containing a
@@ -192,11 +204,11 @@ quillan
 `quillan menu` launches the same menu as an explicit alias.
 
 The menu provides writing assignment config creation and validation through
-Assignment Management, plus class roster creation, viewing, staged editing,
-and validation through Roster Management. Printable Response Pages remains an
-honest placeholder. Workspace Settings can show, set, validate/create, and
-reset the shared Paper Data Suite workspace root. Help summarizes Quillan's
-teacher-controlled purpose and safe-data expectations.
+Assignment Management, class roster creation, viewing, staged editing, and
+validation through Roster Management, and combined class-packet generation
+through Printable Response Pages. Workspace Settings can show, set,
+validate/create, and reset the shared Paper Data Suite workspace root. Help
+summarizes Quillan's teacher-controlled purpose and safe-data expectations.
 
 Show direct CLI help:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -238,8 +238,30 @@ These workflows do not add assignment editing, deletion, import, scoring,
 feedback, tagging execution, requirements checking, reports, scan routing,
 OCR, AI, or printable packet generation.
 
-Printable Response Pages states that PDF generation exists as a Python API but
-has no teacher-facing menu workflow yet.
+Printable Response Pages provides:
+
+```text
+1. Generate class packet
+2. Back
+```
+
+Generation selects a class with an existing canonical roster, then selects a
+canonical assignment config for that class. Invalid configs are identified and
+cannot be selected; the assignment must include the selected class in
+`class_ids`. Blank pages-per-student input defaults to `1`, and nonblank input
+must be a positive integer.
+
+The current output mode is one combined class packet PDF:
+
+```text
+<workspace_root>/classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
+```
+
+An existing packet is replaced only after exact `OVERWRITE` confirmation.
+The workflow uses the existing roster-aware printable generator and does not
+alter roster or assignment data. It does not add individual PDFs, scan
+routing, OCR, review, scoring, feedback, reports, AI, or a direct printable
+CLI command.
 
 Workspace Settings provides:
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -20,6 +20,8 @@ Quillan currently has:
 * teacher-facing shared-roster creation, viewing, staged editing, and
   validation;
 * teacher-facing writing assignment config creation and read-only validation;
+* teacher-facing combined printable response class-packet generation from
+  existing canonical rosters and assignment configs;
 * automated tests for standards validation and CLI behavior;
 * configured development checks using `pytest`, `ruff`, and `mypy`.
 
@@ -154,9 +156,23 @@ Current responsibility:
 * view and validate existing assignment configs without rewriting them.
 
 The menu workflow requires an existing class roster and protects existing
-configs with exact `OVERWRITE` confirmation. Assignment editing, deletion,
-import, scoring, feedback, tagging execution, requirements checking, reports,
-scan routing, OCR, AI, and printable packet generation remain out of scope.
+configs with exact `OVERWRITE` confirmation. The Assignment Management menu
+does not edit, delete, or import assignments and does not perform scoring,
+feedback, tagging execution, requirements checking, reports, scan routing,
+OCR, AI, or printable packet generation.
+
+### `printable_response.py`
+
+Current responsibility:
+
+* generate one combined printable response class packet from validated
+  assignment data and shared `pds-core` roster records;
+* expose that supported mode through the Printable Response Pages menu; and
+* protect an existing stable output from menu-driven replacement unless the
+  teacher types exact `OVERWRITE`.
+
+Individual student PDFs, scan routing, OCR, review, scoring, feedback, reports,
+AI, and a direct printable CLI command remain out of scope.
 
 ### `submissions.py`
 
@@ -299,6 +315,8 @@ Completed work:
 * Add the initial bare `quillan` menu entry point, explicit `quillan menu`
   alias, and navigation skeleton.
 * Add the Roster Management submenu using shared `pds-core` contracts.
+* Add the Printable Response Pages submenu for combined class-packet
+  generation.
 * Add CLI tests.
 
 Remaining possible work:

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -107,10 +107,13 @@ generation.
 ### `templates/`
 
 A shared assignment-local directory for generated or teacher-facing printable
-materials. The implemented Python API creates
-`templates/printable_response_pages.pdf` for a generated batch of
-roster-aware writing-response pages. A dedicated printable-response CLI or
-teacher menu workflow is not yet implemented. The response-page contract is
+materials. The Python API and Printable Response Pages menu create
+`templates/printable_response_pages.pdf` as one combined class packet of
+roster-aware writing-response pages. The menu requires an existing canonical
+roster and assignment config and protects replacement with exact `OVERWRITE`
+confirmation. Generation does not rewrite either source file. Generated PDFs
+are local workspace artifacts and should not be committed. A dedicated
+printable-response CLI is not implemented. The response-page contract is
 defined in
 [`printable_response_template.md`](printable_response_template.md).
 

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -75,15 +75,12 @@ def launch_roster_menu() -> None:
 
 
 def launch_printable_response_menu() -> None:
-    """Display the current printable-response workflow boundary."""
-    clear_screen()
-    print_menu_header("Printable Response Pages")
-    print("Printable response PDF generation exists as a Python API, but the")
-    print("teacher-facing menu workflow is not implemented yet.")
-    print("Generated pages use PDS1 Quillan response payloads and shared pds-core")
-    print("roster records.")
-    print()
-    pause_for_user()
+    """Launch printable response packet workflows."""
+    from quillan.printable_response_workflows import (
+        launch_printable_response_menu as launch,
+    )
+
+    launch()
 
 
 def launch_workspace_menu(

--- a/quillan/printable_response_workflows.py
+++ b/quillan/printable_response_workflows.py
@@ -1,0 +1,257 @@
+"""Teacher-facing workflows for printable Quillan response packets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from pds_core.classes import ClassFolder, list_class_folders
+from pds_core.rosters import RosterError
+from pds_core.routes import class_assignments_dir
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.printable_response import (
+    PRINTABLE_RESPONSE_FILENAME,
+    generate_printable_responses_for_roster,
+)
+from quillan.storage import assignment_templates_dir
+
+
+@dataclass(frozen=True)
+class AssignmentChoice:
+    """One discovered canonical assignment config and its validation state."""
+
+    assignment_id: str
+    path: Path
+    title: str | None
+    class_ids: tuple[str, ...]
+    error: str | None = None
+
+
+def parse_pages_per_student(value: str) -> int:
+    """Parse a positive page count, defaulting blank input to one."""
+    stripped = value.strip()
+    if not stripped:
+        return 1
+    if not stripped.isdigit():
+        raise ValueError("Pages per student must be a positive integer.")
+    pages = int(stripped)
+    if pages < 1:
+        raise ValueError("Pages per student must be a positive integer.")
+    return pages
+
+
+def discover_assignment_configs(
+    workspace_root: str | Path,
+    class_id: str,
+) -> tuple[AssignmentChoice, ...]:
+    """Discover canonical assignment configs for one class folder."""
+    assignments_dir = class_assignments_dir(workspace_root, class_id)
+    try:
+        entries = sorted(assignments_dir.iterdir(), key=lambda entry: entry.name)
+    except (FileNotFoundError, NotADirectoryError):
+        return ()
+
+    choices: list[AssignmentChoice] = []
+    for entry in entries:
+        path = entry / "assignment.json"
+        if not entry.is_dir() or not path.is_file():
+            continue
+        try:
+            assignment = load_assignment_config(path)
+        except (AssignmentConfigError, OSError) as error:
+            choices.append(
+                AssignmentChoice(
+                    assignment_id=entry.name,
+                    path=path,
+                    title=None,
+                    class_ids=(),
+                    error=str(error),
+                )
+            )
+            continue
+        choices.append(
+            AssignmentChoice(
+                assignment_id=cast(str, assignment["assignment_id"]),
+                path=path,
+                title=cast(str, assignment["title"]),
+                class_ids=tuple(cast(list[str], assignment["class_ids"])),
+            )
+        )
+    return tuple(choices)
+
+
+def expected_printable_packet_path(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return the stable output path for a combined printable class packet."""
+    return (
+        assignment_templates_dir(workspace_root, class_id, assignment_id)
+        / PRINTABLE_RESPONSE_FILENAME
+    )
+
+
+def _workspace_root() -> Path | None:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return None
+
+
+def _prompt_class_selection(workspace_root: Path) -> ClassFolder | None:
+    folders = list_class_folders(workspace_root, require_roster=True)
+    if not folders:
+        print("No class rosters found. Create a class roster first.")
+        return None
+
+    print("Available classes:")
+    for index, folder in enumerate(folders, start=1):
+        print(f"{index}. {folder.class_id}")
+    print()
+    selection = input("Select class roster: ").strip()
+    if selection.isdigit() and 1 <= int(selection) <= len(folders):
+        return folders[int(selection) - 1]
+    for folder in folders:
+        if folder.class_id == selection:
+            return folder
+    print(f"Error: Class not found: {selection}")
+    return None
+
+
+def _format_assignment_choice(choice: AssignmentChoice) -> str:
+    if choice.error is not None:
+        return f"{choice.assignment_id} [INVALID: {choice.error}]"
+    if choice.title:
+        return f"{choice.assignment_id} - {choice.title}"
+    return choice.assignment_id
+
+
+def _prompt_assignment_selection(
+    workspace_root: Path,
+    class_id: str,
+) -> AssignmentChoice | None:
+    choices = discover_assignment_configs(workspace_root, class_id)
+    if not choices:
+        print("No assignment configs found for this class. Create an assignment first.")
+        return None
+
+    print("Available assignments:")
+    for index, choice in enumerate(choices, start=1):
+        print(f"{index}. {_format_assignment_choice(choice)}")
+    print()
+    selection = input("Select assignment: ").strip()
+    selected: AssignmentChoice | None = None
+    if selection.isdigit() and 1 <= int(selection) <= len(choices):
+        selected = choices[int(selection) - 1]
+    else:
+        for choice in choices:
+            if choice.assignment_id == selection:
+                selected = choice
+                break
+    if selected is None:
+        print(f"Error: Assignment not found: {selection}")
+        return None
+    if selected.error is not None:
+        print(f"Error: Assignment config is invalid: {selected.error}")
+        return None
+    if class_id not in selected.class_ids:
+        print(
+            f"Error: Assignment '{selected.assignment_id}' does not include "
+            f"class '{class_id}' in class_ids."
+        )
+        return None
+    return selected
+
+
+def prompt_generate_class_packet() -> int:
+    """Prompt for roster and assignment selection, then generate one class PDF."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Generate Printable Response Class Packet")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    class_folder = _prompt_class_selection(workspace_root)
+    if class_folder is None:
+        return 1
+    assignment = _prompt_assignment_selection(workspace_root, class_folder.class_id)
+    if assignment is None:
+        return 1
+
+    try:
+        pages_per_student = parse_pages_per_student(
+            input("Pages per student [1]: ")
+        )
+    except ValueError as error:
+        print(f"Error: {error}")
+        return 1
+
+    output_path = expected_printable_packet_path(
+        workspace_root,
+        class_folder.class_id,
+        assignment.assignment_id,
+    )
+    if output_path.exists():
+        print(f"Printable response packet already exists:\n{output_path}")
+        confirmation = input(
+            "Type OVERWRITE to replace the existing printable response packet: "
+        ).strip()
+        if confirmation != "OVERWRITE":
+            print("Canceled: existing printable response packet was not changed.")
+            return 1
+
+    print("Output mode: one class packet PDF")
+    try:
+        generated_path = generate_printable_responses_for_roster(
+            workspace_root,
+            assignment_path=assignment.path,
+            roster_path=class_folder.roster_path,
+            pages_per_student=pages_per_student,
+            class_label=class_folder.class_id,
+        )
+    except (AssignmentConfigError, RosterError, OSError, ValueError) as error:
+        print(f"Error: {error}")
+        return 1
+
+    assignment_label = assignment.assignment_id
+    if assignment.title:
+        assignment_label = f"{assignment.assignment_id} - {assignment.title}"
+    print("Generated printable response packet:")
+    print(generated_path)
+    print(f"Class: {class_folder.class_id}")
+    print(f"Assignment: {assignment_label}")
+    print(f"Pages per student: {pages_per_student}")
+    return 0
+
+
+def launch_printable_response_menu() -> int:
+    """Launch the teacher-facing printable response pages submenu."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Printable Response Pages")
+            print("1. Generate class packet")
+            print("2. Back")
+            print()
+            choice = input("Select an option: ").strip()
+            print()
+
+            if choice == "2":
+                return 0
+            if choice == "1":
+                clear_screen()
+                prompt_generate_class_packet()
+            else:
+                print("Invalid selection. Please enter a number from 1 to 2.")
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting printable response menu.")
+        return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -425,25 +425,18 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     assert "quillan menu" in output
 
 
-@pytest.mark.parametrize(
-    ("selection", "expected_message"),
-    [
-        (
-            "3",
-            "teacher-facing menu workflow is not implemented yet.",
-        ),
-    ],
-)
-def test_unsupported_menu_sections_are_honest_placeholders(
-    selection: str,
-    expected_message: str,
+def test_main_menu_opens_printable_response_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, [selection, "", "6"])
+    _menu_input(monkeypatch, ["3", "2", "6"])
 
     assert main(["menu"]) == 0
-    assert expected_message in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "Printable Response Pages" in output
+    assert "Generate class packet" in output
+    assert "Back" in output
+    assert "Goodbye." in output
 
 
 def test_main_menu_opens_assignment_management_submenu(

--- a/tests/test_printable_response_workflows.py
+++ b/tests/test_printable_response_workflows.py
@@ -1,0 +1,317 @@
+"""Tests for teacher-facing printable response packet workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+from pathlib import Path
+
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+from pypdf import PdfReader
+import pytest
+
+import quillan.printable_response_workflows as workflows
+
+
+CLASS_ID = "synthetic_english_p3"
+ASSIGNMENT_ID = "synthetic_response"
+
+
+def _inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[str],
+) -> list[str]:
+    response_iterator: Iterator[str] = iter(responses)
+    prompts: list[str] = []
+
+    def fake_input(prompt: str = "") -> str:
+        prompts.append(prompt)
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError("Workflow requested unexpected input.") from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    return prompts
+
+
+def _write_roster(workspace_root: Path, class_id: str = CLASS_ID) -> Path:
+    roster = create_roster(
+        class_id,
+        [
+            {
+                "student_id": "0001",
+                "last_name": "Example",
+                "first_name": "Avery",
+                "period": "3",
+            },
+            {
+                "student_id": "0002",
+                "last_name": "Sample",
+                "first_name": "Morgan",
+                "period": "3",
+            },
+        ],
+    )
+    return write_class_roster(workspace_root, roster)
+
+
+def _assignment(class_ids: list[str] | None = None) -> dict[str, object]:
+    return {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Writing Response",
+        "class_ids": class_ids or [CLASS_ID],
+        "writing_type": "synthetic_response",
+        "standards_profile_id": "synthetic_ela",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.SYN.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+
+
+def _write_assignment(
+    workspace_root: Path,
+    assignment: dict[str, object] | None = None,
+) -> Path:
+    path = (
+        workspace_root
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(assignment or _assignment()),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "abc", "1.5"])
+def test_parse_pages_per_student_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        workflows.parse_pages_per_student(value)
+
+
+def test_parse_pages_per_student_defaults_blank_and_accepts_integer() -> None:
+    assert workflows.parse_pages_per_student("") == 1
+    assert workflows.parse_pages_per_student(" 2 ") == 2
+
+
+def test_generate_class_packet_happy_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    roster_path = _write_roster(tmp_path)
+    assignment_path = _write_assignment(tmp_path)
+    roster_bytes = roster_path.read_bytes()
+    assignment_bytes = assignment_path.read_bytes()
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1", "2"])
+
+    assert workflows.prompt_generate_class_packet() == 0
+
+    output_path = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "templates"
+        / "printable_response_pages.pdf"
+    )
+    assert output_path.is_file()
+    assert output_path.read_bytes().startswith(b"%PDF")
+    assert len(PdfReader(str(output_path)).pages) == 4
+    assert roster_path.read_bytes() == roster_bytes
+    assert assignment_path.read_bytes() == assignment_bytes
+
+    output = capsys.readouterr().out
+    assert "Output mode: one class packet PDF" in output
+    assert "Generated printable response packet:" in output
+    assert str(output_path) in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert "Pages per student: 2" in output
+
+
+def test_generate_class_packet_accepts_exact_ids_and_blank_page_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, [CLASS_ID, ASSIGNMENT_ID, ""])
+
+    assert workflows.prompt_generate_class_packet() == 0
+    output_path = workflows.expected_printable_packet_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+    )
+    assert len(PdfReader(str(output_path)).pages) == 2
+
+
+def test_generate_class_packet_requires_roster(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+
+    assert workflows.prompt_generate_class_packet() == 1
+    assert "No class rosters found. Create a class roster first." in (
+        capsys.readouterr().out
+    )
+    assert not list(tmp_path.rglob("*.pdf"))
+
+
+def test_generate_class_packet_requires_assignment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1"])
+
+    assert workflows.prompt_generate_class_packet() == 1
+    assert "No assignment configs found for this class" in capsys.readouterr().out
+    assert not list(tmp_path.rglob("*.pdf"))
+
+
+def test_generate_class_packet_rejects_invalid_assignment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path, {"assignment_id": ASSIGNMENT_ID})
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1"])
+
+    assert workflows.prompt_generate_class_packet() == 1
+    output = capsys.readouterr().out
+    assert "[INVALID:" in output
+    assert "Assignment config is invalid" in output
+    assert not list(tmp_path.rglob("*.pdf"))
+
+
+def test_generate_class_packet_rejects_assignment_class_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path, _assignment(["different_synthetic_class"]))
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1"])
+
+    assert workflows.prompt_generate_class_packet() == 1
+    output = capsys.readouterr().out
+    assert "does not include" in output
+    assert CLASS_ID in output
+    assert not list(tmp_path.rglob("*.pdf"))
+
+
+def test_generate_class_packet_reports_invalid_pages_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1", "0"])
+
+    assert workflows.prompt_generate_class_packet() == 1
+    output = capsys.readouterr().out
+    assert "Pages per student must be a positive integer" in output
+    assert "Traceback" not in output
+    assert not list(tmp_path.rglob("*.pdf"))
+
+
+@pytest.mark.parametrize("confirmation", ["", "overwrite", "no"])
+def test_generate_class_packet_does_not_overwrite_without_exact_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    confirmation: str,
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    output_path = workflows.expected_printable_packet_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+    )
+    output_path.parent.mkdir(parents=True)
+    original_bytes = b"existing synthetic PDF bytes"
+    output_path.write_bytes(original_bytes)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1", "1", confirmation])
+
+    assert workflows.prompt_generate_class_packet() == 1
+    assert output_path.read_bytes() == original_bytes
+
+
+def test_generate_class_packet_overwrites_after_exact_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    output_path = workflows.expected_printable_packet_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+    )
+    output_path.parent.mkdir(parents=True)
+    output_path.write_bytes(b"old")
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1", "1", "OVERWRITE"])
+
+    assert workflows.prompt_generate_class_packet() == 0
+    assert output_path.read_bytes().startswith(b"%PDF")
+
+
+def test_printable_response_menu_displays_options_and_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls = 0
+
+    def generate() -> int:
+        nonlocal calls
+        calls += 1
+        return 0
+
+    monkeypatch.setattr(workflows, "prompt_generate_class_packet", generate)
+    _inputs(monkeypatch, ["1", "", "2"])
+
+    assert workflows.launch_printable_response_menu() == 0
+    output = capsys.readouterr().out
+    assert calls == 1
+    assert "Generate class packet" in output
+    assert "Back" in output
+
+
+def test_printable_response_menu_invalid_selection_and_keyboard_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _inputs(monkeypatch, ["bad", "", "2"])
+    assert workflows.launch_printable_response_menu() == 0
+    assert "Invalid selection" in capsys.readouterr().out
+
+    def interrupt(_prompt: str = "") -> str:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", interrupt)
+    assert workflows.launch_printable_response_menu() == 0
+    assert "Exiting printable response menu." in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Added a Printable Response Pages submenu with generate class packet and back options.
- Added menu workflow for selecting a canonical class roster and assignment config.
- Added pages-per-student prompting with blank defaulting to `1`.
- Generated the current supported output mode: one combined class packet PDF.
- Wrote printable packets to `classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf`.
- Added exact `OVERWRITE` protection for existing printable packets.
- Reused the existing `generate_printable_responses_for_roster()` API.
- Added workflow and focused menu tests for happy path, missing roster, missing assignment, invalid assignment, class mismatch, invalid page count, overwrite protection, and dispatch.
- Updated documentation and changelog for the new printable response packet menu capability.

Closes #42.

## Validation

- [x] `python -m pytest` — 232 tests passed
- [x] `python -m ruff check .`
- [x] `python -m mypy .`
- [x] `git diff --check`
- [x] `.\run_tests.ps1`

## Notes

- Generates one combined class packet PDF only.
- No individual per-student PDF mode added.
- No direct printable CLI command added.
- No scan routing added.
- No QR extraction from scans added.
- No OCR, review, grading, scoring, feedback, reporting, tagging execution, requirements checking, or AI workflow added.
- No schemas changed.
- No PDS1 payload behavior changed.
- No printable PDF drawing logic changed.
- No assignment configs changed by generation.
- No roster files changed by generation.
- No workspace behavior changed.
- No scan/report behavior changed.
- No generated PDFs, scans, real assignments, real rosters, private files, classroom artifacts, or real student data committed.
- No sibling repositories modified.