### PR TITLE
Add submission status listing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added read-only `quillan list-submissions` status reporting for validated
+  assignment manifests and routed evidence, including submission/page states,
+  present-but-unselected pages, students needing assembly, unassembled routed
+  files, skipped filenames, and optional expected-page visibility without
+  creating or modifying manifests.
 - Added `quillan assemble-submissions` and an assignment-level assembly API
   that discover routed PDF/image evidence by filename convention, group it by
   student, write canonical version `1` manifests, report malformed or

--- a/README.md
+++ b/README.md
@@ -321,6 +321,19 @@ contents or reconstruct retained-source provenance. Existing manifests are
 skipped by default; `--overwrite` fully regenerates them without preserving
 prior review state or teacher selections.
 
+List current manifest and routed-evidence status without changing any files:
+
+```powershell
+quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+```
+
+The status includes submission and page states, present-but-unselected pages,
+students with routed evidence but no manifest, unassembled routed files, and
+skipped malformed or unrelated scan filenames. Existing manifests are loaded
+and validated; an invalid manifest is an error. The command does not open
+evidence, assemble or update manifests, select evidence, score, tag, run OCR,
+or generate feedback.
+
 The current command surface is:
 
 ```powershell
@@ -330,6 +343,7 @@ quillan validate-standards <standards-profile.json>
 quillan validate-assignment <assignment.json>
 quillan route-scan <source-file> --payload "<PDS1|...>"
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
+quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan workspace show
 quillan menu
 ```

--- a/quillan/assignment_submission_assembly.py
+++ b/quillan/assignment_submission_assembly.py
@@ -61,7 +61,9 @@ class AssignmentSubmissionAssemblyResult:
 
 
 @dataclass(frozen=True, slots=True)
-class _DiscoveryResult:
+class AssignmentRoutedEvidenceDiscovery:
+    """Read-only routed-evidence discovery for one assignment."""
+
     evidence_by_student: dict[str, list[RoutedSubmissionEvidence]]
     skipped_files: tuple[SkippedRoutedEvidenceFile, ...]
 
@@ -75,6 +77,17 @@ def discover_assignment_routed_evidence(
     return _discover_assignment_routed_evidence(
         workspace_root, class_id, assignment_id
     ).evidence_by_student
+
+
+def discover_assignment_routed_evidence_status(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> AssignmentRoutedEvidenceDiscovery:
+    """Discover routed evidence plus files excluded from discovery."""
+    return _discover_assignment_routed_evidence(
+        workspace_root, class_id, assignment_id
+    )
 
 
 def assemble_assignment_submissions(
@@ -147,13 +160,13 @@ def _discover_assignment_routed_evidence(
     workspace_root: str | Path,
     class_id: str,
     assignment_id: str,
-) -> _DiscoveryResult:
+) -> AssignmentRoutedEvidenceDiscovery:
     validate_identifier(class_id, "class_id")
     validate_identifier(assignment_id, "assignment_id")
     root = Path(workspace_root).resolve(strict=False)
     scans_dir = assignment_scans_dir(root, class_id, assignment_id)
     if not scans_dir.exists():
-        return _DiscoveryResult({}, ())
+        return AssignmentRoutedEvidenceDiscovery({}, ())
     if not scans_dir.is_dir():
         raise NotADirectoryError(
             f"Assignment scans path is not a directory: {scans_dir}"
@@ -233,7 +246,7 @@ def _discover_assignment_routed_evidence(
         )
         for student_id in sorted(grouped)
     }
-    return _DiscoveryResult(ordered, tuple(skipped))
+    return AssignmentRoutedEvidenceDiscovery(ordered, tuple(skipped))
 
 
 def _unmatched_filename_reason(filename: str) -> str:

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -41,6 +41,10 @@ from quillan.routing_review import (
     preserve_routing_failure_for_review,
 )
 from quillan.standards import StandardsProfileError, load_standards_profile
+from quillan.submission_status import (
+    AssignmentSubmissionStatus,
+    list_assignment_submission_status,
+)
 
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
 
@@ -67,6 +71,13 @@ def main(argv: list[str] | None = None) -> int:
             args.assignment_id,
             expected_pages=args.expected_pages,
             overwrite=args.overwrite,
+        )
+
+    if args.command == "list-submissions":
+        return _handle_list_submissions(
+            args.class_id,
+            args.assignment_id,
+            expected_pages=args.expected_pages,
         )
 
     if args.command == "workspace" and args.workspace_command == "show":
@@ -161,6 +172,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Fully regenerate existing manifests without preserving prior "
             "review state or teacher selections."
+        ),
+    )
+
+    status_parser = subparsers.add_parser(
+        "list-submissions",
+        help="List read-only assignment submission and evidence status.",
+        description=(
+            "Load existing submission manifests and discover routed response "
+            "evidence without creating or modifying any files."
+        ),
+    )
+    status_parser.add_argument("class_id", help="Class identifier.")
+    status_parser.add_argument("assignment_id", help="Assignment identifier.")
+    status_parser.add_argument(
+        "--expected-pages",
+        type=_positive_integer_argument,
+        help=(
+            "Expected page count used only to show missing pages for students "
+            "with routed evidence but no manifest."
         ),
     )
 
