### PR TITLE
feat: add quick review notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan add-note` and a focused quick-note API for appending
+  timestamped, teacher-entered notes to a student's canonical `review.json`.
+  The workflow requires a valid matching `submission.json`, creates a missing
+  review record in `in_progress`, advances only `not_started` records, preserves
+  later review states and all existing review sections, and never mutates the
+  submission manifest or student evidence.
 - Added Quillan-owned version `1` review-record infrastructure with strict
   loading and validation for identities, canonical manifest references,
   review states, timestamps, notes, tags, locations, scores, comments, and

--- a/README.md
+++ b/README.md
@@ -130,8 +130,10 @@ The supported teacher/developer sequence is:
 6. `list-submissions` reports assignment status without writing files.
 7. `open-submission` opens the selected evidence for a specific student.
 8. The teacher reads and evaluates the evidence in the local system viewer.
-9. `set-review-state` records lightweight review progress when the teacher
-   chooses.
+9. `add-note` appends a teacher-entered observation to the student's canonical
+   `review.json`.
+10. `set-review-state` records lightweight submission-manifest progress when
+    the teacher chooses.
 
 Opening evidence and updating review state are separate teacher-controlled
 actions. Opening a file never marks a submission reviewed.
@@ -144,6 +146,7 @@ quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-evidence-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
+quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
@@ -160,6 +163,10 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   low-level helper; it does not determine which student submission to review.
 - `open-submission` opens one student's selected evidence and requires exactly
   one selected evidence item; it does not update review metadata.
+- `add-note` appends teacher-entered text to `review.json`, creating that
+  record only when the adjacent `submission.json` exists, validates, and
+  matches the requested student submission. It does not mutate evidence or
+  the submission manifest.
 - `set-review-state` updates only the manifest's `submission_state` and
   `updated_at`; it does not inspect evidence or make a review decision.
 
@@ -167,10 +174,12 @@ Allowed review states are `unreviewed`, `in_progress`, `needs_rescan`, and
 `reviewed`. The review-state update is metadata-only and occurs only when the
 teacher explicitly requests it.
 
-Quillan v0.6 does not perform OCR, handwriting recognition, PDF text
+Quillan does not perform OCR, handwriting recognition, PDF text
 extraction, AI scoring, AI feedback, AI suggestions, automatic grading,
 automatic review-state updates, automatic evidence selection among duplicates,
-rubric scoring, tagging, comment entry, feedback export, or report generation.
+rubric scoring, structured tagging, reusable comment selection, feedback
+export, or report generation. Quick notes are freeform teacher-entered records;
+they do not score, tag, or generate feedback by themselves.
 The teacher remains responsible for reading and evaluating student work.
 
 ## Current Non-Goals
@@ -382,6 +391,19 @@ Allowed states are `unreviewed`, `in_progress`, `needs_rescan`, and `reviewed`.
 The command changes only `submission_state` and `updated_at` in the validated
 manifest. Opening a submission does not update its state. This command does
 not open or inspect evidence, score, tag, evaluate, run OCR, or generate
+feedback.
+
+Append a quick teacher note to one student's canonical review record:
+
+```powershell
+quillan add-note <class_id> <assignment_id> <student_id> --text "Strong claim, but evidence explanation needs work."
+```
+
+Notes are stored in `review.json` with stable local IDs and timezone-aware
+timestamps. If `review.json` does not exist, Quillan creates it only after the
+adjacent `submission.json` validates and matches the requested class,
+assignment, and student. Adding a note never mutates `submission.json`, routed
+evidence, or retained source scans, and it does not score, tag, or generate
 feedback.
 
 Validate a standards profile:

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -450,6 +450,28 @@ level:
 No command may silently discard teacher-entered records. Editing or deleting
 append-only records requires a future, explicit contract and workflow.
 
+## Quick Teacher Notes
+
+The direct quick-note command is:
+
+```powershell
+quillan add-note <class_id> <assignment_id> <student_id> --text "..."
+```
+
+It appends one teacher-entered note to the canonical `review.json`. A missing
+review record is created only after the adjacent canonical `submission.json`
+loads, validates, and matches the requested identity. New records begin in
+`in_progress`; an existing `not_started` record advances to `in_progress`, while
+`in_progress`, `ready_for_export`, and `exported` are preserved.
+
+Quick notes receive sequential local IDs such as `note_0001`, trim surrounding
+whitespace from non-empty teacher text, and use one timezone-aware timestamp
+for the note's initial `created_at` and `updated_at`. The operation preserves
+existing notes, tags, scores, comments, module details, and top-level
+`created_at`, validates the complete proposed record before an atomic write,
+and does not mutate the submission manifest, routed evidence, or retained
+source scans.
+
 ## Derived Artifacts and Historical Names
 
 `review.json` is the canonical active v0.7 teacher-review record for notes,

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -41,6 +41,11 @@ from quillan.routing_review import (
     preserve_route_failure_for_review,
     preserve_routing_failure_for_review,
 )
+from quillan.review_notes import (
+    AddedReviewNote,
+    ReviewNoteError,
+    add_review_note,
+)
 from quillan.standards import StandardsProfileError, load_standards_profile
 from quillan.submission_status import (
     AssignmentSubmissionStatus,
@@ -107,6 +112,14 @@ def main(argv: list[str] | None = None) -> int:
             args.assignment_id,
             args.student_id,
             args.state,
+        )
+
+    if args.command == "add-note":
+        return _handle_add_note(
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            args.text,
         )
 
     if args.command == "workspace" and args.workspace_command == "show":
@@ -270,6 +283,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Review state: unreviewed, in_progress, needs_rescan, or reviewed."
         ),
+    )
+
+    add_note_parser = subparsers.add_parser(
+        "add-note",
+        help="Add a teacher note to one student review record.",
+        description=(
+            "Append one teacher-entered note to the canonical review.json for "
+            "a student submission. Creates review.json when the adjacent "
+            "submission.json exists and validates."
+        ),
+    )
+    add_note_parser.add_argument("class_id", help="Class identifier.")
+    add_note_parser.add_argument("assignment_id", help="Assignment identifier.")
+    add_note_parser.add_argument("student_id", help="Student identifier.")
+    add_note_parser.add_argument(
+        "--text",
+        required=True,
+        help="Non-empty teacher note text.",
     )
 
     workspace_parser = subparsers.add_parser(
@@ -544,6 +575,41 @@ def _print_updated_submission_review_state(
     print(f"Previous state: {updated.previous_state}")
     print(f"New state: {updated.new_state}")
     print(f"Manifest: {updated.manifest_relative_path}")
+
+
+def _handle_add_note(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    text: str,
+) -> int:
+    """Append one teacher note to a canonical review record."""
+    try:
+        workspace_root = resolve_workspace_root()
+        added = add_review_note(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            text,
+        )
+    except (WorkspaceRootError, ReviewNoteError) as error:
+        print(f"Error: could not add teacher note: {error}")
+        return 1
+
+    _print_added_review_note(added)
+    return 0
+
+
+def _print_added_review_note(added: AddedReviewNote) -> None:
+    """Print a concise teacher-facing note summary."""
+    print("Added teacher note:")
+    print(f"Class: {added.class_id}")
+    print(f"Assignment: {added.assignment_id}")
+    print(f"Student: {added.student_id}")
+    print(f"Note: {added.note_id}")
+    print(f"Review state: {added.review_state}")
+    print(f"Review record: {added.review_record_relative_path}")
 
 
 def _print_assignment_submission_status(

--- a/quillan/review_notes.py
+++ b/quillan/review_notes.py
@@ -1,0 +1,268 @@
+"""Teacher-entered quick notes for submission review records."""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.review_record import (
+    ReviewRecordError,
+    load_review_record,
+    validate_review_record,
+)
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+_SEQUENTIAL_NOTE_ID = re.compile(r"^note_(\d{4})$")
+
+
+class ReviewNoteError(Exception):
+    """Raised when a teacher note cannot be added safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class AddedReviewNote:
+    """Information about a teacher note added to a review record."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    note_id: str
+    review_state: str
+    created_at: str
+
+
+def add_review_note(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    text: str,
+    *,
+    created_at: datetime | str | None = None,
+) -> AddedReviewNote:
+    """Append one teacher-entered note to a canonical review record."""
+    normalized_text = _normalize_text(text)
+    normalized_created_at = _normalize_timestamp(created_at)
+
+    try:
+        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        record_path = review_record_path(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewNoteError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise ReviewNoteError(
+            "Submission manifest does not exist for "
+            f"class={class_id}, assignment={assignment_id}, student={student_id}."
+        )
+
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise ReviewNoteError(
+            f"Could not load submission manifest: {error}"
+        ) from error
+    _validate_identity(
+        manifest,
+        record_name="Submission manifest",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+
+    if record_path.exists():
+        try:
+            review = load_review_record(record_path)
+        except (OSError, ReviewRecordError) as error:
+            raise ReviewNoteError(
+                f"Could not load review record: {error}"
+            ) from error
+        _validate_identity(
+            review,
+            record_name="Review record",
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+        )
+        updated_review = copy.deepcopy(review)
+        if updated_review["review_state"] == "not_started":
+            updated_review["review_state"] = "in_progress"
+    else:
+        manifest_relative_path = _workspace_relative_path(
+            manifest_path, resolved_workspace_root, "submission manifest"
+        )
+        updated_review = {
+            "schema_version": "1",
+            "module": "quillan",
+            "record_type": "submission_review",
+            "class_id": class_id,
+            "assignment_id": assignment_id,
+            "student_id": student_id,
+            "submission_manifest_path": manifest_relative_path,
+            "review_state": "in_progress",
+            "notes": [],
+            "tags": [],
+            "scores": [],
+            "comments": [],
+            "created_at": normalized_created_at,
+            "updated_at": normalized_created_at,
+            "module_details": {},
+        }
+
+    note_id = _next_note_id(updated_review["notes"])
+    updated_review["notes"].append(
+        {
+            "note_id": note_id,
+            "text": normalized_text,
+            "created_at": normalized_created_at,
+            "updated_at": normalized_created_at,
+            "module_details": {},
+        }
+    )
+    updated_review["updated_at"] = normalized_created_at
+
+    try:
+        validate_review_record(updated_review)
+        write_review_record(
+            record_path,
+            updated_review,
+            overwrite=record_path.exists(),
+        )
+        record_relative_path = _workspace_relative_path(
+            record_path, resolved_workspace_root, "review record"
+        )
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        ReviewRecordError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewNoteError(f"Could not write review record: {error}") from error
+
+    return AddedReviewNote(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=record_path,
+        review_record_relative_path=record_relative_path,
+        note_id=note_id,
+        review_state=updated_review["review_state"],
+        created_at=normalized_created_at,
+    )
+
+
+def _normalize_text(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewNoteError("Teacher note text must be a non-empty string.")
+    return value.strip()
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReviewNoteError("created_at datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise ReviewNoteError(
+            "created_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ReviewNoteError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewNoteError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    *,
+    record_name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    requested = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+    for field, expected in requested.items():
+        actual = record[field]
+        if actual != expected:
+            raise ReviewNoteError(
+                f"{record_name} {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _next_note_id(notes: list[dict[str, Any]]) -> str:
+    existing_ids = {note["note_id"] for note in notes}
+    highest = max(
+        (
+            int(match.group(1))
+            for note_id in existing_ids
+            if (match := _SEQUENTIAL_NOTE_ID.fullmatch(note_id))
+        ),
+        default=0,
+    )
+    candidate_number = highest + 1
+    while True:
+        candidate = f"note_{candidate_number:04d}"
+        if candidate not in existing_ids:
+            return candidate
+        candidate_number += 1
+
+
+def _workspace_relative_path(
+    path: Path,
+    workspace_root: Path,
+    description: str,
+) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewNoteError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error

--- a/tests/test_review_notes.py
+++ b/tests/test_review_notes.py
@@ -1,0 +1,560 @@
+"""Tests for teacher-entered quick review notes."""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.review_notes import (
+    AddedReviewNote,
+    ReviewNoteError,
+    add_review_note,
+)
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
+FIRST_NOTE_TIMESTAMP = "2026-06-22T13:30:00-04:00"
+SECOND_NOTE_TIMESTAMP = "2026-06-22T14:00:00-04:00"
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [
+                    {
+                        "evidence_id": "evidence_001",
+                        "routed_evidence_path": (
+                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            "scans/response_00107_pg_001.pdf"
+                        ),
+                        "evidence_role": "selected",
+                        "evidence_state": "active",
+                        "duplicate_number": None,
+                        "created_at": ORIGINAL_TIMESTAMP,
+                        "retained_source": {
+                            "source_scan_id": "scan_001",
+                            "source_filename": "source.pdf",
+                            "source_sha256": "a" * 64,
+                            "retained_source_path": (
+                                "routing/source_scans/scan_001/source.pdf"
+                            ),
+                            "source_page_number": 1,
+                        },
+                        "module_details": {"source": "synthetic"},
+                    }
+                ],
+            }
+        ],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {"teacher_workflow": "paper"},
+    }
+
+
+def _review(state: str = "not_started") -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": state,
+        "notes": [
+            {
+                "note_id": "note_0001",
+                "text": "Existing note.",
+                "created_at": FIRST_NOTE_TIMESTAMP,
+                "updated_at": FIRST_NOTE_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "tags": [
+            {
+                "tag_id": "tag_0001",
+                "label": "Clear claim",
+                "polarity": "positive",
+                "created_at": FIRST_NOTE_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "scores": [
+            {
+                "score_id": "score_0001",
+                "criterion_id": "evidence",
+                "label": "Evidence",
+                "score": 3,
+                "max_score": 4,
+                "updated_at": FIRST_NOTE_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "comments": [
+            {
+                "comment_record_id": "comment_0001",
+                "label": "Explain evidence",
+                "text": "Explain how the evidence supports the claim.",
+                "source": "custom",
+                "include_in_feedback": True,
+                "created_at": FIRST_NOTE_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "created_at": FIRST_NOTE_TIMESTAMP,
+        "updated_at": FIRST_NOTE_TIMESTAMP,
+        "module_details": {"preserve": True},
+    }
+
+
+def _write_manifest(workspace: Path, manifest: dict[str, Any] | None = None) -> Path:
+    path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    return write_submission_manifest(
+        path, _manifest() if manifest is None else manifest
+    )
+
+
+def _write_review(workspace: Path, review: dict[str, Any]) -> Path:
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    return write_review_record(path, review)
+
+
+def test_creates_review_record_from_valid_submission_without_mutating_evidence(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    evidence_path = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_00107_pg_001.pdf"
+    )
+    retained_path = tmp_path / "routing" / "source_scans" / "scan_001" / "source.pdf"
+    evidence_path.parent.mkdir(parents=True)
+    retained_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"routed evidence")
+    retained_path.write_bytes(b"retained source")
+    original_manifest = manifest_path.read_bytes()
+
+    result = add_review_note(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "  Strong claim.  ",
+        created_at=FIRST_NOTE_TIMESTAMP,
+    )
+
+    expected_relative_path = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/review.json"
+    )
+    assert result == AddedReviewNote(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        review_record_path=review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ),
+        review_record_relative_path=expected_relative_path,
+        note_id="note_0001",
+        review_state="in_progress",
+        created_at=FIRST_NOTE_TIMESTAMP,
+    )
+    written = json.loads(result.review_record_path.read_text(encoding="utf-8"))
+    assert written["submission_manifest_path"] == expected_relative_path.replace(
+        "review.json", "submission.json"
+    )
+    assert written["review_state"] == "in_progress"
+    assert written["tags"] == written["scores"] == written["comments"] == []
+    assert written["created_at"] == written["updated_at"] == FIRST_NOTE_TIMESTAMP
+    assert written["notes"] == [
+        {
+            "note_id": "note_0001",
+            "text": "Strong claim.",
+            "created_at": FIRST_NOTE_TIMESTAMP,
+            "updated_at": FIRST_NOTE_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    assert manifest_path.read_bytes() == original_manifest
+    assert evidence_path.read_bytes() == b"routed evidence"
+    assert retained_path.read_bytes() == b"retained source"
+
+
+def test_appends_note_and_preserves_existing_review_sections(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    original = _review()
+    path = _write_review(tmp_path, original)
+
+    result = add_review_note(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "Second note.",
+        created_at=SECOND_NOTE_TIMESTAMP,
+    )
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert result.note_id == "note_0002"
+    assert written["notes"][:-1] == original["notes"]
+    assert written["notes"][-1]["note_id"] == "note_0002"
+    for field in ("tags", "scores", "comments", "module_details"):
+        assert written[field] == original[field]
+    assert written["created_at"] == original["created_at"]
+    assert written["updated_at"] == SECOND_NOTE_TIMESTAMP
+    assert written["review_state"] == "in_progress"
+
+
+@pytest.mark.parametrize(
+    ("initial_state", "expected_state"),
+    [
+        ("not_started", "in_progress"),
+        ("in_progress", "in_progress"),
+        ("ready_for_export", "ready_for_export"),
+        ("exported", "exported"),
+    ],
+)
+def test_append_uses_narrow_review_state_transition(
+    tmp_path: Path,
+    initial_state: str,
+    expected_state: str,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_review(tmp_path, _review(initial_state))
+
+    result = add_review_note(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "State policy note.",
+        created_at=SECOND_NOTE_TIMESTAMP,
+    )
+
+    assert result.review_state == expected_state
+
+
+def test_note_id_skips_nonconforming_ids_and_uses_highest_sequence(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    review = _review()
+    review["notes"].extend(
+        [
+            {
+                "note_id": "custom-note",
+                "text": "Custom identifier.",
+                "created_at": FIRST_NOTE_TIMESTAMP,
+                "updated_at": FIRST_NOTE_TIMESTAMP,
+                "module_details": {},
+            },
+            {
+                "note_id": "note_0004",
+                "text": "Later sequence.",
+                "created_at": FIRST_NOTE_TIMESTAMP,
+                "updated_at": FIRST_NOTE_TIMESTAMP,
+                "module_details": {},
+            },
+        ]
+    )
+    _write_review(tmp_path, review)
+
+    result = add_review_note(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "Next sequence.",
+        created_at=SECOND_NOTE_TIMESTAMP,
+    )
+
+    assert result.note_id == "note_0005"
+
+
+@pytest.mark.parametrize("text", ["", " \t "])
+def test_blank_text_is_rejected_without_creating_review(
+    tmp_path: Path, text: str
+) -> None:
+    _write_manifest(tmp_path)
+    path = review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+
+    with pytest.raises(ReviewNoteError, match="non-empty"):
+        add_review_note(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            text,
+            created_at=FIRST_NOTE_TIMESTAMP,
+        )
+
+    assert not path.exists()
+
+
+def test_missing_submission_is_rejected_without_creating_review(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ReviewNoteError, match="does not exist"):
+        add_review_note(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "A note.",
+            created_at=FIRST_NOTE_TIMESTAMP,
+        )
+
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+
+
+@pytest.mark.parametrize(
+    ("record_kind", "field", "value"),
+    [
+        ("submission", "class_id", "other_class"),
+        ("submission", "assignment_id", "other_assignment"),
+        ("submission", "student_id", "00108"),
+        ("review", "class_id", "other_class"),
+        ("review", "assignment_id", "other_assignment"),
+        ("review", "student_id", "00108"),
+    ],
+)
+def test_identity_mismatch_is_rejected_without_writing(
+    tmp_path: Path,
+    record_kind: str,
+    field: str,
+    value: str,
+) -> None:
+    manifest = _manifest()
+    review = _review()
+    if record_kind == "submission":
+        manifest[field] = value
+    else:
+        review[field] = value
+        review["submission_manifest_path"] = (
+            f"classes/{review['class_id']}/assignments/{review['assignment_id']}"
+            f"/submissions/{review['student_id']}/submission.json"
+        )
+    _write_manifest(tmp_path, manifest)
+    review_path = _write_review(tmp_path, review) if record_kind == "review" else None
+    original = review_path.read_bytes() if review_path else None
+
+    with pytest.raises(ReviewNoteError, match=field):
+        add_review_note(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "A note.",
+            created_at=SECOND_NOTE_TIMESTAMP,
+        )
+
+    if review_path:
+        assert review_path.read_bytes() == original
+    else:
+        assert not review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).exists()
+
+
+@pytest.mark.parametrize("record_kind", ["submission", "review"])
+def test_invalid_existing_record_is_rejected_without_review_write(
+    tmp_path: Path, record_kind: str
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    review_path = review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    if record_kind == "submission":
+        manifest_path.write_text("{", encoding="utf-8")
+    else:
+        review_path.parent.mkdir(parents=True, exist_ok=True)
+        review_path.write_text("{", encoding="utf-8")
+    original = review_path.read_bytes() if review_path.exists() else None
+
+    with pytest.raises(ReviewNoteError, match="not valid JSON"):
+        add_review_note(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "A note.",
+            created_at=SECOND_NOTE_TIMESTAMP,
+        )
+
+    assert (
+        review_path.read_bytes() if review_path.exists() else None
+    ) == original
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "not-a-time",
+        "2026-06-22T13:30:00",
+        datetime(2026, 6, 22, 13, 30),
+        123,
+    ],
+)
+def test_invalid_timestamp_is_rejected_without_writing(
+    tmp_path: Path, timestamp: object
+) -> None:
+    _write_manifest(tmp_path)
+
+    with pytest.raises(ReviewNoteError, match="timezone-aware"):
+        add_review_note(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "A note.",
+            created_at=timestamp,  # type: ignore[arg-type]
+        )
+
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+
+
+def test_timezone_aware_datetime_is_normalized(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    timestamp = datetime(2026, 6, 22, 17, 30, tzinfo=timezone.utc)
+
+    result = add_review_note(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "A note.",
+        created_at=timestamp,
+    )
+
+    assert result.created_at == timestamp.isoformat()
+
+
+def test_cli_success_creates_note_and_prints_teacher_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "add-note",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--text",
+            "CLI note.",
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Added teacher note:" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Note: note_0001" in output
+    assert "Review state: in_progress" in output
+    assert (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/review.json"
+    ) in output
+    written = json.loads(
+        review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert written["notes"][0]["text"] == "CLI note."
+
+
+@pytest.mark.parametrize("prepare_submission", [True, False])
+def test_cli_handled_failure_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    prepare_submission: bool,
+) -> None:
+    if prepare_submission:
+        _write_manifest(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    text = " " if prepare_submission else "A note."
+
+    result = main(
+        [
+            "add-note",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--text",
+            text,
+        ]
+    )
+
+    assert result == 1
+    assert "Error: could not add teacher note:" in capsys.readouterr().out
+
+
+def test_cli_append_preserves_existing_sections(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_manifest(tmp_path)
+    original = _review("ready_for_export")
+    path = _write_review(tmp_path, copy.deepcopy(original))
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "add-note",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--text",
+            "CLI append.",
+        ]
+    ) == 0
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    for field in ("tags", "scores", "comments", "module_details"):
+        assert written[field] == original[field]
+    assert written["review_state"] == "ready_for_export"


### PR DESCRIPTION
## Summary

Adds quick teacher notes for Quillan v0.7 review records.

This PR introduces the first teacher-facing review action built on the canonical `review.json` infrastructure:

```powershell
quillan add-note <class_id> <assignment_id> <student_id> --text "..."
```

The command appends a teacher-entered note to one student’s review record. If `review.json` does not exist, it creates a valid review record only when the adjacent `submission.json` exists, validates, and matches the requested class, assignment, and student.

## Changes

* Added `quillan/review_notes.py`

  * `ReviewNoteError`
  * `AddedReviewNote`
  * `add_review_note(...)`
  * note text validation
  * timestamp normalization
  * sequential note IDs
  * review-record creation
  * review-record append behavior
  * review-state transition policy
  * identity checks against `submission.json` and existing `review.json`

* Added CLI support:

  ```powershell
  quillan add-note <class_id> <assignment_id> <student_id> --text "..."
  ```

* Added teacher-facing success output showing:

  * class
  * assignment
  * student
  * note ID
  * review state
  * review-record path

* Added focused tests covering:

  * new `review.json` creation
  * append behavior
  * sequential note IDs
  * preservation of notes, tags, scores, comments, and module details
  * timestamp behavior
  * review-state transition behavior
  * blank-note rejection
  * missing submission rejection
  * invalid submission rejection
  * identity mismatch rejection
  * invalid existing review-record rejection
  * non-mutation of `submission.json`
  * non-mutation of routed evidence and retained source files
  * CLI success and handled failure behavior

* Updated documentation and changelog.

## Review-State Behavior

This PR applies the narrow note-specific state policy:

* new review record: `in_progress`
* existing `not_started`: advances to `in_progress`
* existing `in_progress`: remains `in_progress`
* existing `ready_for_export`: preserved
* existing `exported`: preserved

The command does not update `submission_state` in `submission.json`.

## Non-Mutation Guarantees

This PR does not mutate:

* `submission.json`
* routed evidence files
* retained source scans
* existing tags
* existing scores
* existing comments
* existing module details

Existing review data is preserved when a note is appended.

## Non-Goals

This PR does not implement:

* note editing
* note deletion
* structured tags
* rubric scores
* reusable comment selection
* comment-bank lookup
* feedback export
* class summary CSV export
* standards summary CSV export
* terminal-menu review workflow
* AI scoring
* AI feedback
* OCR
* automatic grading
* `tags.json` or `scores.json` generation

Those remain separate v0.7 sub-issues.

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

651 tests passed.

Closes #96
