### PR TITLE
feat: add review record infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added Quillan-owned version `1` review-record infrastructure with strict
+  loading and validation for identities, canonical manifest references,
+  review states, timestamps, notes, tags, locations, scores, comments, and
+  extension objects, plus canonical `review.json` path helpers and atomic
+  UTF-8 writing with explicit overwrite protection.
 - Added a synthetic submission review record demonstrating notes, positive and
   developing tags, a criterion score, selected reusable feedback language,
   evidence references, and timezone-aware timestamps.

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -22,8 +22,10 @@ particular, `review.json` references evidence by `evidence_id` and optional
 page number rather than copying routed evidence paths.
 
 This document defines submission review schema version `1` for the v0.7
-contract. Runtime loading, validation, safe writing, commands, and exports are
-not implemented by this contract.
+contract. Runtime loading and validation are implemented by
+`quillan.review_record`. Canonical path computation and safe writing are
+implemented by `quillan.review_record_paths`. Teacher-facing commands and
+exports remain future work.
 
 ## Top-Level Structure
 
@@ -408,8 +410,29 @@ not contain:
 
 Schema version `1` stores only `submission_manifest_path`. It does not copy
 routed evidence paths, retained-source paths, export paths, or report paths.
-Full runtime enforcement belongs to the review-record validation issue that
-follows this contract.
+Runtime validation rejects unsafe paths and requires the canonical manifest
+path matching the record's own class, assignment, and student identifiers.
+
+## Runtime API
+
+`quillan.review_record` provides:
+
+* `load_review_record(path)` for UTF-8 JSON loading and complete validation;
+* `validate_review_record(record)` for isolated schema validation; and
+* `ReviewRecordError` for review-record loading and validation failures.
+
+`quillan.review_record_paths` provides:
+
+* `review_record_dir(...)` and `review_record_path(...)` for canonical active
+  paths;
+* `write_review_record(path, record, overwrite=False)` for validated,
+  atomic, readable UTF-8 JSON writes; and
+* `ReviewRecordPathError` for path and write failures.
+
+Version `1` rejects unknown fields in the top-level and defined nested record
+shapes. Module-specific extension data belongs in each record's
+`module_details` object. The writer creates missing parent directories and
+refuses to replace an existing file unless `overwrite=True`.
 
 ## Mutation and Preservation Policy
 
@@ -455,7 +478,6 @@ selected comment is stored in
 
 This contract does not implement:
 
-* review-record loading, validation, path computation, or safe writing;
 * `add-note`, `add-tag`, `set-score`, or other review commands;
 * comment-bank lookup or reusable-comment management;
 * feedback, class-summary, or standards-summary export;

