### PR TITLE
Added routed-evidence assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a focused routed-evidence assembly API for building and safely writing
+  new version `1` submission manifests. It preserves workspace-relative source
+  provenance, represents expected missing pages and ambiguous duplicates,
+  assigns deterministic evidence IDs, and refuses overwrites by default.
 - Added Quillan-owned helpers for canonical version `1` submission manifest
   paths and safe writing of caller-provided manifests, with validation,
   parent-directory creation, readable UTF-8 JSON, and overwrite protection.
-  Submission assembly remains future work.
 - Added a distinct v0.6 reviewable-evidence submission manifest loader and
   validator with page, evidence, retained-source, selection, path, timestamp,
   state, and identifier validation. The legacy text-oriented loader remains
@@ -29,7 +32,7 @@ planning and do not by themselves represent releases.
 - Documented the draft version `1` reviewable-evidence `submission.json`
   contract, including page and evidence states, duplicate and replacement
   preservation, retained-source provenance, safe relative paths, and a fully
-  synthetic three-page example. Writing and assembly remain future work.
+  synthetic three-page example.
 - Added a direct `route-scan` command for already-decoded Quillan PDS1
   payloads, including successful evidence filing, safe review preservation,
   concise workspace-relative summaries, and documented handled/failure exit

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Quillan currently supports:
 - documented writing-evidence and teacher-review data contracts;
 - loading and validation for the version `1` reviewable-evidence submission
   manifest through the distinct `quillan.submission_manifest` module;
-- canonical active submission manifest path helpers and safe writing of
-  caller-provided, validated manifests without submission assembly;
+- assembly of new version `1` submission manifests from caller-provided routed
+  evidence metadata, including deterministic evidence IDs, missing and
+  duplicate page representation, retained-source provenance, canonical paths,
+  validation, and overwrite protection;
 - printable writing-response PDF generation with student, class, assignment,
   and page identity;
 - QR codes containing canonical PDS1 Quillan response payloads on printable
@@ -73,7 +75,8 @@ particular, Quillan does not currently provide:
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
-- automatic assembly of version `1` submission manifests from routed evidence;
+- automatic discovery of routed evidence from scan folders or merging new
+  evidence into existing teacher review state;
 - assignment creation workflows;
 - implemented requirements-checking, tagging, scoring, feedback, or
   production reporting workflows;
@@ -89,7 +92,8 @@ the shared `pds-core` active scan contract: canonical retained sources belong
 in `scans/source/YYYY-MM-DD/`, canonical routing review records belong in
 `scans/review/`, and assignment-level `scans/` contains routed evidence rather
 than canonical source retention. QR extraction, PDF splitting, OCR, and
-submission assembly remain outside the direct command and internal APIs.
+scan-folder discovery and review-state updates remain outside the direct
+command and assembly API.
 
 ## Current Non-Goals
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -8,12 +8,13 @@ reports.
 
 Standards profiles, assignment configurations, the legacy text-oriented
 submission metadata shape, and the reviewable-evidence submission manifest
-have implemented Python validation support. Manifest writing, assembly,
-selection, and state-changing workflows are not implemented. The
-writing-response payload contract is implemented and used by printable PDF
-generation. Requirements, tagging, scoring, feedback, and reporting records
-remain contracts for teacher-controlled workflows that are not yet
-implemented end to end.
+have implemented Python validation support. New-manifest writing and assembly
+from caller-provided evidence metadata are implemented; evidence discovery,
+merging, and state-changing review workflows are not. The writing-response
+payload contract is implemented and used by printable PDF generation.
+Requirements, tagging, scoring, feedback, and reporting records remain
+contracts for teacher-controlled workflows that are not yet implemented end
+to end.
 
 For the expected workspace layout and file lifecycle of these records, see
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
@@ -237,7 +238,7 @@ identity to routed evidence, retained-source provenance, and explicit review
 state. Routed evidence alone does not establish that a submission is complete,
 reviewed, scored, tagged, or ready for feedback.
 
