### PR TITLE
Add student submission review opener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added read-only `quillan open-submission` support for locating and validating
+  one student's canonical submission manifest, requiring exactly one selected
+  evidence item, and opening its routed evidence through Quillan's existing
+  workspace-safe local evidence opener without changing review state.
 - Added `quillan open-evidence` and a focused evidence-opening API for safely
   opening an existing workspace-relative evidence file through the shared
   `pds-core` system opener, without inspecting or modifying evidence or review

--- a/README.md
+++ b/README.md
@@ -282,7 +282,20 @@ The path must be relative to and remain inside the active PDS workspace.
 Quillan validates that it identifies an existing file, then delegates the
 platform-specific opening behavior to `pds-core`. This command does not
 inspect, parse, modify, select, score, tag, review, or generate feedback from
-the evidence. Student-aware submission lookup and opening remain future work.
+the evidence.
+
+Open the selected routed evidence for one student's canonical submission:
+
+```powershell
+quillan open-submission <class_id> <assignment_id> <student_id>
+```
+
+Quillan loads and validates the student's manifest, verifies its identity, and
+uses the same local evidence-opening support as `open-evidence`. Exactly one
+selected evidence item is currently required. Use `list-submissions` first for
+missing, duplicate, needs-rescan, or unselected submissions. Opening is
+read-only: it does not change review state or select, score, tag, evaluate,
+inspect, OCR, or generate feedback from evidence.
 
 Validate a standards profile:
 
