### PR TITLE
Added Quillan-owned canonical path helpers for v0.6 submission manife…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added Quillan-owned helpers for canonical version `1` submission manifest
+  paths and safe writing of caller-provided manifests, with validation,
+  parent-directory creation, readable UTF-8 JSON, and overwrite protection.
+  Submission assembly remains future work.
 - Added a distinct v0.6 reviewable-evidence submission manifest loader and
   validator with page, evidence, retained-source, selection, path, timestamp,
   state, and identifier validation. The legacy text-oriented loader remains

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Quillan currently supports:
 - documented writing-evidence and teacher-review data contracts;
 - loading and validation for the version `1` reviewable-evidence submission
   manifest through the distinct `quillan.submission_manifest` module;
+- canonical active submission manifest path helpers and safe writing of
+  caller-provided, validated manifests without submission assembly;
 - printable writing-response PDF generation with student, class, assignment,
   and page identity;
 - QR codes containing canonical PDS1 Quillan response payloads on printable
@@ -71,7 +73,7 @@ particular, Quillan does not currently provide:
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
-- writing or assembling version `1` submission manifests;
+- automatic assembly of version `1` submission manifests from routed evidence;
 - assignment creation workflows;
 - implemented requirements-checking, tagging, scoring, feedback, or
   production reporting workflows;

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -244,10 +244,17 @@ The future canonical location is:
 ```
 
 This section defines draft schema version `1`. The distinct
-`quillan.submission_manifest` module loads and validates this contract. The
-existing `quillan.submissions` loader remains responsible for an earlier
-text-oriented metadata shape. Path helpers, writing, assembly, selection, and
-state-changing workflows are future work.
+`quillan.submission_manifest` module loads and validates this contract, and
+`quillan.submission_manifest_paths` computes its canonical active path and
+safely writes a caller-provided manifest. Writes validate before filesystem
+changes, create missing parent directories, and refuse overwrites by default.
+The existing `quillan.submissions` loader remains responsible for an earlier
+text-oriented metadata shape. Manifest assembly from routed evidence,
+selection, and state-changing workflows are future work.
+
+The active path is currently a Quillan-owned artifact contract rather than a
+`pds-core` route. Inactive-preservation tooling such as `pds-sunset` may later
+consume or preserve it without owning Quillan's active layout.
 
 ### Top-Level Structure
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -189,12 +189,13 @@ validation, routed student evidence layout, submission assembly, completeness
 and rescan decisions, and any future OCR behavior. Quillan-specific failure
 details belong under the shared record's `module_details`.
 
-The first version `1` reviewable-evidence submission manifest contract is now
-documented. It defines page entries, duplicate and replacement candidates,
-teacher-controlled selection and review states, retained-source provenance,
-workspace-relative paths, and timezone-aware timestamps. This milestone is
-descriptive only; manifest loading, validation, writing, path helpers, and
-assembly remain unimplemented.
+The first version `1` reviewable-evidence submission manifest contract is
+documented, with loading, validation, canonical Quillan-owned path helpers,
+and safe writing for caller-provided manifests implemented. It defines page
+entries, duplicate and replacement candidates, teacher-controlled selection
+and review states, retained-source provenance, workspace-relative paths, and
+timezone-aware timestamps. Assembly from routed evidence remains
+unimplemented.
 
 Target milestone:
 

--- a/quillan/submission_manifest_paths.py
+++ b/quillan/submission_manifest_paths.py
@@ -1,0 +1,126 @@
+"""Canonical paths and safe writing for Quillan submission manifests."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.submission_manifest import validate_submission_manifest
+
+
+class SubmissionManifestPathError(ValueError):
+    """Raised when a submission manifest path or write operation is invalid."""
+
+
+def submission_dir(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the canonical directory for one student's Quillan submission."""
+    _validate_identifier(class_id, "class_id")
+    _validate_identifier(assignment_id, "assignment_id")
+    _validate_identifier(student_id, "student_id")
+    return (
+        Path(workspace_root)
+        / "classes"
+        / class_id
+        / "assignments"
+        / assignment_id
+        / "submissions"
+        / student_id
+    )
+
+
+def submission_manifest_path(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the canonical submission.json path for one student."""
+    return (
+        submission_dir(workspace_root, class_id, assignment_id, student_id)
+        / "submission.json"
+    )
+
+
+def write_submission_manifest(
+    path: str | Path,
+    manifest: dict[str, Any],
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Validate and safely write a submission manifest as UTF-8 JSON."""
+    validate_submission_manifest(manifest)
+    manifest_path = Path(path)
+
+    if not overwrite and manifest_path.exists():
+        raise SubmissionManifestPathError(
+            f"Submission manifest already exists: {manifest_path}"
+        )
+
+    parent = manifest_path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise SubmissionManifestPathError(
+            f"Could not create submission manifest directory {parent}: {error}"
+        ) from error
+    if not parent.is_dir():
+        raise SubmissionManifestPathError(
+            f"Submission manifest parent is not a directory: {parent}"
+        )
+
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            prefix=f".{manifest_path.name}.",
+            suffix=".tmp",
+            dir=parent,
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            json.dump(manifest, temporary_file, ensure_ascii=False, indent=2)
+            temporary_file.write("\n")
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+
+        if overwrite:
+            os.replace(temporary_path, manifest_path)
+        else:
+            os.link(temporary_path, manifest_path)
+            temporary_path.unlink()
+        temporary_path = None
+    except FileExistsError as error:
+        raise SubmissionManifestPathError(
+            f"Submission manifest already exists: {manifest_path}"
+        ) from error
+    except (OSError, TypeError, ValueError) as error:
+        raise SubmissionManifestPathError(
+            f"Could not write submission manifest {manifest_path}: {error}"
+        ) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    return manifest_path
+
+
+def _validate_identifier(value: str, field: str) -> None:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise SubmissionManifestPathError(str(error)) from error

--- a/tests/test_submission_manifest_paths.py
+++ b/tests/test_submission_manifest_paths.py
@@ -1,0 +1,154 @@
+"""Tests for canonical submission manifest paths and safe writing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_dir,
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": "2026-06-20T00:00:00+00:00",
+        "updated_at": "2026-06-20T00:00:00+00:00",
+        "module_details": {"teacher_note": "Café"},
+    }
+
+
+def test_submission_paths_use_canonical_quillan_layout(tmp_path: Path) -> None:
+    expected_dir = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+    )
+
+    result_dir = submission_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    result_path = submission_manifest_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+
+    assert isinstance(result_dir, Path)
+    assert isinstance(result_path, Path)
+    assert result_dir == expected_dir
+    assert result_path == expected_dir / "submission.json"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("class_id", "../unsafe"),
+        ("assignment_id", "bad assignment"),
+        ("student_id", ""),
+    ],
+)
+def test_submission_paths_reject_invalid_identifiers(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    identifiers = {
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+    }
+    identifiers[field] = value
+
+    with pytest.raises(SubmissionManifestPathError, match=field):
+        submission_dir(tmp_path, **identifiers)
+
+
+def test_valid_manifest_is_written_readably_and_reloads(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "submission.json"
+    manifest = _manifest()
+
+    result = write_submission_manifest(path, manifest)
+
+    raw = path.read_bytes()
+    assert result == path
+    assert path.parent.is_dir()
+    assert raw.endswith(b"\n")
+    assert b"\n  \"schema_version\"" in raw
+    assert "Café" in raw.decode("utf-8")
+    assert load_submission_manifest(path) == manifest
+
+
+def test_invalid_manifest_does_not_create_output(tmp_path: Path) -> None:
+    path = tmp_path / "not-created" / "submission.json"
+    manifest = _manifest()
+    del manifest["schema_version"]
+
+    with pytest.raises(SubmissionManifestError, match="schema_version"):
+        write_submission_manifest(path, manifest)
+
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+def test_existing_manifest_is_not_overwritten_by_default(tmp_path: Path) -> None:
+    path = tmp_path / "submission.json"
+    path.write_text("original\n", encoding="utf-8")
+
+    with pytest.raises(SubmissionManifestPathError, match="already exists"):
+        write_submission_manifest(path, _manifest())
+
+    assert path.read_text(encoding="utf-8") == "original\n"
+
+
+def test_existing_manifest_is_replaced_when_overwrite_is_enabled(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "submission.json"
+    path.write_text("original\n", encoding="utf-8")
+    manifest = _manifest()
+
+    result = write_submission_manifest(path, manifest, overwrite=True)
+
+    assert result == path
+    assert json.loads(path.read_text(encoding="utf-8")) == manifest
+
+
+def test_parent_path_that_is_a_file_raises(tmp_path: Path) -> None:
+    parent = tmp_path / "submission-parent"
+    parent.write_text("not a directory", encoding="utf-8")
+    path = parent / "submission.json"
+
+    with pytest.raises(
+        SubmissionManifestPathError,
+        match="Could not create submission manifest directory",
+    ):
+        write_submission_manifest(path, _manifest())
+
+    assert parent.read_text(encoding="utf-8") == "not a directory"


### PR DESCRIPTION
## Summary

* Added Quillan-owned canonical path helpers for v0.6 submission manifests.
* Added `quillan/submission_manifest_paths.py` with:

  * `SubmissionManifestPathError`
  * `submission_dir(...)`
  * `submission_manifest_path(...)`
  * `write_submission_manifest(...)`
* Computes the canonical active manifest location:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
```

* Validates `class_id`, `assignment_id`, and `student_id` before path construction.
* Validates manifests before writing.
* Writes readable UTF-8 JSON with indentation and a trailing newline.
* Creates parent directories when appropriate.
* Refuses to overwrite existing manifests by default.
* Supports explicit replacement with `overwrite=True`.
* Uses temporary-file publication for safer writes.
* Added focused tests for canonical paths, invalid identifiers, safe writing, reloadability, overwrite behavior, invalid manifests, and parent-path failures.
* Updated README, changelog, and contract/development documentation.
* Left legacy `quillan.submissions` and `pds-core` unchanged.

Closes #71.

## Validation

* [x] `python -m pytest` — 414 tests passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* This adds path helpers and safe writing only.
* Does not assemble submissions.
* Does not discover routed evidence.
* Does not infer missing pages.
* Does not select duplicate/rescan evidence.
* Does not add CLI or menu integration.
* Does not alter `route-scan`.
* Does not modify the legacy `quillan.submissions` loader.
* Does not change `pds-core`.
* Does not implement scoring, tagging, feedback, reports, OCR, handwriting recognition, AI suggestions, AI scoring, or AI feedback drafting.
