### PR TITLE
Add submission manifest validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,14 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a distinct v0.6 reviewable-evidence submission manifest loader and
+  validator with page, evidence, retained-source, selection, path, timestamp,
+  state, and identifier validation. The legacy text-oriented loader remains
+  unchanged.
 - Documented the draft version `1` reviewable-evidence `submission.json`
   contract, including page and evidence states, duplicate and replacement
   preservation, retained-source provenance, safe relative paths, and a fully
-  synthetic three-page example. Loading, validation, writing, and assembly
-  remain future work.
+  synthetic three-page example. Writing and assembly remain future work.
 - Added a direct `route-scan` command for already-decoded Quillan PDS1
   payloads, including successful evidence filing, safe review preservation,
   concise workspace-relative summaries, and documented handled/failure exit

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Quillan currently supports:
 - standards profile loading and validation;
 - validation of the legacy text-oriented submission metadata shape;
 - documented writing-evidence and teacher-review data contracts;
-- a documented, contract-only version `1` reviewable-evidence submission
-  manifest;
+- loading and validation for the version `1` reviewable-evidence submission
+  manifest through the distinct `quillan.submission_manifest` module;
 - printable writing-response PDF generation with student, class, assignment,
   and page identity;
 - QR codes containing canonical PDS1 Quillan response payloads on printable
@@ -71,8 +71,7 @@ particular, Quillan does not currently provide:
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
-- loading, validating, writing, or assembling version `1` submission
-  manifests;
+- writing or assembling version `1` submission manifests;
 - assignment creation workflows;
 - implemented requirements-checking, tagging, scoring, feedback, or
   production reporting workflows;

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -6,10 +6,10 @@ These contracts describe the expected file formats for standards profiles,
 assignments, submissions, requirements checks, tags, scores, feedback, and
 reports.
 
-Standards profiles, assignment configurations, and the legacy text-oriented
-submission metadata shape have implemented Python validation support. The
-reviewable-evidence submission manifest defined below is a contract only and
-is not yet loaded, validated, written, or assembled by Quillan. The
+Standards profiles, assignment configurations, the legacy text-oriented
+submission metadata shape, and the reviewable-evidence submission manifest
+have implemented Python validation support. Manifest writing, assembly,
+selection, and state-changing workflows are not implemented. The
 writing-response payload contract is implemented and used by printable PDF
 generation. Requirements, tagging, scoring, feedback, and reporting records
 remain contracts for teacher-controlled workflows that are not yet
