### PR TITLE
Add retained source and routed evidence filing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a successful-route evidence filing API that exclusively retains source
+  scans under `scans/source/YYYY-MM-DD/`, files response evidence under
+  assignment `scans/`, preserves duplicate rescans, and returns retained-source
+  and routed-evidence provenance.
 - Added a teacher-facing Printable Response Pages menu that generates one
   combined class packet from an existing canonical roster and assignment
   config using the existing roster-aware PDF generator.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Quillan currently supports:
 - assignment-local storage paths based on shared `pds-core` route helpers;
 - an internal, read-only decoded response-page route planner that validates
   class, assignment, roster, and student relationships without writing files;
-  and
+- an internal successful-route evidence filing helper that retains selected
+  source scans under `scans/source/YYYY-MM-DD/`, files routed copies under the
+  assignment `scans/` directory, and returns source and route provenance
+  without assembling submissions; and
 - synthetic examples and fixtures for safe testing and documentation.
 
 Printable response generation is exposed through the teacher-facing menu and
@@ -55,8 +58,9 @@ The data contracts and design documents describe additional teacher-review
 and paper-ingest workflows that are not yet implemented end to end. In
 particular, Quillan does not currently provide:
 
-- production scan routing, copying, or filing (the internal decoded route
-  planner only computes a validated route decision);
+- end-to-end production scan intake and routing (the internal APIs require an
+  already-selected readable source file and an already-successful route plan);
+- routing failure preservation under `scans/review/`;
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -174,7 +174,7 @@ Current responsibility:
 Individual student PDFs, scan routing, OCR, review, scoring, feedback, reports,
 AI, and a direct printable CLI command remain out of scope.
 
-### Future scan routing
+### Scan routing
 
 Future Quillan scan routing must use the shared active scan contract defined by
 `pds-core`. Canonical active retained sources belong in
@@ -189,9 +189,12 @@ validation, routed student evidence layout, submission assembly, completeness
 and rescan decisions, and any future OCR behavior. Quillan-specific failure
 details belong under the shared record's `module_details`.
 
-This remains design work only; scan intake, copying, QR extraction, PDF
-splitting, routing, failure writing, and submission assembly are not
-implemented.
+The first successful-write helper is implemented in `quillan.evidence_filing`.
+It accepts an existing successful `RoutePlan`, retains the selected source
+under `scans/source/YYYY-MM-DD/`, files the retained source or a supplied page
+artifact under assignment `scans/`, preserves duplicate copies, and returns
+provenance. QR extraction, PDF splitting, routing failure records, CLI/menu
+integration, and submission assembly remain unimplemented.
 
 ### `submissions.py`
 

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -24,8 +24,14 @@ active retained source remains in `scans/source/YYYY-MM-DD/`. Routing does not
 make the page a complete submission and does not perform or imply teacher
 review.
 
-This document is a design spike only. It does not implement scan routing, QR
-extraction, image processing, or OCR.
+Quillan now implements the first successful-write slice through
+`quillan.evidence_filing.file_routed_response_evidence()`. Given a readable
+source file and an existing successful `RoutePlan`, it exclusively copies the
+source into `scans/source/YYYY-MM-DD/`, files the retained source or a
+caller-supplied page artifact into assignment `scans/`, preserves duplicates,
+and returns provenance. It does not implement QR extraction, PDF splitting,
+failure preservation, submission assembly, image processing, OCR, or a CLI
+workflow.
 
 ## Design Goals
 
@@ -351,15 +357,14 @@ Inactive historical preservation and end-of-cycle archiving belong to future
 
 ## Future Implementation Phases
 
-1. **Shared retention integration.** Use future `pds-core` source-retention and
-   routing-review helpers without redefining their contracts in Quillan.
-2. **Decoded-payload routing helper.** Define typed inputs and results; parse
-   PDS1; validate Quillan response identity, identifiers, assignment
-   relationships, extensions, filenames, and path containment without writing
-   routed evidence.
-3. **Routed evidence writes.** Create assignment scan destinations, implement
-   exclusive no-overwrite copies or derived artifacts, and preserve provenance
-   to the retained source.
+1. **Shared retention integration.** Partially implemented for successful
+   writes using `pds-core` retained-source naming and path helpers. Shared
+   routing-review integration remains future work.
+2. **Decoded-payload routing helper.** Implemented as the read-only
+   `RoutePlan`/`RouteFailure` planner for already-decoded response-page data.
+3. **Routed evidence writes.** Implemented for successful routes: create
+   assignment scan destinations, use exclusive no-overwrite copies, preserve
+   duplicate evidence, and return provenance to the retained source.
 4. **QR extraction and splitting.** Add Quillan adapters that decode PDS1 text
    from scanned PDFs or images and pass canonical routing inputs to the
    independent routing helper.
