### PR TITLE
docs: define v0.7 review record contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ planning and do not by themselves represent releases.
 
 ### Changed
 
+- Defined the v0.7 canonical `review.json` contract, separating
+  teacher-entered notes, tags, criterion scores, selected comments, and
+  `review_state` from the `submission.json` evidence manifest.
+- Reconciled older `tags.json`, `scores.json`, and `feedback.md` design
+  language: the first two are historical concepts, while feedback and summary
+  files are derived exports from the canonical review record.
 - Documented the v0.6 reviewable-evidence workflow, including retained source
   scans, routed evidence, student submission manifests, local evidence opening,
   student submission opening, status listing, and lightweight review-state
@@ -27,6 +33,9 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a synthetic submission review record demonstrating notes, positive and
+  developing tags, a criterion score, selected reusable feedback language,
+  evidence references, and timezone-aware timestamps.
 - Added a synthetic v0.6 reviewable-evidence smoke test covering routed
   evidence, submission assembly, manifest validation, status listing, mocked
   submission opening, review-state updates, and non-destructive behavior.

--- a/README.md
+++ b/README.md
@@ -505,6 +505,9 @@ Run the complete validation sequence, including the diff whitespace check:
 Quillan's data contracts are documented in
 [`docs/data_contracts.md`](docs/data_contracts.md).
 
+The canonical v0.7 teacher-review `review.json` contract is documented in
+[`docs/review_record_contract.md`](docs/review_record_contract.md).
+
 The printable response contract and implemented generator are described in
 [`docs/printable_response_template.md`](docs/printable_response_template.md).
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -3,8 +3,8 @@
 Quillan stores structured evidence about student writing using local files.
 
 These contracts describe the expected file formats for standards profiles,
-assignments, submissions, requirements checks, tags, scores, feedback, and
-reports.
+assignments, submissions, teacher review, requirements checks, feedback
+exports, and reports.
 
 Standards profiles, assignment configurations, the legacy text-oriented
 submission metadata shape, and the reviewable-evidence submission manifest
@@ -12,9 +12,9 @@ have implemented Python validation support. New-manifest writing and assembly
 from caller-provided evidence metadata are implemented; evidence discovery,
 merging, and state-changing review workflows are not. The writing-response
 payload contract is implemented and used by printable PDF generation.
-Requirements, tagging, scoring, feedback, and reporting records remain
-contracts for teacher-controlled workflows that are not yet implemented end
-to end.
+Requirements, teacher-review records, feedback exports, and reporting records
+remain contracts for teacher-controlled workflows that are not yet
+implemented end to end.
 
 For the expected workspace layout and file lifecycle of these records, see
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
@@ -22,6 +22,10 @@ For the expected workspace layout and file lifecycle of these records, see
 For the teacher-controlled relationship among evidence, review artifacts,
 scores, feedback, and reports, see
 [`teacher_review_model.md`](teacher_review_model.md).
+
+For the canonical v0.7 `review.json` schema, including notes, tags, scores,
+comments, state, paths, timestamps, and mutation policy, see
+[`review_record_contract.md`](review_record_contract.md).
 
 For the required structure and human-readable elements of a printable
 writing-response page, see
@@ -232,11 +236,11 @@ Example:
 
 ## Submission Manifest
 
-A Quillan submission manifest is a local, teacher-controlled review record for
-one student and one assignment. It connects class, assignment, and student
-identity to routed evidence, retained-source provenance, and explicit review
-state. Routed evidence alone does not establish that a submission is complete,
-reviewed, scored, tagged, or ready for feedback.
+A Quillan submission manifest is a local, teacher-controlled evidence record
+for one student and one assignment. It connects class, assignment, and student
+identity to routed evidence, retained-source provenance, and explicit
+submission-management state. Routed evidence alone does not establish that a
+submission is complete, reviewed, scored, tagged, or ready for feedback.
 
 The canonical location is:
 
@@ -255,7 +259,8 @@ unambiguous pages, leaves duplicate pages unselected, represents expected
 missing pages, and preserves complete retained-source provenance.
 The existing `quillan.submissions` loader remains responsible for an earlier
 text-oriented metadata shape. The assembly API does not discover scan-folder
-evidence, merge with an existing manifest, or update teacher review state.
+evidence, merge with an existing manifest, or update submission-management
+state.
 
 The active path is currently a Quillan-owned artifact contract rather than a
 `pds-core` route. Inactive-preservation tooling such as `pds-sunset` may later
