### PR TITLE
Add lightweight submission review state updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan set-review-state` and a focused API for explicit
+  teacher-controlled updates to a validated submission manifest's
+  `submission_state` and `updated_at`, supporting only `unreviewed`,
+  `in_progress`, `needs_rescan`, and `reviewed` while preserving all evidence,
+  selection, provenance, and other manifest content.
 - Added read-only `quillan open-submission` support for locating and validating
   one student's canonical submission manifest, requiring exactly one selected
   evidence item, and opening its routed evidence through Quillan's existing

--- a/README.md
+++ b/README.md
@@ -297,6 +297,18 @@ missing, duplicate, needs-rescan, or unselected submissions. Opening is
 read-only: it does not change review state or select, score, tag, evaluate,
 inspect, OCR, or generate feedback from evidence.
 
+Explicitly update one submission's lightweight teacher review state:
+
+```powershell
+quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+```
+
+Allowed states are `unreviewed`, `in_progress`, `needs_rescan`, and `reviewed`.
+The command changes only `submission_state` and `updated_at` in the validated
+manifest. Opening a submission does not update its state. This command does
+not open or inspect evidence, score, tag, evaluate, run OCR, or generate
+feedback.
+
 Validate a standards profile:
 
 ```powershell
@@ -371,6 +383,7 @@ quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
+quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan workspace show
 quillan menu
 ```

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -413,12 +413,16 @@ Planned work:
 * Represent missing, duplicate, replacement, damaged, and excluded evidence
   without deleting candidates.
 * Add teacher-controlled evidence selection and review-state updates.
+  Lightweight review-state updates are implemented through
+  `quillan set-review-state`, which changes only `submission_state` and
+  `updated_at`; evidence selection remains future work.
 * Preserve retained-source provenance and workspace-relative artifact paths.
 * Open individual workspace-relative evidence files safely through the shared
   `pds-core` local opener. Implemented as a low-level helper,
   `quillan open-evidence`, and the read-only student-aware
   `quillan open-submission`, which currently requires exactly one selected
-  evidence item and does not update review state.
+  evidence item and does not update review state. State changes occur only
+  through the explicit `quillan set-review-state` command.
 * Continue supporting plain-text writing evidence where applicable.
 * Count words.
 * Count paragraphs.

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -416,7 +416,11 @@ Inactive historical preservation and end-of-cycle archiving belong to future
    through that same helper. It does not select evidence, update review state,
    score, tag, inspect, OCR, or generate feedback. Missing, duplicate,
    needs-rescan, and unselected submissions should be inspected with
-   `quillan list-submissions` first.
+   `quillan list-submissions` first. The separate teacher-controlled
+   `quillan set-review-state` command can explicitly set `unreviewed`,
+   `in_progress`, `needs_rescan`, or `reviewed`; it changes only
+   `submission_state` and `updated_at` and does not inspect evidence or perform
+   automated judgment.
 
 Each phase should add focused tests for validation, traversal resistance,
 collision races, preservation on failure, and the absence of unintended

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -51,6 +51,11 @@ from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
     open_student_submission_for_review,
 )
+from quillan.submission_review_state import (
+    SubmissionReviewStateError,
+    UpdatedSubmissionReviewState,
+    update_submission_review_state,
+)
 
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
 
@@ -94,6 +99,14 @@ def main(argv: list[str] | None = None) -> int:
             args.class_id,
             args.assignment_id,
             args.student_id,
+        )
+
+    if args.command == "set-review-state":
+        return _handle_set_review_state(
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            args.state,
         )
 
     if args.command == "workspace" and args.workspace_command == "show":
@@ -238,6 +251,26 @@ def _build_parser() -> argparse.ArgumentParser:
         "assignment_id", help="Assignment identifier."
     )
     open_submission_parser.add_argument("student_id", help="Student identifier.")
+
+    review_state_parser = subparsers.add_parser(
+        "set-review-state",
+        help="Update one student submission's lightweight review state.",
+        description=(
+            "Update only submission_state and updated_at in one canonical "
+            "student submission manifest."
+        ),
+    )
+    review_state_parser.add_argument("class_id", help="Class identifier.")
+    review_state_parser.add_argument(
+        "assignment_id", help="Assignment identifier."
+    )
+    review_state_parser.add_argument("student_id", help="Student identifier.")
+    review_state_parser.add_argument(
+        "state",
+        help=(
+            "Review state: unreviewed, in_progress, needs_rescan, or reviewed."
+        ),
+    )
 
     workspace_parser = subparsers.add_parser(
         "workspace",
@@ -474,6 +507,43 @@ def _print_opened_submission_review(opened: OpenedSubmissionReview) -> None:
     print(f"Evidence: {opened.evidence_id}")
     print(f"Path: {opened.evidence_relative_path}")
     print(f"Manifest: {opened.manifest_relative_path}")
+
+
+def _handle_set_review_state(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    state: str,
+) -> int:
+    """Update one canonical submission's lightweight review state."""
+    try:
+        workspace_root = resolve_workspace_root()
+        updated = update_submission_review_state(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            state,
+        )
+    except (WorkspaceRootError, SubmissionReviewStateError) as error:
+        print(f"Error: could not update submission review state: {error}")
+        return 1
+
+    _print_updated_submission_review_state(updated)
+    return 0
+
+
+def _print_updated_submission_review_state(
+    updated: UpdatedSubmissionReviewState,
+) -> None:
+    """Print a concise teacher-facing review-state update."""
+    print("Updated submission review state:")
+    print(f"Class: {updated.class_id}")
+    print(f"Assignment: {updated.assignment_id}")
+    print(f"Student: {updated.student_id}")
+    print(f"Previous state: {updated.previous_state}")
+    print(f"New state: {updated.new_state}")
+    print(f"Manifest: {updated.manifest_relative_path}")
 
 
 def _print_assignment_submission_status(

--- a/quillan/submission_review_state.py
+++ b/quillan/submission_review_state.py
@@ -1,0 +1,187 @@
+"""Teacher-controlled lightweight submission review-state updates."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.submission_manifest import (
+    ALLOWED_SUBMISSION_STATES,
+    SubmissionManifestError,
+    load_submission_manifest,
+    validate_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+
+class SubmissionReviewStateError(Exception):
+    """Raised when a submission review state cannot be updated safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class UpdatedSubmissionReviewState:
+    """Information about a submission review-state update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    manifest_path: Path
+    manifest_relative_path: str
+    previous_state: str
+    new_state: str
+    updated_at: str
+
+
+def update_submission_review_state(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    state: str,
+    *,
+    updated_at: datetime | str | None = None,
+) -> UpdatedSubmissionReviewState:
+    """Update only the lightweight review state for one student submission."""
+    if state not in ALLOWED_SUBMISSION_STATES:
+        allowed = ", ".join(sorted(ALLOWED_SUBMISSION_STATES))
+        raise SubmissionReviewStateError(
+            f"Invalid submission review state {state!r}. Allowed states: {allowed}."
+        )
+
+    try:
+        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except (OSError, RuntimeError, SubmissionManifestPathError) as error:
+        raise SubmissionReviewStateError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise SubmissionReviewStateError(
+            "Submission manifest does not exist for "
+            f"class={class_id}, assignment={assignment_id}, student={student_id}."
+        )
+
+    try:
+        relative_path = manifest_path.resolve(strict=False).relative_to(
+            resolved_workspace_root
+        ).as_posix()
+        manifest = load_submission_manifest(manifest_path)
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        SubmissionManifestError,
+    ) as error:
+        raise SubmissionReviewStateError(
+            f"Could not load submission manifest: {error}"
+        ) from error
+
+    _validate_manifest_identity(
+        manifest,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+    normalized_updated_at = _normalize_timestamp(updated_at)
+    previous_state = manifest["submission_state"]
+    updated_manifest = copy.deepcopy(manifest)
+    updated_manifest["submission_state"] = state
+    updated_manifest["updated_at"] = normalized_updated_at
+
+    try:
+        validate_submission_manifest(updated_manifest)
+        write_submission_manifest(
+            manifest_path,
+            updated_manifest,
+            overwrite=True,
+        )
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        SubmissionManifestError,
+        SubmissionManifestPathError,
+    ) as error:
+        raise SubmissionReviewStateError(
+            f"Could not write submission manifest: {error}"
+        ) from error
+
+    return UpdatedSubmissionReviewState(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        manifest_path=manifest_path,
+        manifest_relative_path=relative_path,
+        previous_state=previous_state,
+        new_state=state,
+        updated_at=normalized_updated_at,
+    )
+
+
+def _validate_manifest_identity(
+    manifest: dict[str, Any],
+    *,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    requested = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+    for field, expected in requested.items():
+        actual = manifest[field]
+        if actual != expected:
+            raise SubmissionReviewStateError(
+                f"Submission manifest {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise SubmissionReviewStateError(
+                "updated_at datetime must be timezone-aware."
+            )
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise SubmissionReviewStateError(
+            "updated_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+
+    try:
+        validate_submission_manifest(
+            {
+                "schema_version": "1",
+                "module": "quillan",
+                "record_type": "submission_manifest",
+                "class_id": "timestamp_validation",
+                "assignment_id": "timestamp_validation",
+                "student_id": "timestamp_validation",
+                "expected_pages": None,
+                "submission_state": "unreviewed",
+                "pages": [],
+                "created_at": value,
+                "updated_at": value,
+                "module_details": {},
+            }
+        )
+    except SubmissionManifestError as error:
+        raise SubmissionReviewStateError(
+            f"Invalid updated_at timestamp: {error}"
+        ) from error
+    return value

--- a/tests/test_submission_review_state.py
+++ b/tests/test_submission_review_state.py
@@ -1,0 +1,430 @@
+"""Tests for teacher-controlled submission review-state updates."""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.cli
+import quillan.submission_review_state
+from quillan.cli import main
+from quillan.submission_manifest import (
+    ALLOWED_SUBMISSION_STATES,
+    SubmissionManifestError,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+    write_submission_manifest,
+)
+from quillan.submission_review_state import (
+    SubmissionReviewStateError,
+    UpdatedSubmissionReviewState,
+    update_submission_review_state,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
+UPDATED_TIMESTAMP = "2026-06-22T15:30:00+00:00"
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [
+                    {
+                        "evidence_id": "evidence_001",
+                        "routed_evidence_path": (
+                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            "scans/response_00107_pg_001.pdf"
+                        ),
+                        "evidence_role": "selected",
+                        "evidence_state": "active",
+                        "duplicate_number": None,
+                        "created_at": ORIGINAL_TIMESTAMP,
+                        "retained_source": {
+                            "source_scan_id": "scan_001",
+                            "source_filename": "source.pdf",
+                            "source_sha256": "a" * 64,
+                            "retained_source_path": (
+                                "routing/source_scans/scan_001/source.pdf"
+                            ),
+                            "source_page_number": 1,
+                        },
+                        "module_details": {"source": "synthetic"},
+                    }
+                ],
+            }
+        ],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {"teacher_workflow": "paper"},
+    }
+
+
+def _write_manifest(
+    workspace: Path,
+    manifest: dict[str, Any] | None = None,
+) -> Path:
+    path = submission_manifest_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    return write_submission_manifest(
+        path,
+        _manifest() if manifest is None else manifest,
+    )
+
+
+def test_success_updates_state_and_timestamp_only(tmp_path: Path) -> None:
+    original = _manifest()
+    manifest_path = _write_manifest(tmp_path, original)
+
+    result = update_submission_review_state(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "in_progress",
+        updated_at=UPDATED_TIMESTAMP,
+    )
+
+    expected_relative_path = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/submission.json"
+    )
+    assert result == UpdatedSubmissionReviewState(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        manifest_path=manifest_path,
+        manifest_relative_path=expected_relative_path,
+        previous_state="unreviewed",
+        new_state="in_progress",
+        updated_at=UPDATED_TIMESTAMP,
+    )
+
+    written = json.loads(manifest_path.read_text(encoding="utf-8"))
+    expected = copy.deepcopy(original)
+    expected["submission_state"] = "in_progress"
+    expected["updated_at"] = UPDATED_TIMESTAMP
+    assert written == expected
+    assert written["pages"] == original["pages"]
+    assert written["created_at"] == original["created_at"]
+    assert written["module_details"] == original["module_details"]
+
+
+@pytest.mark.parametrize("state", sorted(ALLOWED_SUBMISSION_STATES))
+def test_all_allowed_states_are_accepted(tmp_path: Path, state: str) -> None:
+    _write_manifest(tmp_path)
+
+    result = update_submission_review_state(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        state,
+        updated_at=UPDATED_TIMESTAMP,
+    )
+
+    assert result.new_state == state
+
+
+def test_invalid_state_raises_without_rewriting(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path)
+    original = path.read_bytes()
+
+    with pytest.raises(SubmissionReviewStateError, match="Invalid"):
+        update_submission_review_state(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "graded",
+        )
+
+    assert path.read_bytes() == original
+
+
+def test_missing_manifest_raises(tmp_path: Path) -> None:
+    with pytest.raises(SubmissionReviewStateError, match="does not exist"):
+        update_submission_review_state(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "reviewed",
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("class_id", "other_class"),
+        ("assignment_id", "other_assignment"),
+        ("student_id", "00108"),
+    ],
+)
+def test_manifest_identity_mismatch_raises_without_rewriting(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    manifest = _manifest()
+    manifest[field] = value
+    path = _write_manifest(tmp_path, manifest)
+    original = path.read_bytes()
+
+    with pytest.raises(SubmissionReviewStateError, match=field):
+        update_submission_review_state(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "reviewed",
+        )
+
+    assert path.read_bytes() == original
+
+
+def test_invalid_existing_manifest_raises_without_rewriting(tmp_path: Path) -> None:
+    path = submission_manifest_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    original = path.read_bytes()
+
+    with pytest.raises(SubmissionReviewStateError, match="not valid JSON"):
+        update_submission_review_state(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "reviewed",
+        )
+
+    assert path.read_bytes() == original
+
+
+def test_timezone_aware_datetime_is_accepted(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    timestamp = datetime(2026, 6, 22, 11, 30, tzinfo=timezone.utc)
+
+    result = update_submission_review_state(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "reviewed",
+        updated_at=timestamp,
+    )
+
+    assert result.updated_at == timestamp.isoformat()
+
+
+def test_naive_datetime_is_rejected_without_rewriting(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path)
+    original = path.read_bytes()
+
+    with pytest.raises(SubmissionReviewStateError, match="timezone-aware"):
+        update_submission_review_state(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "reviewed",
+            updated_at=datetime(2026, 6, 22, 11, 30),
+        )
+
+    assert path.read_bytes() == original
+
+
+def test_invalid_timestamp_string_is_rejected(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+
+    with pytest.raises(SubmissionReviewStateError, match="Invalid updated_at"):
+        update_submission_review_state(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "reviewed",
+            updated_at="2026-06-22T11:30:00",
+        )
+
+
+def test_generated_timestamp_is_utc_and_manifest_valid(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+
+    result = update_submission_review_state(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "reviewed",
+    )
+
+    parsed = datetime.fromisoformat(result.updated_at)
+    assert parsed.utcoffset() == timezone.utc.utcoffset(parsed)
+
+
+def test_write_failure_is_wrapped_and_original_remains(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_manifest(tmp_path)
+    original = path.read_bytes()
+
+    def fail_write(*_args: object, **_kwargs: object) -> Path:
+        raise SubmissionManifestPathError("synthetic write failure")
+
+    monkeypatch.setattr(
+        quillan.submission_review_state,
+        "write_submission_manifest",
+        fail_write,
+    )
+
+    with pytest.raises(SubmissionReviewStateError, match="synthetic write failure"):
+        update_submission_review_state(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "reviewed",
+        )
+
+    assert path.read_bytes() == original
+
+
+def test_update_validation_failure_is_wrapped_and_original_remains(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_manifest(tmp_path)
+    original = path.read_bytes()
+
+    def fail_validation(_manifest: dict[str, Any]) -> None:
+        raise SubmissionManifestError("synthetic validation failure")
+
+    monkeypatch.setattr(
+        quillan.submission_review_state,
+        "validate_submission_manifest",
+        fail_validation,
+    )
+
+    with pytest.raises(
+        SubmissionReviewStateError,
+        match="synthetic validation failure",
+    ):
+        update_submission_review_state(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "reviewed",
+        )
+
+    assert path.read_bytes() == original
+
+
+def test_cli_success_prints_teacher_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    relative_path = (
+        "classes/class/assignments/assignment/submissions/00107/submission.json"
+    )
+    updated = UpdatedSubmissionReviewState(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        manifest_path=tmp_path / "submission.json",
+        manifest_relative_path=relative_path,
+        previous_state="unreviewed",
+        new_state="in_progress",
+        updated_at=UPDATED_TIMESTAMP,
+    )
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        quillan.cli,
+        "update_submission_review_state",
+        lambda *_args: updated,
+    )
+
+    assert (
+        main(
+            [
+                "set-review-state",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "in_progress",
+            ]
+        )
+        == 0
+    )
+    assert capsys.readouterr().out == (
+        "Updated submission review state:\n"
+        f"Class: {CLASS_ID}\n"
+        f"Assignment: {ASSIGNMENT_ID}\n"
+        f"Student: {STUDENT_ID}\n"
+        "Previous state: unreviewed\n"
+        "New state: in_progress\n"
+        f"Manifest: {relative_path}\n"
+    )
+
+
+def test_cli_failure_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    def fail(*_args: object) -> UpdatedSubmissionReviewState:
+        raise SubmissionReviewStateError("manifest is unavailable")
+
+    monkeypatch.setattr(quillan.cli, "update_submission_review_state", fail)
+
+    assert (
+        main(
+            [
+                "set-review-state",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "reviewed",
+            ]
+        )
+        == 1
+    )
+    assert capsys.readouterr().out == (
+        "Error: could not update submission review state: "
+        "manifest is unavailable\n"
+    )


### PR DESCRIPTION
## Summary

* Added teacher-controlled lightweight submission review-state updates.
* Added `quillan.submission_review_state`.
* Added:

  * `SubmissionReviewStateError`
  * `UpdatedSubmissionReviewState`
  * `update_submission_review_state(...)`
* Added `quillan set-review-state <class_id> <assignment_id> <student_id> <state>`.
* Supports the existing manifest submission states:

  * `unreviewed`
  * `in_progress`
  * `needs_rescan`
  * `reviewed`
* Updates only:

  * `submission_state`
  * `updated_at`
* Validates:

  * requested state;
  * timestamp;
  * canonical manifest path;
  * manifest identity;
  * updated manifest contract.
* Wraps manifest load, validation, and writer-layer failures as `SubmissionReviewStateError`.
* Writes through the existing validated manifest writer with explicit overwrite.
* Preserves pages, evidence records, selected evidence IDs, provenance, `created_at`, and module details.
* Added focused unit and CLI tests.
* Updated README, changelog, and design documentation.

Closes #77.

## Validation

* [x] `python -m pytest` — 534 passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* This command is intentionally narrow.
* It does not open evidence files.
* It does not assemble submissions.
* It does not change page state.
* It does not change selected evidence.
* It does not modify evidence records, evidence roles, evidence states, or retained-source provenance.
* It does not score, tag, comment, evaluate, OCR, generate feedback, or write reports.
* It does not change pds-core or pds-sunset behavior.