@@ -378,9 +383,9 @@ submission mutations.
 
 ## Out of Scope
 
-This spike does not implement:
+The current successful-write slice does not implement:
 
-* scan routing, copying, moving, or filing;
+* end-to-end scan routing or intake orchestration;
 * QR detection or extraction;
 * PDF splitting, image processing, or OCR;
 * submission assembly or production roster workflows;

--- a/quillan/evidence_filing.py
+++ b/quillan/evidence_filing.py
@@ -1,0 +1,359 @@
+"""Conservative retained-source and routed-evidence filing."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Final
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.scan_routes import (
+    ScanRouteError,
+    build_retained_source_filename,
+    retained_source_scan_path,
+)
+
+from quillan.route_planning import RoutePlan
+from quillan.storage import assignment_scans_dir
+
+_COPY_BUFFER_SIZE: Final[int] = 1024 * 1024
+_MAX_DUPLICATE_ATTEMPTS: Final[int] = 10_000
+_SUPPORTED_EXTENSIONS: Final[frozenset[str]] = frozenset(
+    {".jpeg", ".jpg", ".pdf", ".png", ".tif", ".tiff"}
+)
+
+
+class EvidenceFilingError(RuntimeError):
+    """Raised when retained source or routed evidence cannot be filed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class RetainedSourceScan:
+    """Provenance for one canonical retained source intake event."""
+
+    source_scan_id: str
+    source_filename: str
+    source_sha256: str
+    retained_source_path: Path
+    retained_source_relative_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class RoutedEvidenceFile:
+    """Provenance for one successfully filed Quillan response page."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    page_number: int
+    retained_source: RetainedSourceScan
+    routed_evidence_path: Path
+    routed_evidence_relative_path: str
+    duplicate_number: int | None
+
+
+def file_routed_response_evidence(
+    workspace_root: str | Path,
+    *,
+    route_plan: RoutePlan,
+    source_file_path: str | Path,
+    intake_timestamp: datetime,
+    intake_date: date | str | None = None,
+    routed_source_file_path: str | Path | None = None,
+    routed_extension: str | None = None,
+) -> RoutedEvidenceFile:
+    """Retain a selected source and file one routed response-page artifact.
+
+    ``routed_source_file_path`` may identify an already-extracted page artifact.
+    When omitted, the newly retained source itself is copied as routed evidence.
+    """
+    root = _resolved_workspace_root(workspace_root)
+    routed_dir, page_number = _validated_route_plan(root, route_plan)
+    source_path = _readable_regular_file(source_file_path, "source_file_path")
+    routed_input = (
+        _readable_regular_file(
+            routed_source_file_path,
+            "routed_source_file_path",
+        )
+        if routed_source_file_path is not None
+        else None
+    )
+
+    source_sha256 = _sha256_file(source_path, "source_file_path")
+    try:
+        retained_filename = build_retained_source_filename(
+            intake_timestamp=intake_timestamp,
+            original_filename=source_path.name,
+            sha256_hex=source_sha256,
+        )
+        source_date = (
+            intake_timestamp.astimezone(timezone.utc).date()
+            if intake_date is None
+            else intake_date
+        )
+        retained_path = retained_source_scan_path(
+            root,
+            intake_date=source_date,
+            retained_filename=retained_filename,
+        ).resolve(strict=False)
+    except (ScanRouteError, OSError, ValueError) as error:
+        raise EvidenceFilingError(f"Invalid retained source route: {error}") from error
+
+    routed_input_for_extension = (
+        source_path if routed_input is None else routed_input
+    )
+    extension = _normalized_extension(
+        routed_extension
+        if routed_extension is not None
+        else routed_input_for_extension.suffix
+    )
+
+    retained_dir = retained_path.parent
+    _require_contained(retained_path, retained_dir, "retained source path")
+    _require_contained(retained_dir, root, "retained source directory")
+    _create_directory(retained_dir, root, "retained source directory")
+
+    try:
+        copied_sha256 = _copy_exclusive_with_sha256(source_path, retained_path)
+    except FileExistsError as error:
+        raise EvidenceFilingError(
+            f"Retained source destination already exists: {retained_path}"
+        ) from error
+    except OSError as error:
+        raise EvidenceFilingError(
+            f"Could not copy retained source to {retained_path}: {error}"
+        ) from error
+    if copied_sha256 != source_sha256:
+        _remove_incomplete_copy(retained_path)
+        raise EvidenceFilingError(
+            "Source file changed while it was being retained; no retained copy "
+            "was kept."
+        )
+
+    retained_source = RetainedSourceScan(
+        source_scan_id=f"scan_{retained_path.stem}",
+        source_filename=source_path.name,
+        source_sha256=source_sha256,
+        retained_source_path=retained_path,
+        retained_source_relative_path=_workspace_relative(retained_path, root),
+    )
+
+    routed_input = retained_path if routed_input is None else routed_input
+    _create_directory(routed_dir, root, "routed evidence directory")
+    routed_path, duplicate_number = _copy_routed_evidence(
+        routed_input,
+        routed_dir,
+        route_plan.student_id,
+        page_number,
+        extension,
+    )
+
+    return RoutedEvidenceFile(
+        class_id=route_plan.class_id,
+        assignment_id=route_plan.assignment_id,
+        student_id=route_plan.student_id,
+        page_number=page_number,
+        retained_source=retained_source,
+        routed_evidence_path=routed_path,
+        routed_evidence_relative_path=_workspace_relative(routed_path, root),
+        duplicate_number=duplicate_number,
+    )
+
+
+def _resolved_workspace_root(workspace_root: str | Path) -> Path:
+    try:
+        root = Path(workspace_root).resolve(strict=False)
+        if not root.is_dir():
+            raise EvidenceFilingError(
+                f"Workspace root is not an existing directory: {root}"
+            )
+        return root
+    except (OSError, TypeError, ValueError) as error:
+        raise EvidenceFilingError(f"Invalid workspace root: {error}") from error
+
+
+def _validated_route_plan(root: Path, route_plan: RoutePlan) -> tuple[Path, int]:
+    if not isinstance(route_plan, RoutePlan):
+        raise EvidenceFilingError("route_plan must be a successful RoutePlan.")
+    try:
+        validate_identifier(route_plan.class_id, "class_id")
+        validate_identifier(route_plan.assignment_id, "assignment_id")
+        validate_identifier(route_plan.student_id, "student_id")
+    except IdentifierValidationError as error:
+        raise EvidenceFilingError(f"Unsafe route identity: {error}") from error
+
+    page_number = route_plan.page_number
+    if (
+        page_number is None
+        or isinstance(page_number, bool)
+        or not isinstance(page_number, int)
+        or page_number < 1
+    ):
+        raise EvidenceFilingError(
+            "RoutePlan.page_number must be a positive integer for evidence filing."
+        )
+
+    try:
+        routed_dir = route_plan.routed_evidence_dir.resolve(strict=False)
+    except (OSError, TypeError, ValueError) as error:
+        raise EvidenceFilingError(
+            f"Invalid routed evidence directory: {error}"
+        ) from error
+    _require_contained(routed_dir, root, "routed evidence directory")
+    expected_routed_dir = assignment_scans_dir(
+        root,
+        route_plan.class_id,
+        route_plan.assignment_id,
+    ).resolve(strict=False)
+    if routed_dir != expected_routed_dir:
+        raise EvidenceFilingError(
+            "RoutePlan.routed_evidence_dir does not match its class_id and "
+            "assignment_id."
+        )
+    return routed_dir, page_number
+
+
+def _readable_regular_file(value: str | Path, field_name: str) -> Path:
+    try:
+        path = Path(value)
+        if not path.is_file():
+            raise EvidenceFilingError(
+                f"{field_name} must identify an existing regular file: {path}"
+            )
+        with path.open("rb"):
+            pass
+        return path
+    except EvidenceFilingError:
+        raise
+    except (OSError, TypeError, ValueError) as error:
+        raise EvidenceFilingError(f"Could not read {field_name}: {error}") from error
+
+
+def _sha256_file(path: Path, field_name: str) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            while chunk := source.read(_COPY_BUFFER_SIZE):
+                digest.update(chunk)
+    except OSError as error:
+        raise EvidenceFilingError(f"Could not read {field_name}: {error}") from error
+    return digest.hexdigest()
+
+
+def _copy_exclusive_with_sha256(source: Path, destination: Path) -> str:
+    digest = hashlib.sha256()
+    destination_created = False
+    try:
+        with source.open("rb") as source_file:
+            with destination.open("xb") as destination_file:
+                destination_created = True
+                while chunk := source_file.read(_COPY_BUFFER_SIZE):
+                    destination_file.write(chunk)
+                    digest.update(chunk)
+    except FileExistsError:
+        raise
+    except OSError:
+        if destination_created:
+            _remove_incomplete_copy(destination)
+        raise
+    return digest.hexdigest()
+
+
+def _copy_exclusive(source: Path, destination: Path) -> None:
+    destination_created = False
+    try:
+        with source.open("rb") as source_file:
+            with destination.open("xb") as destination_file:
+                destination_created = True
+                shutil.copyfileobj(
+                    source_file,
+                    destination_file,
+                    length=_COPY_BUFFER_SIZE,
+                )
+    except FileExistsError:
+        raise
+    except OSError:
+        if destination_created:
+            _remove_incomplete_copy(destination)
+        raise
+
+
+def _copy_routed_evidence(
+    source: Path,
+    routed_dir: Path,
+    student_id: str,
+    page_number: int,
+    extension: str,
+) -> tuple[Path, int | None]:
+    base_name = f"response_{student_id}_pg_{page_number:03d}"
+    for duplicate_number in range(_MAX_DUPLICATE_ATTEMPTS):
+        duplicate_suffix = (
+            "" if duplicate_number == 0 else f"__dup_{duplicate_number:03d}"
+        )
+        candidate = (routed_dir / f"{base_name}{duplicate_suffix}{extension}").resolve(
+            strict=False
+        )
+        _require_contained(candidate, routed_dir, "routed evidence path")
+        try:
+            _copy_exclusive(source, candidate)
+        except FileExistsError:
+            continue
+        except OSError as error:
+            raise EvidenceFilingError(
+                f"Could not copy routed evidence to {candidate}: {error}"
+            ) from error
+        return candidate, duplicate_number or None
+
+    raise EvidenceFilingError(
+        "Could not choose an available routed evidence filename after "
+        f"{_MAX_DUPLICATE_ATTEMPTS} attempts."
+    )
+
+
+def _normalized_extension(extension: str) -> str:
+    if not isinstance(extension, str):
+        raise EvidenceFilingError("routed_extension must be a string.")
+    normalized = extension.lower()
+    if not normalized.startswith("."):
+        normalized = f".{normalized}"
+    if normalized not in _SUPPORTED_EXTENSIONS:
+        allowed = ", ".join(sorted(_SUPPORTED_EXTENSIONS))
+        raise EvidenceFilingError(
+            f"Unsupported routed evidence extension; expected one of: {allowed}."
+        )
+    return normalized
+
+
+def _create_directory(path: Path, root: Path, description: str) -> None:
+    _require_contained(path, root, description)
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        resolved_path = path.resolve(strict=True)
+    except OSError as error:
+        raise EvidenceFilingError(f"Could not create {description}: {error}") from error
+    _require_contained(resolved_path, root, description)
+    if not resolved_path.is_dir():
+        raise EvidenceFilingError(f"{description.capitalize()} is not a directory.")
+
+
+def _require_contained(path: Path, parent: Path, description: str) -> None:
+    if path == parent or path.is_relative_to(parent):
+        return
+    raise EvidenceFilingError(f"{description.capitalize()} escapes its allowed root.")
+
+
+def _workspace_relative(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError as error:
+        raise EvidenceFilingError("Filed path is outside the workspace root.") from error
+
+
+def _remove_incomplete_copy(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/tests/test_evidence_filing.py
+++ b/tests/test_evidence_filing.py
@@ -1,0 +1,428 @@
+"""Tests for retained source intake and successful routed evidence filing."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.scan_routes import build_retained_source_filename
+
+from quillan.evidence_filing import (
+    EvidenceFilingError,
+    file_routed_response_evidence,
+)
+from quillan.route_planning import RoutePlan
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+INTAKE_TIMESTAMP = datetime(2026, 6, 19, 23, 45, 1, 123456, tzinfo=timezone.utc)
+SOURCE_BYTES = b"%PDF-1.4\nsynthetic scan evidence\n%%EOF\n"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    assignment_dir = (
+        tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    )
+    assignment_dir.mkdir(parents=True)
+    (assignment_dir / "assignment.json").write_text(
+        '{"synthetic": true}\n',
+        encoding="utf-8",
+    )
+    roster_path = tmp_path / "classes" / CLASS_ID / "roster.csv"
+    roster_path.write_text("student_id\n00107\n", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def route_plan(workspace: Path) -> RoutePlan:
+    assignment_dir = (
+        workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    )
+    return RoutePlan(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        page_number=2,
+        assignment_config_path=assignment_dir / "assignment.json",
+        roster_path=workspace / "classes" / CLASS_ID / "roster.csv",
+        routed_evidence_dir=assignment_dir / "scans",
+        student_submission_dir=assignment_dir / "submissions" / STUDENT_ID,
+    )
+
+
+@pytest.fixture
+def source_file(tmp_path: Path) -> Path:
+    path = tmp_path / "Teacher Scan.PDF"
+    path.write_bytes(SOURCE_BYTES)
+    return path
+
+
+def test_files_retained_source_and_routed_evidence_with_provenance(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+) -> None:
+    original_bytes = source_file.read_bytes()
+    result = file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP,
+    )
+
+    expected_sha256 = hashlib.sha256(SOURCE_BYTES).hexdigest()
+    expected_retained_name = build_retained_source_filename(
+        intake_timestamp=INTAKE_TIMESTAMP,
+        original_filename=source_file.name,
+        sha256_hex=expected_sha256,
+    )
+    expected_retained_path = (
+        workspace / "scans" / "source" / "2026-06-19" / expected_retained_name
+    ).resolve()
+    expected_routed_path = (
+        route_plan.routed_evidence_dir / "response_00107_pg_002.pdf"
+    ).resolve()
+
+    assert result.retained_source.source_filename == "Teacher Scan.PDF"
+    assert result.retained_source.source_sha256 == expected_sha256
+    assert result.retained_source.source_scan_id == (
+        f"scan_{expected_retained_path.stem}"
+    )
+    assert result.retained_source.retained_source_path == expected_retained_path
+    assert result.retained_source.retained_source_relative_path == (
+        f"scans/source/2026-06-19/{expected_retained_name}"
+    )
+    assert result.routed_evidence_path == expected_routed_path
+    assert result.routed_evidence_relative_path == (
+        "classes/english12_p3_synthetic/assignments/"
+        "essay_01_synthetic/scans/response_00107_pg_002.pdf"
+    )
+    assert result.class_id == CLASS_ID
+    assert result.assignment_id == ASSIGNMENT_ID
+    assert result.student_id == "00107"
+    assert result.page_number == 2
+    assert result.duplicate_number is None
+    assert expected_retained_path.read_bytes() == SOURCE_BYTES
+    assert expected_routed_path.read_bytes() == SOURCE_BYTES
+    assert source_file.read_bytes() == original_bytes
+
+
+def test_intake_date_defaults_to_utc_date(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+) -> None:
+    eastern = timezone(timedelta(hours=-4))
+    timestamp = datetime(2026, 6, 19, 23, 30, tzinfo=eastern)
+
+    result = file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=timestamp,
+    )
+
+    assert "/2026-06-20/" in (
+        f"/{result.retained_source.retained_source_relative_path}/"
+    )
+
+
+def test_explicit_intake_date_is_used(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+) -> None:
+    result = file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP,
+        intake_date="2026-06-18",
+    )
+
+    assert "/2026-06-18/" in (
+        f"/{result.retained_source.retained_source_relative_path}/"
+    )
+
+
+def test_retained_source_collision_is_refused(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+) -> None:
+    file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP,
+    )
+
+    with pytest.raises(EvidenceFilingError, match="already exists"):
+        file_routed_response_evidence(
+            workspace,
+            route_plan=route_plan,
+            source_file_path=source_file,
+            intake_timestamp=INTAKE_TIMESTAMP,
+        )
+
+
+@pytest.mark.parametrize("filename", ["scan.txt", "scan.exe", "scan"])
+def test_unsupported_source_extension_fails_without_creating_scan_dirs(
+    workspace: Path,
+    route_plan: RoutePlan,
+    tmp_path: Path,
+    filename: str,
+) -> None:
+    source = tmp_path / filename
+    source.write_bytes(b"synthetic")
+
+    with pytest.raises(EvidenceFilingError, match="supported scan extension"):
+        file_routed_response_evidence(
+            workspace,
+            route_plan=route_plan,
+            source_file_path=source,
+            intake_timestamp=INTAKE_TIMESTAMP,
+        )
+
+    assert not (workspace / "scans").exists()
+    assert not route_plan.routed_evidence_dir.exists()
+
+
+def test_missing_source_fails_without_creating_scan_dirs(
+    workspace: Path,
+    route_plan: RoutePlan,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(EvidenceFilingError, match="existing regular file"):
+        file_routed_response_evidence(
+            workspace,
+            route_plan=route_plan,
+            source_file_path=tmp_path / "missing.pdf",
+            intake_timestamp=INTAKE_TIMESTAMP,
+        )
+
+    assert not (workspace / "scans").exists()
+    assert not route_plan.routed_evidence_dir.exists()
+
+
+def test_directory_source_fails(
+    workspace: Path,
+    route_plan: RoutePlan,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(EvidenceFilingError, match="existing regular file"):
+        file_routed_response_evidence(
+            workspace,
+            route_plan=route_plan,
+            source_file_path=tmp_path,
+            intake_timestamp=INTAKE_TIMESTAMP,
+        )
+
+
+def test_duplicates_use_incrementing_exclusive_filenames(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+) -> None:
+    first = file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP,
+    )
+    second = file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP + timedelta(microseconds=1),
+    )
+    third = file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP + timedelta(microseconds=2),
+    )
+
+    assert first.routed_evidence_path.name == "response_00107_pg_002.pdf"
+    assert second.routed_evidence_path.name == (
+        "response_00107_pg_002__dup_001.pdf"
+    )
+    assert third.routed_evidence_path.name == (
+        "response_00107_pg_002__dup_002.pdf"
+    )
+    assert second.duplicate_number == 1
+    assert third.duplicate_number == 2
+    assert first.routed_evidence_path.read_bytes() == SOURCE_BYTES
+    assert second.routed_evidence_path.read_bytes() == SOURCE_BYTES
+    assert third.routed_evidence_path.read_bytes() == SOURCE_BYTES
+
+
+@pytest.mark.parametrize(
+    ("page_number", "expected_name"),
+    [
+        (1, "response_00107_pg_001.pdf"),
+        (999, "response_00107_pg_999.pdf"),
+        (1000, "response_00107_pg_1000.pdf"),
+    ],
+)
+def test_page_number_formatting(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+    page_number: int,
+    expected_name: str,
+) -> None:
+    result = file_routed_response_evidence(
+        workspace,
+        route_plan=replace(route_plan, page_number=page_number),
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP,
+    )
+
+    assert result.routed_evidence_path.name == expected_name
+
+
+def test_page_number_none_is_rejected_before_writes(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+) -> None:
+    with pytest.raises(EvidenceFilingError, match="positive integer"):
+        file_routed_response_evidence(
+            workspace,
+            route_plan=replace(route_plan, page_number=None),
+            source_file_path=source_file,
+            intake_timestamp=INTAKE_TIMESTAMP,
+        )
+
+    assert not (workspace / "scans").exists()
+    assert not route_plan.routed_evidence_dir.exists()
+
+
+def test_already_extracted_page_artifact_can_be_routed(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+    tmp_path: Path,
+) -> None:
+    page_bytes = b"\x89PNG\r\nsynthetic extracted page"
+    page_artifact = tmp_path / "page-2.PNG"
+    page_artifact.write_bytes(page_bytes)
+
+    result = file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        routed_source_file_path=page_artifact,
+        intake_timestamp=INTAKE_TIMESTAMP,
+    )
+
+    assert result.routed_evidence_path.name == "response_00107_pg_002.png"
+    assert result.routed_evidence_path.read_bytes() == page_bytes
+    assert result.retained_source.retained_source_path.read_bytes() == SOURCE_BYTES
+
+
+@pytest.mark.parametrize(
+    "extension",
+    ["../pdf", "/pdf", r"\pdf", ".html", ""],
+)
+def test_unsafe_or_unsupported_routed_extension_fails_before_writes(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+    extension: str,
+) -> None:
+    with pytest.raises(EvidenceFilingError, match="Unsupported routed"):
+        file_routed_response_evidence(
+            workspace,
+            route_plan=route_plan,
+            source_file_path=source_file,
+            intake_timestamp=INTAKE_TIMESTAMP,
+            routed_extension=extension,
+        )
+
+    assert not (workspace / "scans").exists()
+    assert not route_plan.routed_evidence_dir.exists()
+
+
+def test_routed_directory_outside_workspace_is_rejected_before_writes(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+    tmp_path: Path,
+) -> None:
+    unsafe_plan = replace(
+        route_plan,
+        routed_evidence_dir=tmp_path.parent / "outside-workspace",
+    )
+
+    with pytest.raises(EvidenceFilingError, match="escapes"):
+        file_routed_response_evidence(
+            workspace,
+            route_plan=unsafe_plan,
+            source_file_path=source_file,
+            intake_timestamp=INTAKE_TIMESTAMP,
+        )
+
+    assert not (workspace / "scans").exists()
+
+
+def test_mismatched_routed_evidence_dir_is_rejected_before_writes(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+) -> None:
+    bad_plan = replace(
+        route_plan,
+        routed_evidence_dir=(
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / "different_assignment"
+            / "scans"
+        ),
+    )
+
+    with pytest.raises(EvidenceFilingError, match="does not match"):
+        file_routed_response_evidence(
+            workspace,
+            route_plan=bad_plan,
+            source_file_path=source_file,
+            intake_timestamp=INTAKE_TIMESTAMP,
+        )
+
+    assert not (workspace / "scans").exists()
+    assert not route_plan.routed_evidence_dir.exists()
+    assert not bad_plan.routed_evidence_dir.exists()
+
+
+def test_success_does_not_create_review_submission_or_output_records(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+) -> None:
+    assignment_config_before = route_plan.assignment_config_path.read_bytes()
+    roster_before = route_plan.roster_path.read_bytes()
+
+    file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP,
+    )
+
+    assert not (workspace / "scans" / "review").exists()
+    assert not route_plan.student_submission_dir.exists()
+    assert not list(workspace.rglob("submission.json"))
+    assert not list(workspace.rglob("requirements.json"))
+    assert not list(workspace.rglob("tags.json"))
+    assert not list(workspace.rglob("scores.json"))
+    assert not list(workspace.rglob("feedback.md"))
+    assert route_plan.assignment_config_path.read_bytes() == assignment_config_before
+    assert route_plan.roster_path.read_bytes() == roster_before


