### PR TITLE
Add route-scan command for decoded payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a direct `route-scan` command for already-decoded Quillan PDS1
+  payloads, including successful evidence filing, safe review preservation,
+  concise workspace-relative summaries, and documented handled/failure exit
+  codes.
 - Added a routing failure preservation API that writes shared `pds-core`
   failure metadata exclusively under `scans/review/`, adapts route-planning and
   evidence-filing failures, and records workspace-relative retained-source

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ Quillan currently supports:
   without assembling submissions;
 - an internal routing failure preservation API that writes shared `pds-core`
   failure metadata under `scans/review/`, including retained-source provenance
-  when available, without copying review artifacts; and
+  when available, without copying review artifacts;
+- a direct `route-scan` command for already-decoded payloads that orchestrates
+  the existing parser, route planner, evidence filer, and failure review
+  helpers; and
 - synthetic examples and fixtures for safe testing and documentation.
 
 Printable response generation is exposed through the teacher-facing menu and
@@ -61,8 +64,8 @@ The data contracts and design documents describe additional teacher-review
 and paper-ingest workflows that are not yet implemented end to end. In
 particular, Quillan does not currently provide:
 
-- end-to-end production scan intake and routing (the internal APIs require an
-  already-selected readable source file and caller-managed orchestration);
+- end-to-end production scan intake and routing (the direct command requires
+  an already-selected source file and caller-supplied decoded payload);
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
@@ -80,8 +83,8 @@ route planner, successful filing helper, and failure preservation helper follow
 the shared `pds-core` active scan contract: canonical retained sources belong
 in `scans/source/YYYY-MM-DD/`, canonical routing review records belong in
 `scans/review/`, and assignment-level `scans/` contains routed evidence rather
-than canonical source retention. QR extraction, PDF splitting, OCR, CLI routing,
-and submission assembly remain outside these internal APIs.
+than canonical source retention. QR extraction, PDF splitting, OCR, and
+submission assembly remain outside the direct command and internal APIs.
 
 ## Current Non-Goals
 
@@ -205,8 +208,9 @@ canonical payload such as:
 PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page_number>|doc=response
 ```
 
-Generating this QR code is implemented. Extracting it from a later scan,
-routing the scan, and performing OCR are not.
+Generating this QR code is implemented. A caller can route a selected scan
+after separately decoding its payload, but Quillan does not extract QR codes,
+split PDFs, or perform OCR.
 
 ## Running Quillan
 
@@ -274,6 +278,23 @@ Validate an assignment configuration:
 quillan validate-assignment <assignment.json>
 ```
 
+Route one selected scan using an already-decoded Quillan PDS1 payload:
+
+```powershell
+quillan route-scan <source-file> --payload "PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page>|doc=response"
+```
+
+Successful routing retains the selected source under
+`scans/source/YYYY-MM-DD/` and files response evidence under the assignment
+`scans/` directory. Payload, planning, and filing failures are preserved under
+`scans/review/` when possible. Exit code `0` means the input was routed or
+safely preserved for review; exit code `1` means it could not be handled
+safely.
+
+This direct developer/teacher primitive requires already-decoded payload text.
+It does not extract QR codes, split PDFs, run OCR, assemble submissions, score,
+tag, generate feedback, or create reports.
+
 The current command surface is:
 
 ```powershell
@@ -281,6 +302,7 @@ quillan
 quillan --help
 quillan validate-standards <standards-profile.json>
 quillan validate-assignment <assignment.json>
+quillan route-scan <source-file> --payload "<PDS1|...>"
 quillan workspace show
 quillan menu
 ```

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -199,8 +199,13 @@ Metadata-only failure preservation is implemented in `quillan.routing_review`.
 It writes shared `pds-core` failure records under `scans/review/`, preserves
 route failure and evidence filing context, and records workspace-relative
 retained-source provenance when available. It does not copy review artifacts.
-QR extraction, PDF splitting, OCR, CLI/menu integration, and submission
-assembly remain unimplemented.
+
+The direct
+`quillan route-scan <source-file> --payload "<PDS1|...>"` command is
+implemented for one selected source and an already-decoded payload. It
+orchestrates the existing parser, planner, evidence filer, and review adapters.
+QR extraction, PDF splitting, OCR, menu integration, batch routing, and
+submission assembly remain unimplemented.
 
 ### `submissions.py`
 
