### PR TITLE
Define submission manifest contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Documented the draft version `1` reviewable-evidence `submission.json`
+  contract, including page and evidence states, duplicate and replacement
+  preservation, retained-source provenance, safe relative paths, and a fully
+  synthetic three-page example. Loading, validation, writing, and assembly
+  remain future work.
 - Added a direct `route-scan` command for already-decoded Quillan PDS1
   payloads, including successful evidence filing, safe review preservation,
   concise workspace-relative summaries, and documented handled/failure exit

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Quillan currently supports:
 
 - assignment configuration validation;
 - standards profile loading and validation;
-- submission metadata validation;
+- validation of the legacy text-oriented submission metadata shape;
 - documented writing-evidence and teacher-review data contracts;
+- a documented, contract-only version `1` reviewable-evidence submission
+  manifest;
 - printable writing-response PDF generation with student, class, assignment,
   and page identity;
 - QR codes containing canonical PDS1 Quillan response payloads on printable
@@ -69,6 +71,8 @@ particular, Quillan does not currently provide:
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
+- loading, validating, writing, or assembling version `1` submission
+  manifests;
 - assignment creation workflows;
 - implemented requirements-checking, tagging, scoring, feedback, or
   production reporting workflows;
@@ -307,8 +311,9 @@ quillan workspace show
 quillan menu
 ```
 
-Submission metadata validation and printable response generation currently
-use Python APIs rather than dedicated CLI commands.
+Legacy text-oriented submission metadata validation and printable response
+generation currently use Python APIs rather than dedicated CLI commands. The
+version `1` reviewable-evidence manifest is documented but not implemented.
 
 ## Quality Checks
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -6,11 +6,14 @@ These contracts describe the expected file formats for standards profiles,
 assignments, submissions, requirements checks, tags, scores, feedback, and
 reports.
 
-Standards profiles, assignment configurations, and submission metadata have
-implemented Python validation support. The writing-response payload contract
-is also implemented and used by printable PDF generation. Requirements,
-tagging, scoring, feedback, and reporting records remain contracts for
-teacher-controlled workflows that are not yet implemented end to end.
+Standards profiles, assignment configurations, and the legacy text-oriented
+submission metadata shape have implemented Python validation support. The
+reviewable-evidence submission manifest defined below is a contract only and
+is not yet loaded, validated, written, or assembled by Quillan. The
+writing-response payload contract is implemented and used by printable PDF
+generation. Requirements, tagging, scoring, feedback, and reporting records
+remain contracts for teacher-controlled workflows that are not yet
+implemented end to end.
 
 For the expected workspace layout and file lifecycle of these records, see
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
@@ -226,76 +229,176 @@ Example:
 }
 ```
 
-## Submission
+## Submission Manifest
 
-A submission preserves student-produced writing as evidence and records how
-that writing entered the teacher's review workflow. The writing and its
-metadata are stored separately:
+A Quillan submission manifest is a local, teacher-controlled review record for
+one student and one assignment. It connects class, assignment, and student
+identity to routed evidence, retained-source provenance, and explicit review
+state. Routed evidence alone does not establish that a submission is complete,
+reviewed, scored, tagged, or ready for feedback.
+
+The future canonical location is:
 
 ```text
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.txt
 ```
 
-`submission.txt` contains the student writing. `submission.json` organizes the
-artifact and its provenance without adding scores, feedback, or software-made
-judgments.
+This section defines draft schema version `1`. It is contract-only: the
+existing `quillan.submissions` loader still accepts an earlier text-oriented
+metadata shape and does not load or validate this manifest. Path helpers,
+writing, assembly, selection, and state-changing workflows are future work.
 
-Required submission metadata fields:
+### Top-Level Structure
 