### PR DESCRIPTION
## Summary

* Added successful-route evidence filing for Quillan response pages.
* Added retained source intake under `scans/source/YYYY-MM-DD/` using pds-core retained filename/path helpers.
* Added SHA-256 computation and retained source provenance.
* Added conservative routed evidence filing under assignment-level `scans/`.
* Added normal routed evidence naming as `response_<student_id>_pg_<NNN>.<ext>`.
* Added duplicate routed evidence preservation with `__dup_001`, `__dup_002`, and so on.
* Added exclusive copy behavior to avoid silent overwrites.
* Added path-containment checks for retained source and routed evidence destinations.
* Added route-plan integrity validation so routed evidence directories must match the route plan’s class and assignment identity.
* Added structured return models for retained source and routed evidence provenance.
* Added focused tests for retained source copying, routed evidence filing, duplicate naming, provenance, route-plan integrity, and non-goal boundaries.
* Updated README, scan-routing design, development plan, and changelog.

Closes #45.

## Validation

* [x] `python -m pytest` — 274 tests passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* Original selected source files are left untouched.
* Retained source copies are written under `scans/source/YYYY-MM-DD/`.
* Routed evidence copies are written under assignment-level `scans/`.
* Mismatched routed evidence directories are rejected before retained-source or routed-evidence directories are created.
* No `scans/review/` failure metadata is written.
* No routing failure preservation implemented.
* No QR extraction implemented.
* No PDF splitting implemented.
* No image processing implemented.
* No OCR implemented.
* No CLI or menu integration implemented.
* No submission assembly implemented.
* No `submission.json` writing implemented.
* No scores, feedback, tags, requirements, or reports written.
* No pds-core changes.
* No ScoreForm, pds-sunset, or sibling repository changes.
* No generated private files, classroom artifacts, or real student data committed.