@@ -345,6 +350,7 @@ Completed work:
 * Add the Roster Management submenu using shared `pds-core` contracts.
 * Add the Printable Response Pages submenu for combined class-packet
   generation.
+* Add a direct `route-scan` command for already-decoded Quillan PDS1 payloads.
 * Add CLI tests.
 
 Remaining possible work:

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -31,8 +31,10 @@ source into `scans/source/YYYY-MM-DD/`, files the retained source or a
 caller-supplied page artifact into assignment `scans/`, preserves duplicates,
 and returns provenance. Quillan also implements metadata-only failure
 preservation through `quillan.routing_review`, writing shared failure records
-under `scans/review/`. These slices do not implement QR extraction, PDF
-splitting, submission assembly, image processing, OCR, or a CLI workflow.
+under `scans/review/`. The direct
+`quillan route-scan <source-file> --payload "<PDS1|...>"` command orchestrates
+these slices for a caller-supplied decoded payload. It does not implement QR
+extraction, PDF splitting, submission assembly, image processing, or OCR.
 
 ## Design Goals
 
@@ -371,17 +373,20 @@ Inactive historical preservation and end-of-cycle archiving belong to future
 3. **Routed evidence writes.** Implemented for successful routes: create
    assignment scan destinations, use exclusive no-overwrite copies, preserve
    duplicate evidence, and return provenance to the retained source.
-4. **QR extraction and splitting.** Add Quillan adapters that decode PDS1 text
+4. **Direct decoded-payload command.** Implemented as `quillan route-scan` for
+   one selected source file and an already-decoded payload, with safe review
+   preservation and no submission assembly.
+5. **QR extraction and splitting.** Add Quillan adapters that decode PDS1 text
    from scanned PDFs or images and pass canonical routing inputs to the
    independent routing helper.
-5. **Duplicate and failure review workflows.** Metadata-only failure preservation
+6. **Duplicate and failure review workflows.** Metadata-only failure preservation
    is implemented with shared `pds-core` records under `scans/review/`.
    Future work should expose preserved failures and duplicate routed evidence
    for teacher review.
-6. **Submission assembly and linking.** Define page manifests, completeness
+7. **Submission assembly and linking.** Define page manifests, completeness
    checks, rescan selection, and traceable links from routed evidence to
    student submission records.
-7. **Teacher review integration.** Present assembled evidence to the teacher
+8. **Teacher review integration.** Present assembled evidence to the teacher
    and allow teacher-controlled lifecycle changes without automated judgment.
 
 Each phase should add focused tests for validation, traversal resistance,
@@ -390,13 +395,13 @@ submission mutations.
 
 ## Out of Scope
 
-The current successful-write slice does not implement:
+The current direct decoded-payload routing slice does not implement:
 
-* end-to-end scan routing or intake orchestration;
+* end-to-end production scan intake automation;
 * QR detection or extraction;
 * PDF splitting, image processing, or OCR;
 * submission assembly or production roster workflows;
 * requirements checking, tagging, scoring, feedback, or reporting;
 * AI tagging, scoring, feedback, or automatic grading;
-* CLI, menu, or workspace-settings workflows; or
+* menu or workspace-settings routing workflows; or
 * changes to `pds-core`, `pds-scoreform`, or Python behavior.

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 from pathlib import Path
 