-The future canonical location is:
+The canonical location is:
 
 ```text
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
@@ -248,9 +249,13 @@ This section defines draft schema version `1`. The distinct
 `quillan.submission_manifest_paths` computes its canonical active path and
 safely writes a caller-provided manifest. Writes validate before filesystem
 changes, create missing parent directories, and refuse overwrites by default.
+`quillan.submission_assembly` can build and write a new manifest from
+caller-provided routed evidence metadata. It automatically selects only
+unambiguous pages, leaves duplicate pages unselected, represents expected
+missing pages, and preserves complete retained-source provenance.
 The existing `quillan.submissions` loader remains responsible for an earlier
-text-oriented metadata shape. Manifest assembly from routed evidence,
-selection, and state-changing workflows are future work.
+text-oriented metadata shape. The assembly API does not discover scan-folder
+evidence, merge with an existing manifest, or update teacher review state.
 
 The active path is currently a Quillan-owned artifact contract rather than a
 `pds-core` route. Inactive-preservation tooling such as `pds-sunset` may later
@@ -405,8 +410,8 @@ This contract does not define or implement scoring, tagging, requirements
 checking, feedback, reports, OCR, handwriting recognition, AI suggestions, AI
 scoring, AI feedback drafting, or automatic grading. Those concerns remain
 separate from the evidence manifest and teacher-controlled review state. It
-also does not implement manifest writing, submission assembly, path helpers,
-file opening, review commands, or state updates.
+also does not implement evidence discovery, manifest merging, file opening,
+review commands, or state updates.
 
 ## Writing-Response Payload
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -191,11 +191,12 @@ details belong under the shared record's `module_details`.
 
 The first version `1` reviewable-evidence submission manifest contract is
 documented, with loading, validation, canonical Quillan-owned path helpers,
-and safe writing for caller-provided manifests implemented. It defines page
-entries, duplicate and replacement candidates, teacher-controlled selection
-and review states, retained-source provenance, workspace-relative paths, and
-timezone-aware timestamps. Assembly from routed evidence remains
-unimplemented.
+safe writing, and new-manifest assembly from caller-provided routed evidence
+metadata implemented. It defines page entries, duplicate and replacement
+candidates, teacher-controlled selection and review states, retained-source
+provenance, workspace-relative paths, and timezone-aware timestamps. Assembly
+does not discover scan folders, merge manifests, or preserve prior teacher
+review state during overwrite.
 
 Target milestone:
 
@@ -219,7 +220,8 @@ The direct
 implemented for one selected source and an already-decoded payload. It
 orchestrates the existing parser, planner, evidence filer, and review adapters.
 QR extraction, PDF splitting, OCR, menu integration, batch routing, and
-submission assembly remain unimplemented.
+automatic evidence discovery remain unimplemented. Submission assembly is
+available as a focused Python API and is not part of `route-scan`.
 
 ### `submissions.py`
 

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -333,11 +333,13 @@ A student response may have multiple pages, missing pages, duplicate pages,
 rescans, or damaged scans. The draft version `1` submission manifest contract
 in [`data_contracts.md`](data_contracts.md#submission-manifest) represents
 those conditions without guessing which evidence the teacher intends to use.
-Future submission assembly may link routed pages to that record. The original
-routed files must remain traceable to the canonical retained source after any
-such linking.
+The focused submission assembly API can create that record from
+caller-provided routed evidence metadata, automatically selecting only
+unambiguous pages and preserving duplicates for later review. It does not scan
+folders or update an existing review record. The original routed files remain
+traceable to the canonical retained source after linking.
 
-The future canonical record location is:
+The canonical record location is:
 
 ```text
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
@@ -346,11 +348,11 @@ The future canonical record location is:
 The manifest stores workspace-relative routed-evidence and retained-source
 paths, page and evidence states, nullable teacher selection, and provenance.
 It preserves duplicate, replacement, damaged, and excluded evidence rather
-than overwriting or deleting candidates. Defining that contract does not add
-manifest loading, validation, writing, path helpers, assembly, teacher review
-commands, or changes to `route-scan`.
+than overwriting or deleting candidates. Loading, validation, path helpers,
+safe writing, and focused new-manifest assembly are implemented independently
+of `route-scan`; teacher review commands and state updates are not.
 
-Quillan owns the manifest contract, future submission assembly, page
+Quillan owns the manifest contract, submission assembly, page
 completeness rules, teacher review and rescan decisions, and any future
 Quillan OCR policy. Those module decisions must continue to use the shared
 source-retention, provenance, and routing-review contract.
@@ -362,7 +364,7 @@ including source and review paths, retained-source naming, base failure
 metadata, shared failure categories, copy-first behavior, no-overwrite rules,
 and provenance semantics.
 
-Quillan owns future module-specific behavior, including:
+Quillan module responsibilities include:
 
 * interpreting Quillan `PDS1` response payloads;
 * validating response pages;
@@ -398,9 +400,9 @@ Inactive historical preservation and end-of-cycle archiving belong to future
    Future work should expose preserved failures and duplicate routed evidence
    for teacher review.
 7. **Submission assembly and linking.** The first page-oriented submission