-* `submission_id`
-* `assignment_id`
-* `class_id`
-* `student_id`
-* `source_type`
-* `text_file`
-* `captured_at`
-* `status`
-* `version`
-
-Allowed MVP `source_type` values:
-
-* `manual_entry`
-* `typed_text`
-* `pasted_text`
-* `file_import`
-* `paper_scan`
-* `ocr_scan`
-* `google_doc_export`
-
-Allowed MVP `status` values:
-
-* `captured`
-* `needs_review`
-* `reviewed`
-* `superseded`
-* `invalid`
-
-Example `submission.json`:
+Every version `1` manifest contains:
 
 ```json
 {
-  "submission_id": "sub_stu_0001_v1",
-  "assignment_id": "villainy_final_essay_synthetic",
-  "class_id": "english12_period3_synthetic",
-  "student_id": "stu_0001",
-  "source_type": "manual_entry",
-  "text_file": "submission.txt",
-  "captured_at": "2026-06-07T12:00:00",
-  "status": "captured",
-  "version": 1
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "submission_manifest",
+  "class_id": "english12_p3_synthetic",
+  "assignment_id": "essay_01_synthetic",
+  "student_id": "00107",
+  "expected_pages": null,
+  "submission_state": "unreviewed",
+  "pages": [],
+  "created_at": "2026-06-20T00:00:00+00:00",
+  "updated_at": "2026-06-20T00:00:00+00:00",
+  "module_details": {}
 }
 ```
 
-The metadata identifiers follow shared `pds-core` identifier validation.
-`text_file` must be a relative path contained within the submission record;
-absolute paths and parent-directory traversal are not allowed. `version` is a
-positive integer.
+Field requirements are:
 
-Requirements checks, teacher tags, teacher notes, rubric scores entered or
-confirmed by the teacher, and feedback records remain separate artifacts.
-Software may organize and validate these records, but the student text remains
-the evidence and teacher review remains central.
+* `schema_version`: the string `"1"`;
+* `module`: the string `"quillan"`;
+* `record_type`: the string `"submission_manifest"`;
+* `class_id`, `assignment_id`, and `student_id`: the routed identity;
+* `expected_pages`: `null` when unknown, otherwise a positive integer;
+* `submission_state`: one of the values below;
+* `pages`: an array of structured page entries;
+* `created_at` and `updated_at`: timezone-aware ISO 8601 strings; and
+* `module_details`: an object reserved for compatible Quillan extensions.
+
+Initial `submission_state` values are:
+
+* `unreviewed`: evidence exists or may exist, but teacher review has not begun;
+* `in_progress`: the teacher has started reviewing the submission;
+* `needs_rescan`: the teacher has decided that the submission or at least one
+  page requires correction or another scan; and
+* `reviewed`: the teacher has completed review at the submission-management
+  level.
+
+Submission state is an explicit workflow record. It must not be inferred from
+the number of evidence files and is not a grade, rubric result, feedback
+status, tag status, or automatic judgment.
+
+### Page Entries
+
+Each item in `pages` contains:
+
+```json
+{
+  "page_number": 1,
+  "page_state": "present",
+  "selected_evidence_id": null,
+  "evidence": []
+}
+```
+
+`page_number` is a positive integer and is unique within the manifest.
+`selected_evidence_id` is either `null` or the ID of an evidence candidate in
+the same page entry. It remains nullable so ambiguous duplicate evidence can
+wait for a teacher decision. A non-null selection does not delete or replace
+the other candidates. When it is non-null, the referenced candidate has the
+`selected` role and no other candidate on that page does. When it is `null`,
+no candidate on that page has the `selected` role.
+
+Initial `page_state` values are:
+
+* `present`: at least one evidence candidate exists and no special problem is
+  marked;
+* `missing`: an expected page currently has no routed evidence;
+* `duplicate`: multiple candidates represent the same logical page;
+* `needs_rescan`: the teacher has marked the page for correction or rescan;
+  and
+* `excluded`: the teacher has intentionally removed the page from the active
+  review set while preserving its evidence.
+
+Page state records evidence-management status only. Known pages may be listed
+with an empty `evidence` array, including missing pages.
+
+### Evidence Candidates
+
+A page may have zero, one, or many evidence candidates. Every candidate
+contains:
+
+* `evidence_id`: a stable string unique within the manifest;
+* `routed_evidence_path`: a workspace-relative path to the routed artifact;
+* `evidence_role`: one of the role values below;
+* `evidence_state`: one of the state values below;
+* `duplicate_number`: `null` when not assigned, otherwise a positive integer;
+* `created_at`: a timezone-aware ISO 8601 association timestamp;
+* `retained_source`: retained-source provenance, or `null` when unavailable;
+  and
+* `module_details`: an object reserved for compatible Quillan extensions.
+
+Initial `evidence_role` values are:
+
+* `candidate`: available but not explicitly selected;
+* `selected`: currently selected as the review copy for its page;
+* `replacement`: a rescan or replacement candidate; and
+* `excluded`: preserved but intentionally outside the active review set.
+
+Initial `evidence_state` values are:
+
+* `active`: usable unless the teacher later records otherwise;
+* `needs_rescan`: should be replaced or supplemented;
+* `damaged`: preserved but visibly or technically flawed; and
+* `excluded`: preserved but outside active review.
+
+When `retained_source` is present, it contains:
+
+* `source_scan_id`: the retained source scan identifier;
+* `source_filename`: the original source filename;
+* `source_sha256`: the source SHA-256 digest;
+* `retained_source_path`: the workspace-relative retained source path; and
+* `source_page_number`: `null` when unavailable, otherwise a positive integer.
+
+Evidence candidates are append-and-preserve records. Duplicate, replacement,
+damaged, selected, or excluded candidates remain represented rather than
+being silently overwritten or deleted.
+
+### Path and Timestamp Policy
+
+Every stored artifact path is a workspace-relative string interpreted from
+the resolved PDS workspace root. Manifest paths must not contain:
+
+* an absolute or rooted path;
+* a Windows drive-letter path;
+* `.` or `..` path components;
+* null bytes; or
+* any resolution outside the workspace root.
+
+These requirements apply to routed evidence and retained-source paths.
+Validation is intentionally deferred to a later issue.
+
+All timestamps use ISO 8601 strings with a timezone offset, such as
+`2026-06-20T00:00:00+00:00`. Naive timestamps are not part of this contract.
+
+### Synthetic Example
+
+A complete fake example with one present page, one missing page, one duplicate
+page, and retained-source provenance is stored in
+[`submission_manifest_synthetic.json`](../examples/submissions/submission_manifest_synthetic.json).
+
+This contract does not define or implement scoring, tagging, requirements
+checking, feedback, reports, OCR, handwriting recognition, AI suggestions, AI
+scoring, AI feedback drafting, or automatic grading. Those concerns remain
+separate from the evidence manifest and teacher-controlled review state. It
+also does not implement manifest loading, validation, writing, submission
+assembly, path helpers, file opening, review commands, or state updates.
 
 ## Writing-Response Payload
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -189,6 +189,19 @@ validation, routed student evidence layout, submission assembly, completeness
 and rescan decisions, and any future OCR behavior. Quillan-specific failure
 details belong under the shared record's `module_details`.
 
