### PR TITLE
Add decoded response route planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Quillan currently supports:
 - teacher-facing generation of one combined printable response class packet
   from an existing canonical roster and assignment config;
 - shared Paper Data Suite workspace status reporting;
-- assignment-local storage paths based on shared `pds-core` route helpers; and
+- assignment-local storage paths based on shared `pds-core` route helpers;
+- an internal, read-only decoded response-page route planner that validates
+  class, assignment, roster, and student relationships without writing files;
+  and
 - synthetic examples and fixtures for safe testing and documentation.
 
 Printable response generation is exposed through the teacher-facing menu and
@@ -52,7 +55,8 @@ The data contracts and design documents describe additional teacher-review
 and paper-ingest workflows that are not yet implemented end to end. In
 particular, Quillan does not currently provide:
 
-- production scan routing, copying, or filing;
+- production scan routing, copying, or filing (the internal decoded route
+  planner only computes a validated route decision);
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -171,12 +171,12 @@ before routed-evidence writes, in the following order.
    verify that it remains inside the resolved workspace root. Reject any path
    that escapes the root, including through traversal or filesystem links.
 
-Student roster membership is not an initial routing prerequisite. Quillan
-consumes and manages shared `pds-core` roster records, but roster membership
-does not alter the routing contract described here. A future roster-aware
-routing phase may flag an unknown student for
-review, but it must preserve the source evidence rather than infer a different
-identity. The student identifier must still be valid.
+Quillan's decoded response route planner requires the canonical class roster
+to exist and validates exact student-ID membership before returning a route
+plan. An unknown student produces a structured `student_unknown` failure; the
+planner never substitutes a student based on names or other context. The
+planner only reads routing context and computes destination paths. It does not
+write routed evidence or review metadata.
 
 Validation should return stable, machine-readable failure codes in addition to
 human-readable reasons. It must not attempt to repair identifiers, guess a

