### PR TITLE
Document reviewable evidence workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ planning and do not by themselves represent releases.
 
 ### Changed
 
+- Documented the v0.6 reviewable-evidence workflow, including retained source
+  scans, routed evidence, student submission manifests, local evidence opening,
+  student submission opening, status listing, and lightweight review-state
+  updates.
 - Refined routed-evidence assembly so callers can preserve candidate,
   replacement, and excluded roles plus active, damaged, needs-rescan, and
   excluded states. Only a single ordinary active item with no explicit role is

--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ Quillan currently supports:
   when available, without copying review artifacts;
 - a direct `route-scan` command for already-decoded payloads that orchestrates
   the existing parser, route planner, evidence filer, and failure review
-  helpers; and
+  helpers;
+- read-only assignment submission status listing, workspace-safe local evidence
+  opening, and student-aware selected-evidence opening; and
+- explicit, teacher-controlled lightweight submission review-state updates
+  that change only review metadata;
 - synthetic examples and fixtures for safe testing and documentation.
 
 Printable response generation is exposed through the teacher-facing menu and
@@ -97,6 +101,77 @@ in `scans/source/YYYY-MM-DD/`, canonical routing review records belong in
 `scans/review/`, and assignment-level `scans/` contains routed evidence rather
 than canonical source retention. QR extraction, PDF splitting, OCR, and
 review-state updates remain outside the direct routing and assembly commands.
+
+## Reviewable Evidence Workflow
+
+Quillan's v0.6 workflow separates retained source scans, routed evidence, and
+student submission manifests.
+
+A **retained source scan** is the canonical active source copy Quillan keeps in
+the source scan store during active scan intake. **Routed evidence** is a file
+copied or derived from retained source material and filed under an assignment's
+`scans/` directory for student/assignment review. A **student submission
+manifest** is the structured record connecting one student and assignment to
+pages, page states, one or more evidence records, selected evidence, and
+provenance.
+
+A routed evidence file by itself is not a complete student submission. Routing
+does not mean that work is complete, reviewed, scored, or ready for feedback.
+
+The supported teacher/developer sequence is:
+
+1. The teacher obtains or selects a local source file.
+2. Quillan receives an already-decoded Quillan PDS1 payload.
+3. `route-scan` retains the source scan and files routed assignment evidence.
+4. If routing cannot safely complete, Quillan preserves failure metadata under
+   `scans/review/` rather than silently discarding the failure.
+5. `assemble-submissions` creates missing student submission manifests from
+   routed evidence.
+6. `list-submissions` reports assignment status without writing files.
+7. `open-submission` opens the selected evidence for a specific student.
+8. The teacher reads and evaluates the evidence in the local system viewer.
+9. `set-review-state` records lightweight review progress when the teacher
+   chooses.
+
+Opening evidence and updating review state are separate teacher-controlled
+actions. Opening a file never marks a submission reviewed.
+
+The commands in this workflow are:
+
+```powershell
+quillan route-scan <source-file> --payload "<PDS1 payload>"
+quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
+quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+quillan open-evidence <workspace-relative-evidence-path>
+quillan open-submission <class_id> <assignment_id> <student_id>
+quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+```
+
+- `route-scan` retains one selected source scan and files routed evidence from
+  an already-decoded payload; it does not decode QR codes or assemble a
+  submission.
+- `assemble-submissions` creates missing manifests from routed filenames, or
+  fully regenerates them with `--overwrite`; it does not inspect file contents
+  or choose among ambiguous duplicate evidence.
+- `list-submissions` gives a read-only overview of manifests, routed evidence,
+  missing, duplicate, needs-rescan, and excluded pages, present-but-unselected
+  evidence, and students needing assembly; it does not create or modify files.
+- `open-evidence` opens one workspace-relative local evidence file as a
+  low-level helper; it does not determine which student submission to review.
+- `open-submission` opens one student's selected evidence and requires exactly
+  one selected evidence item; it does not update review metadata.
+- `set-review-state` updates only the manifest's `submission_state` and
+  `updated_at`; it does not inspect evidence or make a review decision.
+
+Allowed review states are `unreviewed`, `in_progress`, `needs_rescan`, and
+`reviewed`. The review-state update is metadata-only and occurs only when the
+teacher explicitly requests it.
+
+Quillan v0.6 does not perform OCR, handwriting recognition, PDF text
+extraction, AI scoring, AI feedback, AI suggestions, automatic grading,
+automatic review-state updates, automatic evidence selection among duplicates,
+rubric scoring, tagging, comment entry, feedback export, or report generation.
+The teacher remains responsible for reading and evaluating student work.
 
 ## Current Non-Goals
 

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -22,6 +22,10 @@ Quillan currently has:
 * teacher-facing writing assignment config creation and read-only validation;
 * teacher-facing combined printable response class-packet generation from
   existing canonical rosters and assignment configs;
