### PR TITLE
Add local evidence opening support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan open-evidence` and a focused evidence-opening API for safely
+  opening an existing workspace-relative evidence file through the shared
+  `pds-core` system opener, without inspecting or modifying evidence or review
+  state.
 - Added read-only `quillan list-submissions` status reporting for validated
   assignment manifests and routed evidence, including submission/page states,
   present-but-unselected pages, students needing assembly, unassembled routed

--- a/README.md
+++ b/README.md
@@ -272,6 +272,18 @@ Resetting clears only the saved preference and does not delete workspace
 files. In both cases, `PDS_WORKSPACE_ROOT` still takes precedence over the
 saved preference when it is set.
 
+Open one local evidence file with the system default application:
+
+```powershell
+quillan open-evidence classes/<class_id>/assignments/<assignment_id>/scans/<file>
+```
+
+The path must be relative to and remain inside the active PDS workspace.
+Quillan validates that it identifies an existing file, then delegates the
+platform-specific opening behavior to `pds-core`. This command does not
+inspect, parse, modify, select, score, tag, review, or generate feedback from
+the evidence. Student-aware submission lookup and opening remain future work.
+
 Validate a standards profile:
 
 ```powershell

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -414,6 +414,10 @@ Planned work:
   without deleting candidates.
 * Add teacher-controlled evidence selection and review-state updates.
 * Preserve retained-source provenance and workspace-relative artifact paths.
+* Open individual workspace-relative evidence files safely through the shared
+  `pds-core` local opener. Implemented as a low-level helper and
+  `quillan open-evidence`; student-aware submission opening remains future
+  work.
 * Continue supporting plain-text writing evidence where applicable.
 * Count words.
 * Count paragraphs.

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -409,6 +409,9 @@ Inactive historical preservation and end-of-cycle archiving belong to future
    provenance reconstruction, and rescan selection remain future work.
 8. **Teacher review integration.** Present assembled evidence to the teacher
    and allow teacher-controlled lifecycle changes without automated judgment.
+   A low-level `quillan open-evidence` command now validates one existing file
+   inside the active workspace and delegates opening to `pds-core`. It does not
+   select evidence, locate student submissions, or update review state.
 
 Each phase should add focused tests for validation, traversal resistance,
 collision races, preservation on failure, and the absence of unintended

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -27,6 +27,7 @@ from quillan.evidence_filing import (
     RoutedEvidenceFile,
     file_routed_response_evidence,
 )
+from quillan.evidence_opening import EvidenceOpeningError, open_workspace_evidence
 from quillan.menu import launch_menu
 from quillan.route_planning import (
     DecodedResponsePage,
@@ -79,6 +80,9 @@ def main(argv: list[str] | None = None) -> int:
             args.assignment_id,
             expected_pages=args.expected_pages,
         )
+
+    if args.command == "open-evidence":
+        return _handle_open_evidence(args.evidence_path)
 
     if args.command == "workspace" and args.workspace_command == "show":
         return _handle_workspace_show()
@@ -192,6 +196,20 @@ def _build_parser() -> argparse.ArgumentParser:
             "Expected page count used only to show missing pages for students "
             "with routed evidence but no manifest."
         ),