-   manifest contract is defined. Loading, validation, path helpers,
-   completeness checks, rescan selection workflows, and assembly of traceable
-   routed evidence links remain future implementation work.
+   manifest contract, loader, validator, path helpers, safe writer, and focused
+   assembly API are implemented. Evidence discovery, completeness workflows,
+   merging, and rescan selection remain future work.
 8. **Teacher review integration.** Present assembled evidence to the teacher
    and allow teacher-controlled lifecycle changes without automated judgment.
 

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -148,15 +148,16 @@ that Quillan currently routes scans, performs OCR, or files captured pages.
 
 ### `submissions/<student_id>/submission.json`
 
-The future Quillan version `1` submission manifest for one student's routed
+The Quillan version `1` submission manifest for one student's routed
 evidence for one assignment. It identifies the class, assignment, and student;
 represents expected, missing, duplicate, replacement, damaged, or excluded
 pages; preserves retained-source provenance; and records teacher-controlled
 review state without containing scores, tags, or feedback.
 
-The manifest contract is documented, but loading, validation, writing,
-assembly, and state-changing workflows are not yet implemented. The current
-Python loader accepts an earlier text-oriented metadata shape.
+Loading, validation, canonical path computation, safe writing, and
+new-manifest assembly from caller-provided evidence metadata are implemented
+in modules distinct from the legacy text-oriented loader. Scan-folder
+discovery, merging, and state-changing review workflows are not implemented.
 
 ### `submissions/<student_id>/submission.txt`
 