+The first version `1` reviewable-evidence submission manifest contract is now
+documented. It defines page entries, duplicate and replacement candidates,
+teacher-controlled selection and review states, retained-source provenance,
+workspace-relative paths, and timezone-aware timestamps. This milestone is
+descriptive only; manifest loading, validation, writing, path helpers, and
+assembly remain unimplemented.
+
+Target milestone:
+
+```text
+v0.6.0 — Reviewable Evidence and Submission Assembly
+```
+
 The first successful-write helper is implemented in `quillan.evidence_filing`.
 It accepts an existing successful `RoutePlan`, retains the selected source
 under `scans/source/YYYY-MM-DD/`, files the retained source or a supplied page
@@ -209,12 +222,15 @@ submission assembly remain unimplemented.
 
 ### `submissions.py`
 
-Planned responsibility:
+Current responsibility:
 
-* load plain-text submissions;
-* manage submission metadata;
-* store or reference student writing;
-* support manual subdivision setup.
+* load and validate the earlier text-oriented submission metadata shape.
+
+Future v0.6 reviewable-evidence manifest work should use a distinct
+loader/module, likely `quillan.submission_manifest` in
+`quillan/submission_manifest.py`, unless a deliberate migration or deprecation
+decision is made later. The legacy metadata loader should not be silently
+repurposed into the page-oriented submission manifest loader.
 
 ### `requirements.py`
 
@@ -382,7 +398,15 @@ Likely first commands:
 
 Planned work:
 