@@ -243,10 +243,11 @@ The future canonical location is:
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
 ```
 
-This section defines draft schema version `1`. It is contract-only: the
-existing `quillan.submissions` loader still accepts an earlier text-oriented
-metadata shape and does not load or validate this manifest. Path helpers,
-writing, assembly, selection, and state-changing workflows are future work.
+This section defines draft schema version `1`. The distinct
+`quillan.submission_manifest` module loads and validates this contract. The
+existing `quillan.submissions` loader remains responsible for an earlier
+text-oriented metadata shape. Path helpers, writing, assembly, selection, and
+state-changing workflows are future work.
 
 ### Top-Level Structure
 
@@ -381,8 +382,8 @@ the resolved PDS workspace root. Manifest paths must not contain:
 * null bytes; or
 * any resolution outside the workspace root.
 
-These requirements apply to routed evidence and retained-source paths.
-Validation is intentionally deferred to a later issue.
+These requirements apply to routed evidence and retained-source paths and are
+enforced by `quillan.submission_manifest`.
 
 All timestamps use ISO 8601 strings with a timezone offset, such as
 `2026-06-20T00:00:00+00:00`. Naive timestamps are not part of this contract.
@@ -397,8 +398,8 @@ This contract does not define or implement scoring, tagging, requirements
 checking, feedback, reports, OCR, handwriting recognition, AI suggestions, AI
 scoring, AI feedback drafting, or automatic grading. Those concerns remain
 separate from the evidence manifest and teacher-controlled review state. It
-also does not implement manifest loading, validation, writing, submission
-assembly, path helpers, file opening, review commands, or state updates.
+also does not implement manifest writing, submission assembly, path helpers,
+file opening, review commands, or state updates.
 
 ## Writing-Response Payload
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -226,11 +226,10 @@ Current responsibility:
 
 * load and validate the earlier text-oriented submission metadata shape.
 
-Future v0.6 reviewable-evidence manifest work should use a distinct
-loader/module, likely `quillan.submission_manifest` in
-`quillan/submission_manifest.py`, unless a deliberate migration or deprecation
-decision is made later. The legacy metadata loader should not be silently
-repurposed into the page-oriented submission manifest loader.
+The v0.6 reviewable-evidence manifest loader is implemented separately as
+`quillan.submission_manifest` in `quillan/submission_manifest.py`. The legacy
+metadata loader remains distinct and has not been repurposed into the
+page-oriented submission manifest loader.
 
 ### `requirements.py`
 

--- a/quillan/submission_manifest.py
+++ b/quillan/submission_manifest.py
@@ -1,0 +1,374 @@
+"""Loading and validation for Quillan reviewable-evidence manifests."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Final, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+REQUIRED_MANIFEST_FIELDS: Final[tuple[str, ...]] = (
+    "schema_version",
+    "module",
+    "record_type",
+    "class_id",
+    "assignment_id",
+    "student_id",
+    "expected_pages",
+    "submission_state",
+    "pages",
+    "created_at",
+    "updated_at",
+    "module_details",
+)
+REQUIRED_PAGE_FIELDS: Final[tuple[str, ...]] = (
+    "page_number",
+    "page_state",
+    "selected_evidence_id",
+    "evidence",
+)
+REQUIRED_EVIDENCE_FIELDS: Final[tuple[str, ...]] = (
+    "evidence_id",
+    "routed_evidence_path",
+    "evidence_role",
+    "evidence_state",
+    "duplicate_number",
+    "created_at",
+    "retained_source",
+    "module_details",
+)
+REQUIRED_RETAINED_SOURCE_FIELDS: Final[tuple[str, ...]] = (
+    "source_scan_id",
+    "source_filename",
+    "source_sha256",
+    "retained_source_path",
+    "source_page_number",
+)
+
+ALLOWED_SUBMISSION_STATES: Final[frozenset[str]] = frozenset(
+    {"unreviewed", "in_progress", "needs_rescan", "reviewed"}
+)
+ALLOWED_PAGE_STATES: Final[frozenset[str]] = frozenset(
+    {"present", "missing", "duplicate", "needs_rescan", "excluded"}
+)
+ALLOWED_EVIDENCE_ROLES: Final[frozenset[str]] = frozenset(
+    {"candidate", "selected", "replacement", "excluded"}
+)
+ALLOWED_EVIDENCE_STATES: Final[frozenset[str]] = frozenset(
+    {"active", "needs_rescan", "damaged", "excluded"}
+)
+_SHA256_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[0-9A-Fa-f]{64}$")
+
+
+class SubmissionManifestError(ValueError):
+    """Raised when a v0.6 submission manifest is missing or invalid."""
+
+
+def load_submission_manifest(path: str | Path) -> dict[str, Any]:
+    """Load and validate a v0.6 submission manifest JSON file."""
+    manifest_path = Path(path)
+
+    try:
+        with manifest_path.open("r", encoding="utf-8") as file:
+            manifest = json.load(file)
+    except FileNotFoundError as error:
+        raise SubmissionManifestError(
+            f"Submission manifest not found: {manifest_path}"
+        ) from error
+    except json.JSONDecodeError as error:
+        raise SubmissionManifestError(
+            f"Submission manifest is not valid JSON: {manifest_path}"
+        ) from error
+
+    if not isinstance(manifest, dict):
+        raise SubmissionManifestError(
+            f"Submission manifest must be a JSON object: {manifest_path}"
+        )
+
+    manifest_dict = cast(dict[str, Any], manifest)
+    validate_submission_manifest(manifest_dict)
+    return manifest_dict
+
+
+def validate_submission_manifest(manifest: dict[str, Any]) -> None:
+    """Validate the structure of a v0.6 submission manifest."""
+    _require_fields(manifest, REQUIRED_MANIFEST_FIELDS, "submission manifest")
+    _validate_exact_value(manifest["schema_version"], "schema_version", "1")
+    _validate_exact_value(manifest["module"], "module", "quillan")
+    _validate_exact_value(
+        manifest["record_type"], "record_type", "submission_manifest"
+    )
+    for field in ("class_id", "assignment_id", "student_id"):
+        _validate_identifier(manifest[field], field)
+
+    _validate_optional_positive_integer(manifest["expected_pages"], "expected_pages")
+    _validate_allowed_value(
+        manifest["submission_state"],
+        "submission_state",
+        ALLOWED_SUBMISSION_STATES,
+    )
+    _validate_timestamp(manifest["created_at"], "created_at")
+    _validate_timestamp(manifest["updated_at"], "updated_at")
+    _validate_json_object(manifest["module_details"], "module_details")
+
+    pages = manifest["pages"]
+    if not isinstance(pages, list):
+        raise SubmissionManifestError("Field 'pages' must be a list.")
+
+    seen_page_numbers: set[int] = set()
+    seen_evidence_ids: set[str] = set()
+    for index, page in enumerate(pages):
+        context = f"pages[{index}]"
+        if not isinstance(page, dict):
+            raise SubmissionManifestError(f"{context} must be an object.")
+        _validate_page(page, context, seen_page_numbers, seen_evidence_ids)
+
+
+def _validate_page(
+    page: dict[str, Any],
+    context: str,
+    seen_page_numbers: set[int],
+    seen_evidence_ids: set[str],
+) -> None:
+    _require_fields(page, REQUIRED_PAGE_FIELDS, context)
+    page_number = _validate_positive_integer(
+        page["page_number"], f"{context}.page_number"
+    )
+    if page_number in seen_page_numbers:
+        raise SubmissionManifestError(
+            f"Duplicate page_number {page_number} in submission manifest."
+        )
+    seen_page_numbers.add(page_number)
+
+    page_state = _validate_allowed_value(
+        page["page_state"], f"{context}.page_state", ALLOWED_PAGE_STATES
+    )
+    selected_evidence_id = page["selected_evidence_id"]
+    if selected_evidence_id is not None:
+        _validate_non_empty_string(
+            selected_evidence_id, f"{context}.selected_evidence_id"
+        )
+
+    evidence = page["evidence"]
+    if not isinstance(evidence, list):
+        raise SubmissionManifestError(f"Field '{context}.evidence' must be a list.")
+    if page_state == "missing" and evidence:
+        raise SubmissionManifestError(
+            f"{context} has page_state 'missing' but contains evidence."
+        )
+    if page_state == "present" and not evidence:
+        raise SubmissionManifestError(
+            f"{context} has page_state 'present' but contains no evidence."
+        )
+    if page_state == "duplicate" and len(evidence) < 2:
+        raise SubmissionManifestError(
+            f"{context} has page_state 'duplicate' but has fewer than two "
+            "evidence candidates."
+        )
+
+    page_evidence_ids: set[str] = set()
+    selected_role_ids: list[str] = []
+    for index, candidate in enumerate(evidence):
+        evidence_context = f"{context}.evidence[{index}]"
+        if not isinstance(candidate, dict):
+            raise SubmissionManifestError(f"{evidence_context} must be an object.")
+        evidence_id, evidence_role = _validate_evidence(
+            candidate, evidence_context, seen_evidence_ids
+        )
+        page_evidence_ids.add(evidence_id)
+        if evidence_role == "selected":
+            selected_role_ids.append(evidence_id)
+
+    if selected_evidence_id is None:
+        if selected_role_ids:
+            raise SubmissionManifestError(
+                f"{context} has selected evidence role but "
+                "selected_evidence_id is null."
+            )
+        return
+    if selected_evidence_id not in page_evidence_ids:
+        raise SubmissionManifestError(
+            f"{context}.selected_evidence_id does not refer to evidence on "
+            "the same page."
+        )
+    if selected_role_ids != [selected_evidence_id]:
+        raise SubmissionManifestError(
+            f"{context} must have exactly one candidate with evidence_role "
+            "'selected', matching selected_evidence_id."
+        )
+
+
+def _validate_evidence(
+    evidence: dict[str, Any],
+    context: str,
+    seen_evidence_ids: set[str],
+) -> tuple[str, str]:
+    _require_fields(evidence, REQUIRED_EVIDENCE_FIELDS, context)
+    evidence_id = _validate_non_empty_string(
+        evidence["evidence_id"], f"{context}.evidence_id"
+    )
+    if evidence_id in seen_evidence_ids:
+        raise SubmissionManifestError(
+            f"Duplicate evidence_id '{evidence_id}' in submission manifest."
+        )
+    seen_evidence_ids.add(evidence_id)
+
+    _validate_workspace_relative_path(
+        evidence["routed_evidence_path"], f"{context}.routed_evidence_path"
+    )
+    evidence_role = _validate_allowed_value(
+        evidence["evidence_role"],
+        f"{context}.evidence_role",
+        ALLOWED_EVIDENCE_ROLES,
+    )
+    _validate_allowed_value(
+        evidence["evidence_state"],
+        f"{context}.evidence_state",
+        ALLOWED_EVIDENCE_STATES,
+    )
+    _validate_optional_positive_integer(
+        evidence["duplicate_number"], f"{context}.duplicate_number"
+    )
+    _validate_timestamp(evidence["created_at"], f"{context}.created_at")
+    _validate_retained_source(
+        evidence["retained_source"], f"{context}.retained_source"
+    )
+    _validate_json_object(
+        evidence["module_details"], f"{context}.module_details"
+    )
+    return evidence_id, evidence_role
+
+
+def _validate_retained_source(value: Any, context: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, dict):
+        raise SubmissionManifestError(f"{context} must be an object or null.")
+
+    _require_fields(value, REQUIRED_RETAINED_SOURCE_FIELDS, context)
+    _validate_non_empty_string(value["source_scan_id"], f"{context}.source_scan_id")
+    _validate_filename(value["source_filename"], f"{context}.source_filename")
+    source_sha256 = value["source_sha256"]
+    if not isinstance(source_sha256, str) or not _SHA256_PATTERN.fullmatch(
+        source_sha256
+    ):
+        raise SubmissionManifestError(
+            f"Field '{context}.source_sha256' must be a 64-character "
+            "hexadecimal SHA-256 digest."
+        )
+    _validate_workspace_relative_path(
+        value["retained_source_path"], f"{context}.retained_source_path"
+    )
+    # This is the page inside the retained source, not the logical response page.
+    _validate_optional_positive_integer(
+        value["source_page_number"], f"{context}.source_page_number"
+    )
+
+
+def _validate_workspace_relative_path(value: Any, field: str) -> None:
+    if not isinstance(value, str) or value == "":
+        raise SubmissionManifestError(
+            f"Field '{field}' must be a non-empty workspace-relative path string."
+        )
+    if "\0" in value:
+        raise SubmissionManifestError(f"Field '{field}' must not contain null bytes.")
+
+    path_variants = (PurePosixPath(value), PureWindowsPath(value))
+    if any(path.anchor or path.drive for path in path_variants):
+        raise SubmissionManifestError(
+            f"Field '{field}' must be a workspace-relative path."
+        )
+    components = re.split(r"[\\/]", value)
+    if "." in components or ".." in components:
+        raise SubmissionManifestError(
+            f"Field '{field}' must not contain '.' or '..' path components."
+        )
+
+
+def _validate_filename(value: Any, field: str) -> None:
+    filename = _validate_non_empty_string(value, field)
+    if "/" in filename or "\\" in filename or "\0" in filename:
+        raise SubmissionManifestError(f"Field '{field}' must be a filename only.")
+    if filename in {".", ".."}:
+        raise SubmissionManifestError(f"Field '{field}' must be a valid filename.")
+
+
+def _validate_timestamp(value: Any, field: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise SubmissionManifestError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise SubmissionManifestError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SubmissionManifestError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+
+
+def _validate_exact_value(value: Any, field: str, expected: str) -> None:
+    if value != expected:
+        raise SubmissionManifestError(
+            f"Field '{field}' must be the string '{expected}'."
+        )
+
+
+def _validate_identifier(value: Any, field: str) -> None:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise SubmissionManifestError(str(error)) from error
+
+
+def _validate_non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SubmissionManifestError(
+            f"Field '{field}' must be a non-empty string."
+        )
+    return value
+
+
+def _validate_positive_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise SubmissionManifestError(
+            f"Field '{field}' must be a positive integer."
+        )
+    return value
+
+
+def _validate_optional_positive_integer(value: Any, field: str) -> None:
+    if value is not None:
+        _validate_positive_integer(value, field)
+
+
+def _validate_allowed_value(
+    value: Any, field: str, allowed_values: frozenset[str]
+) -> str:
+    if not isinstance(value, str) or value not in allowed_values:
+        allowed = ", ".join(sorted(allowed_values))
+        raise SubmissionManifestError(
+            f"Invalid {field} {value!r}. Allowed values: {allowed}."
+        )
+    return value
+
+
+def _validate_json_object(value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        raise SubmissionManifestError(f"Field '{field}' must be an object.")
+
+
+def _require_fields(
+    data: dict[str, Any], fields: tuple[str, ...], context: str
+) -> None:
+    for field in fields:
+        if field not in data:
+            raise SubmissionManifestError(
+                f"Missing required field '{field}' in {context}."
+            )

--- a/tests/test_submission_manifest.py
+++ b/tests/test_submission_manifest.py
@@ -1,0 +1,400 @@
+"""Tests for v0.6 submission manifest loading and validation."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+    validate_submission_manifest,
+)
+
+EXAMPLE_PATH = (
+    Path(__file__).parents[1]
+    / "examples"
+    / "submissions"
+    / "submission_manifest_synthetic.json"
+)
+
+
+def _retained_source() -> dict[str, Any]:
+    return {
+        "source_scan_id": "scan_001",
+        "source_filename": "teacher_scan.pdf",
+        "source_sha256": "a" * 64,
+        "retained_source_path": "scans/source/2026-06-20/teacher_scan.pdf",
+        "source_page_number": 1,
+    }
+
+
+def _candidate(
+    evidence_id: str = "evidence_001",
+    *,
+    role: str = "selected",
+    retained_source: object = None,
+) -> dict[str, Any]:
+    return {
+        "evidence_id": evidence_id,
+        "routed_evidence_path": f"classes/example/scans/{evidence_id}.pdf",
+        "evidence_role": role,
+        "evidence_state": "active",
+        "duplicate_number": None,
+        "created_at": "2026-06-20T00:01:00+00:00",
+        "retained_source": retained_source,
+        "module_details": {},
+    }
+
+
+def _manifest(*, pages: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": "english12_p3_synthetic",
+        "assignment_id": "essay_01_synthetic",
+        "student_id": "00107",
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [] if pages is None else pages,
+        "created_at": "2026-06-20T00:00:00+00:00",
+        "updated_at": "2026-06-20T00:00:00+00:00",
+        "module_details": {},
+    }
+
+
+def _present_page() -> dict[str, Any]:
+    return {
+        "page_number": 1,
+        "page_state": "present",
+        "selected_evidence_id": "evidence_001",
+        "evidence": [_candidate(retained_source=_retained_source())],
+    }
+
+
+def _write_manifest(tmp_path: Path, manifest: object) -> Path:
+    path = tmp_path / "submission.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+def test_synthetic_example_loads_successfully() -> None:
+    manifest = load_submission_manifest(EXAMPLE_PATH)
+
+    assert [page["page_state"] for page in manifest["pages"]] == [
+        "present",
+        "missing",
+        "duplicate",
+    ]
+
+
+def test_minimal_manifest_with_empty_pages_loads(tmp_path: Path) -> None:
+    manifest = _manifest()
+
+    assert load_submission_manifest(_write_manifest(tmp_path, manifest)) == manifest
+
+
+def test_present_missing_and_duplicate_pages_validate() -> None:
+    manifest = _manifest(
+        pages=[
+            _present_page(),
+            {
+                "page_number": 2,
+                "page_state": "missing",
+                "selected_evidence_id": None,
+                "evidence": [],
+            },
+            {
+                "page_number": 3,
+                "page_state": "duplicate",
+                "selected_evidence_id": None,
+                "evidence": [
+                    _candidate("evidence_002", role="candidate"),
+                    _candidate("evidence_003", role="candidate"),
+                ],
+            },
+        ]
+    )
+
+    validate_submission_manifest(manifest)
+
+
+def test_missing_file_invalid_json_and_wrong_root_raise(tmp_path: Path) -> None:
+    with pytest.raises(SubmissionManifestError, match="not found"):
+        load_submission_manifest(tmp_path / "missing.json")
+
+    invalid_path = tmp_path / "invalid.json"
+    invalid_path.write_text("{bad json", encoding="utf-8")
+    with pytest.raises(SubmissionManifestError, match="not valid JSON"):
+        load_submission_manifest(invalid_path)
+
+    with pytest.raises(SubmissionManifestError, match="JSON object"):
+        load_submission_manifest(_write_manifest(tmp_path, []))
+
+
+@pytest.mark.parametrize("field", list(_manifest()))
+def test_missing_top_level_field_raises(field: str) -> None:
+    manifest = _manifest()
+    del manifest[field]
+
+    with pytest.raises(SubmissionManifestError, match=field):
+        validate_submission_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", "2"),
+        ("module", "other"),
+        ("record_type", "legacy_submission"),
+        ("class_id", "../class"),
+        ("assignment_id", "bad assignment"),
+        ("student_id", ""),
+        ("expected_pages", 0),
+        ("expected_pages", True),
+        ("submission_state", "scored"),
+        ("pages", {}),
+        ("created_at", "2026-06-20T00:00:00"),
+        ("updated_at", "not-a-timestamp"),
+        ("module_details", []),
+    ],
+)
+def test_invalid_top_level_field_raises(field: str, value: object) -> None:
+    manifest = _manifest()
+    manifest[field] = value
+
+    with pytest.raises(SubmissionManifestError, match=field):
+        validate_submission_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    "field", ["page_number", "page_state", "selected_evidence_id", "evidence"]
+)
+def test_missing_page_field_raises(field: str) -> None:
+    page = _present_page()
+    del page[field]
+
+    with pytest.raises(SubmissionManifestError, match=field):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("page_number", 0),
+        ("page_number", True),
+        ("page_state", "reviewed"),
+        ("selected_evidence_id", ""),
+        ("evidence", {}),
+    ],
+)
+def test_invalid_page_field_raises(field: str, value: object) -> None:
+    page = _present_page()
+    page[field] = value
+
+    with pytest.raises(SubmissionManifestError, match=field):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+def test_duplicate_page_numbers_raise() -> None:
+    first = _present_page()
+    second = copy.deepcopy(first)
+    second["evidence"][0]["evidence_id"] = "evidence_002"
+    second["selected_evidence_id"] = "evidence_002"
+
+    with pytest.raises(SubmissionManifestError, match="Duplicate page_number"):
+        validate_submission_manifest(_manifest(pages=[first, second]))
+
+
+@pytest.mark.parametrize(
+    "page",
+    [
+        {
+            "page_number": 1,
+            "page_state": "missing",
+            "selected_evidence_id": None,
+            "evidence": [_candidate(role="candidate")],
+        },
+        {
+            "page_number": 1,
+            "page_state": "present",
+            "selected_evidence_id": None,
+            "evidence": [],
+        },
+        {
+            "page_number": 1,
+            "page_state": "duplicate",
+            "selected_evidence_id": None,
+            "evidence": [_candidate(role="candidate")],
+        },
+    ],
+    ids=["missing-with-evidence", "present-without-evidence", "duplicate-with-one"],
+)
+def test_incoherent_page_state_raises(page: dict[str, Any]) -> None:
+    with pytest.raises(SubmissionManifestError):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+@pytest.mark.parametrize(
+    ("selected_id", "roles"),
+    [
+        ("missing", ["candidate"]),
+        ("evidence_001", ["candidate"]),
+        (None, ["selected"]),
+        ("evidence_001", ["selected", "selected"]),
+    ],
+    ids=[
+        "reference-not-found",
+        "reference-without-role",
+        "role-without-reference",
+        "multiple-selected",
+    ],
+)
+def test_invalid_evidence_selection_raises(
+    selected_id: str | None, roles: list[str]
+) -> None:
+    evidence = [
+        _candidate(f"evidence_{index:03d}", role=role)
+        for index, role in enumerate(roles, start=1)
+    ]
+    page = {
+        "page_number": 1,
+        "page_state": "present",
+        "selected_evidence_id": selected_id,
+        "evidence": evidence,
+    }
+
+    with pytest.raises(SubmissionManifestError, match="selected"):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "evidence_id",
+        "routed_evidence_path",
+        "evidence_role",
+        "evidence_state",
+        "duplicate_number",
+        "created_at",
+        "retained_source",
+        "module_details",
+    ],
+)
+def test_missing_evidence_field_raises(field: str) -> None:
+    page = _present_page()
+    del page["evidence"][0][field]
+
+    with pytest.raises(SubmissionManifestError, match=field):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("evidence_id", ""),
+        ("routed_evidence_path", "../evidence.pdf"),
+        ("evidence_role", "primary"),
+        ("evidence_state", "reviewed"),
+        ("duplicate_number", 0),
+        ("duplicate_number", True),
+        ("created_at", "2026-06-20T00:01:00"),
+        ("module_details", None),
+    ],
+)
+def test_invalid_evidence_field_raises(field: str, value: object) -> None:
+    page = _present_page()
+    page["evidence"][0][field] = value
+
+    with pytest.raises(SubmissionManifestError, match=field):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+def test_duplicate_evidence_ids_across_pages_raise() -> None:
+    first = _present_page()
+    second = copy.deepcopy(first)
+    second["page_number"] = 2
+
+    with pytest.raises(SubmissionManifestError, match="Duplicate evidence_id"):
+        validate_submission_manifest(_manifest(pages=[first, second]))
+
+
+def test_null_retained_source_is_allowed() -> None:
+    page = _present_page()
+    page["evidence"][0]["retained_source"] = None
+    validate_submission_manifest(_manifest(pages=[page]))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "source_scan_id",
+        "source_filename",
+        "source_sha256",
+        "retained_source_path",
+        "source_page_number",
+    ],
+)
+def test_missing_retained_source_field_raises(field: str) -> None:
+    page = _present_page()
+    del page["evidence"][0]["retained_source"][field]
+
+    with pytest.raises(SubmissionManifestError, match=field):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_scan_id", ""),
+        ("source_filename", "incoming/teacher_scan.pdf"),
+        ("source_filename", r"incoming\teacher_scan.pdf"),
+        ("source_sha256", "abc123"),
+        ("retained_source_path", "/source.pdf"),
+        ("source_page_number", 0),
+        ("source_page_number", True),
+    ],
+)
+def test_invalid_retained_source_field_raises(field: str, value: object) -> None:
+    page = _present_page()
+    page["evidence"][0]["retained_source"][field] = value
+
+    with pytest.raises(SubmissionManifestError, match=field):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+UNSAFE_PATHS = [
+    "/absolute/file.pdf",
+    r"C:\absolute\file.pdf",
+    r"C:drive-relative\file.pdf",
+    r"\root-relative\file.pdf",
+    "../file.pdf",
+    "folder/../file.pdf",
+    "./file.pdf",
+    "folder/./file.pdf",
+    "",
+    "path\0file.pdf",
+]
+
+
+@pytest.mark.parametrize("unsafe_path", UNSAFE_PATHS)
+def test_unsafe_routed_evidence_path_raises(unsafe_path: str) -> None:
+    page = _present_page()
+    page["evidence"][0]["routed_evidence_path"] = unsafe_path
+
+    with pytest.raises(SubmissionManifestError, match="routed_evidence_path"):
+        validate_submission_manifest(_manifest(pages=[page]))
+
+
+@pytest.mark.parametrize("unsafe_path", UNSAFE_PATHS)
+def test_unsafe_retained_source_path_raises(unsafe_path: str) -> None:
+    page = _present_page()
+    page["evidence"][0]["retained_source"]["retained_source_path"] = unsafe_path
+
+    with pytest.raises(SubmissionManifestError, match="retained_source_path"):
+        validate_submission_manifest(_manifest(pages=[page]))


### PR DESCRIPTION
## Summary

* Added v0.6 reviewable-evidence submission manifest loading and validation.
* Added `quillan/submission_manifest.py` with:

  * `SubmissionManifestError`
  * `load_submission_manifest(...)`
  * `validate_submission_manifest(...)`
* Validates the documented version `1` submission manifest contract.
* Validates top-level manifest fields, module/record type, identifiers, expected pages, submission state, pages, timestamps, and `module_details`.
* Validates page entries, page states, unique page numbers, selected evidence references, and selected-role consistency.
* Validates evidence candidates, unique evidence IDs, routed evidence paths, roles, states, duplicate numbers, timestamps, retained-source provenance, and extension fields.
* Validates retained-source filename, SHA-256, workspace-relative retained-source paths, and source page numbers.
* Rejects unsafe artifact paths including absolute paths, drive-letter paths, parent traversal, `.` / `..` components, empty paths, and null bytes.
* Added focused tests covering valid manifests, the synthetic example, invalid top-level fields, page errors, evidence errors, retained-source errors, unsafe paths, duplicate IDs, and selection consistency.
* Preserved the legacy `quillan.submissions` metadata loader unchanged.

Closes #70.

## Validation

* [x] `python -m pytest` — 405 tests passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* This adds loading and validation only.
* Does not write manifests.
* Does not update manifests.
* Does not add submission path helpers.
* Does not assemble routed evidence into submissions.
* Does not add file-opening behavior.
* Does not add CLI or menu integration.
* Does not modify `route-scan`.
* Does not modify the legacy `quillan.submissions` loader.
* Does not implement scoring, tagging, requirements checks, feedback generation, reports, OCR, handwriting recognition, AI suggestions, AI scoring, AI feedback drafting, or pds-core changes.