@@ -326,6 +356,141 @@ def _handle_assemble_submissions(
 
     _print_assignment_submission_assembly(result, workspace_root)
     return 0
+
+
+def _handle_list_submissions(
+    class_id: str,
+    assignment_id: str,
+    *,
+    expected_pages: int | None,
+) -> int:
+    """List read-only status for one class assignment."""
+    try:
+        workspace_root = resolve_workspace_root()
+        result = list_assignment_submission_status(
+            workspace_root,
+            class_id,
+            assignment_id,
+            expected_pages=expected_pages,
+        )
+    except Exception as error:
+        print(f"Error: could not list submission status: {error}")
+        return 1
+
+    _print_assignment_submission_status(result, workspace_root)
+    return 0
+
+
+def _print_assignment_submission_status(
+    result: AssignmentSubmissionStatus,
+    workspace_root: Path,
+) -> None:
+    """Print a deterministic teacher-facing assignment status summary."""
+    submission_states = (
+        "unreviewed",
+        "in_progress",
+        "needs_rescan",
+        "reviewed",
+    )
+    page_states = ("present", "missing", "duplicate", "needs_rescan", "excluded")
+    submission_counts = {
+        state: sum(
+            status.submission_state == state
+            for status in result.student_statuses
+        )
+        for state in submission_states
+    }
+    page_counts = {
+        state: sum(
+            page.page_state == state
+            for status in result.student_statuses
+            for page in status.pages
+        )
+        for state in page_states
+    }
+    page_counts["missing"] += sum(
+        len(status.missing_pages)
+        for status in result.student_statuses
+        if status.manifest_path is None
+    )
+    unselected_count = sum(
+        len(status.unselected_present_pages)
+        for status in result.student_statuses
+    )
+
+    print(
+        f"Submission status for assignment {result.assignment_id}"
+    )
+    print()
+    print(f"Students with manifests: {len(result.students_with_manifests)}")
+    print(
+        "Students with routed evidence: "
+        f"{len(result.students_with_routed_evidence)}"
+    )
+    print(
+        f"Students needing assembly: {len(result.students_without_manifests)}"
+    )
+    print(
+        f"Unassembled routed files: {len(result.unassembled_routed_files)}"
+    )
+    print(f"Skipped routed files: {len(result.skipped_routed_files)}")
+    print()
+    print("Submission states:")
+    for state in submission_states:
+        print(f"- {state}: {submission_counts[state]}")
+    print()
+    print("Page states:")
+    for state in page_states:
+        print(f"- {state}: {page_counts[state]}")
+    print(f"- present but unselected: {unselected_count}")
+
+    if result.student_statuses:
+        print()
+        print("Students:")
+        for status in result.student_statuses:
+            if status.manifest_path is None:
+                routed_details = "routed evidence exists; no manifest"
+                if status.missing_pages:
+                    routed_details += (
+                        "; missing="
+                        f"{_format_page_numbers(status.missing_pages)}"
+                    )
+                print(f"- {status.student_id}: {routed_details}")
+                continue
+
+            counts = {
+                state: sum(page.page_state == state for page in status.pages)
+                for state in page_states
+            }
+            detail_parts = [
+                f"{state}={counts[state]}"
+                for state in page_states
+                if counts[state]
+            ]
+            if status.unselected_present_pages:
+                detail_parts.append(
+                    "present-but-unselected="
+                    f"{len(status.unselected_present_pages)}"
+                )
+            suffix = ", ".join(detail_parts) if detail_parts else "no pages"
+            print(
+                f"- {status.student_id}: {status.submission_state}; {suffix}"
+            )
+
+    if result.skipped_routed_files:
+        print()
+        print("Skipped routed files:")
+        for skipped in result.skipped_routed_files:
+            print(
+                f"- {_workspace_relative_display(skipped.path, workspace_root)}"
+                f" — {skipped.reason}"
+            )
+
+    if result.unassembled_routed_files:
+        print()
+        print("Unassembled routed files:")
+        for path in result.unassembled_routed_files:
+            print(f"- {_workspace_relative_display(path, workspace_root)}")
 
 
 def _print_assignment_submission_assembly(

--- a/quillan/submission_status.py
+++ b/quillan/submission_status.py
@@ -1,0 +1,295 @@
+"""Read-only assignment submission and routed-evidence status."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pds_core.identifiers import validate_identifier
+
+from quillan.assignment_submission_assembly import (
+    SkippedRoutedEvidenceFile,
+    discover_assignment_routed_evidence_status,
+)
+from quillan.storage import assignment_submissions_dir
+from quillan.submission_assembly import RoutedSubmissionEvidence
+from quillan.submission_manifest import load_submission_manifest
+
+
+@dataclass(frozen=True, slots=True)
+class PageStatusSummary:
+    """Read-only status for one manifest page."""
+
+    page_number: int
+    page_state: str
+    selected_evidence_id: str | None
+    evidence_count: int
+    evidence_roles: tuple[str, ...]
+    evidence_states: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class StudentSubmissionStatus:
+    """Read-only submission status for one student."""
+
+    student_id: str
+    manifest_path: Path | None
+    submission_state: str | None
+    pages: tuple[PageStatusSummary, ...]
+    missing_pages: tuple[int, ...]
+    duplicate_pages: tuple[int, ...]
+    needs_rescan_pages: tuple[int, ...]
+    excluded_pages: tuple[int, ...]
+    unselected_present_pages: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AssignmentSubmissionStatus:
+    """Read-only submission and routed-evidence status for one assignment."""
+
+    class_id: str
+    assignment_id: str
+    students_with_manifests: tuple[str, ...]
+    students_with_routed_evidence: tuple[str, ...]
+    students_without_manifests: tuple[str, ...]
+    unassembled_routed_files: tuple[Path, ...]
+    skipped_routed_files: tuple[SkippedRoutedEvidenceFile, ...]
+    student_statuses: tuple[StudentSubmissionStatus, ...]
+
+
+def list_assignment_submission_status(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    *,
+    expected_pages: int | None = None,
+) -> AssignmentSubmissionStatus:
+    """Return read-only submission/evidence status for one assignment."""
+    validate_identifier(class_id, "class_id")
+    validate_identifier(assignment_id, "assignment_id")
+    _validate_expected_pages(expected_pages)
+
+    root = Path(workspace_root).resolve(strict=False)
+    manifests = _load_assignment_manifests(
+        root, class_id, assignment_id
+    )
+    discovery = discover_assignment_routed_evidence_status(
+        root, class_id, assignment_id
+    )
+
+    manifest_students = tuple(manifests)
+    routed_students = tuple(discovery.evidence_by_student)
+    students_without_manifests = tuple(
+        student_id
+        for student_id in routed_students
+        if student_id not in manifests
+    )
+    assembled_paths = {
+        _resolved_evidence_path(root, item["routed_evidence_path"])
+        for _, manifest in manifests.values()
+        for page in manifest["pages"]
+        for item in page["evidence"]
+    }
+    unassembled_routed_files = tuple(
+        sorted(
+            (
+                _resolved_evidence_path(root, item.routed_evidence_path)
+                for items in discovery.evidence_by_student.values()
+                for item in items
+                if _resolved_evidence_path(
+                    root, item.routed_evidence_path
+                )
+                not in assembled_paths
+            ),
+            key=lambda path: str(path).casefold(),
+        )
+    )
+
+    statuses = [
+        _summarize_manifest(student_id, path, manifest)
+        for student_id, (path, manifest) in manifests.items()
+    ]
+    statuses.extend(
+        _summarize_routed_only_student(
+            student_id,
+            discovery.evidence_by_student[student_id],
+            expected_pages,
+        )
+        for student_id in students_without_manifests
+    )
+    statuses.sort(key=lambda status: status.student_id)
+
+    return AssignmentSubmissionStatus(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        students_with_manifests=manifest_students,
+        students_with_routed_evidence=routed_students,
+        students_without_manifests=students_without_manifests,
+        unassembled_routed_files=unassembled_routed_files,
+        skipped_routed_files=discovery.skipped_files,
+        student_statuses=tuple(statuses),
+    )
+
+
+def _load_assignment_manifests(
+    root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> dict[str, tuple[Path, dict[str, Any]]]:
+    submissions_dir = assignment_submissions_dir(
+        root, class_id, assignment_id
+    )
+    if not submissions_dir.exists():
+        return {}
+    if not submissions_dir.is_dir():
+        raise NotADirectoryError(
+            f"Assignment submissions path is not a directory: {submissions_dir}"
+        )
+
+    manifests: dict[str, tuple[Path, dict[str, Any]]] = {}
+    for student_dir in sorted(
+        submissions_dir.iterdir(), key=lambda path: path.name.casefold()
+    ):
+        if not student_dir.is_dir():
+            continue
+        manifest_path = student_dir / "submission.json"
+        if not manifest_path.exists():
+            continue
+        student_id = student_dir.name
+        validate_identifier(student_id, "student_id")
+        manifest = load_submission_manifest(manifest_path)
+        _validate_manifest_identity(
+            manifest,
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            path=manifest_path,
+        )
+        manifests[student_id] = (manifest_path, manifest)
+    return manifests
+
+
+def _validate_manifest_identity(
+    manifest: dict[str, Any],
+    *,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    path: Path,
+) -> None:
+    expected = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+    for field, value in expected.items():
+        if manifest[field] != value:
+            raise ValueError(
+                f"Manifest identity mismatch at {path}: field '{field}' "
+                f"is {manifest[field]!r}, expected {value!r}."
+            )
+
+
+def _summarize_manifest(
+    student_id: str,
+    manifest_path: Path,
+    manifest: dict[str, Any],
+) -> StudentSubmissionStatus:
+    pages = tuple(
+        PageStatusSummary(
+            page_number=page["page_number"],
+            page_state=page["page_state"],
+            selected_evidence_id=page["selected_evidence_id"],
+            evidence_count=len(page["evidence"]),
+            evidence_roles=tuple(
+                item["evidence_role"] for item in page["evidence"]
+            ),
+            evidence_states=tuple(
+                item["evidence_state"] for item in page["evidence"]
+            ),
+        )
+        for page in sorted(
+            manifest["pages"], key=lambda page: page["page_number"]
+        )
+    )
+    return _student_status(
+        student_id=student_id,
+        manifest_path=manifest_path,
+        submission_state=manifest["submission_state"],
+        pages=pages,
+    )
+
+
+def _summarize_routed_only_student(
+    student_id: str,
+    evidence_items: list[RoutedSubmissionEvidence],
+    expected_pages: int | None,
+) -> StudentSubmissionStatus:
+    routed_page_numbers = {item.page_number for item in evidence_items}
+    missing_pages = (
+        tuple(
+            page_number
+            for page_number in range(1, expected_pages + 1)
+            if page_number not in routed_page_numbers
+        )
+        if expected_pages is not None
+        else ()
+    )
+    return StudentSubmissionStatus(
+        student_id=student_id,
+        manifest_path=None,
+        submission_state=None,
+        pages=(),
+        missing_pages=missing_pages,
+        duplicate_pages=(),
+        needs_rescan_pages=(),
+        excluded_pages=(),
+        unselected_present_pages=(),
+    )
+
+
+def _student_status(
+    *,
+    student_id: str,
+    manifest_path: Path,
+    submission_state: str,
+    pages: tuple[PageStatusSummary, ...],
+) -> StudentSubmissionStatus:
+    def pages_with_state(state: str) -> tuple[int, ...]:
+        return tuple(
+            page.page_number for page in pages if page.page_state == state
+        )
+
+    return StudentSubmissionStatus(
+        student_id=student_id,
+        manifest_path=manifest_path,
+        submission_state=submission_state,
+        pages=pages,
+        missing_pages=pages_with_state("missing"),
+        duplicate_pages=pages_with_state("duplicate"),
+        needs_rescan_pages=pages_with_state("needs_rescan"),
+        excluded_pages=pages_with_state("excluded"),
+        unselected_present_pages=tuple(
+            page.page_number
+            for page in pages
+            if page.page_state == "present"
+            and page.selected_evidence_id is None
+        ),
+    )
+
+
+def _validate_expected_pages(expected_pages: int | None) -> None:
+    if (
+        expected_pages is not None
+        and (
+            isinstance(expected_pages, bool)
+            or not isinstance(expected_pages, int)
+            or expected_pages < 1
+        )
+    ):
+        raise ValueError("expected_pages must be a positive integer.")
+
+
+def _resolved_evidence_path(root: Path, value: str | Path) -> Path:
+    return (root / Path(value)).resolve(strict=False)

--- a/tests/test_submission_status.py
+++ b/tests/test_submission_status.py
@@ -1,0 +1,305 @@
+"""Tests for read-only assignment submission status."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.submission_assembly import (
+    RoutedSubmissionEvidence,
+    build_submission_manifest,
+)
+from quillan.submission_manifest import SubmissionManifestError
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+from quillan.submission_status import list_assignment_submission_status
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+TIMESTAMP = "2026-06-22T12:00:00+00:00"
+
+
+def _assignment_dir(workspace: Path) -> Path:
+    return (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+    )
+
+
+def _touch_routed(workspace: Path, filename: str) -> Path:
+    path = _assignment_dir(workspace) / "scans" / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"synthetic evidence")
+    return path
+
+
+def _evidence(
+    page_number: int,
+    filename: str,
+    **kwargs: Any,
+) -> RoutedSubmissionEvidence:
+    return RoutedSubmissionEvidence(
+        page_number=page_number,
+        routed_evidence_path=(
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/{filename}"
+        ),
+        **kwargs,
+    )
+
+
+def _write_status_manifest(workspace: Path, student_id: str = "00107") -> Path:
+    manifest = build_submission_manifest(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        student_id,
+        [
+            _evidence(1, "response_00107_pg_001.pdf"),
+            _evidence(3, "response_00107_pg_003.pdf"),
+            _evidence(
+                3,
+                "response_00107_pg_003__dup_001.pdf",
+                duplicate_number=1,
+            ),
+            _evidence(
+                4,
+                "response_00107_pg_004.pdf",
+                evidence_state="needs_rescan",
+            ),
+            _evidence(
+                5,
+                "response_00107_pg_005.pdf",
+                evidence_role="excluded",
+            ),
+            _evidence(
+                6,
+                "response_00107_pg_006.pdf",
+                evidence_role="candidate",
+            ),
+        ],
+        expected_pages=6,
+        created_at=TIMESTAMP,
+        updated_at=TIMESTAMP,
+    )
+    manifest["submission_state"] = "in_progress"
+    path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, student_id
+    )
+    return write_submission_manifest(path, manifest)
+
+
+def test_manifest_status_reports_all_page_and_evidence_states(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_status_manifest(tmp_path)
+
+    result = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert result.students_with_manifests == ("00107",)
+    status = result.student_statuses[0]
+    assert status.manifest_path == manifest_path
+    assert status.submission_state == "in_progress"
+    assert [page.page_number for page in status.pages] == [1, 2, 3, 4, 5, 6]
+    assert status.missing_pages == (2,)
+    assert status.duplicate_pages == (3,)
+    assert status.needs_rescan_pages == (4,)
+    assert status.excluded_pages == (5,)
+    assert status.unselected_present_pages == (6,)
+    assert status.pages[2].evidence_count == 2
+    assert status.pages[2].evidence_roles == ("candidate", "candidate")
+    assert status.pages[3].evidence_states == ("needs_rescan",)
+
+
+def test_routed_evidence_without_manifest_needs_assembly_without_writes(
+    tmp_path: Path,
+) -> None:
+    _touch_routed(tmp_path, "response_00108_pg_002.pdf")
+    before = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+
+    result = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, expected_pages=3
+    )
+
+    after = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+    assert result.students_with_routed_evidence == ("00108",)
+    assert result.students_without_manifests == ("00108",)
+    assert [path.name for path in result.unassembled_routed_files] == [
+        "response_00108_pg_002.pdf"
+    ]
+    assert result.student_statuses[0].missing_pages == (1, 3)
+    assert before == after
+    assert not list(tmp_path.rglob("submission.json"))
+
+
+def test_student_can_have_both_manifest_and_routed_evidence(
+    tmp_path: Path,
+) -> None:
+    _write_status_manifest(tmp_path)
+    _touch_routed(tmp_path, "response_00107_pg_001.pdf")
+
+    result = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert result.students_with_manifests == ("00107",)
+    assert result.students_with_routed_evidence == ("00107",)
+    assert not result.students_without_manifests
+    assert not result.unassembled_routed_files
+
+
+def test_new_routed_file_for_manifest_student_is_unassembled(
+    tmp_path: Path,
+) -> None:
+    _write_status_manifest(tmp_path)
+    path = _touch_routed(tmp_path, "response_00107_pg_007.pdf")
+
+    result = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert result.unassembled_routed_files == (path,)
+
+
+def test_skipped_routed_files_are_reported_and_sorted(tmp_path: Path) -> None:
+    _touch_routed(tmp_path, "response_00107_pg_zero.pdf")
+    _touch_routed(tmp_path, "debug_page.png")
+
+    result = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert [item.path.name for item in result.skipped_routed_files] == [
+        "debug_page.png",
+        "response_00107_pg_zero.pdf",
+    ]
+    assert "does not match" in result.skipped_routed_files[0].reason
+    assert "malformed" in result.skipped_routed_files[1].reason
+
+
+def test_missing_and_empty_assignment_return_empty_status(
+    tmp_path: Path,
+) -> None:
+    missing = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    assert not missing.student_statuses
+
+    (_assignment_dir(tmp_path) / "scans").mkdir(parents=True)
+    (_assignment_dir(tmp_path) / "submissions").mkdir()
+    empty = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    assert not empty.student_statuses
+    assert not empty.skipped_routed_files
+
+
+def test_invalid_existing_manifest_is_an_error(tmp_path: Path) -> None:
+    path = submission_manifest_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, "00107"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(SubmissionManifestError, match="not valid JSON"):
+        list_assignment_submission_status(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID
+        )
+
+
+def test_expected_pages_does_not_change_existing_manifest_status(
+    tmp_path: Path,
+) -> None:
+    path = _write_status_manifest(tmp_path)
+    original = path.read_bytes()
+
+    result = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, expected_pages=10
+    )
+
+    assert result.student_statuses[0].missing_pages == (2,)
+    assert path.read_bytes() == original
+
+
+def test_cli_prints_status_students_skips_and_relative_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_status_manifest(tmp_path)
+    _touch_routed(tmp_path, "response_00107_pg_001.pdf")
+    _touch_routed(tmp_path, "response_00108_pg_002.pdf")
+    _touch_routed(tmp_path, "notes.txt")
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    before = {
+        path: path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    exit_code = main(
+        [
+            "list-submissions",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            "--expected-pages",
+            "3",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Students with manifests: 1" in output
+    assert "Students with routed evidence: 2" in output
+    assert "Students needing assembly: 1" in output
+    assert "Unassembled routed files: 1" in output
+    assert "- in_progress: 1" in output
+    assert "- present but unselected: 1" in output
+    assert "- 00107: in_progress" in output
+    assert "- 00108: routed evidence exists; no manifest; missing=1,3" in output
+    assert "classes/" in output
+    assert "response_00108_pg_002.pdf" in output
+    assert str(tmp_path) not in output
+    assert before == {
+        path: path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_cli_invalid_manifest_exits_nonzero_and_bad_expected_pages_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = submission_manifest_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, "00107"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(["list-submissions", CLASS_ID, ASSIGNMENT_ID]) == 1
+    assert "could not list submission status" in capsys.readouterr().out
+
+    with pytest.raises(SystemExit) as error:
+        main(
+            [
+                "list-submissions",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                "--expected-pages",
+                "0",
+            ]
+        )
+    assert error.value.code == 2


### PR DESCRIPTION
## Summary

* Added read-only assignment submission/evidence status listing.
* Added `quillan list-submissions <class_id> <assignment_id>`.
* Added `--expected-pages` for routed-evidence students without manifests.
* Added `quillan.submission_status` with read-only assignment status summaries.
* Reused assignment routed-evidence discovery from #74 instead of duplicating filename parsing.
* Reports:

  * students with manifests;
  * students with routed evidence;
  * students needing assembly;
  * unassembled routed files;
  * skipped routed files;
  * submission-state counts;
  * page-state counts;
  * present-but-unselected pages;
  * per-student status summaries.
* Treats invalid existing manifests as errors.
* Preserves read-only behavior: no manifests are created, updated, overwritten, opened, scored, tagged, or modified.
* Added focused tests for manifest summaries, routed evidence without manifests, skipped routed files, empty assignments, invalid manifests, expected-page handling, CLI output, and read-only behavior.
* Updated README and changelog.

Closes #76.

## Validation

* [x] Focused tests — 10 passed
* [x] `python -m pytest` — 485 passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* This is read-only status reporting.
* Does not assemble submissions.
* Does not update manifests.
* Does not overwrite manifests.
* Does not merge review state.
* Does not select evidence.
* Does not open files.
* Does not inspect PDF/image contents.
* Does not route scans.
* Does not extract QR codes.
* Does not split PDFs.
* Does not use OCR, handwriting recognition, AI, scoring, tagging, feedback generation, reports beyond status output, pds-core changes, or pds-sunset changes.