+    )
+
+    open_evidence_parser = subparsers.add_parser(
+        "open-evidence",
+        help="Open a local evidence file from the active PDS workspace.",
+        description=(
+            "Open one workspace-relative local evidence file with the system "
+            "default application. The path must remain inside the active PDS "
+            "workspace."
+        ),
+    )
+    open_evidence_parser.add_argument(
+        "evidence_path",
+        help="Workspace-relative path to an existing local evidence file.",
     )
 
     workspace_parser = subparsers.add_parser(
@@ -378,6 +396,20 @@ def _handle_list_submissions(
         return 1
 
     _print_assignment_submission_status(result, workspace_root)
+    return 0
+
+
+def _handle_open_evidence(evidence_path: str | Path) -> int:
+    """Open one workspace-relative evidence file with the system viewer."""
+    try:
+        workspace_root = resolve_workspace_root()
+        opened = open_workspace_evidence(workspace_root, evidence_path)
+    except (WorkspaceRootError, EvidenceOpeningError) as error:
+        print(f"Error: could not open evidence file: {error}")
+        return 1
+
+    print("Opened evidence file:")
+    print(opened.evidence_relative_path)
     return 0
 
 

--- a/quillan/evidence_opening.py
+++ b/quillan/evidence_opening.py
@@ -1,0 +1,97 @@
+"""Safely open local Quillan evidence from the active PDS workspace."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+
+from pds_core.local_open import LocalOpenError, open_local_path
+
+
+class EvidenceOpeningError(Exception):
+    """Raised when Quillan evidence cannot be opened safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class OpenedEvidence:
+    """Information about a local evidence file opened for review."""
+
+    evidence_path: Path
+    evidence_relative_path: str
+
+
+def resolve_workspace_evidence_path(
+    workspace_root: str | Path,
+    evidence_path: str | Path,
+) -> Path:
+    """Resolve a workspace-relative evidence path that stays in the workspace."""
+    raw_evidence_path = str(evidence_path)
+    stripped_evidence_path = raw_evidence_path.strip()
+
+    if not stripped_evidence_path:
+        raise EvidenceOpeningError("Evidence path must not be empty.")
+    if stripped_evidence_path.lower().startswith(
+        ("http://", "https://", "file://")
+    ):
+        raise EvidenceOpeningError("Evidence path must be a local path, not a URL.")
+
+    candidate = Path(raw_evidence_path)
+    if candidate.is_absolute() or PureWindowsPath(raw_evidence_path).drive:
+        raise EvidenceOpeningError(
+            "Evidence path must be relative to the PDS workspace."
+        )
+
+    try:
+        resolved_workspace_root = _resolve_workspace_root(workspace_root)
+        resolved_evidence_path = (
+            resolved_workspace_root / candidate
+        ).resolve(strict=False)
+        resolved_evidence_path.relative_to(resolved_workspace_root)
+    except (OSError, RuntimeError, ValueError) as error:
+        raise EvidenceOpeningError(
+            "Evidence path must remain inside the PDS workspace."
+        ) from error
+
+    return resolved_evidence_path
+
+
+def open_workspace_evidence(
+    workspace_root: str | Path,
+    evidence_path: str | Path,
+) -> OpenedEvidence:
+    """Open one existing local evidence file inside the active PDS workspace."""
+    resolved_workspace_root = _resolve_workspace_root(workspace_root)
+    resolved_evidence_path = resolve_workspace_evidence_path(
+        resolved_workspace_root,
+        evidence_path,
+    )
+
+    if not resolved_evidence_path.exists():
+        raise EvidenceOpeningError(
+            f"Evidence file does not exist: "
+            f"{resolved_evidence_path.relative_to(resolved_workspace_root).as_posix()}"
+        )
+    if not resolved_evidence_path.is_file():
+        raise EvidenceOpeningError("Evidence path must identify a file.")
+
+    try:
+        opened_path = open_local_path(resolved_evidence_path)
+    except LocalOpenError as error:
+        raise EvidenceOpeningError(f"Could not open evidence file: {error}") from error
+
+    return OpenedEvidence(
+        evidence_path=opened_path.resolve(strict=False),
+        evidence_relative_path=resolved_evidence_path.relative_to(
+            resolved_workspace_root
+        ).as_posix(),
+    )
+
+
+def _resolve_workspace_root(workspace_root: str | Path) -> Path:
+    """Resolve the workspace root with a Quillan-owned error boundary."""
+    try:
+        return Path(workspace_root).resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        raise EvidenceOpeningError(
+            f"Could not resolve the PDS workspace root: {error}"
+        ) from error

--- a/tests/test_cli_open_evidence.py
+++ b/tests/test_cli_open_evidence.py
@@ -1,0 +1,62 @@
+"""CLI tests for local evidence opening."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.evidence_opening import EvidenceOpeningError, OpenedEvidence
+
+
+def test_open_evidence_uses_active_workspace_and_prints_relative_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    relative_path = "classes/class_1/scans/evidence.pdf"
+    calls: list[tuple[Path, str | Path]] = []
+
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    def open_evidence(
+        workspace_root: str | Path,
+        evidence_path: str | Path,
+    ) -> OpenedEvidence:
+        calls.append((Path(workspace_root), evidence_path))
+        return OpenedEvidence(
+            evidence_path=tmp_path / relative_path,
+            evidence_relative_path=relative_path,
+        )
+
+    monkeypatch.setattr(quillan.cli, "open_workspace_evidence", open_evidence)
+
+    assert main(["open-evidence", relative_path]) == 0
+    assert calls == [(tmp_path, relative_path)]
+    assert capsys.readouterr().out == (
+        "Opened evidence file:\n"
+        "classes/class_1/scans/evidence.pdf\n"
+    )
+
+
+@pytest.mark.parametrize("evidence_path", ["missing.pdf", "../outside.pdf"])
+def test_open_evidence_reports_validation_failure(
+    tmp_path: Path,
+    evidence_path: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    def fail_to_open(
+        _workspace_root: str | Path,
+        _evidence_path: str | Path,
+    ) -> OpenedEvidence:
+        raise EvidenceOpeningError("unsafe or missing evidence")
+
+    monkeypatch.setattr(quillan.cli, "open_workspace_evidence", fail_to_open)
+
+    assert main(["open-evidence", evidence_path]) == 1
+    assert "Error: could not open evidence file" in capsys.readouterr().out

--- a/tests/test_evidence_opening.py
+++ b/tests/test_evidence_opening.py
@@ -1,0 +1,124 @@
+"""Tests for safe local evidence opening."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.local_open import LocalOpenError
+import pytest
+
+import quillan.evidence_opening as evidence_opening
+from quillan.evidence_opening import (
+    EvidenceOpeningError,
+    OpenedEvidence,
+    open_workspace_evidence,
+    resolve_workspace_evidence_path,
+)
+
+
+def test_resolves_workspace_relative_evidence_path(tmp_path: Path) -> None:
+    relative_path = Path("classes") / "english12_p3" / "scan.pdf"
+
+    resolved = resolve_workspace_evidence_path(tmp_path, relative_path)
+
+    assert resolved == (tmp_path / relative_path).resolve(strict=False)
+
+
+@pytest.mark.parametrize(
+    "evidence_path",
+    [
+        "",
+        "   ",
+        "http://example.com/evidence.pdf",
+        "HTTPS://example.com/evidence.pdf",
+        "file:///tmp/evidence.pdf",
+        r"C:\outside\evidence.pdf",
+    ],
+)
+def test_rejects_non_relative_local_paths(
+    tmp_path: Path,
+    evidence_path: str,
+) -> None:
+    with pytest.raises(EvidenceOpeningError):
+        resolve_workspace_evidence_path(tmp_path, evidence_path)
+
+
+def test_rejects_absolute_path(tmp_path: Path) -> None:
+    with pytest.raises(EvidenceOpeningError, match="relative"):
+        resolve_workspace_evidence_path(tmp_path, tmp_path / "evidence.pdf")
+
+
+def test_rejects_path_traversal_outside_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+
+    with pytest.raises(EvidenceOpeningError, match="inside"):
+        resolve_workspace_evidence_path(workspace, "../outside.pdf")
+
+
+def test_opens_existing_file_and_returns_workspace_relative_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence_path = tmp_path / "classes" / "class_1" / "scan.pdf"
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"synthetic evidence")
+    before_paths = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+    before_contents = evidence_path.read_bytes()
+    opened_paths: list[Path] = []
+
+    def fake_open_local_path(path: str | Path) -> Path:
+        opened_path = Path(path)
+        opened_paths.append(opened_path)
+        return opened_path
+
+    monkeypatch.setattr(
+        evidence_opening,
+        "open_local_path",
+        fake_open_local_path,
+    )
+
+    result = open_workspace_evidence(
+        tmp_path,
+        "classes/class_1/scan.pdf",
+    )
+
+    assert result == OpenedEvidence(
+        evidence_path=evidence_path.resolve(strict=False),
+        evidence_relative_path="classes/class_1/scan.pdf",
+    )
+    assert opened_paths == [evidence_path.resolve(strict=False)]
+    assert evidence_path.read_bytes() == before_contents
+    assert sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*")) == (
+        before_paths
+    )
+
+
+def test_rejects_missing_evidence_file(tmp_path: Path) -> None:
+    with pytest.raises(EvidenceOpeningError, match="does not exist"):
+        open_workspace_evidence(tmp_path, "missing.pdf")
+
+
+def test_rejects_evidence_directory(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+
+    with pytest.raises(EvidenceOpeningError, match="file"):
+        open_workspace_evidence(tmp_path, "evidence")
+
+
+def test_wraps_pds_core_local_open_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence_path = tmp_path / "evidence.pdf"
+    evidence_path.write_bytes(b"synthetic evidence")
+
+    def fail_to_open(_path: str | Path) -> Path:
+        raise LocalOpenError("viewer unavailable")
+
+    monkeypatch.setattr(evidence_opening, "open_local_path", fail_to_open)
+
+    with pytest.raises(EvidenceOpeningError, match="viewer unavailable") as error:
+        open_workspace_evidence(tmp_path, "evidence.pdf")
+
+    assert isinstance(error.value.__cause__, LocalOpenError)


### PR DESCRIPTION
## Summary

* Added safe local evidence-opening support for Quillan.
* Added `quillan.evidence_opening`.
* Added:

  * `EvidenceOpeningError`
  * `OpenedEvidence`
  * `resolve_workspace_evidence_path(...)`
  * `open_workspace_evidence(...)`
* Added `quillan open-evidence <path>`.
* Resolves evidence paths relative to the active PDS workspace.
* Rejects:

  * empty evidence paths;
  * URL-like paths;
  * absolute paths;
  * Windows drive paths;
  * path traversal outside the workspace;
  * missing files;
  * directories.
* Delegates actual system opening to `pds_core.local_open.open_local_path(...)`.
* Wraps pds-core `LocalOpenError` as `EvidenceOpeningError`.
* Prints workspace-relative paths in CLI output.
* Added focused API and CLI tests.
* Updated README, changelog, and design documentation.

Closes #75.

## Dependency

Depends on pds-core #75:

* `pds_core.local_open.open_local_path`
* `pds_core.local_open.LocalOpenError`

## Validation

* [x] `python -m pytest` — 501 passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* Tests mock the actual local opener; no files are actually opened.
* This is low-level evidence opening only.
* Does not locate student submissions.
* Does not choose selected evidence from a manifest.
* Does not open a student submission for review.
* Does not update review state.
* Does not modify manifests.
* Does not select, exclude, score, tag, evaluate, inspect, parse, OCR, or generate feedback.
* Does not add pds-core behavior.
