### PR TITLE
Preserve routing failures for review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a routing failure preservation API that writes shared `pds-core`
+  failure metadata exclusively under `scans/review/`, adapts route-planning and
+  evidence-filing failures, and records workspace-relative retained-source
+  provenance when available without copying review artifacts.
 - Added a successful-route evidence filing API that exclusively retains source
   scans under `scans/source/YYYY-MM-DD/`, files response evidence under
   assignment `scans/`, preserves duplicate rescans, and returns retained-source

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Quillan currently supports:
 - an internal successful-route evidence filing helper that retains selected
   source scans under `scans/source/YYYY-MM-DD/`, files routed copies under the
   assignment `scans/` directory, and returns source and route provenance
-  without assembling submissions; and
+  without assembling submissions;
+- an internal routing failure preservation API that writes shared `pds-core`
+  failure metadata under `scans/review/`, including retained-source provenance
+  when available, without copying review artifacts; and
 - synthetic examples and fixtures for safe testing and documentation.
 
 Printable response generation is exposed through the teacher-facing menu and
@@ -59,8 +62,7 @@ and paper-ingest workflows that are not yet implemented end to end. In
 particular, Quillan does not currently provide:
 
 - end-to-end production scan intake and routing (the internal APIs require an
-  already-selected readable source file and an already-successful route plan);
-- routing failure preservation under `scans/review/`;
+  already-selected readable source file and caller-managed orchestration);
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
@@ -68,17 +70,18 @@ particular, Quillan does not currently provide:
 - implemented requirements-checking, tagging, scoring, feedback, or
   production reporting workflows;
 - AI tagging, AI scoring, or AI feedback;
-- automatic grading; or
+- automatic grading;
 - complete teacher-facing assignment editing or review workflows; or
 - a dedicated printable-response command.
 
 The intended scan-routing rules and failure behavior are documented in
-[`docs/scan_routing_design.md`](docs/scan_routing_design.md), but that document
-is a design contract rather than an implemented router. Future routing must use
+[`docs/scan_routing_design.md`](docs/scan_routing_design.md). The implemented
+route planner, successful filing helper, and failure preservation helper follow
 the shared `pds-core` active scan contract: canonical retained sources belong
 in `scans/source/YYYY-MM-DD/`, canonical routing review records belong in
 `scans/review/`, and assignment-level `scans/` contains routed evidence rather
-than canonical source retention.
+than canonical source retention. QR extraction, PDF splitting, OCR, CLI routing,
+and submission assembly remain outside these internal APIs.
 
 ## Current Non-Goals
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -193,8 +193,14 @@ The first successful-write helper is implemented in `quillan.evidence_filing`.
 It accepts an existing successful `RoutePlan`, retains the selected source
 under `scans/source/YYYY-MM-DD/`, files the retained source or a supplied page
 artifact under assignment `scans/`, preserves duplicate copies, and returns
-provenance. QR extraction, PDF splitting, routing failure records, CLI/menu
-integration, and submission assembly remain unimplemented.
+provenance.
+
+Metadata-only failure preservation is implemented in `quillan.routing_review`.
+It writes shared `pds-core` failure records under `scans/review/`, preserves
+route failure and evidence filing context, and records workspace-relative
+retained-source provenance when available. It does not copy review artifacts.
+QR extraction, PDF splitting, OCR, CLI/menu integration, and submission
+assembly remain unimplemented.
 
 ### `submissions.py`
 

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -29,9 +29,10 @@ Quillan now implements the first successful-write slice through
 source file and an existing successful `RoutePlan`, it exclusively copies the
 source into `scans/source/YYYY-MM-DD/`, files the retained source or a
 caller-supplied page artifact into assignment `scans/`, preserves duplicates,
-and returns provenance. It does not implement QR extraction, PDF splitting,
-failure preservation, submission assembly, image processing, OCR, or a CLI
-workflow.
+and returns provenance. Quillan also implements metadata-only failure
+preservation through `quillan.routing_review`, writing shared failure records
+under `scans/review/`. These slices do not implement QR extraction, PDF
+splitting, submission assembly, image processing, OCR, or a CLI workflow.
 
 ## Design Goals
 