@@ -356,6 +369,8 @@ quillan validate-assignment <assignment.json>
 quillan route-scan <source-file> --payload "<PDS1|...>"
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+quillan open-evidence <workspace-relative-path>
+quillan open-submission <class_id> <assignment_id> <student_id>
 quillan workspace show
 quillan menu
 ```

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -415,9 +415,10 @@ Planned work:
 * Add teacher-controlled evidence selection and review-state updates.
 * Preserve retained-source provenance and workspace-relative artifact paths.
 * Open individual workspace-relative evidence files safely through the shared
-  `pds-core` local opener. Implemented as a low-level helper and
-  `quillan open-evidence`; student-aware submission opening remains future
-  work.
+  `pds-core` local opener. Implemented as a low-level helper,
+  `quillan open-evidence`, and the read-only student-aware
+  `quillan open-submission`, which currently requires exactly one selected
+  evidence item and does not update review state.
 * Continue supporting plain-text writing evidence where applicable.
 * Count words.
 * Count paragraphs.

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -410,8 +410,13 @@ Inactive historical preservation and end-of-cycle archiving belong to future
 8. **Teacher review integration.** Present assembled evidence to the teacher
    and allow teacher-controlled lifecycle changes without automated judgment.
    A low-level `quillan open-evidence` command now validates one existing file
-   inside the active workspace and delegates opening to `pds-core`. It does not
-   select evidence, locate student submissions, or update review state.
+   inside the active workspace and delegates opening to `pds-core`. The
+   read-only `quillan open-submission` command locates a student's canonical
+   validated manifest and opens its single selected routed evidence item
+   through that same helper. It does not select evidence, update review state,
+   score, tag, inspect, OCR, or generate feedback. Missing, duplicate,
+   needs-rescan, and unselected submissions should be inspected with
+   `quillan list-submissions` first.
 
 Each phase should add focused tests for validation, traversal resistance,
 collision races, preservation on failure, and the absence of unintended

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -46,6 +46,11 @@ from quillan.submission_status import (
     AssignmentSubmissionStatus,
     list_assignment_submission_status,
 )
+from quillan.submission_review_opening import (
+    OpenedSubmissionReview,
+    SubmissionReviewOpeningError,
+    open_student_submission_for_review,
+)
 
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
 
@@ -83,6 +88,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "open-evidence":
         return _handle_open_evidence(args.evidence_path)
+
+    if args.command == "open-submission":
+        return _handle_open_submission(
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+        )
 
     if args.command == "workspace" and args.workspace_command == "show":
         return _handle_workspace_show()
@@ -211,6 +223,21 @@ def _build_parser() -> argparse.ArgumentParser:
         "evidence_path",
         help="Workspace-relative path to an existing local evidence file.",
     )
+
+    open_submission_parser = subparsers.add_parser(
+        "open-submission",
+        help="Open the selected evidence for one student submission.",
+        description=(
+            "Load one canonical student submission manifest and open its single "
+            "selected routed evidence file. This command is read-only and "
+            "requires exactly one selected evidence item."
+        ),
+    )
+    open_submission_parser.add_argument("class_id", help="Class identifier.")
+    open_submission_parser.add_argument(
+        "assignment_id", help="Assignment identifier."
+    )
+    open_submission_parser.add_argument("student_id", help="Student identifier.")
 
     workspace_parser = subparsers.add_parser(
         "workspace",
@@ -411,6 +438,42 @@ def _handle_open_evidence(evidence_path: str | Path) -> int:
     print("Opened evidence file:")
     print(opened.evidence_relative_path)
     return 0
+
+
+def _handle_open_submission(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> int:
+    """Open the selected evidence for one canonical student submission."""
+    try:
+        workspace_root = resolve_workspace_root()
+        opened = open_student_submission_for_review(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except (WorkspaceRootError, SubmissionReviewOpeningError) as error:
+        print(f"Error: could not open student submission: {error}")
+        return 1
+
+    _print_opened_submission_review(opened)
+    return 0
+
+
+def _print_opened_submission_review(opened: OpenedSubmissionReview) -> None:
+    """Print concise teacher-facing context for opened submission evidence."""
+    print("Opened submission evidence for review:")
+    print(f"Class: {opened.class_id}")
+    print(f"Assignment: {opened.assignment_id}")
+    print(f"Student: {opened.student_id}")
+    print(f"Submission state: {opened.submission_state}")
+    print(f"Page: {opened.page_number}")
+    print(f"Page state: {opened.page_state}")
+    print(f"Evidence: {opened.evidence_id}")
+    print(f"Path: {opened.evidence_relative_path}")
+    print(f"Manifest: {opened.manifest_relative_path}")
 
 
 def _print_assignment_submission_status(

--- a/quillan/submission_review_opening.py
+++ b/quillan/submission_review_opening.py
@@ -1,0 +1,161 @@
+"""Open selected evidence for one student submission review."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from quillan.evidence_opening import EvidenceOpeningError, open_workspace_evidence
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+
+class SubmissionReviewOpeningError(Exception):
+    """Raised when a student submission cannot be opened for review."""
+
+
+@dataclass(frozen=True, slots=True)
+class OpenedSubmissionReview:
+    """Information about a student submission evidence file opened for review."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    manifest_path: Path
+    manifest_relative_path: str
+    page_number: int
+    evidence_id: str
+    evidence_path: Path
+    evidence_relative_path: str
+    submission_state: str
+    page_state: str
+
+
+def open_student_submission_for_review(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> OpenedSubmissionReview:
+    """Open the single selected routed evidence file for one submission."""
+    try:
+        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except (OSError, RuntimeError, SubmissionManifestPathError) as error:
+        raise SubmissionReviewOpeningError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise SubmissionReviewOpeningError(
+            "Submission manifest does not exist for "
+            f"class={class_id}, assignment={assignment_id}, student={student_id}."
+        )
+
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise SubmissionReviewOpeningError(
+            f"Could not load submission manifest: {error}"
+        ) from error
+
+    _validate_manifest_identity(
+        manifest,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+    page, selected_id = _find_selected_page(manifest)
+    evidence = next(
+        (
+            candidate
+            for candidate in page["evidence"]
+            if candidate["evidence_id"] == selected_id
+        ),
+        None,
+    )
+    if evidence is None:
+        raise SubmissionReviewOpeningError(
+            f"Selected evidence ID '{selected_id}' was not found on "
+            f"page {page['page_number']}."
+        )
+
+    try:
+        opened = open_workspace_evidence(
+            resolved_workspace_root,
+            evidence["routed_evidence_path"],
+        )
+        manifest_relative_path = manifest_path.resolve(strict=False).relative_to(
+            resolved_workspace_root
+        ).as_posix()
+    except (EvidenceOpeningError, OSError, RuntimeError, ValueError) as error:
+        raise SubmissionReviewOpeningError(
+            f"Could not open selected evidence: {error}"
+        ) from error
+
+    return OpenedSubmissionReview(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        manifest_path=manifest_path,
+        manifest_relative_path=manifest_relative_path,
+        page_number=page["page_number"],
+        evidence_id=selected_id,
+        evidence_path=opened.evidence_path,
+        evidence_relative_path=opened.evidence_relative_path,
+        submission_state=manifest["submission_state"],
+        page_state=page["page_state"],
+    )
+
+
+def _validate_manifest_identity(
+    manifest: dict[str, Any],
+    *,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    requested = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+    for field, expected in requested.items():
+        actual = manifest[field]
+        if actual != expected:
+            raise SubmissionReviewOpeningError(
+                f"Submission manifest {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _find_selected_page(
+    manifest: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    selected = [
+        (page, page["selected_evidence_id"])
+        for page in manifest["pages"]
+        if page["selected_evidence_id"] is not None
+    ]
+    if not selected:
+        raise SubmissionReviewOpeningError(
+            "Submission has no selected evidence to open. Use status listing "
+            "to inspect missing, duplicate, needs-rescan, or unselected evidence."
+        )
+    if len(selected) > 1:
+        raise SubmissionReviewOpeningError(
+            "Submission has multiple selected evidence files; open-submission "
+            "currently requires exactly one selected evidence file."
+        )
+
+    page, selected_id = selected[0]
+    return page, selected_id

--- a/tests/test_submission_review_opening.py
+++ b/tests/test_submission_review_opening.py
@@ -1,0 +1,374 @@
+"""Tests for opening selected student submission evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.cli
+import quillan.submission_review_opening
+from quillan.cli import main
+from quillan.evidence_opening import EvidenceOpeningError, OpenedEvidence
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+from quillan.submission_review_opening import (
+    OpenedSubmissionReview,
+    SubmissionReviewOpeningError,
+    open_student_submission_for_review,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+EVIDENCE_PATH = (
+    f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+    "response_00107_pg_001.pdf"
+)
+
+
+def _evidence(
+    evidence_id: str = "evidence_001",
+    *,
+    path: str = EVIDENCE_PATH,
+) -> dict[str, Any]:
+    return {
+        "evidence_id": evidence_id,
+        "routed_evidence_path": path,
+        "evidence_role": "selected",
+        "evidence_state": "active",
+        "duplicate_number": None,
+        "created_at": "2026-06-22T12:00:00+00:00",
+        "retained_source": None,
+        "module_details": {},
+    }
+
+
+def _page(
+    page_number: int = 1,
+    evidence_id: str = "evidence_001",
+) -> dict[str, Any]:
+    return {
+        "page_number": page_number,
+        "page_state": "present",
+        "selected_evidence_id": evidence_id,
+        "evidence": [_evidence(evidence_id)],
+    }
+
+
+def _manifest(*, pages: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [_page()] if pages is None else pages,
+        "created_at": "2026-06-22T12:00:00+00:00",
+        "updated_at": "2026-06-22T12:00:00+00:00",
+        "module_details": {},
+    }
+
+
+def _write_manifest(workspace: Path, manifest: dict[str, Any]) -> Path:
+    path = submission_manifest_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    return write_submission_manifest(path, manifest)
+
+
+def test_success_opens_selected_evidence_and_returns_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = _write_manifest(tmp_path, _manifest())
+    evidence_path = tmp_path / EVIDENCE_PATH
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"synthetic evidence")
+    calls: list[tuple[Path, str | Path]] = []
+
+    def open_evidence(
+        workspace_root: str | Path,
+        relative_path: str | Path,
+    ) -> OpenedEvidence:
+        calls.append((Path(workspace_root), relative_path))
+        return OpenedEvidence(evidence_path, EVIDENCE_PATH)
+
+    monkeypatch.setattr(
+        quillan.submission_review_opening,
+        "open_workspace_evidence",
+        open_evidence,
+    )
+
+    result = open_student_submission_for_review(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+
+    assert calls == [(tmp_path.resolve(), EVIDENCE_PATH)]
+    assert result == OpenedSubmissionReview(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        manifest_path=manifest_path,
+        manifest_relative_path=(
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        page_number=1,
+        evidence_id="evidence_001",
+        evidence_path=evidence_path,
+        evidence_relative_path=EVIDENCE_PATH,
+        submission_state="unreviewed",
+        page_state="present",
+    )
+
+
+def test_missing_manifest_raises(tmp_path: Path) -> None:
+    with pytest.raises(SubmissionReviewOpeningError, match="does not exist"):
+        open_student_submission_for_review(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("class_id", "other_class"),
+        ("assignment_id", "other_assignment"),
+        ("student_id", "00108"),
+    ],
+)
+def test_manifest_identity_mismatch_raises(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    manifest = _manifest()
+    manifest[field] = value
+    _write_manifest(tmp_path, manifest)
+
+    with pytest.raises(SubmissionReviewOpeningError, match=field):
+        open_student_submission_for_review(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        )
+
+
+def test_no_selected_evidence_raises(tmp_path: Path) -> None:
+    page = _page()
+    page["selected_evidence_id"] = None
+    page["evidence"][0]["evidence_role"] = "candidate"
+    _write_manifest(tmp_path, _manifest(pages=[page]))
+
+    with pytest.raises(SubmissionReviewOpeningError, match="no selected evidence"):
+        open_student_submission_for_review(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        )
+
+
+def test_multiple_selected_evidence_files_raise(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        _manifest(pages=[_page(), _page(2, "evidence_002")]),
+    )
+
+    with pytest.raises(SubmissionReviewOpeningError, match="multiple selected"):
+        open_student_submission_for_review(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        )
+
+
+def test_broken_selected_evidence_reference_is_wrapped(tmp_path: Path) -> None:
+    manifest = _manifest()
+    manifest["pages"][0]["selected_evidence_id"] = "missing_evidence"
+    path = submission_manifest_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(
+        SubmissionReviewOpeningError,
+        match="selected_evidence_id does not refer",
+    ):
+        open_student_submission_for_review(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Evidence file does not exist: missing.pdf",
+        "Could not open evidence file: viewer failed",
+    ],
+)
+def test_evidence_opening_failure_is_wrapped(
+    tmp_path: Path,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_manifest(tmp_path, _manifest())
+
+    def fail_to_open(
+        _workspace_root: str | Path,
+        _evidence_path: str | Path,
+    ) -> OpenedEvidence:
+        raise EvidenceOpeningError(message)
+
+    monkeypatch.setattr(
+        quillan.submission_review_opening,
+        "open_workspace_evidence",
+        fail_to_open,
+    )
+
+    with pytest.raises(SubmissionReviewOpeningError, match=message):
+        open_student_submission_for_review(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        )
+
+
+def test_opening_is_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = _write_manifest(tmp_path, _manifest())
+    original_manifest = manifest_path.read_bytes()
+    files_before = sorted(
+        path.relative_to(tmp_path)
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    )
+
+    monkeypatch.setattr(
+        quillan.submission_review_opening,
+        "open_workspace_evidence",
+        lambda _root, _path: OpenedEvidence(
+            tmp_path / EVIDENCE_PATH,
+            EVIDENCE_PATH,
+        ),
+    )
+
+    open_student_submission_for_review(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+
+    assert manifest_path.read_bytes() == original_manifest
+    assert files_before == sorted(
+        path.relative_to(tmp_path)
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    )
+
+
+def test_cli_success_prints_teacher_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    opened = OpenedSubmissionReview(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        manifest_path=tmp_path / "submission.json",
+        manifest_relative_path="classes/class/submissions/00107/submission.json",
+        page_number=1,
+        evidence_id="evidence_001",
+        evidence_path=tmp_path / "evidence.pdf",
+        evidence_relative_path="classes/class/scans/evidence.pdf",
+        submission_state="unreviewed",
+        page_state="present",
+    )
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        quillan.cli,
+        "open_student_submission_for_review",
+        lambda *_args: opened,
+    )
+
+    assert (
+        main(["open-submission", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+    )
+    output = capsys.readouterr().out
+    for expected in (
+        f"Class: {CLASS_ID}",
+        f"Assignment: {ASSIGNMENT_ID}",
+        f"Student: {STUDENT_ID}",
+        "Submission state: unreviewed",
+        "Page: 1",
+        "Page state: present",
+        "Evidence: evidence_001",
+        "Path: classes/class/scans/evidence.pdf",
+        "Manifest: classes/class/submissions/00107/submission.json",
+    ):
+        assert expected in output
+    assert str(tmp_path) not in output
+
+
+def test_cli_failure_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    def fail(*_args: object) -> OpenedSubmissionReview:
+        raise SubmissionReviewOpeningError("manifest is unavailable")
+
+    monkeypatch.setattr(quillan.cli, "open_student_submission_for_review", fail)
+
+    assert (
+        main(["open-submission", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 1
+    )
+    assert capsys.readouterr().out == (
+        "Error: could not open student submission: manifest is unavailable\n"
+    )
+
+
+def test_cli_missing_manifest_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert (
+        main(["open-submission", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 1
+    )
+    assert "Submission manifest does not exist" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

* Added read-only selected-evidence opening for one student submission.
* Added `quillan.submission_review_opening`.
* Added:

  * `SubmissionReviewOpeningError`
  * `OpenedSubmissionReview`
  * `open_student_submission_for_review(...)`
* Added `quillan open-submission <class_id> <assignment_id> <student_id>`.
* Locates the canonical student submission manifest.
* Loads and validates the manifest.
* Verifies manifest identity against the requested class, assignment, and student.
* Requires exactly one selected evidence item.
* Opens the selected routed evidence file through `open_workspace_evidence(...)`.
* Prints teacher-facing review context:

  * class;
  * assignment;
  * student;
  * submission state;
  * page;
  * page state;
  * evidence ID;
  * evidence path;
  * manifest path.
* Added unit and CLI tests.
* Updated README, changelog, and design documentation.

Closes #78.

## Validation

* [x] `python -m pytest` — 515 passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* This is read-only review opening.
* Does not create manifests.
* Does not assemble submissions.
* Does not update manifests.
* Does not select evidence.
* Does not resolve duplicate evidence.
* Does not update review state.
* Does not mark submissions reviewed.
* Does not score, tag, evaluate, inspect evidence contents, OCR, or generate feedback.
* Does not change pds-core or pds-sunset behavior.