--- a/quillan/route_planning.py
+++ b/quillan/route_planning.py
@@ -1,0 +1,269 @@
+"""Pure route planning for already-decoded Quillan response pages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from pds_core.classes import load_class_roster
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.rosters import RosterError, student_lookup
+from pds_core.routes import class_dir, class_roster_path
+from pds_core.scan_failure_metadata import is_routing_failure_category
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.storage import (
+    assignment_config_path,
+    assignment_scans_dir,
+    student_submission_dir,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DecodedResponsePage:
+    """Identity fields obtained from an already-decoded response-page payload."""
+
+    module: str | None
+    document_type: str | None
+    class_id: str | None
+    assignment_id: str | None
+    student_id: str | None
+    page_number: int | None
+    raw_payload: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RoutePlan:
+    """Validated paths and identity for a future response-page route."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    page_number: int | None
+    assignment_config_path: Path
+    roster_path: Path
+    routed_evidence_dir: Path
+    student_submission_dir: Path
+
+
+@dataclass(frozen=True, slots=True)
+class RouteFailure:
+    """Structured explanation of why a decoded page cannot be routed."""
+
+    failure_category: str
+    failure_message: str
+    module: str | None
+    class_id: str | None
+    assignment_id: str | None
+    student_id: str | None
+    page_number: int | None
+    raw_payload: str | None
+    module_details: dict[str, object]
+
+
+def plan_decoded_response_page_route(
+    workspace_root: str | Path,
+    decoded_page: DecodedResponsePage,
+) -> RoutePlan | RouteFailure:
+    """Plan a route for decoded Quillan response data without writing files."""
+    if decoded_page.module != "quillan":
+        return _failure(
+            decoded_page,
+            "module_unsupported",
+            "Decoded page is not for the Quillan module.",
+            reason="module_unsupported",
+            expected_module="quillan",
+        )
+
+    if decoded_page.document_type != "response":
+        return _failure(
+            decoded_page,
+            "payload_invalid",
+            "Decoded page is not a Quillan response page.",
+            reason="document_type_invalid",
+            field="document_type",
+            expected_document_type="response",
+        )
+
+    for field_name in ("class_id", "assignment_id", "student_id"):
+        value = getattr(decoded_page, field_name)
+        if value is None:
+            return _failure(
+                decoded_page,
+                "payload_invalid",
+                f"Decoded response page is missing {field_name}.",
+                reason="field_missing",
+                field=field_name,
+            )
+        try:
+            validate_identifier(value, field_name)
+        except IdentifierValidationError as error:
+            return _failure(
+                decoded_page,
+                "identifier_invalid",
+                str(error),
+                reason="identifier_invalid",
+                field=field_name,
+            )
+
+    if decoded_page.page_number is not None and (
+        isinstance(decoded_page.page_number, bool)
+        or not isinstance(decoded_page.page_number, int)
+        or decoded_page.page_number < 1
+    ):
+        return _failure(
+            decoded_page,
+            "payload_invalid",
+            "page_number must be a positive integer when present.",
+            reason="page_number_invalid",
+            field="page_number",
+        )
+
+    class_id = cast(str, decoded_page.class_id)
+    assignment_id = cast(str, decoded_page.assignment_id)
+    student_id = cast(str, decoded_page.student_id)
+    root = Path(workspace_root)
+    resolved_class_dir = class_dir(root, class_id)
+
+    try:
+        class_exists = resolved_class_dir.is_dir()
+    except OSError as error:
+        return _failure(
+            decoded_page,
+            "processing_error",
+            f"Could not inspect class directory: {error}",
+            reason="class_check_failed",
+        )
+    if not class_exists:
+        return _failure(
+            decoded_page,
+            "class_unknown",
+            f"Class is not present in the workspace: {class_id}",
+            reason="class_unknown",
+        )
+
+    roster_path = class_roster_path(root, class_id)
+    try:
+        roster_exists = roster_path.is_file()
+    except OSError as error:
+        return _failure(
+            decoded_page,
+            "processing_error",
+            f"Could not inspect class roster: {error}",
+            reason="roster_check_failed",
+        )
+    if not roster_exists:
+        return _failure(
+            decoded_page,
+            "processing_error",
+            f"Class roster is missing: {roster_path}",
+            reason="roster_missing",
+        )
+
+    try:
+        roster = load_class_roster(root, class_id)
+    except RosterError as error:
+        return _failure(
+            decoded_page,
+            "processing_error",
+            f"Class roster is invalid or unreadable: {error}",
+            reason="roster_invalid",
+        )
+
+    resolved_assignment_config_path = assignment_config_path(
+        root,
+        class_id,
+        assignment_id,
+    )
+    try:
+        assignment_exists = resolved_assignment_config_path.is_file()
+    except OSError as error:
+        return _failure(
+            decoded_page,
+            "processing_error",
+            f"Could not inspect assignment config: {error}",
+            reason="assignment_check_failed",
+        )
+    if not assignment_exists:
+        return _failure(
+            decoded_page,
+            "assignment_unknown",
+            f"Assignment is not present for class {class_id}: {assignment_id}",
+            reason="assignment_unknown",
+        )
+
+    try:
+        assignment = load_assignment_config(resolved_assignment_config_path)
+    except (AssignmentConfigError, OSError, UnicodeError) as error:
+        return _failure(
+            decoded_page,
+            "processing_error",
+            f"Assignment config is invalid or unreadable: {error}",
+            reason="assignment_config_invalid",
+        )
+
+    configured_assignment_id = cast(str, assignment["assignment_id"])
+    if configured_assignment_id != assignment_id:
+        return _failure(
+            decoded_page,
+            "route_mismatch",
+            "Assignment config ID does not match the decoded assignment ID.",
+            reason="assignment_id_mismatch",
+            configured_assignment_id=configured_assignment_id,
+        )
+
+    configured_class_ids = cast(list[str], assignment["class_ids"])
+    if class_id not in configured_class_ids:
+        return _failure(
+            decoded_page,
+            "route_mismatch",
+            "Assignment config does not include the decoded class ID.",
+            reason="assignment_class_mismatch",
+            configured_class_ids=list(configured_class_ids),
+        )
+
+    if student_id not in student_lookup(roster):
+        return _failure(
+            decoded_page,
+            "student_unknown",
+            f"Student is not present in the class roster: {student_id}",
+            reason="student_unknown",
+        )
+
+    return RoutePlan(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        page_number=decoded_page.page_number,
+        assignment_config_path=resolved_assignment_config_path,
+        roster_path=roster_path,
+        routed_evidence_dir=assignment_scans_dir(root, class_id, assignment_id),
+        student_submission_dir=student_submission_dir(
+            root,
+            class_id,
+            assignment_id,
+            student_id,
+        ),
+    )
+
+
+def _failure(
+    decoded_page: DecodedResponsePage,
+    category: str,
+    message: str,
+    **module_details: object,
+) -> RouteFailure:
+    if not is_routing_failure_category(category):
+        raise ValueError(f"Unsupported routing failure category: {category}")
+    return RouteFailure(
+        failure_category=category,
+        failure_message=message,
+        module=decoded_page.module,
+        class_id=decoded_page.class_id,
+        assignment_id=decoded_page.assignment_id,
+        student_id=decoded_page.student_id,
+        page_number=decoded_page.page_number,
+        raw_payload=decoded_page.raw_payload,
+        module_details=dict(module_details),
+    )