--- a/quillan/review_record.py
+++ b/quillan/review_record.py
@@ -1,0 +1,494 @@
+"""Loading and validation for Quillan submission review records."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Final, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+REQUIRED_REVIEW_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "module",
+        "record_type",
+        "class_id",
+        "assignment_id",
+        "student_id",
+        "submission_manifest_path",
+        "review_state",
+        "notes",
+        "tags",
+        "scores",
+        "comments",
+        "created_at",
+        "updated_at",
+        "module_details",
+    }
+)
+REQUIRED_NOTE_FIELDS: Final[frozenset[str]] = frozenset(
+    {"note_id", "text", "created_at", "updated_at", "module_details"}
+)
+REQUIRED_TAG_FIELDS: Final[frozenset[str]] = frozenset(
+    {"tag_id", "label", "polarity", "created_at", "module_details"}
+)
+OPTIONAL_TAG_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "standard_code",
+        "comment_id",
+        "severity",
+        "teacher_note",
+        "page_number",
+        "evidence_id",
+        "location",
+    }
+)
+REQUIRED_SCORE_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "score_id",
+        "criterion_id",
+        "label",
+        "score",
+        "max_score",
+        "updated_at",
+        "module_details",
+    }
+)
+OPTIONAL_SCORE_FIELDS: Final[frozenset[str]] = frozenset(
+    {"scale", "teacher_note"}
+)
+REQUIRED_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "comment_record_id",
+        "label",
+        "text",
+        "source",
+        "include_in_feedback",
+        "created_at",
+        "module_details",
+    }
+)
+OPTIONAL_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
+    {"comment_id", "standard_code"}
+)
+
+ALLOWED_REVIEW_STATES: Final[frozenset[str]] = frozenset(
+    {"not_started", "in_progress", "ready_for_export", "exported"}
+)
+ALLOWED_TAG_POLARITIES: Final[frozenset[str]] = frozenset(
+    {"positive", "developing", "negative", "neutral"}
+)
+ALLOWED_COMMENT_SOURCES: Final[frozenset[str]] = frozenset(
+    {"standards_profile", "comment_bank", "custom"}
+)
+ALLOWED_LOCATION_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "whole_submission",
+        "page",
+        "paragraph",
+        "sentence",
+        "line",
+        "section",
+        "scene",
+        "stanza",
+        "custom",
+    }
+)
+INTEGER_LOCATION_TYPES: Final[frozenset[str]] = frozenset(
+    {"page", "paragraph", "sentence", "line"}
+)
+FLEXIBLE_LOCATION_TYPES: Final[frozenset[str]] = frozenset(
+    {"section", "scene", "stanza", "custom"}
+)
+
+
+class ReviewRecordError(ValueError):
+    """Raised when a Quillan submission review record is missing or invalid."""
+
+
+def load_review_record(path: str | Path) -> dict[str, Any]:
+    """Load and validate a version 1 submission review record."""
+    review_path = Path(path)
+    try:
+        with review_path.open("r", encoding="utf-8") as file:
+            record = json.load(file)
+    except FileNotFoundError as error:
+        raise ReviewRecordError(f"Review record not found: {review_path}") from error
+    except json.JSONDecodeError as error:
+        raise ReviewRecordError(
+            f"Review record is not valid JSON: {review_path}"
+        ) from error
+    except OSError as error:
+        raise ReviewRecordError(
+            f"Could not read review record {review_path}: {error}"
+        ) from error
+
+    if not isinstance(record, dict):
+        raise ReviewRecordError(
+            f"Review record must be a JSON object: {review_path}"
+        )
+    record_dict = cast(dict[str, Any], record)
+    validate_review_record(record_dict)
+    return record_dict
+
+
+def validate_review_record(record: dict[str, Any]) -> None:
+    """Validate the intrinsic version 1 submission review record contract."""
+    if not isinstance(record, dict):
+        raise ReviewRecordError("Review record must be an object.")
+    _validate_fields(record, REQUIRED_REVIEW_FIELDS, frozenset(), "review record")
+    _validate_exact_value(record["schema_version"], "schema_version", "1")
+    _validate_exact_value(record["module"], "module", "quillan")
+    _validate_exact_value(
+        record["record_type"], "record_type", "submission_review"
+    )
+    for field in ("class_id", "assignment_id", "student_id"):
+        _validate_identifier(record[field], field)
+
+    _validate_submission_manifest_path(record)
+    _validate_allowed_value(
+        record["review_state"], "review_state", ALLOWED_REVIEW_STATES
+    )
+    created_at = _validate_timestamp(record["created_at"], "created_at")
+    updated_at = _validate_timestamp(record["updated_at"], "updated_at")
+    if updated_at < created_at:
+        raise ReviewRecordError(
+            "Field 'updated_at' must not precede field 'created_at'."
+        )
+    _validate_json_object(record["module_details"], "module_details")
+
+    _validate_notes(record["notes"])
+    _validate_tags(record["tags"])
+    _validate_scores(record["scores"])
+    _validate_comments(record["comments"])
+
+
+def _validate_submission_manifest_path(record: dict[str, Any]) -> None:
+    value = record["submission_manifest_path"]
+    _validate_workspace_relative_path(value, "submission_manifest_path")
+    expected = (
+        f"classes/{record['class_id']}/assignments/{record['assignment_id']}"
+        f"/submissions/{record['student_id']}/submission.json"
+    )
+    if value != expected:
+        raise ReviewRecordError(
+            "Field 'submission_manifest_path' must be the canonical path "
+            f"'{expected}'."
+        )
+
+
+def _validate_notes(value: Any) -> None:
+    notes = _validate_array(value, "notes")
+    seen_ids: set[str] = set()
+    for index, note in enumerate(notes):
+        context = f"notes[{index}]"
+        item = _validate_record(note, context)
+        _validate_fields(item, REQUIRED_NOTE_FIELDS, frozenset(), context)
+        _validate_unique_local_id(item["note_id"], f"{context}.note_id", seen_ids)
+        _validate_non_empty_string(item["text"], f"{context}.text")
+        created_at = _validate_timestamp(
+            item["created_at"], f"{context}.created_at"
+        )
+        updated_at = _validate_timestamp(
+            item["updated_at"], f"{context}.updated_at"
+        )
+        if updated_at < created_at:
+            raise ReviewRecordError(
+                f"Field '{context}.updated_at' must not precede "
+                f"field '{context}.created_at'."
+            )
+        _validate_json_object(item["module_details"], f"{context}.module_details")
+
+
+def _validate_tags(value: Any) -> None:
+    tags = _validate_array(value, "tags")
+    seen_ids: set[str] = set()
+    for index, tag in enumerate(tags):
+        context = f"tags[{index}]"
+        item = _validate_record(tag, context)
+        _validate_fields(item, REQUIRED_TAG_FIELDS, OPTIONAL_TAG_FIELDS, context)
+        _validate_unique_local_id(item["tag_id"], f"{context}.tag_id", seen_ids)
+        _validate_non_empty_string(item["label"], f"{context}.label")
+        _validate_allowed_value(
+            item["polarity"], f"{context}.polarity", ALLOWED_TAG_POLARITIES
+        )
+        for field in (
+            "standard_code",
+            "comment_id",
+            "teacher_note",
+            "evidence_id",
+        ):
+            if field in item:
+                _validate_non_empty_string(item[field], f"{context}.{field}")
+        if "severity" in item:
+            _validate_non_negative_integer(
+                item["severity"], f"{context}.severity"
+            )
+        if "page_number" in item:
+            _validate_positive_integer(
+                item["page_number"], f"{context}.page_number"
+            )
+        if "location" in item:
+            _validate_location(
+                item["location"], f"{context}.location", item.get("page_number")
+            )
+        _validate_timestamp(item["created_at"], f"{context}.created_at")
+        _validate_json_object(item["module_details"], f"{context}.module_details")
+
+
+def _validate_location(
+    value: Any, context: str, page_number: Any
+) -> None:
+    location = _validate_record(value, context)
+    _validate_fields(
+        location, frozenset({"type", "value"}), frozenset(), context
+    )
+    location_type = _validate_allowed_value(
+        location["type"], f"{context}.type", ALLOWED_LOCATION_TYPES
+    )
+    location_value = location["value"]
+    if location_type == "whole_submission":
+        if location_value is not None:
+            raise ReviewRecordError(
+                f"Field '{context}.value' must be null for whole_submission."
+            )
+    elif location_type in INTEGER_LOCATION_TYPES:
+        location_value = _validate_positive_integer(
+            location_value, f"{context}.value"
+        )
+    elif location_type in FLEXIBLE_LOCATION_TYPES:
+        if isinstance(location_value, bool) or not (
+            (
+                isinstance(location_value, int)
+                and location_value >= 1
+            )
+            or (
+                isinstance(location_value, str)
+                and bool(location_value.strip())
+            )
+        ):
+            raise ReviewRecordError(
+                f"Field '{context}.value' must be a positive integer or "
+                "non-empty string."
+            )
+    if (
+        location_type == "page"
+        and page_number is not None
+        and location_value != page_number
+    ):
+        raise ReviewRecordError(
+            f"Field '{context}.value' must agree with the tag's page_number."
+        )
+
+
+def _validate_scores(value: Any) -> None:
+    scores = _validate_array(value, "scores")
+    seen_score_ids: set[str] = set()
+    seen_criterion_ids: set[str] = set()
+    for index, score_record in enumerate(scores):
+        context = f"scores[{index}]"
+        item = _validate_record(score_record, context)
+        _validate_fields(
+            item, REQUIRED_SCORE_FIELDS, OPTIONAL_SCORE_FIELDS, context
+        )
+        _validate_unique_local_id(
+            item["score_id"], f"{context}.score_id", seen_score_ids
+        )
+        _validate_unique_local_id(
+            item["criterion_id"],
+            f"{context}.criterion_id",
+            seen_criterion_ids,
+        )
+        _validate_non_empty_string(item["label"], f"{context}.label")
+        score = _validate_finite_number(item["score"], f"{context}.score")
+        max_score = _validate_finite_number(
+            item["max_score"], f"{context}.max_score"
+        )
+        if score < 0:
+            raise ReviewRecordError(
+                f"Field '{context}.score' must be greater than or equal to zero."
+            )
+        if max_score <= 0:
+            raise ReviewRecordError(
+                f"Field '{context}.max_score' must be greater than zero."
+            )
+        if score > max_score:
+            raise ReviewRecordError(
+                f"Field '{context}.score' must not exceed max_score."
+            )
+        for field in ("scale", "teacher_note"):
+            if field in item:
+                _validate_non_empty_string(item[field], f"{context}.{field}")
+        _validate_timestamp(item["updated_at"], f"{context}.updated_at")
+        _validate_json_object(item["module_details"], f"{context}.module_details")
+
+
+def _validate_comments(value: Any) -> None:
+    comments = _validate_array(value, "comments")
+    seen_ids: set[str] = set()
+    for index, comment in enumerate(comments):
+        context = f"comments[{index}]"
+        item = _validate_record(comment, context)
+        _validate_fields(
+            item, REQUIRED_COMMENT_FIELDS, OPTIONAL_COMMENT_FIELDS, context
+        )
+        _validate_unique_local_id(
+            item["comment_record_id"],
+            f"{context}.comment_record_id",
+            seen_ids,
+        )
+        for field in ("label", "text"):
+            _validate_non_empty_string(item[field], f"{context}.{field}")
+        for field in ("comment_id", "standard_code"):
+            if field in item:
+                _validate_non_empty_string(item[field], f"{context}.{field}")
+        _validate_allowed_value(
+            item["source"], f"{context}.source", ALLOWED_COMMENT_SOURCES
+        )
+        if not isinstance(item["include_in_feedback"], bool):
+            raise ReviewRecordError(
+                f"Field '{context}.include_in_feedback' must be a boolean."
+            )
+        _validate_timestamp(item["created_at"], f"{context}.created_at")
+        _validate_json_object(item["module_details"], f"{context}.module_details")
+
+
+def _validate_workspace_relative_path(value: Any, field: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ReviewRecordError(
+            f"Field '{field}' must be a non-empty workspace-relative path string."
+        )
+    if "\0" in value:
+        raise ReviewRecordError(f"Field '{field}' must not contain null bytes.")
+    path_variants = (PurePosixPath(value), PureWindowsPath(value))
+    if any(path.anchor or path.drive for path in path_variants):
+        raise ReviewRecordError(
+            f"Field '{field}' must be a workspace-relative path."
+        )
+    components = re.split(r"[\\/]", value)
+    if "." in components or ".." in components:
+        raise ReviewRecordError(
+            f"Field '{field}' must not contain '.' or '..' path components."
+        )
+
+
+def _validate_fields(
+    data: dict[str, Any],
+    required: frozenset[str],
+    optional: frozenset[str],
+    context: str,
+) -> None:
+    missing = required - data.keys()
+    if missing:
+        field = sorted(missing)[0]
+        raise ReviewRecordError(
+            f"Missing required field '{field}' in {context}."
+        )
+    unknown = data.keys() - required - optional
+    if unknown:
+        field = sorted(unknown)[0]
+        raise ReviewRecordError(f"Unknown field '{field}' in {context}.")
+
+
+def _validate_record(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ReviewRecordError(f"{context} must be an object.")
+    return cast(dict[str, Any], value)
+
+
+def _validate_array(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ReviewRecordError(f"Field '{field}' must be a list.")
+    return value
+
+
+def _validate_exact_value(value: Any, field: str, expected: str) -> None:
+    if value != expected:
+        raise ReviewRecordError(
+            f"Field '{field}' must be the string '{expected}'."
+        )
+
+
+def _validate_identifier(value: Any, field: str) -> None:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise ReviewRecordError(str(error)) from error
+
+
+def _validate_unique_local_id(
+    value: Any, field: str, seen_ids: set[str]
+) -> str:
+    local_id = _validate_non_empty_string(value, field)
+    if local_id in seen_ids:
+        raise ReviewRecordError(f"Duplicate {field.rsplit('.', 1)[-1]} '{local_id}'.")
+    seen_ids.add(local_id)
+    return local_id
+
+
+def _validate_non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewRecordError(f"Field '{field}' must be a non-empty string.")
+    return value
+
+
+def _validate_positive_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ReviewRecordError(f"Field '{field}' must be a positive integer.")
+    return value
+
+
+def _validate_non_negative_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ReviewRecordError(
+            f"Field '{field}' must be a non-negative integer."
+        )
+    return value
+
+
+def _validate_finite_number(value: Any, field: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+    ):
+        raise ReviewRecordError(f"Field '{field}' must be a finite number.")
+    return float(value)
+
+
+def _validate_allowed_value(
+    value: Any, field: str, allowed_values: frozenset[str]
+) -> str:
+    if not isinstance(value, str) or value not in allowed_values:
+        allowed = ", ".join(sorted(allowed_values))
+        raise ReviewRecordError(
+            f"Invalid {field} {value!r}. Allowed values: {allowed}."
+        )
+    return value
+
+
+def _validate_timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ReviewRecordError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ReviewRecordError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewRecordError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    return parsed
+
+
+def _validate_json_object(value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        raise ReviewRecordError(f"Field '{field}' must be an object.")

--- a/quillan/review_record_paths.py
+++ b/quillan/review_record_paths.py
@@ -1,0 +1,124 @@
+"""Canonical paths and safe writing for Quillan submission review records."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.review_record import validate_review_record
+
+
+class ReviewRecordPathError(ValueError):
+    """Raised when a review record path or write operation is invalid."""
+
+
+def review_record_dir(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the canonical directory for one student's review record."""
+    _validate_identifier(class_id, "class_id")
+    _validate_identifier(assignment_id, "assignment_id")
+    _validate_identifier(student_id, "student_id")
+    return (
+        Path(workspace_root)
+        / "classes"
+        / class_id
+        / "assignments"
+        / assignment_id
+        / "submissions"
+        / student_id
+    )
+
+
+def review_record_path(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the canonical review.json path for one student."""
+    return (
+        review_record_dir(workspace_root, class_id, assignment_id, student_id)
+        / "review.json"
+    )
+
+
+def write_review_record(
+    path: str | Path,
+    record: dict[str, Any],
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Validate and safely write a review record as UTF-8 JSON."""
+    validate_review_record(record)
+    review_path = Path(path)
+
+    if not overwrite and review_path.exists():
+        raise ReviewRecordPathError(f"Review record already exists: {review_path}")
+
+    parent = review_path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise ReviewRecordPathError(
+            f"Could not create review record directory {parent}: {error}"
+        ) from error
+    if not parent.is_dir():
+        raise ReviewRecordPathError(
+            f"Review record parent is not a directory: {parent}"
+        )
+
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            prefix=f".{review_path.name}.",
+            suffix=".tmp",
+            dir=parent,
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            json.dump(record, temporary_file, ensure_ascii=False, indent=2)
+            temporary_file.write("\n")
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+
+        if overwrite:
+            os.replace(temporary_path, review_path)
+        else:
+            os.link(temporary_path, review_path)
+            temporary_path.unlink()
+        temporary_path = None
+    except FileExistsError as error:
+        raise ReviewRecordPathError(
+            f"Review record already exists: {review_path}"
+        ) from error
+    except (OSError, TypeError, ValueError) as error:
+        raise ReviewRecordPathError(
+            f"Could not write review record {review_path}: {error}"
+        ) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    return review_path
+
+
+def _validate_identifier(value: str, field: str) -> None:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise ReviewRecordPathError(str(error)) from error

--- a/tests/test_review_record.py
+++ b/tests/test_review_record.py
@@ -1,0 +1,487 @@
+"""Tests for Quillan submission review record loading and validation."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.review_record import (
+    ReviewRecordError,
+    load_review_record,
+    validate_review_record,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+EXAMPLE_PATH = (
+    Path(__file__).parents[1]
+    / "examples"
+    / "submissions"
+    / "review_record_synthetic.json"
+)
+
+
+def _record() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": "not_started",
+        "notes": [],
+        "tags": [],
+        "scores": [],
+        "comments": [],
+        "created_at": "2026-06-22T00:00:00+00:00",
+        "updated_at": "2026-06-22T00:00:00+00:00",
+        "module_details": {},
+    }
+
+
+def _note(note_id: str = "note_0001") -> dict[str, Any]:
+    return {
+        "note_id": note_id,
+        "text": "Teacher observation.",
+        "created_at": "2026-06-22T10:00:00-04:00",
+        "updated_at": "2026-06-22T10:05:00-04:00",
+        "module_details": {},
+    }
+
+
+def _tag(tag_id: str = "tag_0001") -> dict[str, Any]:
+    return {
+        "tag_id": tag_id,
+        "label": "Clear claim",
+        "polarity": "positive",
+        "created_at": "2026-06-22T10:00:00-04:00",
+        "module_details": {},
+    }
+
+
+def _score(
+    score_id: str = "score_0001",
+    criterion_id: str = "evidence",
+) -> dict[str, Any]:
+    return {
+        "score_id": score_id,
+        "criterion_id": criterion_id,
+        "label": "Evidence",
+        "score": 3,
+        "max_score": 4,
+        "updated_at": "2026-06-22T10:00:00-04:00",
+        "module_details": {},
+    }
+
+
+def _comment(comment_record_id: str = "comment_0001") -> dict[str, Any]:
+    return {
+        "comment_record_id": comment_record_id,
+        "label": "Explain evidence",
+        "text": "Explain how the evidence supports the claim.",
+        "source": "custom",
+        "include_in_feedback": True,
+        "created_at": "2026-06-22T10:00:00-04:00",
+        "module_details": {},
+    }
+
+
+def _write_json(path: Path, value: Any) -> Path:
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def test_valid_minimal_review_record() -> None:
+    validate_review_record(_record())
+
+
+def test_valid_populated_synthetic_review_record_loads() -> None:
+    record = load_review_record(EXAMPLE_PATH)
+
+    assert record["record_type"] == "submission_review"
+    assert len(record["tags"]) == 2
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "schema_version",
+        "module",
+        "record_type",
+        "class_id",
+        "assignment_id",
+        "student_id",
+        "submission_manifest_path",
+        "review_state",
+        "notes",
+        "tags",
+        "scores",
+        "comments",
+        "created_at",
+        "updated_at",
+        "module_details",
+    ],
+)
+def test_missing_required_top_level_field_is_rejected(field: str) -> None:
+    record = _record()
+    del record[field]
+
+    with pytest.raises(ReviewRecordError, match=field):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", "2"),
+        ("module", "other"),
+        ("record_type", "review"),
+    ],
+)
+def test_invalid_fixed_value_is_rejected(field: str, value: str) -> None:
+    record = _record()
+    record[field] = value
+
+    with pytest.raises(ReviewRecordError, match=field):
+        validate_review_record(record)
+
+
+def test_unknown_top_level_field_is_rejected() -> None:
+    record = _record()
+    record["extra"] = "not in schema version 1"
+
+    with pytest.raises(ReviewRecordError, match="Unknown field 'extra'"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("class_id", "../unsafe"),
+        ("assignment_id", "bad assignment"),
+        ("student_id", ""),
+    ],
+)
+def test_invalid_identifier_is_rejected(field: str, value: str) -> None:
+    record = _record()
+    record[field] = value
+
+    with pytest.raises(ReviewRecordError, match=field):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/classes/class/assignment/submission.json",
+        r"C:\workspace\submission.json",
+        (
+            f"classes/{CLASS_ID}/./assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        (
+            f"classes/{CLASS_ID}/assignments/../{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json\0"
+        ),
+        "submission.json",
+        (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            "different_student/submission.json"
+        ),
+    ],
+)
+def test_invalid_submission_manifest_path_is_rejected(path: str) -> None:
+    record = _record()
+    record["submission_manifest_path"] = path
+
+    with pytest.raises(ReviewRecordError, match="submission_manifest_path"):
+        validate_review_record(record)
+
+
+def test_invalid_review_state_is_rejected() -> None:
+    record = _record()
+    record["review_state"] = "reviewed"
+
+    with pytest.raises(ReviewRecordError, match="review_state"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize("value", ["", "not-a-time", "2026-06-22T10:00:00"])
+def test_invalid_or_naive_top_level_timestamp_is_rejected(value: str) -> None:
+    record = _record()
+    record["created_at"] = value
+
+    with pytest.raises(ReviewRecordError, match="created_at"):
+        validate_review_record(record)
+
+
+def test_top_level_updated_at_before_created_at_is_rejected() -> None:
+    record = _record()
+    record["created_at"] = "2026-06-22T11:00:00+00:00"
+    record["updated_at"] = "2026-06-22T10:59:59+00:00"
+
+    with pytest.raises(ReviewRecordError, match="must not precede"):
+        validate_review_record(record)
+
+
+def test_notes_must_be_a_list() -> None:
+    record = _record()
+    record["notes"] = {}
+
+    with pytest.raises(ReviewRecordError, match="notes.*list"):
+        validate_review_record(record)
+
+
+def test_duplicate_note_id_is_rejected() -> None:
+    record = _record()
+    record["notes"] = [_note(), _note()]
+
+    with pytest.raises(ReviewRecordError, match="Duplicate note_id"):
+        validate_review_record(record)
+
+
+def test_blank_note_text_is_rejected() -> None:
+    record = _record()
+    note = _note()
+    note["text"] = " \t"
+    record["notes"] = [note]
+
+    with pytest.raises(ReviewRecordError, match="text"):
+        validate_review_record(record)
+
+
+def test_note_updated_at_before_created_at_is_rejected() -> None:
+    record = _record()
+    note = _note()
+    note["updated_at"] = "2026-06-22T09:59:59-04:00"
+    record["notes"] = [note]
+
+    with pytest.raises(ReviewRecordError, match="must not precede"):
+        validate_review_record(record)
+
+
+def test_invalid_tag_polarity_is_rejected() -> None:
+    record = _record()
+    tag = _tag()
+    tag["polarity"] = "mixed"
+    record["tags"] = [tag]
+
+    with pytest.raises(ReviewRecordError, match="polarity"):
+        validate_review_record(record)
+
+
+def test_duplicate_tag_id_is_rejected() -> None:
+    record = _record()
+    record["tags"] = [_tag(), _tag()]
+
+    with pytest.raises(ReviewRecordError, match="Duplicate tag_id"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        {"type": "word", "value": 1},
+        {"type": "page", "value": 0},
+        {"type": "paragraph", "value": "one"},
+        {"type": "section", "value": ""},
+        {"type": "whole_submission", "value": 1},
+        {"type": "page"},
+        {"type": "page", "value": 1, "extra": True},
+    ],
+)
+def test_malformed_tag_location_is_rejected(location: dict[str, Any]) -> None:
+    record = _record()
+    tag = _tag()
+    tag["location"] = location
+    record["tags"] = [tag]
+
+    with pytest.raises(ReviewRecordError, match="location"):
+        validate_review_record(record)
+
+
+def test_page_location_must_agree_with_page_number() -> None:
+    record = _record()
+    tag = _tag()
+    tag["page_number"] = 2
+    tag["location"] = {"type": "page", "value": 1}
+    record["tags"] = [tag]
+
+    with pytest.raises(ReviewRecordError, match="agree"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("severity", -1),
+        ("severity", True),
+        ("page_number", 0),
+        ("teacher_note", " "),
+        ("evidence_id", ""),
+    ],
+)
+def test_invalid_optional_tag_field_is_rejected(field: str, value: Any) -> None:
+    record = _record()
+    tag = _tag()
+    tag[field] = value
+    record["tags"] = [tag]
+
+    with pytest.raises(ReviewRecordError, match=field):
+        validate_review_record(record)
+
+
+def test_duplicate_score_id_is_rejected() -> None:
+    record = _record()
+    record["scores"] = [_score(), _score(criterion_id="organization")]
+
+    with pytest.raises(ReviewRecordError, match="Duplicate score_id"):
+        validate_review_record(record)
+
+
+def test_duplicate_criterion_id_is_rejected() -> None:
+    record = _record()
+    record["scores"] = [_score(), _score(score_id="score_0002")]
+
+    with pytest.raises(ReviewRecordError, match="Duplicate criterion_id"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("score", "3"),
+        ("score", True),
+        ("score", -1),
+        ("score", float("inf")),
+        ("max_score", 0),
+        ("max_score", float("nan")),
+    ],
+)
+def test_invalid_score_value_is_rejected(field: str, value: Any) -> None:
+    record = _record()
+    score = _score()
+    score[field] = value
+    record["scores"] = [score]
+
+    with pytest.raises(ReviewRecordError, match=field):
+        validate_review_record(record)
+
+
+def test_score_greater_than_max_score_is_rejected() -> None:
+    record = _record()
+    score = _score()
+    score["score"] = 5
+    record["scores"] = [score]
+
+    with pytest.raises(ReviewRecordError, match="must not exceed"):
+        validate_review_record(record)
+
+
+def test_invalid_comment_source_is_rejected() -> None:
+    record = _record()
+    comment = _comment()
+    comment["source"] = "generated"
+    record["comments"] = [comment]
+
+    with pytest.raises(ReviewRecordError, match="source"):
+        validate_review_record(record)
+
+
+def test_non_boolean_include_in_feedback_is_rejected() -> None:
+    record = _record()
+    comment = _comment()
+    comment["include_in_feedback"] = 1
+    record["comments"] = [comment]
+
+    with pytest.raises(ReviewRecordError, match="include_in_feedback"):
+        validate_review_record(record)
+
+
+def test_duplicate_comment_record_id_is_rejected() -> None:
+    record = _record()
+    record["comments"] = [_comment(), _comment()]
+
+    with pytest.raises(ReviewRecordError, match="Duplicate comment_record_id"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    ("container", "item_factory"),
+    [
+        ("notes", _note),
+        ("tags", _tag),
+        ("scores", _score),
+        ("comments", _comment),
+    ],
+)
+def test_nested_module_details_must_be_an_object(
+    container: str,
+    item_factory: Any,
+) -> None:
+    record = _record()
+    item = item_factory()
+    item["module_details"] = []
+    record[container] = [item]
+
+    with pytest.raises(ReviewRecordError, match="module_details"):
+        validate_review_record(record)
+
+
+def test_top_level_module_details_must_be_an_object() -> None:
+    record = _record()
+    record["module_details"] = []
+
+    with pytest.raises(ReviewRecordError, match="module_details"):
+        validate_review_record(record)
+
+
+def test_valid_json_file_loads_successfully(tmp_path: Path) -> None:
+    record = _record()
+    path = _write_json(tmp_path / "review.json", record)
+
+    assert load_review_record(path) == record
+
+
+def test_missing_file_raises_review_record_error(tmp_path: Path) -> None:
+    with pytest.raises(ReviewRecordError, match="not found"):
+        load_review_record(tmp_path / "missing.json")
+
+
+def test_invalid_json_raises_review_record_error(tmp_path: Path) -> None:
+    path = tmp_path / "review.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ReviewRecordError, match="not valid JSON"):
+        load_review_record(path)
+
+
+@pytest.mark.parametrize("value", [[], "review", 1, None])
+def test_non_object_json_is_rejected(tmp_path: Path, value: Any) -> None:
+    path = _write_json(tmp_path / "review.json", value)
+
+    with pytest.raises(ReviewRecordError, match="JSON object"):
+        load_review_record(path)
+
+
+def test_structurally_invalid_json_object_is_rejected(tmp_path: Path) -> None:
+    record = copy.deepcopy(_record())
+    record["review_state"] = "invalid"
+    path = _write_json(tmp_path / "review.json", record)
+
+    with pytest.raises(ReviewRecordError, match="review_state"):
+        load_review_record(path)

--- a/tests/test_review_record_paths.py
+++ b/tests/test_review_record_paths.py
@@ -1,0 +1,155 @@
+"""Tests for canonical review record paths and safe writing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_dir,
+    review_record_path,
+    write_review_record,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+
+
+def _record() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": "not_started",
+        "notes": [],
+        "tags": [],
+        "scores": [],
+        "comments": [],
+        "created_at": "2026-06-22T00:00:00+00:00",
+        "updated_at": "2026-06-22T00:00:00+00:00",
+        "module_details": {"teacher_note": "Café"},
+    }
+
+
+def test_review_record_paths_use_canonical_quillan_layout(tmp_path: Path) -> None:
+    expected_dir = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+    )
+
+    result_dir = review_record_dir(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    result_path = review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+
+    assert result_dir == expected_dir
+    assert result_path == expected_dir / "review.json"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("class_id", "../unsafe"),
+        ("assignment_id", "bad assignment"),
+        ("student_id", ""),
+    ],
+)
+def test_review_record_paths_reject_invalid_identifiers(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    identifiers = {
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+    }
+    identifiers[field] = value
+
+    with pytest.raises(ReviewRecordPathError, match=field):
+        review_record_dir(tmp_path, **identifiers)
+
+
+def test_valid_record_is_written_readably_and_reloads(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "review.json"
+    record = _record()
+
+    result = write_review_record(path, record)
+
+    raw = path.read_bytes()
+    assert result == path
+    assert path.parent.is_dir()
+    assert raw.endswith(b"\n")
+    assert b'\n  "schema_version"' in raw
+    assert "Café" in raw.decode("utf-8")
+    assert load_review_record(path) == record
+
+
+def test_invalid_record_is_rejected_before_filesystem_write(tmp_path: Path) -> None:
+    path = tmp_path / "not-created" / "review.json"
+    record = _record()
+    del record["schema_version"]
+
+    with pytest.raises(ReviewRecordError, match="schema_version"):
+        write_review_record(path, record)
+
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+def test_existing_record_is_not_overwritten_by_default(tmp_path: Path) -> None:
+    path = tmp_path / "review.json"
+    path.write_text("original\n", encoding="utf-8")
+
+    with pytest.raises(ReviewRecordPathError, match="already exists"):
+        write_review_record(path, _record())
+
+    assert path.read_text(encoding="utf-8") == "original\n"
+
+
+def test_existing_record_is_replaced_only_when_overwrite_enabled(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "review.json"
+    path.write_text("original\n", encoding="utf-8")
+    record = _record()
+    record["review_state"] = "in_progress"
+
+    result = write_review_record(path, record, overwrite=True)
+
+    assert result == path
+    assert json.loads(path.read_text(encoding="utf-8")) == record
+
+
+def test_parent_path_that_is_a_file_raises(tmp_path: Path) -> None:
+    parent = tmp_path / "review-parent"
+    parent.write_text("not a directory", encoding="utf-8")
+    path = parent / "review.json"
+
+    with pytest.raises(
+        ReviewRecordPathError,
+        match="Could not create review record directory",
+    ):
+        write_review_record(path, _record())
+
+    assert parent.read_text(encoding="utf-8") == "not a directory"


### PR DESCRIPTION
## Summary

Adds the core v0.7 infrastructure for Quillan submission review records.

This PR implements runtime support for the canonical `review.json` contract defined in #94:

* strict review-record loading
* schema validation
* canonical review-record path helpers
* safe JSON writing
* overwrite protection
* focused test coverage

`review.json` remains separate from `submission.json`: the submission manifest continues to represent routed evidence and evidence-management state, while the review record represents teacher-entered notes, tags, scores, selected comments, and review/export state.

## Changes

* Added `quillan/review_record.py`

  * `ReviewRecordError`
  * `load_review_record(...)`
  * `validate_review_record(...)`
  * strict schema validation for version `1` review records
  * validation for notes, tags, scores, comments, timestamps, identifiers, canonical `submission_manifest_path`, controlled vocabularies, and local ID uniqueness

* Added `quillan/review_record_paths.py`

  * `ReviewRecordPathError`
  * `review_record_dir(...)`
  * `review_record_path(...)`
  * `write_review_record(...)`
  * validate-before-write behavior
  * parent directory creation
  * default overwrite refusal
  * explicit overwrite support
  * UTF-8 pretty JSON output with trailing newline

* Added focused tests for:

  * valid minimal review records
  * the synthetic populated review example
  * required fields
  * fixed top-level values
  * unknown fields
  * invalid identifiers
  * unsafe or noncanonical paths
  * invalid review states
  * invalid and naive timestamps
  * malformed notes, tags, scores, and comments
  * duplicate local IDs
  * loader failures
  * canonical path helpers
  * safe writing and overwrite protection

* Updated documentation and changelog to reflect the new infrastructure.

## Non-Goals

This PR does not implement:

* CLI commands
* terminal-menu workflows
* `add-note`
* `add-tag`
* `set-score`
* comment-bank lookup
* feedback export
* class or standards summary export
* AI scoring
* AI feedback
* OCR
* automatic grading
* `tags.json` or `scores.json` generation

Those remain separate v0.7 sub-issues.

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

624 tests passed.

Closes #95
