### PR TITLE
Refine submission evidence semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ planning and do not by themselves represent releases.
 
 ### Changed
 
+- Refined routed-evidence assembly so callers can preserve candidate,
+  replacement, and excluded roles plus active, damaged, needs-rescan, and
+  excluded states. Only a single ordinary active item with no explicit role is
+  auto-selected; replacement, problematic, excluded, and ambiguous evidence
+  remains preserved and unselected for later teacher choice.
 - Aligned the future Quillan scan-routing design with the shared `pds-core`
   active scan contract, including source retention, routed evidence,
   `scans/review/`, shared failure metadata, and ownership boundaries.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Quillan currently supports:
   manifest through the distinct `quillan.submission_manifest` module;
 - assembly of new version `1` submission manifests from caller-provided routed
   evidence metadata, including deterministic evidence IDs, missing and
-  duplicate page representation, retained-source provenance, canonical paths,
-  validation, and overwrite protection;
+  duplicate page representation, replacement, damaged, needs-rescan, and
+  excluded evidence semantics, retained-source provenance, canonical paths,
+  validation, and overwrite protection without choosing among ambiguous
+  evidence;
 - printable writing-response PDF generation with student, class, assignment,
   and page identity;
 - QR codes containing canonical PDS1 Quillan response payloads on printable

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -383,6 +383,16 @@ Evidence candidates are append-and-preserve records. Duplicate, replacement,
 damaged, selected, or excluded candidates remain represented rather than
 being silently overwritten or deleted.
 
+The focused new-manifest assembly API accepts caller-provided `candidate`,
+`replacement`, and `excluded` roles. Callers cannot provide `selected`;
+assembly reserves that role for the single ordinary active evidence item on an
+otherwise unambiguous page. An explicit candidate remains unselected, a lone
+replacement or damaged/needs-rescan item produces a `needs_rescan` page, and a
+page containing only excluded evidence produces an `excluded` page. Multiple
+items remain a `duplicate` page unless all are excluded. No timestamp,
+duplicate number, replacement role, or ordering is treated as teacher intent.
+All evidence remains represented for a later teacher-selection workflow.
+
 ### Path and Timestamp Policy
 
 Every stored artifact path is a workspace-relative string interpreted from

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -195,8 +195,12 @@ safe writing, and new-manifest assembly from caller-provided routed evidence
 metadata implemented. It defines page entries, duplicate and replacement
 candidates, teacher-controlled selection and review states, retained-source
 provenance, workspace-relative paths, and timezone-aware timestamps. Assembly
-does not discover scan folders, merge manifests, or preserve prior teacher
-review state during overwrite.
+preserves explicit candidate, replacement, and excluded roles plus damaged,
+needs-rescan, and excluded states without choosing among ambiguous evidence.
+Only a single ordinary active item with no explicit role is selected
+automatically. Assembly does not discover scan folders, merge manifests, or
+preserve prior teacher review state during overwrite; teacher selection and
+review-state updates remain future workflows.
 
 Target milestone:
 

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -335,9 +335,11 @@ in [`data_contracts.md`](data_contracts.md#submission-manifest) represents
 those conditions without guessing which evidence the teacher intends to use.
 The focused submission assembly API can create that record from
 caller-provided routed evidence metadata, automatically selecting only
-unambiguous pages and preserving duplicates for later review. It does not scan
-folders or update an existing review record. The original routed files remain
-traceable to the canonical retained source after linking.
+unambiguous ordinary active pages and preserving replacement, damaged,
+needs-rescan, excluded, and duplicate evidence for later review. Explicit
+candidate roles also remain unselected. It does not scan folders, infer teacher
+choice from recency or role, or update an existing review record. The original
+routed files remain traceable to the canonical retained source after linking.
 
 The canonical record location is:
 

--- a/quillan/submission_assembly.py
+++ b/quillan/submission_assembly.py
@@ -26,6 +26,9 @@ _RETAINED_SOURCE_FIELDS: Final[tuple[str, ...]] = (
     "source_sha256",
     "retained_source_path",
 )
+_ALLOWED_CALLER_EVIDENCE_ROLES: Final[frozenset[str]] = frozenset(
+    {"candidate", "replacement", "excluded"}
+)
 _SHA256_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[0-9A-Fa-f]{64}$")
 
 
@@ -48,6 +51,7 @@ class RoutedSubmissionEvidence:
     created_at: datetime | str | None = None
     evidence_state: str = "active"
     module_details: dict[str, Any] | None = None
+    evidence_role: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,6 +62,7 @@ class _NormalizedEvidence:
     duplicate_number: int | None
     created_at: str
     evidence_state: str
+    evidence_role: str | None
     module_details: dict[str, Any]
 
 
@@ -175,6 +180,18 @@ def _normalize_evidence(
             f"Invalid evidence_state {item.evidence_state!r}. "
             f"Allowed values: {allowed}."
         )
+    if (
+        item.evidence_role is not None
+        and (
+            not isinstance(item.evidence_role, str)
+            or item.evidence_role not in _ALLOWED_CALLER_EVIDENCE_ROLES
+        )
+    ):
+        allowed = ", ".join(sorted(_ALLOWED_CALLER_EVIDENCE_ROLES))
+        raise SubmissionAssemblyError(
+            f"Invalid evidence_role {item.evidence_role!r}. "
+            f"Allowed caller-provided values: {allowed}."
+        )
 
     module_details = {} if item.module_details is None else item.module_details
     _validate_json_object(module_details, "module_details")
@@ -192,6 +209,7 @@ def _normalize_evidence(
             default=manifest_created_at,
         ),
         evidence_state=item.evidence_state,
+        evidence_role=item.evidence_role,
         module_details=module_details.copy(),
     )
 