+from pds_core.pds1 import Pds1PayloadError, parse_pds1_payload
 from pds_core.workspace import (
     WorkspaceRootError,
     WorkspaceStatus,
@@ -16,7 +18,24 @@ from pds_core.workspace import (
 )
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.evidence_filing import (
+    EvidenceFilingError,
+    RoutedEvidenceFile,
+    file_routed_response_evidence,
+)
 from quillan.menu import launch_menu
+from quillan.route_planning import (
+    DecodedResponsePage,
+    RouteFailure,
+    plan_decoded_response_page_route,
+)
+from quillan.routing_review import (
+    RoutingReviewError,
+    RoutingReviewRecord,
+    preserve_evidence_filing_error_for_review,
+    preserve_route_failure_for_review,
+    preserve_routing_failure_for_review,
+)
 from quillan.standards import StandardsProfileError, load_standards_profile
 
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
@@ -34,6 +53,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "validate-assignment":
         _handle_validate_assignment(args.path)
         return 0
+
+    if args.command == "route-scan":
+        return _handle_route_scan(args.source_file, args.payload)
 
     if args.command == "workspace" and args.workspace_command == "show":
         return _handle_workspace_show()
@@ -82,6 +104,26 @@ def _build_parser() -> argparse.ArgumentParser:
         "path",
         type=Path,
         help="Path to the assignment config JSON file.",
+    )
+
+    route_scan_parser = subparsers.add_parser(
+        "route-scan",
+        help="Route a scan using an already-decoded Quillan PDS1 payload.",
+        description=(
+            "Route a scan file using an already-decoded Quillan PDS1 payload. "
+            "Exit 0 means the file was routed or safely preserved for review; "
+            "exit 1 means the input could not be handled safely."
+        ),
+    )
+    route_scan_parser.add_argument(
+        "source_file",
+        type=Path,
+        help="Path to the selected source scan file.",
+    )
+    route_scan_parser.add_argument(
+        "--payload",
+        required=True,
+        help="Already-decoded canonical PDS1 payload text.",
     )
 
     workspace_parser = subparsers.add_parser(
@@ -139,6 +181,190 @@ def _handle_validate_assignment(path: Path) -> None:
         raise SystemExit(f"Invalid assignment config: {error}") from error
 
     print(f"Valid assignment config: {assignment['assignment_id']}")
+
+
+def _handle_route_scan(source_file: Path, payload_text: str) -> int:
+    """Route one source scan from caller-supplied decoded PDS1 text."""
+    intake_timestamp = datetime.now(timezone.utc)
+    try:
+        workspace_root = resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: could not resolve the PDS workspace: {error}")
+        return 1
+    except Exception as error:
+        print(f"Error: unexpected workspace resolution failure: {error}")
+        return 1
+
+    if not _validate_route_scan_source_file(source_file):
+        return 1
+
+    try:
+        payload = parse_pds1_payload(payload_text)
+    except Pds1PayloadError as error:
+        return _preserve_payload_parse_failure(
+            workspace_root,
+            source_file=source_file,
+            payload_text=payload_text,
+            error=error,
+            created_at=intake_timestamp,
+        )
+    except Exception as error:
+        print(f"Error: unexpected PDS1 payload parsing failure: {error}")
+        return 1
+
+    decoded_page = DecodedResponsePage(
+        module=payload.module,
+        document_type=payload.metadata.get("doc"),
+        class_id=payload.class_id,
+        assignment_id=payload.assignment_id,
+        student_id=payload.student_id,
+        page_number=payload.page,
+        raw_payload=payload_text,
+    )
+
+    try:
+        route_result = plan_decoded_response_page_route(
+            workspace_root,
+            decoded_page,
+        )
+        if isinstance(route_result, RouteFailure):
+            review_record = preserve_route_failure_for_review(
+                workspace_root,
+                route_failure=route_result,
+                source_filename=source_file.name,
+                created_at=intake_timestamp,
+            )
+            _print_route_failure_review(route_result, review_record)
+            return 0
+
+        try:
+            filed_evidence = file_routed_response_evidence(
+                workspace_root,
+                route_plan=route_result,
+                source_file_path=source_file,
+                intake_timestamp=intake_timestamp,
+            )
+        except EvidenceFilingError as error:
+            review_record = preserve_evidence_filing_error_for_review(
+                workspace_root,
+                error=error,
+                route_plan=route_result,
+                source_filename=source_file.name,
+                created_at=intake_timestamp,
+            )
+            _print_evidence_filing_review(error, review_record)
+            return 0
+    except RoutingReviewError as error:
+        print(f"Error: could not preserve scan routing failure for review: {error}")
+        return 1
+    except Exception as error:
+        print(f"Error: unexpected route-scan failure: {error}")
+        return 1
+
+    _print_routed_evidence(filed_evidence)
+    return 0
+
+
+def _validate_route_scan_source_file(source_file: Path) -> bool:
+    """Return whether the selected scan is an existing readable file."""
+    try:
+        if not source_file.is_file():
+            print(
+                "Error: source file must be an existing regular file: "
+                f"{source_file}"
+            )
+            return False
+        with source_file.open("rb"):
+            pass
+    except OSError as error:
+        print(f"Error: source file is not readable: {error}")
+        return False
+    return True
+
+
+def _preserve_payload_parse_failure(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    payload_text: str,
+    error: Pds1PayloadError,
+    created_at: datetime,
+) -> int:
+    """Preserve malformed payload context without inventing route identity."""
+    try:
+        review_record = preserve_routing_failure_for_review(
+            workspace_root,
+            failure_category="payload_invalid",
+            failure_message=str(error),
+            source_filename=source_file.name,
+            module="quillan",
+            detected_payload=payload_text,
+            module_details={
+                "failure_origin": "payload_parse",
+                "parse_error": str(error),
+            },
+            created_at=created_at,
+        )
+    except RoutingReviewError as review_error:
+        print(
+            "Error: payload was invalid and could not be preserved for review: "
+            f"{review_error}"
+        )
+        return 1
+    except Exception as unexpected_error:
+        print(
+            "Error: unexpected failure while preserving invalid payload: "
+            f"{unexpected_error}"
+        )
+        return 1
+
+    print("Quillan response page was not routed; preserved for review.")
+    print(f"Reason: {error}")
+    print("Category: payload_invalid")
+    print(f"Review record: {review_record.failure_metadata_relative_path}")
+    return 0
+
+
+def _print_routed_evidence(filed_evidence: RoutedEvidenceFile) -> None:
+    """Print a concise successful-route summary."""
+    duplicate = (
+        "no"
+        if filed_evidence.duplicate_number is None
+        else f"yes (__dup_{filed_evidence.duplicate_number:03d})"
+    )
+    print("Routed Quillan response page.")
+    print(
+        "Retained source: "
+        f"{filed_evidence.retained_source.retained_source_relative_path}"
+    )
+    print(f"Routed evidence: {filed_evidence.routed_evidence_relative_path}")
+    print(f"Class: {filed_evidence.class_id}")
+    print(f"Assignment: {filed_evidence.assignment_id}")
+    print(f"Student: {filed_evidence.student_id}")
+    print(f"Page: {filed_evidence.page_number}")
+    print(f"Duplicate: {duplicate}")
+
+
+def _print_route_failure_review(
+    route_failure: RouteFailure,
+    review_record: RoutingReviewRecord,
+) -> None:
+    """Print a safely preserved route-planning failure summary."""
+    print("Quillan response page was not routed; preserved for review.")
+    print(f"Reason: {route_failure.failure_message}")
+    print(f"Category: {route_failure.failure_category}")
+    print(f"Review record: {review_record.failure_metadata_relative_path}")
+
+
+def _print_evidence_filing_review(
+    error: EvidenceFilingError,
+    review_record: RoutingReviewRecord,
+) -> None:
+    """Print a safely preserved evidence-filing failure summary."""
+    print("Quillan response page could not be filed; preserved for review.")
+    print(f"Reason: {error}")
+    print("Category: evidence_write_failed")
+    print(f"Review record: {review_record.failure_metadata_relative_path}")
 
 
 def _handle_workspace_show() -> int:

--- a/tests/test_cli_route_scan.py
+++ b/tests/test_cli_route_scan.py
@@ -1,0 +1,344 @@
+"""Focused tests for the direct already-decoded scan routing command."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.evidence_filing import EvidenceFilingError
+from quillan.routing_review import RoutingReviewError
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+VALID_PAYLOAD = (
+    "PDS1|module=quillan|class=english12_p3_synthetic|"
+    "aid=essay_01_synthetic|sid=00107|page=2|doc=response"
+)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    class_dir = tmp_path / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def source_file(tmp_path: Path) -> Path:
+    source = tmp_path / "teacher-scan.pdf"
+    source.write_bytes(b"%PDF-1.4\nsynthetic response scan\n%%EOF\n")
+    return source
+
+
+def _review_metadata(workspace: Path) -> dict[str, object]:
+    records = list((workspace / "scans" / "review").glob("*.json"))
+    assert len(records) == 1
+    loaded = json.loads(records[0].read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_route_scan_successfully_files_retained_and_routed_evidence(
+    workspace: Path,
+    source_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    original_bytes = source_file.read_bytes()
+
+    result = main(
+        ["route-scan", str(source_file), "--payload", VALID_PAYLOAD]
+    )
+
+    output = capsys.readouterr().out
+    retained_files = list((workspace / "scans" / "source").rglob("*.pdf"))
+    routed_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_00107_pg_002.pdf"
+    )
+
+    assert result == 0
+    assert len(retained_files) == 1
+    assert retained_files[0].read_bytes() == original_bytes
+    assert routed_path.read_bytes() == original_bytes
+    assert source_file.read_bytes() == original_bytes
+    assert not (workspace / "scans" / "review").exists()
+    assert not list(workspace.rglob("submissions"))
+    assert "Routed Quillan response page." in output
+    assert "Routed evidence: classes/" in output
+    assert "Duplicate: no" in output
+    assert str(workspace) not in output
+
+
+def test_route_scan_preserves_duplicate_routed_evidence(
+    workspace: Path,
+    source_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["route-scan", str(source_file), "--payload", VALID_PAYLOAD]) == 0
+    capsys.readouterr()
+
+    assert main(["route-scan", str(source_file), "--payload", VALID_PAYLOAD]) == 0
+
+    output = capsys.readouterr().out
+    duplicate = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_00107_pg_002__dup_001.pdf"
+    )
+    assert duplicate.is_file()
+    assert "Duplicate: yes (__dup_001)" in output
+
+
+def test_route_scan_preserves_route_planning_failure(
+    workspace: Path,
+    source_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = VALID_PAYLOAD.replace(CLASS_ID, "unknown_class")
+
+    result = main(["route-scan", str(source_file), "--payload", payload])
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata(workspace)
+    assert result == 0
+    assert metadata["failure_category"] == "class_unknown"
+    assert metadata["detected_payload"] == payload
+    assert not list(workspace.rglob("response_*.pdf"))
+    assert not list(workspace.rglob("submissions"))
+    assert "preserved for review" in output
+    assert "Category: class_unknown" in output
+
+
+def test_route_scan_preserves_payload_parse_failure(
+    workspace: Path,
+    source_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    malformed_payload = "not-a-pds1-payload"
+
+    result = main(
+        ["route-scan", str(source_file), "--payload", malformed_payload]
+    )
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata(workspace)
+    assert result == 0
+    assert metadata["failure_category"] == "payload_invalid"
+    assert metadata["detected_payload"] == malformed_payload
+    assert metadata["class_id"] is None
+    assert metadata["assignment_id"] is None
+    assert metadata["student_id"] is None
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "payload_parse"
+    assert not list(workspace.rglob("response_*.pdf"))
+    assert not list(workspace.rglob("submissions"))
+    assert "preserved for review" in output
+
+
+def test_route_scan_missing_source_returns_one_without_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_source = workspace / "missing.pdf"
+
+    result = main(
+        ["route-scan", str(missing_source), "--payload", "malformed"]
+    )
+
+    output = capsys.readouterr().out
+    assert result == 1
+    assert "source file" in output
+    assert "existing regular file" in output
+    assert not (workspace / "scans" / "review").exists()
+    assert not (workspace / "scans" / "source").exists()
+    assert not list(workspace.rglob("response_*.pdf"))
+    assert not list(workspace.rglob("submissions"))
+
+
+def test_route_scan_directory_source_returns_one_without_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = main(
+        ["route-scan", str(workspace), "--payload", "malformed"]
+    )
+
+    output = capsys.readouterr().out
+    assert result == 1
+    assert "source file" in output
+    assert "existing regular file" in output
+    assert not (workspace / "scans" / "review").exists()
+    assert not (workspace / "scans" / "source").exists()
+    assert not list(workspace.rglob("response_*.pdf"))
+    assert not list(workspace.rglob("submissions"))
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_category"),
+    [
+        (
+            VALID_PAYLOAD.replace("module=quillan", "module=scoreform"),
+            "module_unsupported",
+        ),
+        (VALID_PAYLOAD.replace("doc=response", "doc=cover"), "payload_invalid"),
+        (VALID_PAYLOAD.replace("|doc=response", ""), "payload_invalid"),
+    ],
+)
+def test_route_scan_preserves_wrong_module_or_document_type(
+    workspace: Path,
+    source_file: Path,
+    payload: str,
+    expected_category: str,
+) -> None:
+    assert main(["route-scan", str(source_file), "--payload", payload]) == 0
+
+    metadata = _review_metadata(workspace)
+    assert metadata["failure_category"] == expected_category
+    assert metadata["detected_payload"] == payload
+
+
+def test_route_scan_preserves_evidence_filing_error(
+    workspace: Path,
+    source_file: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_filing(*_args: object, **_kwargs: object) -> None:
+        raise EvidenceFilingError("Synthetic disk write failure.")
+
+    monkeypatch.setattr(
+        quillan.cli,
+        "file_routed_response_evidence",
+        fail_filing,
+    )
+
+    result = main(
+        ["route-scan", str(source_file), "--payload", VALID_PAYLOAD]
+    )
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata(workspace)
+    assert result == 0
+    assert metadata["failure_category"] == "evidence_write_failed"
+    assert metadata["class_id"] == CLASS_ID
+    assert metadata["assignment_id"] == ASSIGNMENT_ID
+    assert metadata["student_id"] == STUDENT_ID
+    assert "could not be filed; preserved for review" in output
+
+
+def test_route_scan_returns_one_when_failure_cannot_be_preserved(
+    workspace: Path,
+    source_file: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_preservation(*_args: object, **_kwargs: object) -> None:
+        raise RoutingReviewError("Synthetic review write failure.")
+
+    monkeypatch.setattr(
+        quillan.cli,
+        "preserve_routing_failure_for_review",
+        fail_preservation,
+    )
+
+    result = main(
+        ["route-scan", str(source_file), "--payload", "malformed"]
+    )
+
+    output = capsys.readouterr().out
+    assert result == 1
+    assert "could not be preserved for review" in output
+    assert "Synthetic review write failure" in output
+
+
+def test_route_scan_help_documents_safe_exit_codes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["route-scan", "--help"])
+
+    output = capsys.readouterr().out
+    assert error.value.code == 0
+    assert "already-decoded Quillan PDS1 payload" in output
+    assert "Exit 0" in output
+    assert "exit 1" in output
+
+
+def test_route_scan_does_not_create_downstream_or_intake_outputs(
+    workspace: Path,
+    source_file: Path,
+) -> None:
+    assert main(["route-scan", str(source_file), "--payload", VALID_PAYLOAD]) == 0
+
+    prohibited_names = {
+        "submission.json",
+        "requirements.json",
+        "tags.json",
+        "scores.json",
+        "feedback.md",
+    }
+    assert not [
+        path for path in workspace.rglob("*") if path.name in prohibited_names
+    ]
+    assert not (workspace / "reports").exists()
+    assert not (workspace / "scans_inbox").exists()


### PR DESCRIPTION
## Summary

* Added `quillan route-scan <source-file> --payload "<PDS1|...>"`.
* Added direct CLI orchestration for already-decoded Quillan PDS1 payloads.
* Parsed supplied PDS1 text with shared pds-core payload parsing.
* Converted parsed payloads into Quillan `DecodedResponsePage` values.
* Added source-file preflight validation before PDS1 parsing or failure preservation.
* Routed successful decoded pages through the existing route planner and evidence filing helper.
* Preserved route-planning failures under `scans/review/`.
* Preserved evidence-filing failures under `scans/review/`.
* Preserved malformed payload failures under `scans/review/` when the source file can be handled safely.
* Printed workspace-relative retained source, routed evidence, and review record paths.
* Documented exit behavior: `0` means routed or safely preserved; `1` means the input could not be handled safely.
* Added focused CLI tests for success, duplicates, route failures, malformed payloads, wrong module/doc type, evidence filing errors, preservation failures, source-file preflight, help text, and non-goal boundaries.
* Updated README, changelog, scan-routing design, and development-plan documentation.

Closes #47.

## Validation

* [x] `python -m pytest` — 309 tests passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* Requires an already-decoded Quillan PDS1 payload.
* Missing or non-regular source files return `1` before payload parsing or review preservation.
* Malformed payloads with readable source files are preserved under `scans/review/`.
* Does not extract QR codes.
* Does not split PDFs.
* Does not process images.
* Does not perform OCR.
* Does not poll `scans_inbox/`.
* Does not implement batch scan routing.
* Does not add menu integration.
* Does not assemble submissions.
* Does not write `submission.json`.
* Does not write scores, feedback, tags, requirements, or reports.
* Does not change PDS1 payload format.
* Does not change assignment or roster schemas.
* Does not modify pds-core, ScoreForm, pds-sunset, or sibling repositories.
* No generated private files, classroom artifacts, or real student data committed.