@@ -289,17 +290,19 @@ Failure cases include:
 If the workspace root itself cannot be resolved or written, the router cannot
 safely retain a source or create a shared review record. It should leave the
 teacher's original file untouched and return a hard failure with enough context
-for the caller to surface the problem. Exact review-record and optional
-problem-artifact naming belong to the shared `pds-core` contract and its future
-implementation.
+for the caller to surface the problem. Review-record naming and exclusive JSON
+writes use the shared `pds-core` contract. Quillan does not currently create or
+copy optional problem artifacts.
 
 ## Routing Failure Metadata
 
-A future implementation must use the shared `pds-core` routing failure metadata
-shape and shared failure categories. Quillan must not define a parallel
-failure-record schema. Validated Quillan identity and payload information use
-the shared base fields where available; Quillan-only details, such as response
-page validation or submission completeness context, belong under:
+`quillan.routing_review` implements metadata-only failure preservation using
+the shared `pds-core` routing failure metadata model, writer, paths, and failure
+categories. It accepts general failures and provides adapters for `RouteFailure`
+and `EvidenceFilingError`; it does not re-run planning or successful evidence
+filing. Quillan does not define a parallel failure-record schema. Validated
+Quillan identity and payload information use the shared base fields where
+available; Quillan-only details belong under:
 
 ```text
 module_details
@@ -309,7 +312,9 @@ Canonical failure JSON records live in `scans/review/`. They must preserve
 provenance back to the retained source, use workspace-relative paths, avoid
 guessed identities, and follow the shared no-overwrite and path-safety rules.
 Failure metadata must not contain a score, feedback, or an inferred student
-identity.
+identity. Retained-source provenance is recorded only when available, and a
+supplied review artifact path is recorded only as workspace-relative metadata;
+the helper does not copy that artifact.
 
 ## Relationship to Submissions
 
@@ -357,9 +362,10 @@ Inactive historical preservation and end-of-cycle archiving belong to future
 
 ## Future Implementation Phases
 
-1. **Shared retention integration.** Partially implemented for successful
-   writes using `pds-core` retained-source naming and path helpers. Shared
-   routing-review integration remains future work.
+1. **Shared retention and routing-review integration.** Partially implemented
+   through successful retained-source filing with `pds-core` retained-source
+   naming/path helpers and metadata-only failure preservation through shared
+   `pds-core` routing failure records under `scans/review/`.
 2. **Decoded-payload routing helper.** Implemented as the read-only
    `RoutePlan`/`RouteFailure` planner for already-decoded response-page data.
 3. **Routed evidence writes.** Implemented for successful routes: create
@@ -368,9 +374,10 @@ Inactive historical preservation and end-of-cycle archiving belong to future
 4. **QR extraction and splitting.** Add Quillan adapters that decode PDS1 text
    from scanned PDFs or images and pass canonical routing inputs to the
    independent routing helper.
-5. **Duplicate and failure review metadata.** Use shared failure records and
-   categories, put Quillan-specific context under `module_details`, and expose
-   duplicates and failures for teacher review.
+5. **Duplicate and failure review workflows.** Metadata-only failure preservation
+   is implemented with shared `pds-core` records under `scans/review/`.
+   Future work should expose preserved failures and duplicate routed evidence
+   for teacher review.
 6. **Submission assembly and linking.** Define page manifests, completeness
    checks, rescan selection, and traceable links from routed evidence to
    student submission records.

--- a/quillan/routing_review.py
+++ b/quillan/routing_review.py
@@ -1,0 +1,335 @@
+"""Preserve Quillan scan-routing failures for teacher review."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pds_core.scan_failure_metadata import (
+    RoutingFailureMetadata,
+    RoutingFailureMetadataError,
+    RoutingFailureMetadataWriteError,
+    is_routing_failure_category,
+    routing_failure_metadata_path,
+    write_routing_failure_metadata,
+)
+
+from quillan.evidence_filing import (
+    EvidenceFilingError,
+    RetainedSourceScan,
+)
+from quillan.route_planning import RouteFailure, RoutePlan
+
+_FAILURE_ID_DIGEST_LENGTH = 12
+
+
+class RoutingReviewError(RuntimeError):
+    """Raised when routing failure metadata cannot be preserved safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingReviewRecord:
+    """Provenance for one preserved routing failure metadata record."""
+
+    failure_id: str
+    failure_metadata_path: Path
+    failure_metadata_relative_path: str
+    failure_category: str
+    failure_message: str
+    retained_source_relative_path: str | None
+    review_copy_relative_path: str | None
+
+
+def preserve_routing_failure_for_review(
+    workspace_root: str | Path,
+    *,
+    failure_category: str,
+    failure_message: str,
+    source_filename: str,
+    module: str | None = "quillan",
+    source_scan_id: str | None = None,
+    source_sha256: str | None = None,
+    retained_source_path: str | Path | None = None,
+    review_copy_path: str | Path | None = None,
+    source_page_number: int | None = None,
+    detected_payload: str | None = None,
+    payload_page_number: int | None = None,
+    class_id: str | None = None,
+    assignment_id: str | None = None,
+    student_id: str | None = None,
+    module_details: dict[str, object] | None = None,
+    created_at: datetime | None = None,
+) -> RoutingReviewRecord:
+    """Write one shared routing failure record under ``scans/review/``."""
+    root = _resolved_workspace_root(workspace_root)
+    if not is_routing_failure_category(failure_category):
+        raise RoutingReviewError(
+            "failure_category must be a shared routing failure category."
+        )
+
+    retained_relative_path = _optional_workspace_relative_path(
+        retained_source_path,
+        root,
+        "retained_source_path",
+    )
+    review_relative_path = _optional_workspace_relative_path(
+        review_copy_path,
+        root,
+        "review_copy_path",
+    )
+    timestamp = _normalized_timestamp(created_at)
+    failure_id = _build_failure_id(
+        timestamp=timestamp,
+        source_filename=source_filename,
+        failure_category=failure_category,
+        detected_payload=detected_payload,
+        retained_source_path=retained_relative_path,
+    )
+
+    try:
+        metadata = RoutingFailureMetadata(
+            schema_version="1",
+            failure_id=failure_id,
+            scope="page",
+            stage="quillan_route_review",
+            created_at=timestamp.isoformat(timespec="microseconds"),
+            failure_category=failure_category,
+            failure_message=failure_message,
+            source_filename=source_filename,
+            module_details=(
+                {} if module_details is None else dict(module_details)
+            ),
+            module=module,
+            source_scan_id=source_scan_id,
+            source_sha256=source_sha256,
+            retained_source_path=retained_relative_path,
+            review_copy_path=review_relative_path,
+            source_page_number=source_page_number,
+            detected_payload=detected_payload,
+            payload_page_number=payload_page_number,
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+        )
+        expected_path = routing_failure_metadata_path(root, failure_id).resolve(
+            strict=False
+        )
+        written_path = write_routing_failure_metadata(root, metadata).resolve(
+            strict=False
+        )
+    except (
+        RoutingFailureMetadataError,
+        RoutingFailureMetadataWriteError,
+        OSError,
+        TypeError,
+        ValueError,
+    ) as error:
+        raise RoutingReviewError(
+            f"Could not preserve routing failure metadata: {error}"
+        ) from error
+
+    if written_path != expected_path:
+        raise RoutingReviewError(
+            "Shared routing failure writer returned an unexpected path."
+        )
+
+    return RoutingReviewRecord(
+        failure_id=failure_id,
+        failure_metadata_path=written_path,
+        failure_metadata_relative_path=_workspace_relative(written_path, root),
+        failure_category=failure_category,
+        failure_message=failure_message,
+        retained_source_relative_path=retained_relative_path,
+        review_copy_relative_path=review_relative_path,
+    )
+
+
+def preserve_route_failure_for_review(
+    workspace_root: str | Path,
+    *,
+    route_failure: RouteFailure,
+    source_filename: str,
+    retained_source: RetainedSourceScan | None = None,
+    review_copy_path: str | Path | None = None,
+    source_page_number: int | None = None,
+    created_at: datetime | None = None,
+) -> RoutingReviewRecord:
+    """Preserve a route planner failure without re-running route planning."""
+    if not isinstance(route_failure, RouteFailure):
+        raise RoutingReviewError("route_failure must be a RouteFailure.")
+
+    return preserve_routing_failure_for_review(
+        workspace_root,
+        failure_category=route_failure.failure_category,
+        failure_message=route_failure.failure_message,
+        source_filename=source_filename,
+        module=route_failure.module,
+        source_scan_id=(
+            None if retained_source is None else retained_source.source_scan_id
+        ),
+        source_sha256=(
+            None if retained_source is None else retained_source.source_sha256
+        ),
+        retained_source_path=(
+            None
+            if retained_source is None
+            else retained_source.retained_source_path
+        ),
+        review_copy_path=review_copy_path,
+        source_page_number=source_page_number,
+        detected_payload=route_failure.raw_payload,
+        payload_page_number=route_failure.page_number,
+        class_id=route_failure.class_id,
+        assignment_id=route_failure.assignment_id,
+        student_id=route_failure.student_id,
+        module_details=route_failure.module_details,
+        created_at=created_at,
+    )
+
+
+def preserve_evidence_filing_error_for_review(
+    workspace_root: str | Path,
+    *,
+    error: EvidenceFilingError,
+    route_plan: RoutePlan,
+    source_filename: str,
+    retained_source: RetainedSourceScan | None = None,
+    review_copy_path: str | Path | None = None,
+    module_details: dict[str, object] | None = None,
+    created_at: datetime | None = None,
+) -> RoutingReviewRecord:
+    """Preserve a successful-plan evidence filing failure for review."""
+    if not isinstance(error, EvidenceFilingError):
+        raise RoutingReviewError("error must be an EvidenceFilingError.")
+    if not isinstance(route_plan, RoutePlan):
+        raise RoutingReviewError("route_plan must be a RoutePlan.")
+
+    details: dict[str, object] = {"failure_origin": "evidence_filing"}
+    if module_details is not None:
+        details.update(module_details)
+
+    return preserve_routing_failure_for_review(
+        workspace_root,
+        failure_category="evidence_write_failed",
+        failure_message=str(error),
+        source_filename=source_filename,
+        module="quillan",
+        source_scan_id=(
+            None if retained_source is None else retained_source.source_scan_id
+        ),
+        source_sha256=(
+            None if retained_source is None else retained_source.source_sha256
+        ),
+        retained_source_path=(
+            None
+            if retained_source is None
+            else retained_source.retained_source_path
+        ),
+        review_copy_path=review_copy_path,
+        payload_page_number=route_plan.page_number,
+        class_id=route_plan.class_id,
+        assignment_id=route_plan.assignment_id,
+        student_id=route_plan.student_id,
+        module_details=details,
+        created_at=created_at,
+    )
+
+
+def _resolved_workspace_root(workspace_root: str | Path) -> Path:
+    try:
+        root = Path(workspace_root).resolve(strict=True)
+        if not root.is_dir():
+            raise RoutingReviewError(
+                f"Workspace root is not an existing directory: {root}"
+            )
+        return root
+    except RoutingReviewError:
+        raise
+    except (OSError, TypeError, ValueError) as error:
+        raise RoutingReviewError(f"Invalid workspace root: {error}") from error
+
+
+def _normalized_timestamp(created_at: datetime | None) -> datetime:
+    value = datetime.now(timezone.utc) if created_at is None else created_at
+    if not isinstance(value, datetime):
+        raise RoutingReviewError("created_at must be a datetime.")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise RoutingReviewError("created_at must be timezone-aware.")
+    try:
+        return value.astimezone(timezone.utc)
+    except (OSError, OverflowError, ValueError) as error:
+        raise RoutingReviewError(
+            f"created_at cannot be represented in UTC: {error}"
+        ) from error
+
+
+def _optional_workspace_relative_path(
+    value: str | Path | None,
+    root: Path,
+    field_name: str,
+) -> str | None:
+    if value is None:
+        return None
+    try:
+        supplied_path = Path(value)
+        path = (
+            supplied_path
+            if supplied_path.is_absolute()
+            else root / supplied_path
+        ).resolve(strict=False)
+    except (OSError, TypeError, ValueError) as error:
+        raise RoutingReviewError(f"Invalid {field_name}: {error}") from error
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError as error:
+        raise RoutingReviewError(
+            f"{field_name} must be inside the workspace root."
+        ) from error
+
+
+def _build_failure_id(
+    *,
+    timestamp: datetime,
+    source_filename: str,
+    failure_category: str,
+    detected_payload: str | None,
+    retained_source_path: str | None,
+) -> str:
+    timestamp_component = (
+        f"{timestamp.year:04d}{timestamp.month:02d}{timestamp.day:02d}"
+        f"T{timestamp.hour:02d}{timestamp.minute:02d}{timestamp.second:02d}"
+        f"{timestamp.microsecond:06d}Z"
+    )
+    digest_context = "\0".join(
+        (
+            timestamp.isoformat(timespec="microseconds"),
+            _digest_value(source_filename),
+            failure_category,
+            _digest_value(detected_payload),
+            retained_source_path or "",
+        )
+    )
+    digest = hashlib.sha256(digest_context.encode("utf-8")).hexdigest()
+    return (
+        f"failure_{timestamp_component}_"
+        f"{digest[:_FAILURE_ID_DIGEST_LENGTH]}"
+    )
+
+
+def _digest_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return repr(value)
+
+
+def _workspace_relative(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError as error:
+        raise RoutingReviewError(
+            "Failure metadata path is outside the workspace root."
+        ) from error

--- a/tests/test_routing_review.py
+++ b/tests/test_routing_review.py
@@ -1,0 +1,378 @@
+"""Tests for Quillan routing failure preservation."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pds_core.scan_failure_metadata import ROUTING_FAILURE_CATEGORIES
+
+from quillan.evidence_filing import (
+    EvidenceFilingError,
+    RetainedSourceScan,
+)
+from quillan.route_planning import (
+    DecodedResponsePage,
+    RouteFailure,
+    RoutePlan,
+    plan_decoded_response_page_route,
+)
+from quillan.routing_review import (
+    RoutingReviewError,
+    preserve_evidence_filing_error_for_review,
+    preserve_route_failure_for_review,
+    preserve_routing_failure_for_review,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+CREATED_AT = datetime(2026, 6, 19, 23, 59, 1, 123456, tzinfo=timezone.utc)
+SOURCE_SHA256 = "a" * 64
+RAW_PAYLOAD = (
+    "PDS1|module=quillan|class=english12_p3_synthetic|"
+    "aid=essay_01_synthetic|sid=00107|page=2|doc=response"
+)
+
+
+def _read_metadata(path: Path) -> dict[str, object]:
+    return cast(
+        dict[str, object],
+        json.loads(path.read_text(encoding="utf-8")),
+    )
+
+
+def _route_failure(workspace: Path) -> RouteFailure:
+    result = plan_decoded_response_page_route(
+        workspace,
+        DecodedResponsePage(
+            module="quillan",
+            document_type="response",
+            class_id=CLASS_ID,
+            assignment_id=ASSIGNMENT_ID,
+            student_id=STUDENT_ID,
+            page_number=2,
+            raw_payload=RAW_PAYLOAD,
+        ),
+    )
+    assert isinstance(result, RouteFailure)
+    return result
+
+
+def _route_plan(workspace: Path) -> RoutePlan:
+    assignment_dir = (
+        workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    )
+    return RoutePlan(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        page_number=2,
+        assignment_config_path=assignment_dir / "assignment.json",
+        roster_path=workspace / "classes" / CLASS_ID / "roster.csv",
+        routed_evidence_dir=assignment_dir / "scans",
+        student_submission_dir=assignment_dir / "submissions" / STUDENT_ID,
+    )
+
+
+def test_writes_shared_metadata_only_under_scans_review(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "Teacher Scan.pdf"
+    source.write_bytes(b"original source remains untouched")
+    original_bytes = source.read_bytes()
+
+    record = preserve_routing_failure_for_review(
+        tmp_path,
+        failure_category="payload_invalid",
+        failure_message="Decoded payload is invalid.",
+        source_filename=source.name,
+        detected_payload="not-a-valid-payload",
+        module_details={"reason": "syntax"},
+        created_at=CREATED_AT,
+    )
+
+    assert record.failure_metadata_path.parent == (
+        tmp_path / "scans" / "review"
+    ).resolve()
+    assert record.failure_metadata_relative_path == (
+        f"scans/review/{record.failure_id}.json"
+    )
+    assert re.fullmatch(
+        r"failure_20260619T235901123456Z_[0-9a-f]{12}",
+        record.failure_id,
+    )
+    metadata = _read_metadata(record.failure_metadata_path)
+    assert metadata["schema_version"] == "1"
+    assert metadata["scope"] == "page"
+    assert metadata["stage"] == "quillan_route_review"
+    assert metadata["failure_id"] == record.failure_id
+    assert metadata["module_details"] == {"reason": "syntax"}
+    assert record.failure_metadata_path.read_bytes().endswith(b"\n")
+    assert source.read_bytes() == original_bytes
+    assert not (tmp_path / "scans" / "source").exists()
+    assert not (tmp_path / "classes").exists()
+    assert not list(tmp_path.rglob("submission.json"))
+
+
+def test_review_directory_is_created_only_when_failure_is_preserved(
+    tmp_path: Path,
+) -> None:
+    assert not (tmp_path / "scans").exists()
+
+    with pytest.raises(RoutingReviewError, match="source_filename"):
+        preserve_routing_failure_for_review(
+            tmp_path,
+            failure_category="payload_invalid",
+            failure_message="Invalid.",
+            source_filename="../unsafe.pdf",
+            created_at=CREATED_AT,
+        )
+
+    assert not (tmp_path / "scans").exists()
+
+
+def test_shared_writer_refuses_failure_id_collision(tmp_path: Path) -> None:
+    preserve_routing_failure_for_review(
+        tmp_path,
+        failure_category="payload_invalid",
+        failure_message="Invalid.",
+        source_filename="scan.pdf",
+        created_at=CREATED_AT,
+    )
+
+    with pytest.raises(RoutingReviewError, match="already exists"):
+        preserve_routing_failure_for_review(
+            tmp_path,
+            failure_category="payload_invalid",
+            failure_message="Invalid.",
+            source_filename="scan.pdf",
+            created_at=CREATED_AT,
+        )
+
+
+def test_preserves_route_failure_fields_without_replanning(
+    tmp_path: Path,
+) -> None:
+    failure = _route_failure(tmp_path)
+
+    record = preserve_route_failure_for_review(
+        tmp_path,
+        route_failure=failure,
+        source_filename="batch.pdf",
+        created_at=CREATED_AT,
+    )
+
+    metadata = _read_metadata(record.failure_metadata_path)
+    assert metadata["failure_category"] == "class_unknown"
+    assert metadata["failure_message"] == failure.failure_message
+    assert metadata["module"] == "quillan"
+    assert metadata["class_id"] == CLASS_ID
+    assert metadata["assignment_id"] == ASSIGNMENT_ID
+    assert metadata["student_id"] == STUDENT_ID
+    assert metadata["detected_payload"] == RAW_PAYLOAD
+    assert metadata["payload_page_number"] == 2
+    assert metadata["module_details"] == failure.module_details
+
+
+def test_route_failure_adapter_accepts_retained_source_provenance(
+    tmp_path: Path,
+) -> None:
+    retained_path = (
+        tmp_path / "scans" / "source" / "2026-06-19" / "retained.pdf"
+    )
+    retained_path.parent.mkdir(parents=True)
+    retained_path.write_bytes(b"retained")
+    retained = RetainedSourceScan(
+        source_scan_id="scan_20260619",
+        source_filename="batch.pdf",
+        source_sha256=SOURCE_SHA256,
+        retained_source_path=retained_path.resolve(),
+        retained_source_relative_path=(
+            "scans/source/2026-06-19/retained.pdf"
+        ),
+    )
+
+    record = preserve_route_failure_for_review(
+        tmp_path,
+        route_failure=_route_failure(tmp_path),
+        source_filename="batch.pdf",
+        retained_source=retained,
+        created_at=CREATED_AT,
+    )
+
+    metadata = _read_metadata(record.failure_metadata_path)
+    assert metadata["source_scan_id"] == "scan_20260619"
+    assert metadata["source_sha256"] == SOURCE_SHA256
+    assert metadata["retained_source_path"] == (
+        "scans/source/2026-06-19/retained.pdf"
+    )
+    assert record.retained_source_relative_path == (
+        "scans/source/2026-06-19/retained.pdf"
+    )
+
+
+def test_pre_retention_failure_allows_absent_provenance(
+    tmp_path: Path,
+) -> None:
+    record = preserve_routing_failure_for_review(
+        tmp_path,
+        failure_category="source_retention_failed",
+        failure_message="Source could not be retained.",
+        source_filename="batch.pdf",
+        created_at=CREATED_AT,
+    )
+
+    metadata = _read_metadata(record.failure_metadata_path)
+    assert metadata["source_scan_id"] is None
+    assert metadata["source_sha256"] is None
+    assert metadata["retained_source_path"] is None
+    assert record.retained_source_relative_path is None
+
+
+@pytest.mark.parametrize("field_name", ["retained_source_path", "review_copy_path"])
+def test_rejects_provenance_paths_outside_workspace(
+    tmp_path: Path,
+    field_name: str,
+) -> None:
+    outside = tmp_path.parent / "outside.pdf"
+    retained_source_path = (
+        outside if field_name == "retained_source_path" else None
+    )
+    review_copy_path = outside if field_name == "review_copy_path" else None
+
+    with pytest.raises(RoutingReviewError, match="inside the workspace"):
+        preserve_routing_failure_for_review(
+            tmp_path,
+            failure_category="processing_error",
+            failure_message="Failed.",
+            source_filename="batch.pdf",
+            created_at=CREATED_AT,
+            retained_source_path=retained_source_path,
+            review_copy_path=review_copy_path,
+        )
+
+    assert not (tmp_path / "scans").exists()
+
+
+def test_normalizes_workspace_relative_paths_to_posix(tmp_path: Path) -> None:
+    record = preserve_routing_failure_for_review(
+        tmp_path,
+        failure_category="processing_error",
+        failure_message="Failed.",
+        source_filename="batch.pdf",
+        retained_source_path=Path("scans") / "source" / "retained.pdf",
+        review_copy_path=Path("scans") / "review" / "problem.pdf",
+        created_at=CREATED_AT,
+    )
+
+    metadata = _read_metadata(record.failure_metadata_path)
+    assert metadata["retained_source_path"] == "scans/source/retained.pdf"
+    assert metadata["review_copy_path"] == "scans/review/problem.pdf"
+    assert record.review_copy_relative_path == "scans/review/problem.pdf"
+    assert not (tmp_path / "scans" / "review" / "problem.pdf").exists()
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        "payload_invalid",
+        "module_unsupported",
+        "identifier_invalid",
+        "class_unknown",
+        "assignment_unknown",
+        "student_unknown",
+        "route_mismatch",
+        "processing_error",
+        "evidence_write_failed",
+    ],
+)
+def test_accepts_required_shared_failure_categories(
+    tmp_path: Path,
+    category: str,
+) -> None:
+    assert category in ROUTING_FAILURE_CATEGORIES
+    record = preserve_routing_failure_for_review(
+        tmp_path,
+        failure_category=category,
+        failure_message=f"Synthetic {category} failure.",
+        source_filename=f"{category}.pdf",
+        created_at=CREATED_AT,
+    )
+    assert record.failure_category == category
+
+
+def test_rejects_custom_failure_category_before_writes(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(RoutingReviewError, match="shared"):
+        preserve_routing_failure_for_review(
+            tmp_path,
+            failure_category="quillan_custom_failure",
+            failure_message="Custom.",
+            source_filename="batch.pdf",
+            created_at=CREATED_AT,
+        )
+
+    assert not (tmp_path / "scans").exists()
+
+
+def test_evidence_filing_error_adapter_preserves_route_context(
+    tmp_path: Path,
+) -> None:
+    plan = _route_plan(tmp_path)
+    record = preserve_evidence_filing_error_for_review(
+        tmp_path,
+        error=EvidenceFilingError("Disk write failed."),
+        route_plan=plan,
+        source_filename="batch.pdf",
+        module_details={"operation": "copy_routed_evidence"},
+        created_at=CREATED_AT,
+    )
+
+    metadata = _read_metadata(record.failure_metadata_path)
+    assert metadata["failure_category"] == "evidence_write_failed"
+    assert metadata["failure_message"] == "Disk write failed."
+    assert metadata["module"] == "quillan"
+    assert metadata["class_id"] == CLASS_ID
+    assert metadata["assignment_id"] == ASSIGNMENT_ID
+    assert metadata["student_id"] == STUDENT_ID
+    assert metadata["payload_page_number"] == 2
+    assert metadata["module_details"] == {
+        "failure_origin": "evidence_filing",
+        "operation": "copy_routed_evidence",
+    }
+    assert not plan.routed_evidence_dir.exists()
+    assert not plan.student_submission_dir.exists()
+    assert not (tmp_path / "scans" / "source").exists()
+
+
+def test_invalid_metadata_does_not_leave_partial_json(tmp_path: Path) -> None:
+    with pytest.raises(RoutingReviewError, match="source_sha256"):
+        preserve_routing_failure_for_review(
+            tmp_path,
+            failure_category="processing_error",
+            failure_message="Failed.",
+            source_filename="batch.pdf",
+            source_sha256="not-a-sha256",
+            created_at=CREATED_AT,
+        )
+
+    assert not list(tmp_path.rglob("*.json"))
+
+
+def test_naive_timestamp_is_rejected_before_writes(tmp_path: Path) -> None:
+    with pytest.raises(RoutingReviewError, match="timezone-aware"):
+        preserve_routing_failure_for_review(
+            tmp_path,
+            failure_category="processing_error",
+            failure_message="Failed.",
+            source_filename="batch.pdf",
+            created_at=CREATED_AT.replace(tzinfo=None),
+        )
+
+    assert not (tmp_path / "scans").exists()


### PR DESCRIPTION
## Summary

* Added Quillan routing failure preservation under `scans/review/`.
* Added shared pds-core routing failure metadata writing through pds-core’s metadata model and exclusive writer.
* Added safe timestamp/digest-based failure IDs.
* Added `RoutingReviewRecord` and `RoutingReviewError`.
* Added a general `preserve_routing_failure_for_review(...)` helper.
* Added a `RouteFailure` adapter for preserving decoded route-planning failures.
* Added an `EvidenceFilingError` adapter for preserving successful-plan evidence filing failures.
* Added workspace-relative retained-source and review-copy provenance validation.
* Added retained-source provenance support when a `RetainedSourceScan` is available.
* Added tests for metadata writing, route-failure preservation, retained-source provenance, pre-retention failures, shared failure categories, path safety, collision refusal, and non-goal boundaries.
* Updated README, changelog, scan-routing design, and development-plan documentation.

Closes #46.

## Validation

* [x] `python -m pytest` — 296 tests passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* Failure metadata is written under `scans/review/`.
* No stale `routing_review/` directory or references added.
* Review artifact copying was deliberately omitted.
* Retained-source provenance is recorded when available.
* Pre-retention failures can be preserved without invented retained-source paths.
* No successful routed evidence filing implemented here.
* No retained source intake implemented here.
* No QR extraction implemented.
* No PDF splitting implemented.
* No image processing implemented.
* No OCR implemented.
* No CLI or menu integration implemented.
* No submission assembly implemented.
* No `submission.json` writing implemented.
* No scores, feedback, tags, requirements, or reports written.
* No pds-core changes.
* No ScoreForm, pds-sunset, or sibling repository changes.
* No generated private files, classroom artifacts, or real student data committed.