--- a/quillan/submission_assembly.py
+++ b/quillan/submission_assembly.py
@@ -1,0 +1,422 @@
+"""Assembly of routed Quillan evidence into new submission manifests."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Final, Sequence
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.submission_manifest import (
+    ALLOWED_EVIDENCE_STATES,
+    validate_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+_RETAINED_SOURCE_FIELDS: Final[tuple[str, ...]] = (
+    "source_scan_id",
+    "source_filename",
+    "source_sha256",
+    "retained_source_path",
+)
+_SHA256_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[0-9A-Fa-f]{64}$")
+
+
+class SubmissionAssemblyError(ValueError):
+    """Raised when routed evidence cannot be assembled into a manifest."""
+
+
+@dataclass(frozen=True, slots=True)
+class RoutedSubmissionEvidence:
+    """Caller-provided metadata for one routed response-page artifact."""
+
+    page_number: int
+    routed_evidence_path: str | Path
+    retained_source_path: str | Path | None = None
+    source_scan_id: str | None = None
+    source_filename: str | None = None
+    source_sha256: str | None = None
+    source_page_number: int | None = None
+    duplicate_number: int | None = None
+    created_at: datetime | str | None = None
+    evidence_state: str = "active"
+    module_details: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _NormalizedEvidence:
+    page_number: int
+    routed_evidence_path: str
+    retained_source: dict[str, Any] | None
+    duplicate_number: int | None
+    created_at: str
+    evidence_state: str
+    module_details: dict[str, Any]
+
+
+def build_submission_manifest(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    evidence_items: Sequence[RoutedSubmissionEvidence],
+    *,
+    expected_pages: int | None = None,
+    created_at: datetime | str | None = None,
+    updated_at: datetime | str | None = None,
+) -> dict[str, Any]:
+    """Build a v0.6 submission manifest from routed evidence without writing."""
+    root = _resolved_workspace_root(workspace_root)
+    _validate_identifiers(class_id, assignment_id, student_id)
+    _validate_optional_positive_integer(expected_pages, "expected_pages")
+
+    now = datetime.now(timezone.utc).isoformat()
+    manifest_created_at = _normalize_timestamp(
+        created_at, "created_at", default=now
+    )
+    manifest_updated_at = _normalize_timestamp(
+        updated_at, "updated_at", default=now
+    )
+
+    normalized = [
+        _normalize_evidence(item, root, manifest_created_at)
+        for item in evidence_items
+    ]
+    normalized.sort(key=_evidence_sort_key)
+
+    evidence_by_page: dict[int, list[tuple[str, _NormalizedEvidence]]] = {}
+    for index, item in enumerate(normalized, start=1):
+        evidence_id = f"evidence_{index:03d}"
+        evidence_by_page.setdefault(item.page_number, []).append(
+            (evidence_id, item)
+        )
+
+    page_numbers = set(evidence_by_page)
+    if expected_pages is not None:
+        page_numbers.update(range(1, expected_pages + 1))
+
+    pages = [
+        _build_page(page_number, evidence_by_page.get(page_number, []))
+        for page_number in sorted(page_numbers)
+    ]
+    manifest: dict[str, Any] = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+        "expected_pages": expected_pages,
+        "submission_state": "unreviewed",
+        "pages": pages,
+        "created_at": manifest_created_at,
+        "updated_at": manifest_updated_at,
+        "module_details": {},
+    }
+    validate_submission_manifest(manifest)
+    return manifest
+
+
+def assemble_submission_manifest(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    evidence_items: Sequence[RoutedSubmissionEvidence],
+    *,
+    expected_pages: int | None = None,
+    overwrite: bool = False,
+    created_at: datetime | str | None = None,
+    updated_at: datetime | str | None = None,
+) -> Path:
+    """Assemble and write a v0.6 submission manifest from routed evidence."""
+    manifest = build_submission_manifest(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        evidence_items,
+        expected_pages=expected_pages,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+    path = submission_manifest_path(
+        workspace_root, class_id, assignment_id, student_id
+    )
+    return write_submission_manifest(path, manifest, overwrite=overwrite)
+
+
+def _normalize_evidence(
+    item: RoutedSubmissionEvidence,
+    root: Path,
+    manifest_created_at: str,
+) -> _NormalizedEvidence:
+    if not isinstance(item, RoutedSubmissionEvidence):
+        raise SubmissionAssemblyError(
+            "Each evidence item must be a RoutedSubmissionEvidence instance."
+        )
+    page_number = _validate_positive_integer(item.page_number, "page_number")
+    duplicate_number = _validate_optional_positive_integer(
+        item.duplicate_number, "duplicate_number"
+    )
+    if (
+        not isinstance(item.evidence_state, str)
+        or item.evidence_state not in ALLOWED_EVIDENCE_STATES
+    ):
+        allowed = ", ".join(sorted(ALLOWED_EVIDENCE_STATES))
+        raise SubmissionAssemblyError(
+            f"Invalid evidence_state {item.evidence_state!r}. "
+            f"Allowed values: {allowed}."
+        )
+
+    module_details = {} if item.module_details is None else item.module_details
+    _validate_json_object(module_details, "module_details")
+
+    return _NormalizedEvidence(
+        page_number=page_number,
+        routed_evidence_path=_workspace_relative_path(
+            item.routed_evidence_path, root, "routed_evidence_path"
+        ),
+        retained_source=_normalize_retained_source(item, root),
+        duplicate_number=duplicate_number,
+        created_at=_normalize_timestamp(
+            item.created_at,
+            "evidence created_at",
+            default=manifest_created_at,
+        ),
+        evidence_state=item.evidence_state,
+        module_details=module_details.copy(),
+    )
+
+
+def _normalize_retained_source(
+    item: RoutedSubmissionEvidence, root: Path
+) -> dict[str, Any] | None:
+    values = {
+        "source_scan_id": item.source_scan_id,
+        "source_filename": item.source_filename,
+        "source_sha256": item.source_sha256,
+        "retained_source_path": item.retained_source_path,
+    }
+    supplied = [field for field, value in values.items() if value is not None]
+    if not supplied:
+        if item.source_page_number is not None:
+            raise SubmissionAssemblyError(
+                "Retained-source provenance is partial; source_page_number "
+                "requires all retained-source fields."
+            )
+        return None
+    if len(supplied) != len(_RETAINED_SOURCE_FIELDS):
+        missing = ", ".join(
+            field for field in _RETAINED_SOURCE_FIELDS if values[field] is None
+        )
+        raise SubmissionAssemblyError(
+            f"Retained-source provenance is partial; missing: {missing}."
+        )
+
+    source_page_number = _validate_optional_positive_integer(
+        item.source_page_number, "source_page_number"
+    )
+    _validate_non_empty_string(item.source_scan_id, "source_scan_id")
+    source_filename = _validate_non_empty_string(
+        item.source_filename, "source_filename"
+    )
+    if (
+        "/" in source_filename
+        or "\\" in source_filename
+        or "\0" in source_filename
+        or source_filename in {".", ".."}
+    ):
+        raise SubmissionAssemblyError(
+            "source_filename must be a filename only."
+        )
+    if (
+        not isinstance(item.source_sha256, str)
+        or not _SHA256_PATTERN.fullmatch(item.source_sha256)
+    ):
+        raise SubmissionAssemblyError(
+            "source_sha256 must be a 64-character hexadecimal SHA-256 digest."
+        )
+    retained_path = item.retained_source_path
+    assert retained_path is not None
+    return {
+        "source_scan_id": item.source_scan_id,
+        "source_filename": item.source_filename,
+        "source_sha256": item.source_sha256,
+        "retained_source_path": _workspace_relative_path(
+            retained_path, root, "retained_source_path"
+        ),
+        "source_page_number": source_page_number,
+    }
+
+
+def _build_page(
+    page_number: int,
+    items: list[tuple[str, _NormalizedEvidence]],
+) -> dict[str, Any]:
+    if not items:
+        return {
+            "page_number": page_number,
+            "page_state": "missing",
+            "selected_evidence_id": None,
+            "evidence": [],
+        }
+
+    unambiguous = len(items) == 1
+    evidence = [
+        {
+            "evidence_id": evidence_id,
+            "routed_evidence_path": item.routed_evidence_path,
+            "evidence_role": "selected" if unambiguous else "candidate",
+            "evidence_state": item.evidence_state,
+            "duplicate_number": item.duplicate_number,
+            "created_at": item.created_at,
+            "retained_source": item.retained_source,
+            "module_details": item.module_details,
+        }
+        for evidence_id, item in items
+    ]
+    return {
+        "page_number": page_number,
+        "page_state": "present" if unambiguous else "duplicate",
+        "selected_evidence_id": items[0][0] if unambiguous else None,
+        "evidence": evidence,
+    }
+
+
+def _evidence_sort_key(item: _NormalizedEvidence) -> tuple[Any, ...]:
+    retained = item.retained_source or {}
+    return (
+        item.page_number,
+        item.duplicate_number is not None,
+        item.duplicate_number or 0,
+        item.routed_evidence_path,
+        item.created_at,
+        item.evidence_state,
+        retained.get("retained_source_path", ""),
+        retained.get("source_scan_id", ""),
+        retained.get("source_filename", ""),
+        retained.get("source_sha256", ""),
+        retained.get("source_page_number") or 0,
+        json.dumps(item.module_details, sort_keys=True, ensure_ascii=False),
+    )
+
+
+def _resolved_workspace_root(workspace_root: str | Path) -> Path:
+    try:
+        return Path(workspace_root).resolve(strict=False)
+    except (OSError, TypeError, ValueError) as error:
+        raise SubmissionAssemblyError(f"Invalid workspace_root: {error}") from error
+
+
+def _workspace_relative_path(
+    value: str | Path, root: Path, field: str
+) -> str:
+    if not isinstance(value, (str, Path)):
+        raise SubmissionAssemblyError(f"{field} must be a string or Path.")
+    try:
+        raw = str(value)
+    except (TypeError, ValueError) as error:
+        raise SubmissionAssemblyError(f"Invalid {field}: {error}") from error
+    if not raw:
+        raise SubmissionAssemblyError(f"{field} must be a non-empty path.")
+    if "\0" in raw:
+        raise SubmissionAssemblyError(f"{field} must not contain null bytes.")
+
+    variants = (PurePosixPath(raw), PureWindowsPath(raw))
+    is_absolute = any(path.anchor or path.drive for path in variants)
+    if not is_absolute:
+        components = re.split(r"[\\/]", raw)
+        if "." in components or ".." in components:
+            raise SubmissionAssemblyError(
+                f"{field} must not contain '.' or '..' path components."
+            )
+        return raw
+
+    try:
+        absolute = Path(value).resolve(strict=False)
+        relative = absolute.relative_to(root)
+    except (OSError, TypeError, ValueError) as error:
+        raise SubmissionAssemblyError(
+            f"{field} must be located under the workspace root."
+        ) from error
+    return relative.as_posix()
+
+
+def _normalize_timestamp(
+    value: datetime | str | None,
+    field: str,
+    *,
+    default: str,
+) -> str:
+    if value is None:
+        return default
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise SubmissionAssemblyError(
+                f"{field} must be timezone-aware."
+            )
+        return value.isoformat()
+    if not isinstance(value, str) or not value:
+        raise SubmissionAssemblyError(
+            f"{field} must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise SubmissionAssemblyError(
+            f"{field} must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SubmissionAssemblyError(f"{field} must be timezone-aware.")
+    return value
+
+
+def _validate_identifiers(
+    class_id: str, assignment_id: str, student_id: str
+) -> None:
+    for field, value in (
+        ("class_id", class_id),
+        ("assignment_id", assignment_id),
+        ("student_id", student_id),
+    ):
+        try:
+            validate_identifier(value, field)
+        except IdentifierValidationError as error:
+            raise SubmissionAssemblyError(str(error)) from error
+
+
+def _validate_positive_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise SubmissionAssemblyError(f"{field} must be a positive integer.")
+    return value
+
+
+def _validate_optional_positive_integer(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    return _validate_positive_integer(value, field)
+
+
+def _validate_json_object(value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        raise SubmissionAssemblyError(f"{field} must be a JSON object.")
+    try:
+        json.dumps(value, allow_nan=False, sort_keys=True)
+    except (TypeError, ValueError) as error:
+        raise SubmissionAssemblyError(
+            f"{field} must contain only JSON-compatible values."
+        ) from error
+
+
+def _validate_non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SubmissionAssemblyError(f"{field} must be a non-empty string.")
+    return value

--- a/tests/test_submission_assembly.py
+++ b/tests/test_submission_assembly.py
@@ -1,0 +1,391 @@
+"""Tests for assembling routed evidence into submission manifests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.submission_assembly import (
+    RoutedSubmissionEvidence,
+    SubmissionAssemblyError,
+    assemble_submission_manifest,
+    build_submission_manifest,
+)
+from quillan.submission_manifest import (
+    load_submission_manifest,
+    validate_submission_manifest,
+)
+from quillan.submission_manifest_paths import SubmissionManifestPathError
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+TIMESTAMP = "2026-06-20T12:00:00+00:00"
+
+
+def _build(
+    tmp_path: Path,
+    evidence: list[RoutedSubmissionEvidence],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    return build_submission_manifest(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        evidence,
+        created_at=TIMESTAMP,
+        updated_at=TIMESTAMP,
+        **kwargs,
+    )
+
+
+def _evidence(
+    page_number: int,
+    path: str | Path | None = None,
+    **kwargs: Any,
+) -> RoutedSubmissionEvidence:
+    return RoutedSubmissionEvidence(
+        page_number=page_number,
+        routed_evidence_path=path or f"classes/example/page_{page_number}.pdf",
+        **kwargs,
+    )
+
+
+def test_one_evidence_item_builds_valid_selected_present_page(
+    tmp_path: Path,
+) -> None:
+    manifest = _build(tmp_path, [_evidence(1)])
+
+    page = manifest["pages"][0]
+    candidate = page["evidence"][0]
+    assert manifest["submission_state"] == "unreviewed"
+    assert page["page_state"] == "present"
+    assert page["selected_evidence_id"] == "evidence_001"
+    assert candidate["evidence_id"] == "evidence_001"
+    assert candidate["evidence_role"] == "selected"
+    assert candidate["retained_source"] is None
+    validate_submission_manifest(manifest)
+
+
+def test_expected_pages_add_missing_pages_and_keep_extras(tmp_path: Path) -> None:
+    manifest = _build(
+        tmp_path,
+        [_evidence(3), _evidence(1)],
+        expected_pages=2,
+    )
+
+    assert [page["page_number"] for page in manifest["pages"]] == [1, 2, 3]
+    missing = manifest["pages"][1]
+    assert missing == {
+        "page_number": 2,
+        "page_state": "missing",
+        "selected_evidence_id": None,
+        "evidence": [],
+    }
+    validate_submission_manifest(manifest)
+
+
+def test_unknown_expected_pages_does_not_invent_missing_pages(
+    tmp_path: Path,
+) -> None:
+    manifest = _build(tmp_path, [_evidence(3), _evidence(1)])
+
+    assert [page["page_number"] for page in manifest["pages"]] == [1, 3]
+
+
+def test_duplicate_page_is_ambiguous_and_deterministically_ordered(
+    tmp_path: Path,
+) -> None:
+    manifest = _build(
+        tmp_path,
+        [
+            _evidence(1, "z/page.pdf", duplicate_number=2),
+            _evidence(1, "a/page.pdf"),
+            _evidence(1, "b/page.pdf", duplicate_number=1),
+        ],
+    )
+
+    page = manifest["pages"][0]
+    assert page["page_state"] == "duplicate"
+    assert page["selected_evidence_id"] is None
+    assert [item["evidence_id"] for item in page["evidence"]] == [
+        "evidence_001",
+        "evidence_002",
+        "evidence_003",
+    ]
+    assert [item["routed_evidence_path"] for item in page["evidence"]] == [
+        "a/page.pdf",
+        "b/page.pdf",
+        "z/page.pdf",
+    ]
+    assert {item["evidence_role"] for item in page["evidence"]} == {"candidate"}
+    validate_submission_manifest(manifest)
+
+
+def test_full_retained_source_is_preserved_with_nullable_source_page(
+    tmp_path: Path,
+) -> None:
+    manifest = _build(
+        tmp_path,
+        [
+            _evidence(
+                1,
+                retained_source_path="scans/source/2026-06-20/source.pdf",
+                source_scan_id="scan_001",
+                source_filename="source.pdf",
+                source_sha256="a" * 64,
+                source_page_number=None,
+            )
+        ],
+    )
+
+    assert manifest["pages"][0]["evidence"][0]["retained_source"] == {
+        "source_scan_id": "scan_001",
+        "source_filename": "source.pdf",
+        "source_sha256": "a" * 64,
+        "retained_source_path": "scans/source/2026-06-20/source.pdf",
+        "source_page_number": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"source_scan_id": "scan_001"},
+        {"source_page_number": 1},
+        {"retained_source_path": "scans/source/source.pdf"},
+    ],
+)
+def test_partial_retained_source_raises(
+    tmp_path: Path, kwargs: dict[str, Any]
+) -> None:
+    with pytest.raises(SubmissionAssemblyError, match="partial"):
+        _build(tmp_path, [_evidence(1, **kwargs)])
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_scan_id", ""),
+        ("source_filename", "folder/source.pdf"),
+        ("source_sha256", "not-a-digest"),
+        ("source_page_number", 0),
+    ],
+)
+def test_invalid_retained_source_fields_raise(
+    tmp_path: Path, field: str, value: Any
+) -> None:
+    kwargs: dict[str, Any] = {
+        "retained_source_path": "scans/source/source.pdf",
+        "source_scan_id": "scan_001",
+        "source_filename": "source.pdf",
+        "source_sha256": "a" * 64,
+    }
+    kwargs[field] = value
+
+    with pytest.raises(SubmissionAssemblyError, match=field):
+        _build(tmp_path, [_evidence(1, **kwargs)])
+
+
+def test_paths_are_preserved_or_made_workspace_relative(tmp_path: Path) -> None:
+    routed = tmp_path / "classes" / "class_a" / "page.pdf"
+    retained = tmp_path / "scans" / "source" / "source.pdf"
+    manifest = _build(
+        tmp_path,
+        [
+            _evidence(
+                1,
+                path=routed,
+                retained_source_path=retained,
+                source_scan_id="scan_001",
+                source_filename="source.pdf",
+                source_sha256="b" * 64,
+            ),
+            _evidence(2, path=r"classes\class_a\page_2.pdf"),
+        ],
+    )
+
+    first, second = (
+        manifest["pages"][0]["evidence"][0],
+        manifest["pages"][1]["evidence"][0],
+    )
+    assert first["routed_evidence_path"] == "classes/class_a/page.pdf"
+    assert (
+        first["retained_source"]["retained_source_path"]
+        == "scans/source/source.pdf"
+    )
+    assert second["routed_evidence_path"] == r"classes\class_a\page_2.pdf"
+
+
+@pytest.mark.parametrize("field", ["routed", "retained"])
+def test_absolute_paths_outside_workspace_raise(
+    tmp_path: Path, field: str
+) -> None:
+    outside = tmp_path.parent / "outside.pdf"
+    kwargs: dict[str, Any] = {}
+    routed: str | Path = "classes/page.pdf"
+    if field == "routed":
+        routed = outside
+    else:
+        kwargs = {
+            "retained_source_path": outside,
+            "source_scan_id": "scan_001",
+            "source_filename": "outside.pdf",
+            "source_sha256": "c" * 64,
+        }
+
+    with pytest.raises(SubmissionAssemblyError, match="workspace root"):
+        _build(tmp_path, [_evidence(1, path=routed, **kwargs)])
+
+
+def test_timestamps_are_preserved_normalized_and_default_to_utc(
+    tmp_path: Path,
+) -> None:
+    aware = datetime(2026, 6, 20, 8, 30, tzinfo=timezone.utc)
+    manifest = build_submission_manifest(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [_evidence(1, created_at=aware)],
+        created_at="2026-06-20T08:00:00-04:00",
+        updated_at=aware,
+    )
+
+    assert manifest["created_at"] == "2026-06-20T08:00:00-04:00"
+    assert manifest["updated_at"] == aware.isoformat()
+    assert manifest["pages"][0]["evidence"][0]["created_at"] == aware.isoformat()
+
+    generated = build_submission_manifest(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, []
+    )
+    for field in ("created_at", "updated_at"):
+        parsed = datetime.fromisoformat(generated[field])
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timezone.utc.utcoffset(parsed)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"created_at": datetime(2026, 6, 20, 8, 0)},
+        {"updated_at": "2026-06-20T08:00:00"},
+    ],
+)
+def test_naive_manifest_timestamps_raise(
+    tmp_path: Path, kwargs: dict[str, Any]
+) -> None:
+    with pytest.raises(SubmissionAssemblyError, match="timezone-aware"):
+        build_submission_manifest(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            [],
+            **kwargs,
+        )
+
+
+def test_assemble_writes_canonical_reloadable_manifest_and_overwrite(
+    tmp_path: Path,
+) -> None:
+    path = assemble_submission_manifest(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [_evidence(1)],
+        created_at=TIMESTAMP,
+        updated_at=TIMESTAMP,
+    )
+    assert path == (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "submission.json"
+    )
+    assert load_submission_manifest(path)["pages"][0]["page_number"] == 1
+
+    with pytest.raises(SubmissionManifestPathError, match="already exists"):
+        assemble_submission_manifest(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            [_evidence(2)],
+            created_at=TIMESTAMP,
+            updated_at=TIMESTAMP,
+        )
+
+    assemble_submission_manifest(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [_evidence(2)],
+        overwrite=True,
+        created_at=TIMESTAMP,
+        updated_at=TIMESTAMP,
+    )
+    assert load_submission_manifest(path)["pages"][0]["page_number"] == 2
+
+
+@pytest.mark.parametrize("value", [0, -1, True, "1"])
+def test_invalid_page_numbers_raise(tmp_path: Path, value: Any) -> None:
+    with pytest.raises(SubmissionAssemblyError, match="page_number"):
+        _build(tmp_path, [_evidence(value)])
+
+
+@pytest.mark.parametrize("value", [0, -1, True])
+def test_invalid_duplicate_numbers_raise(tmp_path: Path, value: Any) -> None:
+    with pytest.raises(SubmissionAssemblyError, match="duplicate_number"):
+        _build(tmp_path, [_evidence(1, duplicate_number=value)])
+
+
+@pytest.mark.parametrize("value", [0, -1, True])
+def test_invalid_expected_pages_raise(tmp_path: Path, value: Any) -> None:
+    with pytest.raises(SubmissionAssemblyError, match="expected_pages"):
+        _build(tmp_path, [], expected_pages=value)
+
+
+def test_invalid_evidence_state_and_module_details_raise(tmp_path: Path) -> None:
+    with pytest.raises(SubmissionAssemblyError, match="evidence_state"):
+        _build(tmp_path, [_evidence(1, evidence_state="reviewed")])
+    with pytest.raises(SubmissionAssemblyError, match="JSON-compatible"):
+        _build(tmp_path, [_evidence(1, module_details={"bad": object()})])
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("class_id", "../unsafe"),
+        ("assignment_id", "bad assignment"),
+        ("student_id", ""),
+    ],
+)
+def test_invalid_identifiers_raise(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    identifiers = {
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+    }
+    identifiers[field] = value
+
+    with pytest.raises(SubmissionAssemblyError, match=field):
+        build_submission_manifest(
+            tmp_path,
+            identifiers["class_id"],
+            identifiers["assignment_id"],
+            identifiers["student_id"],
+            [],
+        )


### PR DESCRIPTION
## Summary

* Added routed-evidence submission assembly for v0.6 Quillan manifests.
* Added `quillan.submission_assembly` with:

  * `SubmissionAssemblyError`
  * `RoutedSubmissionEvidence`
  * `build_submission_manifest(...)`
  * `assemble_submission_manifest(...)`
* Builds valid version `1` reviewable-evidence manifests from caller-provided routed evidence metadata.
* Automatically selects unambiguous single-evidence pages.
* Preserves duplicate/ambiguous pages as unselected candidate evidence.
* Represents expected missing pages when `expected_pages` is provided.
* Preserves extra evidence pages beyond `expected_pages`.
* Preserves retained-source provenance when complete.
* Rejects partial retained-source provenance.
* Normalizes workspace-relative artifact paths.
* Rejects absolute paths outside the workspace root.
* Uses timezone-aware timestamps.
* Generates deterministic evidence ordering and evidence IDs.
* Writes assembled manifests to the canonical student submission path through the safe writer.
* Refuses to overwrite existing manifests unless `overwrite=True`.
* Added 33 focused tests for assembly behavior.
* Updated documentation/status notes.
* Left legacy `quillan.submissions` untouched.

Closes #72.

## Validation

* [x] Focused submission assembly tests — 33 passed
* [x] Unaffected repository tests — 341 passed
* [x] `python -m ruff check .`
* [x] Targeted `python -m mypy ...`
* [x] `git diff --check`

## Known Environment Limitation

Full-suite pytest/mypy remain blocked in this local checkout because the sibling `pds-core` checkout is missing APIs already required by existing Quillan code, specifically `scan_failure_metadata` and retained-source helper APIs.

This branch does not introduce that dependency mismatch. The new assembly module only relies on existing identifier validation from `pds-core`.

## Notes

* This adds build/write assembly only.
* Does not scan folders.
* Does not discover routed evidence automatically.
* Does not extract QR codes.
* Does not split PDFs.
* Does not alter `route-scan`.
* Does not merge with existing manifests.
* Does not preserve prior teacher selections during overwrite.
* Does not add CLI or menu integration.
* Does not open files.
* Does not implement OCR, handwriting recognition, AI suggestions, AI scoring, AI feedback drafting, scoring, tagging, feedback generation, reports, pds-core changes, or pds-sunset changes.