+* retained source scan routing and routed assignment evidence filing;
+* student submission manifest assembly and read-only status listing;
+* local evidence opening and student submission opening;
+* teacher-controlled lightweight review-state updates;
 * automated tests for standards validation and CLI behavior;
 * configured development checks using `pytest`, `ruff`, and `mypy`.
 
@@ -202,13 +206,36 @@ automatically. Assignment-level filename discovery and assembly from existing
 routed evidence is implemented through `quillan assemble-submissions`.
 Assembly does not inspect evidence contents, reconstruct retained-source
 provenance, merge manifests, or preserve prior teacher review state during
-overwrite; teacher selection and review-state updates remain future workflows.
+overwrite. Evidence selection remains a future workflow; lightweight
+review-state updates are implemented as a separate teacher-controlled,
+metadata-only command.
 
 Target milestone:
 
 ```text
 v0.6.0 — Reviewable Evidence and Submission Assembly
 ```
+
+The completed/current v0.6 workflow includes:
+
+* retained source scan routing into the active source scan store;
+* routed evidence filing under assignment `scans/`;
+* student submission manifest assembly from routed evidence;
+* read-only submission and evidence status listing;
+* workspace-safe local evidence opening;
+* student submission opening for exactly one selected evidence item;
+* lightweight review-state updates limited to `submission_state` and
+  `updated_at`; and
+* end-to-end workflow documentation.
+
+Smoke testing remains pending after the documentation update. v0.6 does not
+include OCR, handwriting recognition, PDF text extraction, automatic evidence
+selection, automatic grading, automatic review-state updates, AI scoring, AI
+feedback, AI suggestions, rubric scoring, tagging, comment entry, feedback
+export, or report generation.
+
+Teacher tags, teacher comments, rubric/score entry, feedback export, and
+reporting remain likely v0.7 work rather than v0.6 scope.
 
 The first successful-write helper is implemented in `quillan.evidence_filing`.
 It accepts an existing successful `RoutePlan`, retains the selected source
@@ -375,6 +402,8 @@ Completed work:
 * Add the Printable Response Pages submenu for combined class-packet
   generation.
 * Add a direct `route-scan` command for already-decoded Quillan PDS1 payloads.
+* Add `assemble-submissions`, `list-submissions`, `open-evidence`,
+  `open-submission`, and `set-review-state`.
 * Add CLI tests.
 
 Remaining possible work:
@@ -404,7 +433,7 @@ Likely first commands:
 
 ### Phase 6 — Submissions and Requirements
 
-Planned work:
+Completed reviewable-evidence work:
 
 * Implement loading and validation for the documented version `1` submission
   manifest.
@@ -412,10 +441,8 @@ Planned work:
 * Assemble routed evidence into teacher-controlled manifests.
 * Represent missing, duplicate, replacement, damaged, and excluded evidence
   without deleting candidates.
-* Add teacher-controlled evidence selection and review-state updates.
-  Lightweight review-state updates are implemented through
-  `quillan set-review-state`, which changes only `submission_state` and
-  `updated_at`; evidence selection remains future work.
+* Add lightweight review-state updates through `quillan set-review-state`,
+  changing only `submission_state` and `updated_at`.
 * Preserve retained-source provenance and workspace-relative artifact paths.
 * Open individual workspace-relative evidence files safely through the shared
   `pds-core` local opener. Implemented as a low-level helper,
@@ -423,6 +450,10 @@ Planned work:
   `quillan open-submission`, which currently requires exactly one selected
   evidence item and does not update review state. State changes occur only
   through the explicit `quillan set-review-state` command.
+
+Remaining requirements and review work:
+
+* Add teacher-controlled evidence selection and duplicate resolution.
 * Continue supporting plain-text writing evidence where applicable.
 * Count words.
 * Count paragraphs.

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -2,11 +2,13 @@
 
 ## Overview
 
-This design describes how a future Quillan scan router should accept a scanned
-writing-response page with an already-decoded PDS1 payload, validate its page
-identity, and select a safe location in the Paper Data Suite workspace.
+This design describes how Quillan accepts a selected writing-response scan with
+an already-decoded PDS1 payload, validates its page identity, retains the active
+source copy, and files routed evidence in the Paper Data Suite workspace. It
+also describes how that evidence feeds the v0.6 student submission and review
+workflow.
 
-Future Quillan scan routing must follow the shared active scan contract defined
+Quillan scan routing follows the shared active scan contract defined
 by `pds-core` in `docs/active_scan_contract.md`. That contract owns active
 source retention, routing review, shared failure metadata, and provenance
 semantics. This document adds only Quillan-specific response-page validation,
@@ -34,7 +36,8 @@ preservation through `quillan.routing_review`, writing shared failure records
 under `scans/review/`. The direct
 `quillan route-scan <source-file> --payload "<PDS1|...>"` command orchestrates
 these slices for a caller-supplied decoded payload. It does not implement QR
-extraction, PDF splitting, submission assembly, image processing, or OCR.
+extraction, PDF splitting, image processing, or OCR. Submission assembly is a
+separate implemented step through `quillan assemble-submissions`.
 
 ## Design Goals
 