@@ -269,12 +287,14 @@ def _build_page(
             "evidence": [],
         }
 
-    unambiguous = len(items) == 1
+    auto_selected = len(items) == 1 and _can_auto_select(items[0][1])
     evidence = [
         {
             "evidence_id": evidence_id,
             "routed_evidence_path": item.routed_evidence_path,
-            "evidence_role": "selected" if unambiguous else "candidate",
+            "evidence_role": (
+                "selected" if auto_selected else _manifest_evidence_role(item)
+            ),
             "evidence_state": item.evidence_state,
             "duplicate_number": item.duplicate_number,
             "created_at": item.created_at,
@@ -283,12 +303,46 @@ def _build_page(
         }
         for evidence_id, item in items
     ]
+    if all(_is_excluded(item) for _, item in items):
+        page_state = "excluded"
+    elif len(items) > 1:
+        page_state = "duplicate"
+    elif _requires_rescan(items[0][1]):
+        page_state = "needs_rescan"
+    else:
+        page_state = "present"
+
     return {
         "page_number": page_number,
-        "page_state": "present" if unambiguous else "duplicate",
-        "selected_evidence_id": items[0][0] if unambiguous else None,
+        "page_state": page_state,
+        "selected_evidence_id": items[0][0] if auto_selected else None,
         "evidence": evidence,
     }
+
+
+def _can_auto_select(item: _NormalizedEvidence) -> bool:
+    return item.evidence_role is None and item.evidence_state == "active"
+
+
+def _manifest_evidence_role(item: _NormalizedEvidence) -> str:
+    if item.evidence_role is not None:
+        return item.evidence_role
+    if item.evidence_state == "excluded":
+        return "excluded"
+    return "candidate"
+
+
+def _is_excluded(item: _NormalizedEvidence) -> bool:
+    return (
+        item.evidence_role == "excluded" or item.evidence_state == "excluded"
+    )
+
+
+def _requires_rescan(item: _NormalizedEvidence) -> bool:
+    return (
+        item.evidence_role == "replacement"
+        or item.evidence_state in {"damaged", "needs_rescan"}
+    )
 
 
 def _evidence_sort_key(item: _NormalizedEvidence) -> tuple[Any, ...]:
@@ -300,6 +354,7 @@ def _evidence_sort_key(item: _NormalizedEvidence) -> tuple[Any, ...]:
         item.routed_evidence_path,
         item.created_at,
         item.evidence_state,
+        item.evidence_role or "",
         retained.get("retained_source_path", ""),
         retained.get("source_scan_id", ""),
         retained.get("source_filename", ""),

--- a/tests/test_submission_assembly.py
+++ b/tests/test_submission_assembly.py
@@ -126,6 +126,121 @@ def test_duplicate_page_is_ambiguous_and_deterministically_ordered(
     validate_submission_manifest(manifest)
 
 
+def test_single_replacement_is_preserved_without_selection(
+    tmp_path: Path,
+) -> None:
+    manifest = _build(
+        tmp_path, [_evidence(1, evidence_role="replacement")]
+    )
+
+    page = manifest["pages"][0]
+    assert page["page_state"] == "needs_rescan"
+    assert page["selected_evidence_id"] is None
+    assert page["evidence"][0]["evidence_role"] == "replacement"
+    validate_submission_manifest(manifest)
+
+
+def test_original_and_replacement_remain_ambiguous(tmp_path: Path) -> None:
+    manifest = _build(
+        tmp_path,
+        [
+            _evidence(1, "pages/original.pdf"),
+            _evidence(
+                1,
+                "pages/replacement.pdf",
+                evidence_role="replacement",
+            ),
+        ],
+    )
+
+    page = manifest["pages"][0]
+    assert page["page_state"] == "duplicate"
+    assert page["selected_evidence_id"] is None
+    assert [item["evidence_role"] for item in page["evidence"]] == [
+        "candidate",
+        "replacement",
+    ]
+    assert len(page["evidence"]) == 2
+    validate_submission_manifest(manifest)
+
+
+@pytest.mark.parametrize("evidence_state", ["damaged", "needs_rescan"])
+def test_problematic_single_evidence_requires_rescan(
+    tmp_path: Path, evidence_state: str
+) -> None:
+    manifest = _build(
+        tmp_path, [_evidence(1, evidence_state=evidence_state)]
+    )
+
+    page = manifest["pages"][0]
+    assert page["page_state"] == "needs_rescan"
+    assert page["selected_evidence_id"] is None
+    assert page["evidence"][0]["evidence_state"] == evidence_state
+    assert page["evidence"][0]["evidence_role"] == "candidate"
+    validate_submission_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"evidence_role": "excluded"},
+        {"evidence_state": "excluded"},
+    ],
+)
+def test_single_excluded_evidence_is_preserved(
+    tmp_path: Path, kwargs: dict[str, Any]
+) -> None:
+    manifest = _build(tmp_path, [_evidence(1, **kwargs)])
+
+    page = manifest["pages"][0]
+    assert page["page_state"] == "excluded"
+    assert page["selected_evidence_id"] is None
+    assert page["evidence"][0]["evidence_role"] == "excluded"
+    assert len(page["evidence"]) == 1
+    validate_submission_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    "problematic",
+    [
+        {"evidence_state": "damaged"},
+        {"evidence_role": "excluded"},
+    ],
+)
+def test_mixed_evidence_preserves_all_candidates_without_selection(
+    tmp_path: Path, problematic: dict[str, Any]
+) -> None:
+    manifest = _build(
+        tmp_path,
+        [
+            _evidence(1, "pages/active.pdf"),
+            _evidence(1, "pages/problematic.pdf", **problematic),
+        ],
+    )
+
+    page = manifest["pages"][0]
+    assert page["page_state"] == "duplicate"
+    assert page["selected_evidence_id"] is None
+    assert len(page["evidence"]) == 2
+    assert {item["routed_evidence_path"] for item in page["evidence"]} == {
+        "pages/active.pdf",
+        "pages/problematic.pdf",
+    }
+    validate_submission_manifest(manifest)
+
+
+def test_explicit_candidate_remains_unselected(tmp_path: Path) -> None:
+    manifest = _build(
+        tmp_path, [_evidence(1, evidence_role="candidate")]
+    )
+
+    page = manifest["pages"][0]
+    assert page["page_state"] == "present"
+    assert page["selected_evidence_id"] is None
+    assert page["evidence"][0]["evidence_role"] == "candidate"
+    validate_submission_manifest(manifest)
+
+
 def test_full_retained_source_is_preserved_with_nullable_source_page(
     tmp_path: Path,
 ) -> None:
@@ -361,6 +476,14 @@ def test_invalid_evidence_state_and_module_details_raise(tmp_path: Path) -> None
         _build(tmp_path, [_evidence(1, evidence_state="reviewed")])
     with pytest.raises(SubmissionAssemblyError, match="JSON-compatible"):
         _build(tmp_path, [_evidence(1, module_details={"bad": object()})])
+
+
+@pytest.mark.parametrize("value", ["selected", "primary", "", 1])
+def test_invalid_caller_evidence_role_raises(
+    tmp_path: Path, value: Any
+) -> None:
+    with pytest.raises(SubmissionAssemblyError, match="evidence_role"):
+        _build(tmp_path, [_evidence(1, evidence_role=value)])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

* Refined v0.6 routed-evidence submission assembly semantics.
* Added caller-provided `evidence_role` support for:

  * `candidate`
  * `replacement`
  * `excluded`
* Rejected caller-provided `selected` roles so teacher selection remains a later explicit workflow.
* Preserved replacement/rescan candidates without automatically selecting them.
* Preserved damaged, needs-rescan, excluded, replacement, and duplicate evidence.
* Auto-selection now occurs only for a single ordinary active evidence item with no explicit role.
* Added conservative page-state mapping:

  * ordinary unambiguous active evidence → `present`
  * single replacement/damaged/needs-rescan evidence → `needs_rescan`
  * only excluded evidence → `excluded`
  * multiple evidence items → `duplicate`
* Preserved all evidence candidates without discarding, overwriting, or inferring teacher intent.
* Added focused tests for replacement, damaged, needs-rescan, excluded, mixed, explicit-candidate, and invalid-role cases.
* Updated README, changelog, and design/contract documentation.
* Left legacy `quillan.submissions` unchanged.

Closes #73.

## Validation

* [x] `python -m pytest` — 460 tests passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* This refines manifest assembly semantics only.
* Does not add assignment-level evidence discovery.
* Does not scan folders.
* Does not add CLI or menu integration.
* Does not add teacher selection commands.
* Does not add review-state update commands.
* Does not open files.
* Does not implement OCR, handwriting recognition, AI suggestions, AI scoring, AI feedback drafting, scoring, tagging, feedback generation, reports, pds-core changes, or pds-sunset changes.