-* Load plain-text submissions.
+* Implement loading and validation for the documented version `1` submission
+  manifest.
+* Add canonical submission path helpers.
+* Assemble routed evidence into teacher-controlled manifests.
+* Represent missing, duplicate, replacement, damaged, and excluded evidence
+  without deleting candidates.
+* Add teacher-controlled evidence selection and review-state updates.
+* Preserve retained-source provenance and workspace-relative artifact paths.
+* Continue supporting plain-text writing evidence where applicable.
 * Count words.
 * Count paragraphs.
 * Manually enter or store subdivision count.

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -326,20 +326,34 @@ not automatically a reviewed submission. Routing a page must not:
 * score the response;
 * generate feedback;
 * create requirements results or evidence tags;
-* mark work as `needs_review` or `reviewed`; or
+* set a submission manifest's `submission_state`; or
 * necessarily create or update `submission.json`.
 
 A student response may have multiple pages, missing pages, duplicate pages,
-rescans, or damaged scans. Future submission assembly may link routed pages to
-a student submission only after page completeness, provenance, and teacher
-review requirements are defined. The original routed files should remain
-traceable to the canonical retained source after any such linking.
+rescans, or damaged scans. The draft version `1` submission manifest contract
+in [`data_contracts.md`](data_contracts.md#submission-manifest) represents
+those conditions without guessing which evidence the teacher intends to use.
+Future submission assembly may link routed pages to that record. The original
+routed files must remain traceable to the canonical retained source after any
+such linking.
 
-Quillan owns the future routed evidence layout inside
-`submissions/<student_id>/`, submission assembly, page completeness rules,
-teacher review and rescan decisions, and any future Quillan OCR policy. Those
-module decisions must continue to use the shared source-retention, provenance,
-and routing-review contract.
+The future canonical record location is:
+
+```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+```
+
+The manifest stores workspace-relative routed-evidence and retained-source
+paths, page and evidence states, nullable teacher selection, and provenance.
+It preserves duplicate, replacement, damaged, and excluded evidence rather
+than overwriting or deleting candidates. Defining that contract does not add
+manifest loading, validation, writing, path helpers, assembly, teacher review
+commands, or changes to `route-scan`.
+
+Quillan owns the manifest contract, future submission assembly, page
+completeness rules, teacher review and rescan decisions, and any future
+Quillan OCR policy. Those module decisions must continue to use the shared
+source-retention, provenance, and routing-review contract.
 
 ## Ownership Boundaries
 
@@ -383,9 +397,10 @@ Inactive historical preservation and end-of-cycle archiving belong to future
    is implemented with shared `pds-core` records under `scans/review/`.
    Future work should expose preserved failures and duplicate routed evidence
    for teacher review.
-7. **Submission assembly and linking.** Define page manifests, completeness
-   checks, rescan selection, and traceable links from routed evidence to
-   student submission records.
+7. **Submission assembly and linking.** The first page-oriented submission
+   manifest contract is defined. Loading, validation, path helpers,
+   completeness checks, rescan selection workflows, and assembly of traceable
+   routed evidence links remain future implementation work.
 8. **Teacher review integration.** Present assembled evidence to the teacher
    and allow teacher-controlled lifecycle changes without automated judgment.
 

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -148,10 +148,15 @@ that Quillan currently routes scans, performs OCR, or files captured pages.
 
 ### `submissions/<student_id>/submission.json`
 
-Submission metadata for the student's writing artifact. It identifies the
-assignment, class, student, source type, text file, capture time, lifecycle
-status, and version. It describes provenance and workflow state without
-containing scores or feedback.
+The future Quillan version `1` submission manifest for one student's routed
+evidence for one assignment. It identifies the class, assignment, and student;
+represents expected, missing, duplicate, replacement, damaged, or excluded
+pages; preserves retained-source provenance; and records teacher-controlled
+review state without containing scores, tags, or feedback.
+
+The manifest contract is documented, but loading, validation, writing,
+assembly, and state-changing workflows are not yet implemented. The current
+Python loader accepts an earlier text-oriented metadata shape.
 
 ### `submissions/<student_id>/submission.txt`
 
@@ -201,64 +206,17 @@ needed. Debug files are operational aids and must not be treated as
 authoritative instructional records, source evidence, scores, feedback, or
 reports.
 
-## File Lifecycle States
+## Submission Review States
 
-The `status` field in `submission.json` describes whether a submission record
-is usable and where it is in the teacher-controlled review workflow. A status
-change does not, by itself, require moving the submission to another
-directory.
+The version `1` manifest's `submission_state` is one of `unreviewed`,
+`in_progress`, `needs_rescan`, or `reviewed`. Page and evidence entries carry
+their own narrower evidence-management states. Replacement, duplicate,
+damaged, and excluded artifacts remain in the manifest for traceability.
 
-### `captured`
-
-The writing evidence has been collected or imported and has submission
-metadata. Capture establishes the record and its provenance; it does not mean
-that teacher review is complete.
-
-### `needs_review`
-
-The submission exists but still requires teacher review. This may be used
-after capture when the record is ready to enter the teacher's review queue.
-
-### `reviewed`
-
-The teacher has reviewed the submission or confirmed the relevant review
-artifacts. This state represents teacher confirmation, not a software-made
-judgment about achievement.
-
-### `superseded`
-
-A newer version or corrected record has replaced this record for current use.
-The older record may remain in place so its provenance and relationship to
-later records can be traced.
-
-### `invalid`
-
-The record should not be used for scoring or reporting because it is
-incomplete, misfiled, corrupt, mismatched, or otherwise unusable. Retaining an
-invalid record may still be useful for diagnosis and traceability.
-
-These are the active MVP lifecycle states. `archived` is not an active
-submission status.
-
-## Versioning and Supersession
-
-The `version` field in `submission.json` is a positive integer that identifies
-the version of the submission record. A newer version may supersede an older
-version when writing is recaptured, corrected, or replaced.
-
-At MVP level:
-
-* version numbers begin at `1` and remain positive integers;
-* a higher version can replace a lower version for current instructional use;
-* an older record can be marked `superseded` and retained for traceability;
-* version and status should be read together rather than assuming every
-  higher number is automatically teacher-approved; and
-* no versioned directory structure or automatic file movement is required.
-
-Because the current shared route is student-local, this contract does not
-prescribe how multiple retained versions must be named or arranged inside the
-student directory. That routing decision requires a separate design before
-implementation.
+These states do not encode a score, grade, rubric result, feedback status,
+tagging status, OCR result, AI judgment, or automatic grading decision. See
+[`data_contracts.md`](data_contracts.md#submission-manifest) for the complete
+contract.
 
 ## Source Evidence vs. Teacher-Review Artifacts
 
@@ -266,15 +224,16 @@ Quillan keeps three record categories distinct.
 
 ### Source Evidence
 
-Source evidence is the student-produced writing and the metadata needed to
-identify what was submitted and how it entered the workflow:
+Source evidence is the student-produced work and the manifest needed to
+identify routed artifacts and their retained-source provenance:
 
 * `submission.txt`
 * `submission.json`
 
-The metadata is part of the evidentiary record because it establishes identity,
-provenance, status, and version. It does not contain the teacher's score or
-feedback.
+`submission.txt` remains an optional text-oriented evidence artifact for
+workflows that use it. The manifest is part of the evidentiary record because
+it establishes identity, provenance, page state, and teacher-controlled review
+state. It does not contain the teacher's score, tags, or feedback.
 
 ### Teacher-Review Artifacts
 

--- a/examples/submissions/submission_manifest_synthetic.json
+++ b/examples/submissions/submission_manifest_synthetic.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "submission_manifest",
+  "class_id": "english12_p3_synthetic",
+  "assignment_id": "essay_01_synthetic",
+  "student_id": "00107",
+  "expected_pages": 3,
+  "submission_state": "unreviewed",
+  "pages": [
+    {
+      "page_number": 1,
+      "page_state": "present",
+      "selected_evidence_id": "evidence_001",
+      "evidence": [
+        {
+          "evidence_id": "evidence_001",
+          "routed_evidence_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/scans/response_00107_pg_001.pdf",
+          "evidence_role": "selected",
+          "evidence_state": "active",
+          "duplicate_number": null,
+          "created_at": "2026-06-20T00:01:00+00:00",
+          "retained_source": {
+            "source_scan_id": "scan_20260620T000000000000Z__teacher_scan__abc123def456",
+            "source_filename": "teacher_scan.pdf",
+            "source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "retained_source_path": "scans/source/2026-06-20/20260620T000000000000Z__teacher_scan__abc123def456.pdf",
+            "source_page_number": 1
+          },
+          "module_details": {}
+        }
+      ]
+    },
+    {
+      "page_number": 2,
+      "page_state": "missing",
+      "selected_evidence_id": null,
+      "evidence": []
+    },
+    {
+      "page_number": 3,
+      "page_state": "duplicate",
+      "selected_evidence_id": null,
+      "evidence": [
+        {
+          "evidence_id": "evidence_002",
+          "routed_evidence_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/scans/response_00107_pg_003.pdf",
+          "evidence_role": "candidate",
+          "evidence_state": "active",
+          "duplicate_number": null,
+          "created_at": "2026-06-20T00:03:00+00:00",
+          "retained_source": {
+            "source_scan_id": "scan_20260620T000000000000Z__teacher_scan__abc123def456",
+            "source_filename": "teacher_scan.pdf",
+            "source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "retained_source_path": "scans/source/2026-06-20/20260620T000000000000Z__teacher_scan__abc123def456.pdf",
+            "source_page_number": 3
+          },
+          "module_details": {}
+        },
+        {
+          "evidence_id": "evidence_003",
+          "routed_evidence_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/scans/response_00107_pg_003__dup_001.pdf",
+          "evidence_role": "candidate",
+          "evidence_state": "active",
+          "duplicate_number": 1,
+          "created_at": "2026-06-20T00:08:00+00:00",
+          "retained_source": {
+            "source_scan_id": "scan_20260620T000700000000Z__teacher_rescan__def456abc123",
+            "source_filename": "teacher_rescan.pdf",
+            "source_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "retained_source_path": "scans/source/2026-06-20/20260620T000700000000Z__teacher_rescan__def456abc123.pdf",
+            "source_page_number": 1
+          },
+          "module_details": {}
+        }
+      ]
+    }
+  ],
+  "created_at": "2026-06-20T00:10:00+00:00",
+  "updated_at": "2026-06-20T00:10:00+00:00",
+  "module_details": {}
+}


### PR DESCRIPTION
## Summary

* Defined the draft version `1` Quillan reviewable-evidence `submission.json` contract.
* Documented the future canonical manifest location under `classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json`.
* Defined top-level manifest fields, page entries, evidence candidates, retained-source provenance, workspace-relative path policy, and timezone-aware timestamp policy.
* Defined initial submission, page, evidence role, and evidence state vocabularies.
* Added a fully synthetic three-page example covering:

  * one present page;
  * one missing page;
  * one duplicate page;
  * multiple evidence candidates;
  * retained-source provenance.
* Clarified that the existing legacy `quillan.submissions` loader remains separate from the future v0.6 reviewable-evidence manifest loader.
* Clarified that future v0.6 manifest loading should use a distinct module, likely `quillan.submission_manifest`, unless a deliberate migration/deprecation decision is made later.
* Updated routing, lifecycle/development-plan, README, and changelog documentation.

Closes #69.

## Validation

* [x] `git diff --check`
* [x] Synthetic JSON structure reviewed
* [ ] `python -m pytest` — not run; local `python.exe` could not launch: “A specified logon session does not exist.”
* [ ] `python -m ruff check .` — not run; local `python.exe` could not launch
* [ ] `python -m mypy .` — not run; local `python.exe` could not launch
* [ ] `.\run_tests.ps1` — not run because Python could not launch in this environment

## Notes

* This is a contract-only documentation/example change.
* Does not implement manifest loading.
* Does not implement manifest validation.
* Does not implement manifest writing.
* Does not add path helpers.
* Does not assemble submissions.
* Does not open files.
* Does not alter `quillan.submissions`.
* Does not alter `route-scan`.
* Does not implement OCR, handwriting recognition, AI suggestions, AI scoring, AI feedback drafting, tagging, scoring, feedback generation, reports, or pds-core changes.
* Uses only synthetic example data.
