### PR TITLE
Add assignment submission assembly command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan assemble-submissions` and an assignment-level assembly API
+  that discover routed PDF/image evidence by filename convention, group it by
+  student, write canonical version `1` manifests, report malformed or
+  unrelated files plus missing and duplicate pages, skip existing manifests
+  by default, and support explicit full regeneration with `--overwrite`.
 - Added a focused routed-evidence assembly API for building and safely writing
   new version `1` submission manifests. It preserves workspace-relative source
   provenance, represents expected missing pages and ambiguous duplicates,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Quillan currently supports:
   excluded evidence semantics, retained-source provenance, canonical paths,
   validation, and overwrite protection without choosing among ambiguous
   evidence;
+- assignment-level discovery and assembly of already-routed response evidence
+  through `quillan assemble-submissions`, with existing manifests skipped by
+  default and explicit full regeneration through `--overwrite`;
 - printable writing-response PDF generation with student, class, assignment,
   and page identity;
 - QR codes containing canonical PDS1 Quillan response payloads on printable
@@ -77,8 +80,7 @@ particular, Quillan does not currently provide:
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
-- automatic discovery of routed evidence from scan folders or merging new
-  evidence into existing teacher review state;
+- merging newly routed evidence into existing teacher review state;
 - assignment creation workflows;
 - implemented requirements-checking, tagging, scoring, feedback, or
   production reporting workflows;
@@ -94,8 +96,7 @@ the shared `pds-core` active scan contract: canonical retained sources belong
 in `scans/source/YYYY-MM-DD/`, canonical routing review records belong in
 `scans/review/`, and assignment-level `scans/` contains routed evidence rather
 than canonical source retention. QR extraction, PDF splitting, OCR, and
-scan-folder discovery and review-state updates remain outside the direct
-command and assembly API.
+review-state updates remain outside the direct routing and assembly commands.
 
 ## Current Non-Goals
 
@@ -303,8 +304,22 @@ safely preserved for review; exit code `1` means it could not be handled
 safely.
 
 This direct developer/teacher primitive requires already-decoded payload text.
-It does not extract QR codes, split PDFs, run OCR, assemble submissions, score,
-tag, generate feedback, or create reports.
+It does not extract QR codes, split PDFs, run OCR, score, tag, generate
+feedback, or create reports.
+
+Assemble all student manifests discoverable from routed filenames in an
+assignment's `scans/` directory:
+
+```powershell
+quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
+```
+
+Discovery recognizes routed PDF and image filenames such as
+`response_00107_pg_003.pdf` and
+`response_00107_pg_003__dup_001.png`. It does not inspect evidence file
+contents or reconstruct retained-source provenance. Existing manifests are
+skipped by default; `--overwrite` fully regenerates them without preserving
+prior review state or teacher selections.
 
 The current command surface is:
 
@@ -314,13 +329,13 @@ quillan --help
 quillan validate-standards <standards-profile.json>
 quillan validate-assignment <assignment.json>
 quillan route-scan <source-file> --payload "<PDS1|...>"
+quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan workspace show
 quillan menu
 ```
 
 Legacy text-oriented submission metadata validation and printable response
-generation currently use Python APIs rather than dedicated CLI commands. The
-version `1` reviewable-evidence manifest is documented but not implemented.
+generation currently use Python APIs rather than dedicated CLI commands.
 
 ## Quality Checks
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -198,9 +198,11 @@ provenance, workspace-relative paths, and timezone-aware timestamps. Assembly
 preserves explicit candidate, replacement, and excluded roles plus damaged,
 needs-rescan, and excluded states without choosing among ambiguous evidence.
 Only a single ordinary active item with no explicit role is selected
-automatically. Assembly does not discover scan folders, merge manifests, or
-preserve prior teacher review state during overwrite; teacher selection and
-review-state updates remain future workflows.
+automatically. Assignment-level filename discovery and assembly from existing
+routed evidence is implemented through `quillan assemble-submissions`.
+Assembly does not inspect evidence contents, reconstruct retained-source
+provenance, merge manifests, or preserve prior teacher review state during
+overwrite; teacher selection and review-state updates remain future workflows.
 
 Target milestone:
 
@@ -223,9 +225,9 @@ The direct
 `quillan route-scan <source-file> --payload "<PDS1|...>"` command is
 implemented for one selected source and an already-decoded payload. It
 orchestrates the existing parser, planner, evidence filer, and review adapters.