@@ -318,7 +321,7 @@ identity. Retained-source provenance is recorded only when available, and a
 supplied review artifact path is recorded only as workspace-relative metadata;
 the helper does not copy that artifact.
 
-## Relationship to Submissions
+## Relationship to Reviewable Evidence and Submissions
 
 A routed scan page is evidence derived or copied from a retained source scan,
 not automatically a reviewed submission. Routing a page must not:
@@ -337,9 +340,12 @@ The focused submission assembly API can create that record from
 caller-provided routed evidence metadata, automatically selecting only
 unambiguous ordinary active pages and preserving replacement, damaged,
 needs-rescan, excluded, and duplicate evidence for later review. Explicit
-candidate roles also remain unselected. It does not scan folders, infer teacher
-choice from recency or role, or update an existing review record. The original
-routed files remain traceable to the canonical retained source after linking.
+candidate roles also remain unselected. The `quillan assemble-submissions`
+command discovers supported routed filenames in the assignment `scans/`
+directory and creates missing manifests. It does not inspect evidence contents,
+infer teacher choice among ambiguous duplicates, merge existing manifests, or
+update review metadata. The original routed files remain traceable to the
+canonical retained source after linking when that provenance is available.
 
 The canonical record location is:
 
@@ -352,7 +358,28 @@ paths, page and evidence states, nullable teacher selection, and provenance.
 It preserves duplicate, replacement, damaged, and excluded evidence rather
 than overwriting or deleting candidates. Loading, validation, path helpers,
 safe writing, and focused new-manifest assembly are implemented independently
-of `route-scan`; teacher review commands and state updates are not.
+of `route-scan`.
+
+The supported review sequence after routing and assembly is deliberately
+small:
+
+1. `quillan list-submissions <class_id> <assignment_id>` reports manifests,
+   routed evidence, missing pages, duplicate pages, needs-rescan pages,
+   excluded pages, present-but-unselected evidence, and students needing
+   assembly without modifying files.
+2. `quillan open-evidence <path>` opens a specific workspace-relative evidence
+   file as a low-level local helper; it has no student-submission context.
+3. `quillan open-submission <class_id> <assignment_id> <student_id>` loads the
+   canonical manifest and opens its evidence only when exactly one item is
+   selected.
+4. The teacher reviews the evidence in the system viewer.
+5. `quillan set-review-state <class_id> <assignment_id> <student_id> <state>`
+   may then set `unreviewed`, `in_progress`, `needs_rescan`, or `reviewed`.
+
+Opening evidence and updating review state are separate actions. The
+review-state command is teacher-controlled and metadata-only: it changes only
+`submission_state` and `updated_at`. Routed evidence never automatically
+implies reviewed work.
 
 Quillan owns the manifest contract, submission assembly, page
 completeness rules, teacher review and rescan decisions, and any future
@@ -428,13 +455,16 @@ submission mutations.
 
 ## Out of Scope
 
-The current direct decoded-payload routing slice does not implement:
+The v0.6 reviewable-evidence workflow does not implement:
 
 * end-to-end production scan intake automation;
 * QR detection or extraction;
-* PDF splitting, image processing, or OCR;
-* submission assembly or production roster workflows;
-* requirements checking, tagging, scoring, feedback, or reporting;
-* AI tagging, scoring, feedback, or automatic grading;
+* PDF splitting, PDF text extraction, image processing, OCR, or handwriting
+  recognition;
+* automatic evidence selection among duplicates;
+* automatic review-state updates;
+* requirements checking, rubric scoring, tagging, teacher comment entry,
+  feedback export, or report generation;
+* AI suggestions, AI scoring, AI feedback, or automatic grading;
 * menu or workspace-settings routing workflows; or
 * changes to `pds-core`, `pds-scoreform`, or Python behavior.


### PR DESCRIPTION
## Summary

* Documented the v0.6 reviewable-evidence workflow.
* Updated README with end-to-end workflow and command boundaries.
* Updated the development plan to reflect the current v0.6/v0.7 boundary.
* Updated scan routing design documentation to connect:

  * retained source scans;
  * routed evidence;
  * student submission manifests;
  * local evidence opening;
  * student submission opening;
  * lightweight review-state updates;
  * review metadata.
* Added an unreleased changelog entry.
* Clarified that v0.6 does not include OCR, AI scoring, AI feedback, automatic grading, tagging, scoring, comments, feedback export, or reporting.

Closes #79.

## Validation

* [x] `python -m pytest` — 534 passed
* [x] `python -m ruff check .`
* [x] `python -m mypy .`
* [x] `git diff --check`
* [x] `.\run_tests.ps1`

## Notes

* Documentation-only change.
* No runtime source files changed.
* No test source files changed.
* Does not add commands.
* Does not change manifest behavior.
* Does not change routing behavior.
* Does not change review-state behavior.
* Does not change pds-core or pds-sunset behavior.