@@ -419,9 +424,31 @@ page, and retained-source provenance is stored in
 This contract does not define or implement scoring, tagging, requirements
 checking, feedback, reports, OCR, handwriting recognition, AI suggestions, AI
 scoring, AI feedback drafting, or automatic grading. Those concerns remain
-separate from the evidence manifest and teacher-controlled review state. It
-also does not implement evidence discovery, manifest merging, file opening,
-review commands, or state updates.
+separate from the evidence manifest. Teacher-entered notes, tags, scores,
+selected comments, and their distinct `review_state` belong in the adjacent
+`review.json` defined by
+[`review_record_contract.md`](review_record_contract.md). This manifest
+contract also does not implement evidence discovery, manifest merging, file
+opening, review commands, or state updates.
+
+## Submission Review Record
+
+The canonical active v0.7 teacher-review artifact is:
+
+```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+```
+
+It stores teacher-entered notes, tags, criterion scores, selected comments,
+and a `review_state` that is independent of the evidence manifest's
+`submission_state`. All required fields, nested record shapes, identifier and
+reference rules, controlled vocabularies, timestamp policy,
+workspace-relative path policy, and append-versus-update behavior are defined
+in [`review_record_contract.md`](review_record_contract.md).
+
+The adjacent `submission.json` remains the canonical evidence manifest.
+`review.json` references that manifest and its evidence IDs without copying
+routed evidence paths.
 
 ## Writing-Response Payload
 