--- a/quillan/storage.py
+++ b/quillan/storage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pds_core.routes import (
     assignment_config_path as pds_assignment_config_path,
     assignment_dir as pds_assignment_dir,
+    assignment_scans_dir as pds_assignment_scans_dir,
     assignment_submissions_dir as pds_assignment_submissions_dir,
     assignment_templates_dir as pds_assignment_templates_dir,
     student_submission_dir as pds_student_submission_dir,
@@ -38,6 +39,15 @@ def assignment_submissions_dir(
 ) -> Path:
     """Return the shared PDS submissions directory for an assignment."""
     return pds_assignment_submissions_dir(root, class_id, assignment_id)
+
+
+def assignment_scans_dir(
+    root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return the shared PDS routed-evidence directory for an assignment."""
+    return pds_assignment_scans_dir(root, class_id, assignment_id)
 
 
 def assignment_templates_dir(

--- a/tests/test_route_planning.py
+++ b/tests/test_route_planning.py
@@ -1,0 +1,303 @@
+"""Tests for decoded Quillan response-page route planning."""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.route_planning import (
+    DecodedResponsePage,
+    RouteFailure,
+    RoutePlan,
+    plan_decoded_response_page_route,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    class_dir = tmp_path / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def decoded_page() -> DecodedResponsePage:
+    return DecodedResponsePage(
+        module="quillan",
+        document_type="response",
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        page_number=2,
+        raw_payload=(
+            "PDS1|module=quillan|class=english12_p3_synthetic|"
+            "aid=essay_01_synthetic|sid=00107|page=2|doc=response"
+        ),
+    )
+
+
+def _failure(result: RoutePlan | RouteFailure) -> RouteFailure:
+    assert isinstance(result, RouteFailure)
+    return result
+
+
+def test_valid_decoded_page_returns_expected_route_plan(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    result = plan_decoded_response_page_route(workspace, decoded_page)
+
+    assert result == RoutePlan(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        page_number=2,
+        assignment_config_path=(
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "assignment.json"
+        ),
+        roster_path=workspace / "classes" / CLASS_ID / "roster.csv",
+        routed_evidence_dir=(
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "scans"
+        ),
+        student_submission_dir=(
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "submissions"
+            / STUDENT_ID
+        ),
+    )
+    assert result.student_id == "00107"
+
+
+@pytest.mark.parametrize(
+    ("changes", "category"),
+    [
+        ({"module": "scoreform"}, "module_unsupported"),
+        ({"document_type": None}, "payload_invalid"),
+        ({"document_type": "cover"}, "payload_invalid"),
+        ({"class_id": None}, "payload_invalid"),
+        ({"class_id": "../unsafe"}, "identifier_invalid"),
+        ({"assignment_id": None}, "payload_invalid"),
+        ({"student_id": None}, "payload_invalid"),
+        ({"page_number": 0}, "payload_invalid"),
+        ({"page_number": True}, "payload_invalid"),
+    ],
+)
+def test_invalid_decoded_values_return_structured_failure(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+    changes: dict[str, Any],
+    category: str,
+) -> None:
+    result = plan_decoded_response_page_route(
+        workspace,
+        replace(decoded_page, **changes),
+    )
+
+    assert _failure(result).failure_category == category
+
+
+def test_optional_page_number_may_be_absent(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    result = plan_decoded_response_page_route(
+        workspace,
+        replace(decoded_page, page_number=None),
+    )
+
+    assert isinstance(result, RoutePlan)
+    assert result.page_number is None
+
+
+def test_unknown_class_returns_class_unknown(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    result = plan_decoded_response_page_route(
+        workspace,
+        replace(decoded_page, class_id="unknown_class"),
+    )
+
+    assert _failure(result).failure_category == "class_unknown"
+
+
+def test_missing_roster_returns_processing_error(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    (workspace / "classes" / CLASS_ID / "roster.csv").unlink()
+
+    result = plan_decoded_response_page_route(workspace, decoded_page)
+
+    failure = _failure(result)
+    assert failure.failure_category == "processing_error"
+    assert failure.module_details["reason"] == "roster_missing"
+
+
+def test_unknown_assignment_returns_assignment_unknown(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    result = plan_decoded_response_page_route(
+        workspace,
+        replace(decoded_page, assignment_id="unknown_assignment"),
+    )
+
+    assert _failure(result).failure_category == "assignment_unknown"
+
+
+def test_invalid_assignment_config_returns_processing_error(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    assignment_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment_path.write_text("{}", encoding="utf-8")
+
+    result = plan_decoded_response_page_route(workspace, decoded_page)
+
+    failure = _failure(result)
+    assert failure.failure_category == "processing_error"
+    assert failure.module_details["reason"] == "assignment_config_invalid"
+
+
+def test_assignment_class_mismatch_returns_route_mismatch(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    assignment_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment = json.loads(assignment_path.read_text(encoding="utf-8"))
+    assignment["class_ids"] = ["different_class"]
+    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
+
+    result = plan_decoded_response_page_route(workspace, decoded_page)
+
+    assert _failure(result).failure_category == "route_mismatch"
+
+
+def test_assignment_id_mismatch_returns_route_mismatch(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    assignment_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment = json.loads(assignment_path.read_text(encoding="utf-8"))
+    assignment["assignment_id"] = "different_assignment"
+    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
+
+    result = plan_decoded_response_page_route(workspace, decoded_page)
+
+    assert _failure(result).failure_category == "route_mismatch"
+
+
+def test_unknown_student_returns_student_unknown(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    result = plan_decoded_response_page_route(
+        workspace,
+        replace(decoded_page, student_id="00999"),
+    )
+
+    assert _failure(result).failure_category == "student_unknown"
+
+
+def test_planner_does_not_write_or_create_scan_directories(
+    workspace: Path,
+    decoded_page: DecodedResponsePage,
+) -> None:
+    before = sorted(path.relative_to(workspace) for path in workspace.rglob("*"))
+
+    result = plan_decoded_response_page_route(workspace, decoded_page)
+
+    after = sorted(path.relative_to(workspace) for path in workspace.rglob("*"))
+    assert isinstance(result, RoutePlan)
+    assert after == before
+    assert not (workspace / "scans").exists()
+    assert not result.routed_evidence_dir.exists()
+    assert not result.student_submission_dir.exists()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pds_core.routes import (
     assignment_config_path as pds_assignment_config_path,
     assignment_dir as pds_assignment_dir,
+    assignment_scans_dir as pds_assignment_scans_dir,
     assignment_submissions_dir as pds_assignment_submissions_dir,
     assignment_templates_dir as pds_assignment_templates_dir,
     student_submission_dir as pds_student_submission_dir,
@@ -15,6 +16,7 @@ from pds_core.routes import (
 from quillan.storage import (
     assignment_config_path,
     assignment_dir,
+    assignment_scans_dir,
     assignment_submissions_dir,
     assignment_templates_dir,
     feedback_path,
@@ -44,6 +46,9 @@ def test_assignment_paths_use_shared_pds_routes(tmp_path: Path) -> None:
     assert assignment_submissions_dir(
         tmp_path, CLASS_ID, ASSIGNMENT_ID
     ) == pds_assignment_submissions_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    assert assignment_scans_dir(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    ) == pds_assignment_scans_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
     assert assignment_templates_dir(
         tmp_path, CLASS_ID, ASSIGNMENT_ID
     ) == pds_assignment_templates_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)


### PR DESCRIPTION
## Summary

* Added a pure decoded response route-planning API for Quillan response pages.
* Added `DecodedResponsePage`, `RoutePlan`, and `RouteFailure` models, with route plans carrying explicit assignment config, roster, routed-evidence, and student-submission paths.
* Added `plan_decoded_response_page_route()` to determine whether a decoded Quillan response page can be routed to a known class, assignment, and student.
* Added an assignment-level routed-evidence path helper.
* Added focused tests for successful route plans and structured route failures.
* Used shared pds-core failure categories for route-planning failures.
* Updated storage tests, README, and scan-routing documentation.

Closes #62.

## Validation

* [x] `python -m pytest` — 251 tests passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .` — 34 files checked
* [x] `git diff --check`
* [x] `.\run_tests.ps1`
* [x] Boundary search confirmed no prohibited operations were added.

## Notes

* Planner performs filesystem reads only.
* No directories are created by the planner.
* No source scans are created.
* No review records are written.
* No routed evidence is written.
* No student submissions are assembled.
* No scan intake implemented.
* No source scan copying implemented.
* No QR extraction implemented.
* No PDF splitting implemented.
* No image processing implemented.
* No failure metadata writing implemented.
* No OCR, scoring, feedback, or review UI implemented.
* No payload formats changed.
* No assignment schema changed.
* No roster schema changed.
* No menu or CLI behavior changed.
* No pds-core, ScoreForm, pds-sunset, or sibling repository changes.
* No generated files, scans, private files, classroom artifacts, or real student data committed.