-QR extraction, PDF splitting, OCR, menu integration, batch routing, and
-automatic evidence discovery remain unimplemented. Submission assembly is
-available as a focused Python API and is not part of `route-scan`.
+QR extraction, PDF splitting, OCR, menu integration, and batch routing remain
+unimplemented. Assignment submission assembly is available through a focused
+Python API and `quillan assemble-submissions`; it is not part of `route-scan`.
 
 ### `submissions.py`
 

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -403,8 +403,10 @@ Inactive historical preservation and end-of-cycle archiving belong to future
    for teacher review.
 7. **Submission assembly and linking.** The first page-oriented submission
    manifest contract, loader, validator, path helpers, safe writer, and focused
-   assembly API are implemented. Evidence discovery, completeness workflows,
-   merging, and rescan selection remain future work.
+   assembly API are implemented. Assignment-level filename discovery and direct
+   assembly are implemented through `quillan assemble-submissions`, including
+   optional expected-page completeness reporting. Manifest merging, retained
+   provenance reconstruction, and rescan selection remain future work.
 8. **Teacher review integration.** Present assembled evidence to the teacher
    and allow teacher-controlled lifecycle changes without automated judgment.
 

--- a/quillan/assignment_submission_assembly.py
+++ b/quillan/assignment_submission_assembly.py
@@ -1,0 +1,264 @@
+"""Assignment-level assembly of routed evidence into submission manifests."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Final
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.storage import assignment_scans_dir
+from quillan.submission_assembly import (
+    RoutedSubmissionEvidence,
+    assemble_submission_manifest,
+)
+from quillan.submission_manifest import load_submission_manifest
+from quillan.submission_manifest_paths import submission_manifest_path
+
+_ROUTED_EVIDENCE_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^response_(?P<student_id>[A-Za-z0-9_-]+)_pg_"
+    r"(?P<page_number>[0-9]+)"
+    r"(?:__dup_(?P<duplicate_number>[0-9]+))?"
+    r"\.(?P<extension>pdf|png|jpg|jpeg|tif|tiff)$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedRoutedEvidenceFile:
+    """One assignment scans file excluded from routed-evidence discovery."""
+
+    path: Path
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class StudentSubmissionAssemblySummary:
+    """Page-state summary for one newly written student manifest."""
+
+    student_id: str
+    manifest_path: Path
+    missing_pages: tuple[int, ...]
+    duplicate_pages: tuple[int, ...]
+    needs_rescan_pages: tuple[int, ...]
+    excluded_pages: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AssignmentSubmissionAssemblyResult:
+    """Outcome of assembling all routed evidence for one assignment."""
+
+    class_id: str
+    assignment_id: str
+    written_manifests: tuple[Path, ...]
+    skipped_existing_manifests: tuple[Path, ...]
+    skipped_files: tuple[SkippedRoutedEvidenceFile, ...]
+    students_with_evidence: tuple[str, ...]
+    student_summaries: tuple[StudentSubmissionAssemblySummary, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveryResult:
+    evidence_by_student: dict[str, list[RoutedSubmissionEvidence]]
+    skipped_files: tuple[SkippedRoutedEvidenceFile, ...]
+
+
+def discover_assignment_routed_evidence(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> dict[str, list[RoutedSubmissionEvidence]]:
+    """Discover routed response evidence files grouped by student ID."""
+    return _discover_assignment_routed_evidence(
+        workspace_root, class_id, assignment_id
+    ).evidence_by_student
+
+
+def assemble_assignment_submissions(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    *,
+    expected_pages: int | None = None,
+    overwrite: bool = False,
+    created_at: datetime | str | None = None,
+    updated_at: datetime | str | None = None,
+) -> AssignmentSubmissionAssemblyResult:
+    """Assemble manifests for every student with routed assignment evidence.
+
+    ``overwrite=True`` performs full regeneration. It does not merge prior
+    review state or preserve prior teacher selections.
+    """
+    if (
+        expected_pages is not None
+        and (
+            isinstance(expected_pages, bool)
+            or not isinstance(expected_pages, int)
+            or expected_pages < 1
+        )
+    ):
+        raise ValueError("expected_pages must be a positive integer.")
+
+    discovery = _discover_assignment_routed_evidence(
+        workspace_root, class_id, assignment_id
+    )
+    students = tuple(discovery.evidence_by_student)
+    written: list[Path] = []
+    skipped_existing: list[Path] = []
+    summaries: list[StudentSubmissionAssemblySummary] = []
+
+    for student_id, evidence_items in discovery.evidence_by_student.items():
+        manifest_path = submission_manifest_path(
+            workspace_root, class_id, assignment_id, student_id
+        )
+        if manifest_path.exists() and not overwrite:
+            skipped_existing.append(manifest_path)
+            continue
+
+        written_path = assemble_submission_manifest(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            evidence_items,
+            expected_pages=expected_pages,
+            overwrite=overwrite,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+        written.append(written_path)
+        summaries.append(_summarize_manifest(student_id, written_path))
+
+    return AssignmentSubmissionAssemblyResult(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        written_manifests=tuple(written),
+        skipped_existing_manifests=tuple(skipped_existing),
+        skipped_files=discovery.skipped_files,
+        students_with_evidence=students,
+        student_summaries=tuple(summaries),
+    )
+
+
+def _discover_assignment_routed_evidence(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> _DiscoveryResult:
+    validate_identifier(class_id, "class_id")
+    validate_identifier(assignment_id, "assignment_id")
+    root = Path(workspace_root).resolve(strict=False)
+    scans_dir = assignment_scans_dir(root, class_id, assignment_id)
+    if not scans_dir.exists():
+        return _DiscoveryResult({}, ())
+    if not scans_dir.is_dir():
+        raise NotADirectoryError(
+            f"Assignment scans path is not a directory: {scans_dir}"
+        )
+
+    grouped: dict[str, list[RoutedSubmissionEvidence]] = {}
+    skipped: list[SkippedRoutedEvidenceFile] = []
+    try:
+        entries = sorted(scans_dir.iterdir(), key=lambda path: path.name.casefold())
+    except OSError:
+        raise
+
+    for path in entries:
+        if not path.is_file():
+            continue
+        match = _ROUTED_EVIDENCE_PATTERN.fullmatch(path.name)
+        if match is None:
+            skipped.append(
+                SkippedRoutedEvidenceFile(
+                    path=path,
+                    reason=_unmatched_filename_reason(path.name),
+                )
+            )
+            continue
+
+        student_id = match.group("student_id")
+        try:
+            validate_identifier(student_id, "student_id")
+        except IdentifierValidationError as error:
+            skipped.append(SkippedRoutedEvidenceFile(path=path, reason=str(error)))
+            continue
+
+        page_number = int(match.group("page_number"))
+        duplicate_text = match.group("duplicate_number")
+        duplicate_number = (
+            int(duplicate_text) if duplicate_text is not None else None
+        )
+        if page_number < 1:
+            skipped.append(
+                SkippedRoutedEvidenceFile(
+                    path=path,
+                    reason="page number must be a positive integer",
+                )
+            )
+            continue
+        if duplicate_number is not None and duplicate_number < 1:
+            skipped.append(
+                SkippedRoutedEvidenceFile(
+                    path=path,
+                    reason="duplicate number must be a positive integer",
+                )
+            )
+            continue
+
+        grouped.setdefault(student_id, []).append(
+            RoutedSubmissionEvidence(
+                page_number=page_number,
+                routed_evidence_path=path.relative_to(root),
+                duplicate_number=duplicate_number,
+                retained_source_path=None,
+                source_scan_id=None,
+                source_filename=None,
+                source_sha256=None,
+                source_page_number=None,
+            )
+        )
+
+    ordered = {
+        student_id: sorted(
+            grouped[student_id],
+            key=lambda item: (
+                item.page_number,
+                item.duplicate_number is not None,
+                item.duplicate_number or 0,
+                str(item.routed_evidence_path).casefold(),
+            ),
+        )
+        for student_id in sorted(grouped)
+    }
+    return _DiscoveryResult(ordered, tuple(skipped))
+
+
+def _unmatched_filename_reason(filename: str) -> str:
+    if filename.casefold().startswith("response_"):
+        return "malformed routed response evidence filename"
+    return "filename does not match routed response evidence convention"
+
+
+def _summarize_manifest(
+    student_id: str, manifest_path: Path
+) -> StudentSubmissionAssemblySummary:
+    manifest = load_submission_manifest(manifest_path)
+
+    def pages_with_state(state: str) -> tuple[int, ...]:
+        return tuple(
+            page["page_number"]
+            for page in manifest["pages"]
+            if page["page_state"] == state
+        )
+
+    return StudentSubmissionAssemblySummary(
+        student_id=student_id,
+        manifest_path=manifest_path,
+        missing_pages=pages_with_state("missing"),
+        duplicate_pages=pages_with_state("duplicate"),
+        needs_rescan_pages=pages_with_state("needs_rescan"),
+        excluded_pages=pages_with_state("excluded"),
+    )

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -17,6 +17,10 @@ from pds_core.workspace import (
     save_workspace_root,
 )
 
+from quillan.assignment_submission_assembly import (
+    AssignmentSubmissionAssemblyResult,
+    assemble_assignment_submissions,
+)
 from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.evidence_filing import (
     EvidenceFilingError,
@@ -56,6 +60,14 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "route-scan":
         return _handle_route_scan(args.source_file, args.payload)
+
+    if args.command == "assemble-submissions":
+        return _handle_assemble_submissions(
+            args.class_id,
+            args.assignment_id,
+            expected_pages=args.expected_pages,
+            overwrite=args.overwrite,
+        )
 
     if args.command == "workspace" and args.workspace_command == "show":
         return _handle_workspace_show()
@@ -124,6 +136,32 @@ def _build_parser() -> argparse.ArgumentParser:
         "--payload",
         required=True,
         help="Already-decoded canonical PDS1 payload text.",
+    )
+
+    assemble_parser = subparsers.add_parser(
+        "assemble-submissions",
+        help="Assemble assignment submission manifests from routed evidence.",
+        description=(
+            "Discover routed response evidence already filed under an "
+            "assignment's scans directory and assemble one submission manifest "
+            "per student. Existing manifests are skipped unless --overwrite is "
+            "given."
+        ),
+    )
+    assemble_parser.add_argument("class_id", help="Class identifier.")
+    assemble_parser.add_argument("assignment_id", help="Assignment identifier.")
+    assemble_parser.add_argument(
+        "--expected-pages",
+        type=_positive_integer_argument,
+        help="Expected number of response pages per student.",
+    )
+    assemble_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "Fully regenerate existing manifests without preserving prior "
+            "review state or teacher selections."
+        ),
     )
 
     workspace_parser = subparsers.add_parser(
@@ -263,6 +301,158 @@ def _handle_route_scan(source_file: Path, payload_text: str) -> int:
 
     _print_routed_evidence(filed_evidence)
     return 0
+
+
+def _handle_assemble_submissions(
+    class_id: str,
+    assignment_id: str,
+    *,
+    expected_pages: int | None,
+    overwrite: bool,
+) -> int:
+    """Assemble all routed evidence for one class assignment."""
+    try:
+        workspace_root = resolve_workspace_root()
+        result = assemble_assignment_submissions(
+            workspace_root,
+            class_id,
+            assignment_id,
+            expected_pages=expected_pages,
+            overwrite=overwrite,
+        )
+    except Exception as error:
+        print(f"Error: could not assemble submission manifests: {error}")
+        return 1
+
+    _print_assignment_submission_assembly(result, workspace_root)
+    return 0
+
+
+def _print_assignment_submission_assembly(
+    result: AssignmentSubmissionAssemblyResult,
+    workspace_root: Path,
+) -> None:
+    """Print a concise assignment assembly summary."""
+    missing = sum(
+        len(summary.missing_pages) for summary in result.student_summaries
+    )
+    duplicate = sum(
+        len(summary.duplicate_pages) for summary in result.student_summaries
+    )
+    needs_rescan = sum(
+        len(summary.needs_rescan_pages) for summary in result.student_summaries
+    )
+    excluded = sum(
+        len(summary.excluded_pages) for summary in result.student_summaries
+    )
+
+    print(
+        "Assembled submission manifests for assignment "
+        f"{result.assignment_id}."
+    )
+    print()
+    print(f"Students with routed evidence: {len(result.students_with_evidence)}")
+    print(f"Created manifests: {len(result.written_manifests)}")
+    print(
+        "Skipped existing manifests: "
+        f"{len(result.skipped_existing_manifests)}"
+    )
+    print(f"Skipped files: {len(result.skipped_files)}")
+    print(f"Missing pages: {missing}")
+    print(f"Duplicate pages: {duplicate}")
+    print(f"Needs-rescan pages: {needs_rescan}")
+    print(f"Excluded pages: {excluded}")
+    print("Failures: 0")
+
+    _print_path_section(
+        "Created", result.written_manifests, workspace_root
+    )
+    _print_path_section(
+        "Skipped existing",
+        result.skipped_existing_manifests,
+        workspace_root,
+    )
+    if result.skipped_files:
+        print()
+        print("Skipped files:")
+        for skipped in result.skipped_files:
+            print(
+                f"- {_workspace_relative_display(skipped.path, workspace_root)}"
+                f" — {skipped.reason}"
+            )
+
+    state_details = [
+        (
+            summary.student_id,
+            summary.missing_pages,
+            summary.duplicate_pages,
+            summary.needs_rescan_pages,
+            summary.excluded_pages,
+        )
+        for summary in result.student_summaries
+        if (
+            summary.missing_pages
+            or summary.duplicate_pages
+            or summary.needs_rescan_pages
+            or summary.excluded_pages
+        )
+    ]
+    if state_details:
+        print()
+        print("Page-state details:")
+        for student_id, missing_pages, duplicate_pages, rescan_pages, excluded_pages in (
+            state_details
+        ):
+            details = []
+            if missing_pages:
+                details.append(f"missing={_format_page_numbers(missing_pages)}")
+            if duplicate_pages:
+                details.append(
+                    f"duplicate={_format_page_numbers(duplicate_pages)}"
+                )
+            if rescan_pages:
+                details.append(
+                    f"needs-rescan={_format_page_numbers(rescan_pages)}"
+                )
+            if excluded_pages:
+                details.append(
+                    f"excluded={_format_page_numbers(excluded_pages)}"
+                )
+            print(f"- {student_id}: {', '.join(details)}")
+
+
+def _print_path_section(
+    heading: str, paths: tuple[Path, ...], workspace_root: Path
+) -> None:
+    if not paths:
+        return
+    print()
+    print(f"{heading}:")
+    for path in paths:
+        print(f"- {_workspace_relative_display(path, workspace_root)}")
+
+
+def _workspace_relative_display(path: Path, workspace_root: Path) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(
+            workspace_root.resolve(strict=False)
+        ).as_posix()
+    except (OSError, ValueError):
+        return str(path)
+
+
+def _format_page_numbers(page_numbers: tuple[int, ...]) -> str:
+    return ",".join(str(page_number) for page_number in page_numbers)
+
+
+def _positive_integer_argument(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a positive integer") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
 
 
 def _validate_route_scan_source_file(source_file: Path) -> bool:

--- a/tests/test_assignment_submission_assembly.py
+++ b/tests/test_assignment_submission_assembly.py
@@ -1,0 +1,274 @@
+"""Tests for assignment-level routed-evidence assembly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.assignment_submission_assembly import (
+    assemble_assignment_submissions,
+    discover_assignment_routed_evidence,
+)
+from quillan.cli import main
+from quillan.submission_manifest import load_submission_manifest
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+TIMESTAMP = "2026-06-22T12:00:00+00:00"
+
+
+def _scans_dir(workspace: Path) -> Path:
+    path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+    )
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _touch_evidence(workspace: Path, filename: str) -> Path:
+    path = _scans_dir(workspace) / filename
+    path.write_bytes(b"synthetic evidence")
+    return path
+
+
+@pytest.mark.parametrize("extension", ["pdf", "png", "jpg", "jpeg", "tif", "tiff"])
+def test_discovery_supports_extensions_case_insensitively(
+    tmp_path: Path, extension: str
+) -> None:
+    _touch_evidence(tmp_path, f"response_00107_pg_001.{extension.upper()}")
+
+    discovered = discover_assignment_routed_evidence(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert list(discovered) == ["00107"]
+    assert discovered["00107"][0].page_number == 1
+
+
+def test_discovery_groups_students_and_parses_duplicates_deterministically(
+    tmp_path: Path,
+) -> None:
+    _touch_evidence(tmp_path, "response_00108_pg_003__dup_002.pdf")
+    _touch_evidence(tmp_path, "response_00107_pg_002__dup_001.png")
+    _touch_evidence(tmp_path, "response_00107_pg_002.pdf")
+
+    discovered = discover_assignment_routed_evidence(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert list(discovered) == ["00107", "00108"]
+    first_student = discovered["00107"]
+    assert [
+        (item.page_number, item.duplicate_number) for item in first_student
+    ] == [(2, None), (2, 1)]
+    assert first_student[0].retained_source_path is None
+    assert first_student[0].source_scan_id is None
+    assert first_student[0].source_filename is None
+    assert first_student[0].source_sha256 is None
+    assert first_student[0].source_page_number is None
+
+
+def test_discovery_skips_unrelated_and_malformed_files_with_reasons(
+    tmp_path: Path,
+) -> None:
+    _touch_evidence(tmp_path, "debug_page.png")
+    _touch_evidence(tmp_path, "response_00107_pg_zero.pdf")
+    _touch_evidence(tmp_path, "response_00107_pg_000.pdf")
+    _touch_evidence(tmp_path, "response_00107_pg_001__dup_000.pdf")
+
+    result = assemble_assignment_submissions(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert not result.students_with_evidence
+    assert len(result.skipped_files) == 4
+    reasons = {item.path.name: item.reason for item in result.skipped_files}
+    assert "does not match" in reasons["debug_page.png"]
+    assert "malformed" in reasons["response_00107_pg_zero.pdf"]
+    assert "page number" in reasons["response_00107_pg_000.pdf"]
+    assert "duplicate number" in reasons[
+        "response_00107_pg_001__dup_000.pdf"
+    ]
+
+
+def test_assembly_writes_reloadable_manifests_with_missing_duplicate_and_extra_pages(
+    tmp_path: Path,
+) -> None:
+    _touch_evidence(tmp_path, "response_00107_pg_001.pdf")
+    _touch_evidence(tmp_path, "response_00107_pg_001__dup_001.pdf")
+    _touch_evidence(tmp_path, "response_00107_pg_004.jpg")
+    _touch_evidence(tmp_path, "response_00108_pg_002.tif")
+
+    result = assemble_assignment_submissions(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        expected_pages=3,
+        created_at=TIMESTAMP,
+        updated_at=TIMESTAMP,
+    )
+
+    assert result.students_with_evidence == ("00107", "00108")
+    assert len(result.written_manifests) == 2
+    first = load_submission_manifest(result.written_manifests[0])
+    assert [page["page_number"] for page in first["pages"]] == [1, 2, 3, 4]
+    assert [page["page_state"] for page in first["pages"]] == [
+        "duplicate",
+        "missing",
+        "missing",
+        "present",
+    ]
+    assert first["pages"][0]["selected_evidence_id"] is None
+    assert {
+        item["evidence_role"] for item in first["pages"][0]["evidence"]
+    } == {"candidate"}
+    assert all(
+        item["retained_source"] is None
+        for page in first["pages"]
+        for item in page["evidence"]
+    )
+    summary = result.student_summaries[0]
+    assert summary.duplicate_pages == (1,)
+    assert summary.missing_pages == (2, 3)
+
+
+def test_existing_manifest_is_skipped_while_other_students_assemble(
+    tmp_path: Path,
+) -> None:
+    _touch_evidence(tmp_path, "response_00107_pg_001.pdf")
+    first_result = assemble_assignment_submissions(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    existing_manifest = first_result.written_manifests[0]
+    original_text = existing_manifest.read_text(encoding="utf-8")
+
+    for path in _scans_dir(tmp_path).iterdir():
+        path.unlink()
+    _touch_evidence(tmp_path, "response_00108_pg_002.pdf")
+    _touch_evidence(tmp_path, "response_00107_pg_003.pdf")
+
+    result = assemble_assignment_submissions(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert result.skipped_existing_manifests == (existing_manifest,)
+    assert existing_manifest.read_text(encoding="utf-8") == original_text
+    assert len(result.written_manifests) == 1
+    assert result.written_manifests[0].parent.name == "00108"
+
+
+def test_overwrite_fully_regenerates_existing_manifest(tmp_path: Path) -> None:
+    evidence = _touch_evidence(tmp_path, "response_00107_pg_001.pdf")
+    first = assemble_assignment_submissions(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    manifest_path = first.written_manifests[0]
+    evidence.unlink()
+    _touch_evidence(tmp_path, "response_00107_pg_002.pdf")
+
+    result = assemble_assignment_submissions(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, overwrite=True
+    )
+
+    assert result.written_manifests == (manifest_path,)
+    assert not result.skipped_existing_manifests
+    manifest = load_submission_manifest(manifest_path)
+    assert [page["page_number"] for page in manifest["pages"]] == [2]
+
+
+def test_missing_or_empty_scans_directory_returns_empty_result(
+    tmp_path: Path,
+) -> None:
+    missing = assemble_assignment_submissions(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    assert not missing.students_with_evidence
+    assert not missing.written_manifests
+
+    _scans_dir(tmp_path)
+    empty = assemble_assignment_submissions(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    assert not empty.students_with_evidence
+    assert not empty.skipped_files
+
+
+def test_empty_assignment_still_validates_expected_pages(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="expected_pages"):
+        assemble_assignment_submissions(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, expected_pages=0
+        )
+
+
+def test_cli_assembles_and_prints_workspace_relative_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _touch_evidence(tmp_path, "response_00107_pg_001.pdf")
+    _touch_evidence(tmp_path, "response_00107_pg_001__dup_001.pdf")
+    _touch_evidence(tmp_path, "notes.txt")
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    result = main(
+        [
+            "assemble-submissions",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            "--expected-pages",
+            "2",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert "Students with routed evidence: 1" in output
+    assert "Created manifests: 1" in output
+    assert "Missing pages: 1" in output
+    assert "Duplicate pages: 1" in output
+    assert "Skipped files: 1" in output
+    assert "Failures: 0" in output
+    assert "classes/" in output
+    assert str(tmp_path) not in output
+
+    overwrite_result = main(
+        [
+            "assemble-submissions",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            "--overwrite",
+        ]
+    )
+    assert overwrite_result == 0
+
+
+def test_cli_handles_empty_assignment_and_rejects_invalid_expected_pages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(["assemble-submissions", CLASS_ID, ASSIGNMENT_ID]) == 0
+    output = capsys.readouterr().out
+    assert "Students with routed evidence: 0" in output
+    assert "Created manifests: 0" in output
+
+    with pytest.raises(SystemExit) as error:
+        main(
+            [
+                "assemble-submissions",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                "--expected-pages",
+                "0",
+            ]
+        )
+    assert error.value.code == 2


### PR DESCRIPTION
## Summary

* Added assignment-level submission assembly from existing routed evidence files.
* Added `quillan assemble-submissions <class_id> <assignment_id>`.
* Added support for:

  * `--expected-pages`
  * `--overwrite`
* Discovers routed evidence filenames case-insensitively from assignment `scans/`.
* Supports routed evidence extensions:

  * `.pdf`
  * `.png`
  * `.jpg`
  * `.jpeg`
  * `.tif`
  * `.tiff`
* Parses student ID, page number, and duplicate number from routed evidence filenames.
* Groups routed evidence by student.
* Writes canonical v0.6 submission manifests.
* Skips existing manifests by default.
* Performs full regeneration only with `--overwrite`.
* Reports:

  * students with routed evidence;
  * created manifests;
  * skipped existing manifests;
  * skipped files;
  * missing pages;
  * duplicate pages;
  * needs-rescan pages;
  * excluded pages;
  * failures.
* Preserves `retained_source = null` for filename-discovered evidence rather than inventing provenance.
* Added focused tests for discovery, grouping, assembly, overwrite behavior, empty assignments, CLI behavior, skipped files, and existing-manifest skip behavior.
* Updated documentation/status notes.

Closes #74.

## Validation

* [x] Focused tests — 15 passed
* [x] `python -m pytest` — 475 passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* This assembles manifests only from already-routed evidence.
* Does not route scans.
* Does not scan inboxes.
* Does not extract QR codes.
* Does not split PDFs.
* Does not inspect PDF/image contents.
* Does not reconstruct retained-source provenance from filenames.
* Does not open files.
* Does not update review state.
* Does not select among ambiguous evidence.
* Does not score, tag, evaluate, generate feedback, produce reports, use OCR, use handwriting recognition, or use AI.
* Does not modify `pds-core`, `pds-sunset`, or legacy `quillan.submissions`.