@@ -507,15 +534,15 @@ Example:
 }
 ```
 
-## Tag Record
+## Tag Record (Historical Design)
 
-A tag record connects a teacher-created or teacher-confirmed observation to a
-location in the writing, a standard, and a structured comment. A tag is not an
-automatic mark, a score, or proof that a standard was met or missed. Tags can
-support review consistency and reporting, but they do not mechanically
-determine scores.
+This section preserves the earlier separate-file design for historical
+context. It is not an active v0.7 contract. Canonical tag records are items in
+the `tags` array of `review.json`, with their current shape defined in
+[`review_record_contract.md`](review_record_contract.md). Implementations must
+not create or mirror active tag data in `tags.json`.
 
-Suggested path:
+Historical suggested path (not active in v0.7):
 
 ```text
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/tags.json
@@ -581,14 +608,15 @@ Example:
 ]
 ```
 
-## Score Record
+## Score Record (Historical Design)
 
-A score record stores a teacher-entered or teacher-confirmed scoring decision.
-Scores may be informed by source evidence, rubric criteria, requirements
-checks, tags, and teacher notes, but they are not automatically generated or
-determined by those records.
+This section preserves the earlier aggregate score-file design for historical
+context. It is not an active v0.7 contract. Canonical criterion score records
+are items in the `scores` array of `review.json`. Scores remain
+teacher-entered or teacher-confirmed decisions and are never automatically
+generated or determined by tags or other records.
 
-Suggested path:
+Historical suggested path (not active in v0.7):
 
 ```text
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/scores.json
@@ -615,14 +643,19 @@ Example:
 }
 ```
 
-## Feedback File
+## Feedback File (Derived Export)
 
-A feedback file stores student-readable teacher communication. It may draw on
+A future feedback file may store exported student-readable teacher
+communication. It may draw on
 teacher-reviewed tags, notes, score records, requirements checks, and
 teacher-approved standards profile comments. Any future drafting or formatting
 support must remain teacher-reviewed and teacher-controlled.
 
-Suggested path:
+Unlike the historical `tags.json` and `scores.json` concepts, `feedback.md`
+may remain a derived export path. It is not the canonical review record and
+must not replace `review.json`.
+
+Reserved export path:
 
 ```text
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/feedback.md

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -1,0 +1,470 @@
+# Quillan Submission Review Record Contract
+
+## Purpose and Boundary
+
+The Quillan submission review record stores teacher-entered evaluation data
+for one student submission. Its canonical workspace-relative path is:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+```
+
+`review.json` is separate from the adjacent `submission.json` evidence
+manifest:
+
+* `submission.json` answers what evidence exists, where it came from, which
+  evidence is selected, and what evidence-management state it is in.
+* `review.json` answers what the teacher recorded about that evidence,
+  including notes, tags, scores, selected comments, and review/export state.
+
+Teacher review must not rewrite or duplicate the evidence manifest. In
+particular, `review.json` references evidence by `evidence_id` and optional
+page number rather than copying routed evidence paths.
+
+This document defines submission review schema version `1` for the v0.7
+contract. Runtime loading, validation, safe writing, commands, and exports are
+not implemented by this contract.
+
+## Top-Level Structure
+
+Every version `1` review record contains:
+
+```json
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "submission_review",
+  "class_id": "english12_p3_synthetic",
+  "assignment_id": "essay_01_synthetic",
+  "student_id": "00107",
+  "submission_manifest_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/submissions/00107/submission.json",
+  "review_state": "not_started",
+  "notes": [],
+  "tags": [],
+  "scores": [],
+  "comments": [],
+  "created_at": "2026-06-22T00:00:00+00:00",
+  "updated_at": "2026-06-22T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+All fields shown above are required, including arrays that are initially
+empty.
+
+Field requirements are:
+
+* `schema_version`: the string `"1"`;
+* `module`: the string `"quillan"`;
+* `record_type`: the string `"submission_review"`;
+* `class_id`, `assignment_id`, and `student_id`: identifiers matching the
+  associated submission manifest;
+* `submission_manifest_path`: the canonical workspace-relative path to that
+  submission's `submission.json`;
+* `review_state`: one of the controlled values below;
+* `notes`, `tags`, `scores`, and `comments`: arrays of the records defined
+  below;
+* `created_at`: the review-record creation timestamp;
+* `updated_at`: the timestamp of the most recent change anywhere in the
+  review record; and
+* `module_details`: an object reserved for compatible Quillan extensions.
+
+Unknown top-level fields are not part of schema version `1`. A future contract
+change must use a new schema version when it changes the meaning or required
+shape of existing data.
+
+## Identity and Submission Reference
+
+`class_id`, `assignment_id`, and `student_id` use the shared `pds-core`
+identifier policy. They are case-sensitive strings, and student identifiers
+remain strings so leading zeros are preserved.
+
+The three identifiers must match both:
+
+1. the values in the referenced `submission.json`; and
+2. the corresponding path segments in `submission_manifest_path`.
+
+For a review record with identity `<class_id>`, `<assignment_id>`, and
+`<student_id>`, the only valid manifest reference is:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+```
+
+Review-local identifiers such as `note_id`, `tag_id`, `score_id`, and
+`comment_record_id` are opaque, non-empty strings. Each identifier must be
+unique within its own array. Consumers must not derive ordering, timestamps,
+or meaning from an identifier's spelling.
+
+When present:
+
+* `evidence_id` must identify an evidence candidate in the referenced
+  `submission.json`;
+* `page_number` must identify the page entry containing that evidence when
+  both fields are present;
+* `standard_code` should identify an active standard in the assignment's
+  standards profile; and
+* `criterion_id` should identify a criterion in the assignment rubric or
+  rubric profile.
+
+These references do not copy the referenced records into `review.json`.
+
+## Review State
+
+Allowed `review_state` values are:
+
+* `not_started`: no substantive teacher-review artifacts have been entered;
+* `in_progress`: the teacher has begun entering or revising review artifacts;
+* `ready_for_export`: the teacher has explicitly marked the current review
+  data ready for feedback or report export; and
+* `exported`: feedback or reporting output has been exported from the review
+  record.
+
+`review_state` describes teacher-entered review artifacts. It is distinct from
+`submission_state` in `submission.json`, which describes evidence and
+submission management. Neither state determines or automatically changes the
+other. Later workflows must make any state change explicit.
+
+The state is not inferred merely because an array is empty or populated.
+Writers are responsible for keeping the explicit state meaningful. For
+example, an add-note command may explicitly move `not_started` to
+`in_progress`, but validation must not silently make that decision.
+
+`ready_for_export` and `exported` do not assert that a submission is complete,
+that evidence is unambiguous, or that a particular score exists. Exported
+files are derived artifacts and are not stored as paths in schema version `1`.
+
+## Notes
+
+`notes` contains private, teacher-entered freeform observations. A note is not
+student-readable feedback unless the teacher later chooses to include its
+content in an export. A note does not score or tag work by itself.
+
+Each note contains:
+
+```json
+{
+  "note_id": "note_0001",
+  "text": "The essay has a clear central claim but needs stronger evidence explanation.",
+  "created_at": "2026-06-22T00:00:00+00:00",
+  "updated_at": "2026-06-22T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+All note fields shown above are required.
+
+* `note_id` is unique within `notes`.
+* `text` is a non-empty string after trimming surrounding whitespace.
+* `created_at` records original creation and is preserved.
+* `updated_at` initially equals `created_at` and changes only if a future
+  editing workflow explicitly supports note edits.
+* `module_details` is an object.
+
+Notes are append-only for the MVP. Editing and deletion are reserved for a
+future contract or explicitly defined command; later commands must not
+silently replace existing notes.
+
+## Tags
+
+`tags` contains teacher-created or teacher-confirmed observations. A tag may
+refer to a standard, reusable comment, page, evidence candidate, location, or
+the whole submission. It is not a score, proof that a standard was met or
+missed, or an instruction to calculate a score.
+
+Each tag contains:
+
+```json
+{
+  "tag_id": "tag_0001",
+  "standard_code": "W.AW.11-12.1",
+  "comment_id": "evidence_needs_explanation",
+  "label": "Evidence needs more explanation",
+  "polarity": "developing",
+  "severity": 2,
+  "teacher_note": "The quotation is relevant, but the analysis does not explain how it supports the claim.",
+  "page_number": 1,
+  "evidence_id": "evidence_001",
+  "location": {
+    "type": "paragraph",
+    "value": 2
+  },
+  "created_at": "2026-06-22T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+Required tag fields are:
+
+* `tag_id`;
+* `label`;
+* `polarity`;
+* `created_at`; and
+* `module_details`.
+
+Optional tag fields are:
+
+* `standard_code`;
+* `comment_id`;
+* `severity`;
+* `teacher_note`;
+* `page_number`;
+* `evidence_id`; and
+* `location`.
+
+Tag field rules are:
+
+* `tag_id` is unique within `tags`.
+* `label` is a non-empty, teacher-readable string.
+* `polarity` is one of `positive`, `developing`, `negative`, or `neutral`.
+* `severity`, when present, is a non-negative integer used for organization,
+  not a score.
+* `teacher_note`, when present, is a non-empty string.
+* `page_number`, when present, is a positive integer.
+* `standard_code` and `comment_id`, when present, are non-empty strings.
+  Together they may identify reusable language in a standards profile.
+* `evidence_id`, when present, is a non-empty reference to the submission
+  manifest as described above.
+* `module_details` is an object.
+
+### Tag Locations
+
+`location`, when present, contains exactly a controlled `type` and a `value`:
+
+```json
+{
+  "type": "paragraph",
+  "value": 2
+}
+```
+
+Allowed location types are:
+
+* `whole_submission`;
+* `page`;
+* `paragraph`;
+* `sentence`;
+* `line`;
+* `section`;
+* `scene`;
+* `stanza`; and
+* `custom`.
+
+For `whole_submission`, `value` must be `null`. For `page`, `paragraph`,
+`sentence`, and `line`, `value` must be a positive integer. For `section`,
+`scene`, `stanza`, and `custom`, `value` must be either a positive integer or
+a non-empty string. A `page` location must agree with `page_number` when both
+are present.
+
+Tags are append-only for the MVP. Editing, deletion, deduplication, and any
+interpretation of severity are future work. Tags must never calculate or
+compel scores.
+
+## Scores
+
+`scores` is an array of criterion score records. The array form is canonical
+for schema version `1` because it supports validation and focused updates
+without replacing an unrelated score.
+
+Each score contains:
+
+```json
+{
+  "score_id": "score_0001",
+  "criterion_id": "evidence",
+  "label": "Evidence",
+  "score": 3,
+  "max_score": 4,
+  "scale": "4_point",
+  "teacher_note": "Evidence is relevant but unevenly explained.",
+  "updated_at": "2026-06-22T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+Required score fields are:
+
+* `score_id`;
+* `criterion_id`;
+* `label`;
+* `score`;
+* `max_score`;
+* `updated_at`; and
+* `module_details`.
+
+Optional score fields are:
+
+* `scale`; and
+* `teacher_note`.
+
+Score field rules are:
+
+* `score_id` is unique within `scores`.
+* `criterion_id` is non-empty and unique within `scores`. When a rubric is
+  available, it should reference one rubric criterion.
+* `label` is a non-empty, teacher-readable string.
+* `score` is a finite number greater than or equal to zero.
+* `max_score` is a finite number greater than zero.
+* `score` is less than or equal to `max_score`.
+* `scale` and `teacher_note`, when present, are non-empty strings.
+* `updated_at` records the most recent teacher update to that criterion.
+* `module_details` is an object.
+
+Scores are teacher-entered or teacher-confirmed decisions. Quillan must not
+infer a score from student writing, tags, requirements, comments, or other
+records.
+
+Scores are mutable by `criterion_id` for the MVP. A later set-score workflow
+updates the matching criterion record and its `updated_at`, preserves its
+`score_id`, and updates top-level `updated_at`. It appends a new score only
+when the criterion is not already present. It must not replace the entire
+`scores` array or erase unrelated criteria.
+
+## Comments
+
+`comments` contains teacher-selected reusable language or teacher-entered
+custom language intended for possible feedback export.
+
+Each comment contains:
+
+```json
+{
+  "comment_record_id": "comment_0001",
+  "comment_id": "evidence_needs_explanation",
+  "standard_code": "W.AW.11-12.1",
+  "label": "Evidence needs more explanation",
+  "text": "The evidence is relevant, but the explanation needs to show more clearly how it supports the claim.",
+  "source": "standards_profile",
+  "include_in_feedback": true,
+  "created_at": "2026-06-22T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+Required comment fields are:
+
+* `comment_record_id`;
+* `label`;
+* `text`;
+* `source`;
+* `include_in_feedback`;
+* `created_at`; and
+* `module_details`.
+
+Optional comment fields are:
+
+* `comment_id`; and
+* `standard_code`.
+
+Comment field rules are:
+
+* `comment_record_id` is unique within `comments`.
+* `comment_id` may identify reusable language in a standards profile or
+  comment bank.
+* `standard_code` may identify the associated profile standard.
+* `label` and `text` are non-empty strings.
+* `source` is one of `standards_profile`, `comment_bank`, or `custom`.
+* `include_in_feedback` is a boolean expressing the teacher's export choice.
+* `module_details` is an object.
+
+Comments are teacher-selected or teacher-entered; they are not generated from
+student writing or supplied as AI judgments. Comments are append-only for the
+MVP. Editing, deletion, and toggling export inclusion are reserved for future
+explicit workflows, which must not silently erase other comment records.
+
+## Timestamp Policy
+
+Every timestamp is an ISO 8601 string with an explicit timezone offset, for
+example:
+
+```text
+2026-06-22T00:00:00+00:00
+2026-06-22T13:45:30-04:00
+```
+
+Naive timestamps are invalid. Equivalent offsets are allowed; UTC is
+recommended for stable serialization.
+
+Top-level `created_at` records creation of `review.json` and never changes.
+Top-level `updated_at` changes whenever any top-level field or nested review
+artifact changes. It must not precede `created_at`.
+
+Append-only notes, tags, and comments preserve their original `created_at`.
+Notes also reserve `updated_at` for future explicit editing. Mutable score
+records update their own `updated_at`. A nested update also updates top-level
+`updated_at`.
+
+## Workspace-Relative Path Policy
+
+Every stored path in `review.json` is interpreted from the resolved active PDS
+workspace root. Paths must use forward slashes in serialized JSON and must
+not contain:
+
+* an absolute or rooted path;
+* a Windows drive-letter path;
+* `.` or `..` path components;
+* null bytes; or
+* any value that resolves outside the workspace root.
+
+Schema version `1` stores only `submission_manifest_path`. It does not copy
+routed evidence paths, retained-source paths, export paths, or report paths.
+Full runtime enforcement belongs to the review-record validation issue that
+follows this contract.
+
+## Mutation and Preservation Policy
+
+Later writers must validate the complete proposed record before replacing an
+existing `review.json` and must use safe-write behavior. At the data-model
+level:
+
+* notes are append-only;
+* tags are append-only;
+* comments are append-only;
+* scores are appended or updated by unique `criterion_id`;
+* top-level metadata and `review_state` are explicitly replaceable; and
+* every artifact change also replaces top-level `updated_at`.
+
+No command may silently discard teacher-entered records. Editing or deleting
+append-only records requires a future, explicit contract and workflow.
+
+## Derived Artifacts and Historical Names
+
+`review.json` is the canonical active v0.7 teacher-review record for notes,
+tags, criterion scores, and selected comments.
+
+Earlier design documents used separate `tags.json` and `scores.json` files.
+Those names are historical design background, not alternate active v0.7
+contracts. Implementations must not split or mirror canonical review data
+across those files.
+
+`feedback.md`, `reports/class_summary.csv`, and
+`reports/standards_summary.csv` are derived export artifacts. They may be
+generated from teacher-controlled review records in later issues, but they do
+not replace `review.json` and are not authoritative independent evidence.
+`requirements.json` remains a separate reserved structural-check record
+because requirements checks are not teacher evaluation artifacts in this
+schema.
+
+## Synthetic Example
+
+A complete fake record with a note, two tags, one criterion score, and one
+selected comment is stored in
+[`review_record_synthetic.json`](../examples/submissions/review_record_synthetic.json).
+
+## Explicit Non-Goals
+
+This contract does not implement:
+
+* review-record loading, validation, path computation, or safe writing;
+* `add-note`, `add-tag`, `set-score`, or other review commands;
+* comment-bank lookup or reusable-comment management;
+* feedback, class-summary, or standards-summary export;
+* CLI or terminal-menu review workflows;
+* editing or deletion of append-only review artifacts;
+* AI scoring, feedback, comments, suggestions, or automated grading;
+* automatic standard detection;
+* OCR, handwriting recognition, PDF text extraction, or QR extraction;
+* evidence selection or duplicate resolution;
+* email sending, LMS integration, dashboards, or report visualization.
+
+The record describes teacher-entered or teacher-confirmed judgment only.

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -6,7 +6,7 @@ Quillan's review model is teacher-controlled. Quillan preserves student
 writing, organizes teacher-review artifacts, and reduces clerical friction,
 but it does not replace the teacher's professional judgment.
 
-The model keeps source evidence, teacher-review artifacts, and derived reports
+The model keeps source evidence, teacher-review artifacts, and derived exports
 distinct. Software may validate records, organize observations, format
 teacher-approved language, and summarize confirmed records. It must not
 present an unconfirmed software judgment as a teacher evaluation or encourage
@@ -28,8 +28,9 @@ identify and preserve it:
 * `submission.json`
 
 The writing is the student's work. The metadata records its identity,
-provenance, capture time, lifecycle status, and version. Source evidence does
-not contain teacher tags, scores, feedback, or reports.
+provenance, capture time, evidence-management state, and version. Source
+evidence does not contain teacher notes, tags, scores, selected comments,
+feedback exports, or reports.
 
 Keeping source evidence separate allows a teacher to compare later review
 artifacts with the writing that was actually submitted.
@@ -40,25 +41,30 @@ Teacher-review artifacts are records created by the teacher or confirmed
 through teacher review:
 
 * `requirements.json`
-* `tags.json`
-* `scores.json`
+* `review.json`
+
+`review.json` is the canonical active v0.7 record for teacher-entered notes,
+tags, criterion scores, and teacher-selected comments. It is adjacent to and
+references `submission.json`, but remains separate so teacher judgment does
+not alter the student's original work. `requirements.json` remains a
+separate, reserved structural-check support artifact.
+
+Earlier designs named separate `tags.json` and `scores.json` files. Those are
+historical concepts, not alternate active v0.7 records. Their content belongs
+in `review.json`.
+
+## Derived Exports and Reports
+
+Derived outputs are generated from teacher-reviewed records:
+
 * `feedback.md`
-
-These records describe structural checks, observations, decisions, and
-communication associated with a submission. They remain connected to, but
-separate from, the source evidence so teacher judgment does not alter the
-student's original work.
-
-## Derived Reports
-
-Derived reports are aggregations generated from teacher-reviewed records:
-
 * `reports/standards_summary.csv`
 * `reports/class_summary.csv`
 
-Reports are not independent evidence. They summarize existing
-teacher-confirmed observations and decisions and should remain traceable to
-the records from which they were derived.
+`feedback.md` is a possible student-readable export. CSV reports are
+aggregations. These outputs are not independent evidence or substitutes for
+`review.json`; they should remain traceable to the teacher-confirmed records
+from which they were derived.
 
 ## Tag Philosophy
 
@@ -146,8 +152,9 @@ Feedback is student-readable teacher communication. It may draw on:
 Feedback remains teacher-controlled. Future tooling may help select
 teacher-approved language, draft text, or format a feedback file, but the
 teacher must review and confirm the communication before it is treated as a
-teacher-review artifact. Quillan must not present authoritative AI-generated
-feedback.
+teacher export. Selected reusable or custom comments are stored in
+`review.json`; a rendered `feedback.md` remains a derived artifact. Quillan
+must not present authoritative AI-generated feedback.
 
 ## Report Philosophy
 
@@ -169,6 +176,10 @@ reviewing the underlying records.
 [`data_contracts.md`](data_contracts.md) defines the fields and formats of
 individual Quillan records. This document defines the review philosophy and
 the conceptual relationships among those records.
+
+[`review_record_contract.md`](review_record_contract.md) defines the canonical
+v0.7 `review.json` shape and its identity, state, timestamp, path, reference,
+and mutation rules.
 
 [`workspace_lifecycle.md`](workspace_lifecycle.md) defines where records live
 in the shared PDS workspace and how active records relate over time. It does

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -58,8 +58,7 @@ The expected current and reserved layout is:
               submission.json
               submission.txt
               requirements.json
-              tags.json
-              scores.json
+              review.json
               feedback.md
           reports/
             standards_summary.csv
@@ -85,8 +84,8 @@ student IDs remain strings. Menu edits are staged until explicit `SAVE`, and
 discarded edits are not written.
 
 Removing a student from this active roster does not delete or modify
-assignments, submissions, printable PDFs, scans, reports, tags, scores,
-feedback, or historical evidence.
+assignments, submissions, printable PDFs, scans, review records, reports,
+feedback exports, or historical evidence.
 
 ### `assignment.json`
 
@@ -152,7 +151,8 @@ The Quillan version `1` submission manifest for one student's routed
 evidence for one assignment. It identifies the class, assignment, and student;
 represents expected, missing, duplicate, replacement, damaged, or excluded
 pages; preserves retained-source provenance; and records teacher-controlled
-review state without containing scores, tags, or feedback.
+submission-management state without containing notes, scores, tags, selected
+comments, or feedback exports.
 
 Loading, validation, canonical path computation, safe writing, and
 new-manifest assembly from caller-provided evidence metadata are implemented
@@ -172,25 +172,27 @@ requirements. It should record whether requirements were met, partially met,
 not met, or not checked. It is a teacher-review support artifact, not a score.
 Requirements checking is not implemented by this document.
 
-### `submissions/<student_id>/tags.json`
+### `submissions/<student_id>/review.json`
 
-A future collection of teacher-review evidence tags. Each tag should connect a
-teacher observation to a location in the writing, a standard, a reusable
-comment, and a polarity. Tags organize reviewed evidence; they do not
-determine a score. Tagging is not implemented by this document.
+The canonical active v0.7 teacher-review record for one submission. It stores
+teacher-entered notes, tags, criterion scores, selected reusable or custom
+comments, and an explicit `review_state`. It references the adjacent
+`submission.json` and evidence IDs without copying routed evidence paths.
 
-### `submissions/<student_id>/scores.json`
+`review_state` is independent of `submission_state`; neither state
+automatically determines the other. The complete record contract is defined
+in [`review_record_contract.md`](review_record_contract.md). Loading, writing,
+review commands, and exports are not implemented by this document.
 
-A future teacher scoring record. Scores are teacher judgment artifacts and are
-not automatically determined by tags, requirement results, or other software
-outputs. Scoring is not implemented by this document.
+Earlier separate `tags.json` and `scores.json` designs are historical and are
+not alternate active v0.7 paths.
 
 ### `submissions/<student_id>/feedback.md`
 
-A future student-readable feedback record reflecting teacher review. It should
-remain traceable to the teacher-reviewed submission and should not be treated
-as a replacement for teacher judgment. Feedback generation is not implemented
-by this document.
+A reserved future student-readable export derived from teacher-controlled
+review data. It should remain traceable to `review.json` and must not be
+treated as an independent review record or a replacement for teacher
+judgment. Feedback export is not implemented by this document.
 
 ### `reports/`
 
@@ -233,8 +235,9 @@ identify routed artifacts and their retained-source provenance:
 
 `submission.txt` remains an optional text-oriented evidence artifact for
 workflows that use it. The manifest is part of the evidentiary record because
-it establishes identity, provenance, page state, and teacher-controlled review
-state. It does not contain the teacher's score, tags, or feedback.
+it establishes identity, provenance, page state, and teacher-controlled
+submission-management state. It does not contain the teacher's notes, score,
+tags, selected comments, or feedback export.
 
 ### Teacher-Review Artifacts
 
@@ -242,23 +245,24 @@ Teacher-review artifacts are records created by the teacher or confirmed
 through teacher review:
 
 * `requirements.json`
-* `tags.json`
-* `scores.json`
-* `feedback.md`
+* `review.json`
 
 These records support efficient review while preserving the teacher as the
 source of evaluative judgment. They should remain connected to, but separate
-from, the source evidence.
+from, the source evidence. `review.json` is the canonical active v0.7
+container for notes, tags, criterion scores, and selected comments.
 
-### Derived Reports
+### Derived Exports and Reports
 
-Derived reports aggregate teacher-reviewed records:
+Derived outputs are generated from teacher-reviewed records:
 
+* `feedback.md`
 * `reports/standards_summary.csv`
 * `reports/class_summary.csv`
 
-Reports should be reproducible from the applicable reviewed records and should
-not become the sole copy of submission evidence or teacher decisions.
+Exports and reports should be reproducible from the applicable reviewed
+records and should not become the sole copy of submission evidence or teacher
+decisions.
 
 ## Active Records vs. Historical Preservation
 

--- a/examples/submissions/review_record_synthetic.json
+++ b/examples/submissions/review_record_synthetic.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "submission_review",
+  "class_id": "english12_p3_synthetic",
+  "assignment_id": "essay_01_synthetic",
+  "student_id": "00107",
+  "submission_manifest_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/submissions/00107/submission.json",
+  "review_state": "in_progress",
+  "notes": [
+    {
+      "note_id": "note_0001",
+      "text": "The essay has a clear central claim but needs stronger evidence explanation.",
+      "created_at": "2026-06-22T13:30:00-04:00",
+      "updated_at": "2026-06-22T13:30:00-04:00",
+      "module_details": {}
+    }
+  ],
+  "tags": [
+    {
+      "tag_id": "tag_0001",
+      "standard_code": "W.AW.11-12.1",
+      "comment_id": "clear_claim",
+      "label": "Clear central claim",
+      "polarity": "positive",
+      "page_number": 1,
+      "evidence_id": "evidence_001",
+      "location": {
+        "type": "paragraph",
+        "value": 1
+      },
+      "created_at": "2026-06-22T13:32:00-04:00",
+      "module_details": {}
+    },
+    {
+      "tag_id": "tag_0002",
+      "standard_code": "W.AW.11-12.1",
+      "comment_id": "evidence_needs_explanation",
+      "label": "Evidence needs more explanation",
+      "polarity": "developing",
+      "severity": 2,
+      "teacher_note": "The quotation is relevant, but the analysis does not explain how it supports the claim.",
+      "page_number": 1,
+      "evidence_id": "evidence_001",
+      "location": {
+        "type": "paragraph",
+        "value": 2
+      },
+      "created_at": "2026-06-22T13:35:00-04:00",
+      "module_details": {}
+    }
+  ],
+  "scores": [
+    {
+      "score_id": "score_0001",
+      "criterion_id": "evidence",
+      "label": "Evidence",
+      "score": 3,
+      "max_score": 4,
+      "scale": "4_point",
+      "teacher_note": "Evidence is relevant but unevenly explained.",
+      "updated_at": "2026-06-22T13:40:00-04:00",
+      "module_details": {}
+    }
+  ],
+  "comments": [
+    {
+      "comment_record_id": "comment_0001",
+      "comment_id": "evidence_needs_explanation",
+      "standard_code": "W.AW.11-12.1",
+      "label": "Evidence needs more explanation",
+      "text": "The evidence is relevant, but the explanation needs to show more clearly how it supports the claim.",
+      "source": "standards_profile",
+      "include_in_feedback": true,
+      "created_at": "2026-06-22T13:42:00-04:00",
+      "module_details": {}
+    }
+  ],
+  "created_at": "2026-06-22T13:25:00-04:00",
+  "updated_at": "2026-06-22T13:42:00-04:00",
+  "module_details": {}
+}


### PR DESCRIPTION
## Summary

Defines the canonical v0.7 `review.json` contract for Quillan teacher-review records.

This PR establishes `review.json` as the active teacher-review artifact for:

* teacher notes
* standards/comment tags
* criterion scores
* selected reusable or custom comments
* explicit `review_state`

It keeps `review.json` separate from `submission.json`, which remains the evidence manifest for routed evidence, retained-source provenance, selected evidence, page state, and submission-management state.

Closes #94 

## Changes

* Added `docs/review_record_contract.md`.
* Added `examples/submissions/review_record_synthetic.json`.
* Updated `docs/data_contracts.md` to reference the new canonical review contract.
* Updated `docs/teacher_review_model.md` to clarify the distinction between source evidence, teacher-review artifacts, and derived exports.
* Updated `docs/workspace_lifecycle.md` to include `review.json` in the active workspace layout.
* Updated `README.md` to point to the new review contract.
* Updated `CHANGELOG.md`.

## Contract Decisions

* `review.json` lives at:

  ```text
  classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
  ```

* `submission.json` remains the canonical evidence manifest.

* `review_state` is distinct from `submission_state`.

* `review.json` references evidence by `evidence_id` and optional `page_number` instead of copying routed evidence paths.

* `notes`, `tags`, and `comments` are append-only for the MVP.

* `scores` are updated by unique `criterion_id`.

* All timestamps require explicit timezone offsets.

* Stored paths must be workspace-relative.

* `tags.json` and `scores.json` are now documented as historical design concepts, not active v0.7 records.

* `feedback.md` and summary CSV files are treated as derived exports.

## Non-Goals

This PR does not implement:

* runtime review-record loading
* validation
* path helpers
* safe writing
* CLI commands
* menu workflows
* note entry
* tag entry
* score entry
* feedback export
* summary CSV export
* AI scoring
* AI feedback
* OCR
* automatic grading

Those belong in later v0.7 sub-issues.

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

535 tests passed.
