### PR TITLE
feat: add structured review tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan add-tag` and a focused structured-tag API for appending
+  teacher-entered tags to canonical `review.json` records. The workflow
+  validates tag fields, timestamps, pages, evidence IDs, locations, assignment
+  standards, and reusable profile comments; assigns stable sequential IDs;
+  preserves existing review content and later review states; and never mutates
+  submission manifests or evidence.
 - Added `quillan add-note` and a focused quick-note API for appending
   timestamped, teacher-entered notes to a student's canonical `review.json`.
   The workflow requires a valid matching `submission.json`, creates a missing

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ The supported teacher/developer sequence is:
 8. The teacher reads and evaluates the evidence in the local system viewer.
 9. `add-note` appends a teacher-entered observation to the student's canonical
    `review.json`.
-10. `set-review-state` records lightweight submission-manifest progress when
+10. `add-tag` appends a teacher-entered structured observation to that review
+    record.
+11. `set-review-state` records lightweight submission-manifest progress when
     the teacher chooses.
 
 Opening evidence and updating review state are separate teacher-controlled
@@ -147,6 +149,7 @@ quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-evidence-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
+quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
@@ -167,6 +170,10 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   record only when the adjacent `submission.json` exists, validates, and
   matches the requested student submission. It does not mutate evidence or
   the submission manifest.
+- `add-tag` appends a teacher-entered structured tag to `review.json`. Tags
+  may reference a validated standard, reusable profile comment, page,
+  evidence ID, or writing location, but they do not score work, prove mastery,
+  or generate feedback.
 - `set-review-state` updates only the manifest's `submission_state` and
   `updated_at`; it does not inspect evidence or make a review decision.
 
@@ -177,9 +184,9 @@ teacher explicitly requests it.
 Quillan does not perform OCR, handwriting recognition, PDF text
 extraction, AI scoring, AI feedback, AI suggestions, automatic grading,
 automatic review-state updates, automatic evidence selection among duplicates,
-rubric scoring, structured tagging, reusable comment selection, feedback
-export, or report generation. Quick notes are freeform teacher-entered records;
-they do not score, tag, or generate feedback by themselves.
+rubric scoring, reusable comment selection into feedback, feedback export, or
+report generation. Quick notes and structured tags are teacher-entered
+records; they do not score or generate feedback by themselves.
 The teacher remains responsible for reading and evaluating student work.
 
 ## Current Non-Goals
@@ -406,6 +413,24 @@ assignment, and student. Adding a note never mutates `submission.json`, routed
 evidence, or retained source scans, and it does not score, tag, or generate
 feedback.
 
+Append a structured teacher tag:
+
+```powershell
+quillan add-tag <class_id> <assignment_id> <student_id> --label "Evidence needs more explanation" --polarity developing
+```
+
+Tags are stored in the `tags` array of the student's canonical `review.json`.
+Optional flags can reference a standard (`--standard`), profile comment
+(`--comment-id`), severity, teacher note, page, evidence ID, and controlled
+location. Standard and comment references use the assignment config and
+`shared/standards/<profile_id>.json`; standards in the profile are allowed
+even when they are not assignment focus standards. A missing review record is
+created only for a valid matching `submission.json`.
+
+Tags remain teacher-entered review artifacts. Adding one does not mutate the
+submission manifest or evidence, calculate a score, establish standard
+mastery, analyze writing, or generate feedback.
+
 Validate a standards profile:
 
 ```powershell
@@ -480,6 +505,8 @@ quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
+quillan add-note <class_id> <assignment_id> <student_id> --text "..."
+quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan workspace show
 quillan menu

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -356,6 +356,24 @@ A future command that writes files must document its destination, overwrite
 policy, and partial-failure behavior before that behavior is treated as
 stable.
 
+## Structured Review Tags
+
+```powershell
+quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
+```
+
+This direct command appends one teacher-entered tag to the canonical
+`review.json`, creating that record only when the adjacent `submission.json`
+exists, validates, and matches the requested identity. Optional flags are
+`--standard`, `--comment-id`, `--severity`, `--note`, `--page`,
+`--evidence-id`, `--location-type`, and `--location-value`.
+
+Handled workspace, record, and tag-validation failures return `1`. Success
+returns `0` and reports the class, assignment, student, tag ID, polarity,
+review state, and workspace-relative review-record path. The command never
+mutates the submission manifest, routed evidence, or retained source scans,
+and it does not score, analyze, or generate feedback.
+
 ## Output and Error Handling
 
 Human-readable command results are the current output contract. Quillan does

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -472,6 +472,27 @@ existing notes, tags, scores, comments, module details, and top-level
 and does not mutate the submission manifest, routed evidence, or retained
 source scans.
 
+## Structured Teacher Tags
+
+The direct structured-tag command is:
+
+```powershell
+quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
+```
+
+It appends one teacher-entered tag to `tags`, using sequential IDs such as
+`tag_0001`. Optional references to pages and evidence IDs are validated
+against the adjacent submission manifest. Optional standard and comment
+references are validated through the assignment config and the canonical
+`shared/standards/<profile_id>.json` profile. Standards present in the profile
+are accepted even when they are outside `focus_standards`; reusable comment
+labels and polarities must match their stored profile values.
+
+The command follows the same creation, timestamp, state-transition, complete
+record validation, safe-write, preservation, and non-mutation policies as
+quick notes. Tags organize teacher judgment only; they do not calculate
+scores, prove mastery, analyze student writing, or generate feedback.
+
 ## Derived Artifacts and Historical Names
 
 `review.json` is the canonical active v0.7 teacher-review record for notes,
@@ -500,10 +521,10 @@ selected comment is stored in
 
 This contract does not implement:
 
-* `add-note`, `add-tag`, `set-score`, or other review commands;
-* comment-bank lookup or reusable-comment management;
+* `set-score` or other review commands beyond `add-note` and `add-tag`;
+* standalone comment-bank lookup or reusable-comment management;
 * feedback, class-summary, or standards-summary export;
-* CLI or terminal-menu review workflows;
+* terminal-menu review workflows or review CLI commands beyond those listed;
 * editing or deletion of append-only review artifacts;
 * AI scoring, feedback, comments, suggestions, or automated grading;
 * automatic standard detection;

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -13,11 +13,12 @@ present an unconfirmed software judgment as a teacher evaluation or encourage
 review without reading the student's work.
 
 This document defines the review model and data boundaries. Quillan currently
-validates relevant data contracts and can prepare printable writing-response
-pages, but it does not yet implement complete requirements-checking, tagging,
-scoring, feedback, reporting, or teacher-facing review workflows. Its initial
-terminal menu is a navigation skeleton rather than a review implementation.
-AI tagging, AI scoring, AI feedback, and automatic grading are not implemented.
+validates relevant data contracts, can prepare printable writing-response
+pages, and supports direct teacher-entered quick notes and structured tags.
+It does not yet implement complete requirements-checking, scoring, feedback,
+reporting, or terminal-menu review workflows. Its initial terminal menu is a
+navigation skeleton rather than a review implementation. AI tagging, AI
+scoring, AI feedback, and automatic grading are not implemented.
 
 ## Source Evidence
 

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -46,6 +46,11 @@ from quillan.review_notes import (
     ReviewNoteError,
     add_review_note,
 )
+from quillan.review_tags import (
+    AddedReviewTag,
+    ReviewTagError,
+    add_review_tag,
+)
 from quillan.standards import StandardsProfileError, load_standards_profile
 from quillan.submission_status import (
     AssignmentSubmissionStatus,
@@ -120,6 +125,23 @@ def main(argv: list[str] | None = None) -> int:
             args.assignment_id,
             args.student_id,
             args.text,
+        )
+
+    if args.command == "add-tag":
+        return _handle_add_tag(
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            label=args.label,
+            polarity=args.polarity,
+            standard_code=args.standard,
+            comment_id=args.comment_id,
+            severity=args.severity,
+            teacher_note=args.note,
+            page_number=args.page,
+            evidence_id=args.evidence_id,
+            location_type=args.location_type,
+            location_value=args.location_value,
         )
 
     if args.command == "workspace" and args.workspace_command == "show":
@@ -301,6 +323,57 @@ def _build_parser() -> argparse.ArgumentParser:
         "--text",
         required=True,
         help="Non-empty teacher note text.",
+    )
+
+    add_tag_parser = subparsers.add_parser(
+        "add-tag",
+        help="Add a structured teacher tag to one student review record.",
+        description=(
+            "Append one teacher-entered structured tag to the canonical "
+            "review.json for a student submission. Creates review.json when "
+            "the adjacent submission.json exists and validates."
+        ),
+    )
+    add_tag_parser.add_argument("class_id", help="Class identifier.")
+    add_tag_parser.add_argument("assignment_id", help="Assignment identifier.")
+    add_tag_parser.add_argument("student_id", help="Student identifier.")
+    add_tag_parser.add_argument("--label", required=True, help="Teacher tag label.")
+    add_tag_parser.add_argument(
+        "--polarity",
+        required=True,
+        help="Tag polarity: positive, developing, negative, or neutral.",
+    )
+    add_tag_parser.add_argument(
+        "--standard",
+        help="Optional standards-profile code.",
+    )
+    add_tag_parser.add_argument(
+        "--comment-id",
+        help="Optional reusable comment ID under --standard.",
+    )
+    add_tag_parser.add_argument(
+        "--severity",
+        type=_non_negative_integer_argument,
+        help="Optional non-negative organizational severity.",
+    )
+    add_tag_parser.add_argument("--note", help="Optional teacher note for the tag.")
+    add_tag_parser.add_argument(
+        "--page",
+        type=_positive_integer_argument,
+        help="Optional submission page number.",
+    )
+    add_tag_parser.add_argument(
+        "--evidence-id",
+        help="Optional evidence ID from submission.json.",
+    )
+    add_tag_parser.add_argument(
+        "--location-type",
+        help="Optional controlled location type.",
+    )
+    add_tag_parser.add_argument(
+        "--location-value",
+        type=_location_value_argument,
+        help="Optional positive integer or non-empty location value.",
     )
 
     workspace_parser = subparsers.add_parser(
@@ -612,6 +685,61 @@ def _print_added_review_note(added: AddedReviewNote) -> None:
     print(f"Review record: {added.review_record_relative_path}")
 
 
+def _handle_add_tag(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    label: str,
+    polarity: str,
+    standard_code: str | None,
+    comment_id: str | None,
+    severity: int | None,
+    teacher_note: str | None,
+    page_number: int | None,
+    evidence_id: str | None,
+    location_type: str | None,
+    location_value: int | str | None,
+) -> int:
+    """Append one structured teacher tag to a canonical review record."""
+    try:
+        workspace_root = resolve_workspace_root()
+        added = add_review_tag(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            label=label,
+            polarity=polarity,
+            standard_code=standard_code,
+            comment_id=comment_id,
+            severity=severity,
+            teacher_note=teacher_note,
+            page_number=page_number,
+            evidence_id=evidence_id,
+            location_type=location_type,
+            location_value=location_value,
+        )
+    except (WorkspaceRootError, ReviewTagError) as error:
+        print(f"Error: could not add review tag: {error}")
+        return 1
+
+    _print_added_review_tag(added)
+    return 0
+
+
+def _print_added_review_tag(added: AddedReviewTag) -> None:
+    """Print a concise teacher-facing tag summary."""
+    print("Added review tag:")
+    print(f"Class: {added.class_id}")
+    print(f"Assignment: {added.assignment_id}")
+    print(f"Student: {added.student_id}")
+    print(f"Tag: {added.tag_id}")
+    print(f"Polarity: {added.polarity}")
+    print(f"Review state: {added.review_state}")
+    print(f"Review record: {added.review_record_relative_path}")
+
+
 def _print_assignment_submission_status(
     result: AssignmentSubmissionStatus,
     workspace_root: Path,
@@ -849,6 +977,28 @@ def _positive_integer_argument(value: str) -> int:
     if parsed < 1:
         raise argparse.ArgumentTypeError("must be a positive integer")
     return parsed
+
+
+def _non_negative_integer_argument(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "must be a non-negative integer"
+        ) from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed
+
+
+def _location_value_argument(value: str) -> int | str:
+    stripped = value.strip()
+    if not stripped:
+        raise argparse.ArgumentTypeError("must be a non-empty value")
+    try:
+        return int(stripped)
+    except ValueError:
+        return stripped
 
 
 def _validate_route_scan_source_file(source_file: Path) -> bool:

--- a/quillan/review_tags.py
+++ b/quillan/review_tags.py
@@ -1,0 +1,525 @@
+"""Teacher-entered structured tags for submission review records."""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.review_record import (
+    ALLOWED_LOCATION_TYPES,
+    ALLOWED_TAG_POLARITIES,
+    FLEXIBLE_LOCATION_TYPES,
+    INTEGER_LOCATION_TYPES,
+    ReviewRecordError,
+    load_review_record,
+    validate_review_record,
+)
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
+from quillan.standards import StandardsProfileError, load_standards_profile
+from quillan.storage import assignment_config_path
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+_SEQUENTIAL_TAG_ID = re.compile(r"^tag_(\d{4})$")
+
+
+class ReviewTagError(Exception):
+    """Raised when a teacher tag cannot be added safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class AddedReviewTag:
+    """Information about a teacher tag added to a review record."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    tag_id: str
+    polarity: str
+    review_state: str
+    created_at: str
+
+
+def add_review_tag(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    label: str,
+    polarity: str,
+    standard_code: str | None = None,
+    comment_id: str | None = None,
+    severity: int | None = None,
+    teacher_note: str | None = None,
+    page_number: int | None = None,
+    evidence_id: str | None = None,
+    location_type: str | None = None,
+    location_value: int | str | None = None,
+    created_at: datetime | str | None = None,
+) -> AddedReviewTag:
+    """Append one teacher-entered structured tag to a review record."""
+    normalized_label = _normalize_required_string(label, "label")
+    normalized_polarity = _normalize_polarity(polarity)
+    normalized_standard = _normalize_optional_string(
+        standard_code, "standard_code"
+    )
+    normalized_comment = _normalize_optional_string(comment_id, "comment_id")
+    normalized_note = _normalize_optional_string(teacher_note, "teacher_note")
+    normalized_evidence = _normalize_optional_string(evidence_id, "evidence_id")
+    _validate_severity(severity)
+    _validate_page_number(page_number)
+    location = _build_location(location_type, location_value, page_number)
+    normalized_created_at = _normalize_timestamp(created_at)
+
+    if normalized_comment is not None and normalized_standard is None:
+        raise ReviewTagError("comment_id requires standard_code.")
+
+    try:
+        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        record_path = review_record_path(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewTagError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise ReviewTagError(
+            "Submission manifest does not exist for "
+            f"class={class_id}, assignment={assignment_id}, student={student_id}."
+        )
+
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise ReviewTagError(
+            f"Could not load submission manifest: {error}"
+        ) from error
+    _validate_identity(
+        manifest,
+        record_name="Submission manifest",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+    _validate_manifest_references(
+        manifest,
+        page_number=(
+            page_number
+            if page_number is not None
+            else (
+                location["value"]
+                if location is not None and location["type"] == "page"
+                else None
+            )
+        ),
+        evidence_id=normalized_evidence,
+    )
+
+    if normalized_standard is not None:
+        severity = _validate_profile_references(
+            resolved_workspace_root,
+            class_id=class_id,
+            assignment_id=assignment_id,
+            standard_code=normalized_standard,
+            comment_id=normalized_comment,
+            label=normalized_label,
+            polarity=normalized_polarity,
+            severity=severity,
+        )
+
+    if record_path.exists():
+        try:
+            review = load_review_record(record_path)
+        except (OSError, ReviewRecordError) as error:
+            raise ReviewTagError(f"Could not load review record: {error}") from error
+        _validate_identity(
+            review,
+            record_name="Review record",
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+        )
+        updated_review = copy.deepcopy(review)
+        if updated_review["review_state"] == "not_started":
+            updated_review["review_state"] = "in_progress"
+    else:
+        manifest_relative_path = _workspace_relative_path(
+            manifest_path, resolved_workspace_root, "submission manifest"
+        )
+        updated_review = {
+            "schema_version": "1",
+            "module": "quillan",
+            "record_type": "submission_review",
+            "class_id": class_id,
+            "assignment_id": assignment_id,
+            "student_id": student_id,
+            "submission_manifest_path": manifest_relative_path,
+            "review_state": "in_progress",
+            "notes": [],
+            "tags": [],
+            "scores": [],
+            "comments": [],
+            "created_at": normalized_created_at,
+            "updated_at": normalized_created_at,
+            "module_details": {},
+        }
+
+    tag_id = _next_tag_id(updated_review["tags"])
+    tag: dict[str, Any] = {
+        "tag_id": tag_id,
+        "label": normalized_label,
+        "polarity": normalized_polarity,
+        "created_at": normalized_created_at,
+        "module_details": {},
+    }
+    optional_fields = {
+        "standard_code": normalized_standard,
+        "comment_id": normalized_comment,
+        "severity": severity,
+        "teacher_note": normalized_note,
+        "page_number": page_number,
+        "evidence_id": normalized_evidence,
+        "location": location,
+    }
+    tag.update(
+        {field: value for field, value in optional_fields.items() if value is not None}
+    )
+    updated_review["tags"].append(tag)
+    updated_review["updated_at"] = normalized_created_at
+
+    try:
+        validate_review_record(updated_review)
+        write_review_record(
+            record_path,
+            updated_review,
+            overwrite=record_path.exists(),
+        )
+        record_relative_path = _workspace_relative_path(
+            record_path, resolved_workspace_root, "review record"
+        )
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        ReviewRecordError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewTagError(f"Could not write review record: {error}") from error
+
+    return AddedReviewTag(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=record_path,
+        review_record_relative_path=record_relative_path,
+        tag_id=tag_id,
+        polarity=normalized_polarity,
+        review_state=updated_review["review_state"],
+        created_at=normalized_created_at,
+    )
+
+
+def _normalize_required_string(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewTagError(f"{field} must be a non-empty string.")
+    return value.strip()
+
+
+def _normalize_optional_string(value: str | None, field: str) -> str | None:
+    if value is None:
+        return None
+    return _normalize_required_string(value, field)
+
+
+def _normalize_polarity(value: str) -> str:
+    if not isinstance(value, str) or value not in ALLOWED_TAG_POLARITIES:
+        allowed = ", ".join(sorted(ALLOWED_TAG_POLARITIES))
+        raise ReviewTagError(
+            f"Invalid polarity {value!r}. Allowed values: {allowed}."
+        )
+    return value
+
+
+def _validate_severity(value: int | None) -> None:
+    if value is not None and (
+        isinstance(value, bool) or not isinstance(value, int) or value < 0
+    ):
+        raise ReviewTagError("severity must be a non-negative integer.")
+
+
+def _validate_page_number(value: int | None) -> None:
+    if value is not None and (
+        isinstance(value, bool) or not isinstance(value, int) or value < 1
+    ):
+        raise ReviewTagError("page_number must be a positive integer.")
+
+
+def _build_location(
+    location_type: str | None,
+    location_value: int | str | None,
+    page_number: int | None,
+) -> dict[str, Any] | None:
+    if location_type is None:
+        if location_value is not None:
+            raise ReviewTagError("location_value requires location_type.")
+        return None
+    if location_type not in ALLOWED_LOCATION_TYPES:
+        allowed = ", ".join(sorted(ALLOWED_LOCATION_TYPES))
+        raise ReviewTagError(
+            f"Invalid location_type {location_type!r}. Allowed values: {allowed}."
+        )
+    if location_type == "whole_submission":
+        if location_value is not None:
+            raise ReviewTagError(
+                "location_value must be omitted for whole_submission."
+            )
+        return {"type": location_type, "value": None}
+    if location_type in INTEGER_LOCATION_TYPES:
+        if (
+            isinstance(location_value, bool)
+            or not isinstance(location_value, int)
+            or location_value < 1
+        ):
+            raise ReviewTagError(
+                f"location_value must be a positive integer for {location_type}."
+            )
+    elif location_type in FLEXIBLE_LOCATION_TYPES and (
+        isinstance(location_value, bool)
+        or not (
+            isinstance(location_value, int)
+            and location_value >= 1
+            or isinstance(location_value, str)
+            and bool(location_value.strip())
+        )
+    ):
+        raise ReviewTagError(
+            f"location_value must be a positive integer or non-empty string "
+            f"for {location_type}."
+        )
+    if (
+        location_type == "page"
+        and page_number is not None
+        and location_value != page_number
+    ):
+        raise ReviewTagError(
+            "page location_value must agree with page_number."
+        )
+    return {
+        "type": location_type,
+        "value": (
+            location_value.strip()
+            if isinstance(location_value, str)
+            else location_value
+        ),
+    }
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReviewTagError("created_at datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise ReviewTagError(
+            "created_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ReviewTagError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewTagError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    *,
+    record_name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    requested = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+    for field, expected in requested.items():
+        actual = record[field]
+        if actual != expected:
+            raise ReviewTagError(
+                f"{record_name} {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _validate_manifest_references(
+    manifest: dict[str, Any],
+    *,
+    page_number: int | None,
+    evidence_id: str | None,
+) -> None:
+    pages = {page["page_number"]: page for page in manifest["pages"]}
+    if page_number is not None and page_number not in pages:
+        raise ReviewTagError(
+            f"page_number {page_number} does not exist in the submission manifest."
+        )
+    if evidence_id is None:
+        return
+    evidence_pages = {
+        candidate["evidence_id"]: page["page_number"]
+        for page in manifest["pages"]
+        for candidate in page["evidence"]
+    }
+    if evidence_id not in evidence_pages:
+        raise ReviewTagError(
+            f"evidence_id {evidence_id!r} does not exist in the submission manifest."
+        )
+    if page_number is not None and evidence_pages[evidence_id] != page_number:
+        raise ReviewTagError(
+            f"evidence_id {evidence_id!r} occurs on page "
+            f"{evidence_pages[evidence_id]}, not page {page_number}."
+        )
+
+
+def _validate_profile_references(
+    workspace_root: Path,
+    *,
+    class_id: str,
+    assignment_id: str,
+    standard_code: str,
+    comment_id: str | None,
+    label: str,
+    polarity: str,
+    severity: int | None,
+) -> int | None:
+    config_path = assignment_config_path(
+        workspace_root, class_id, assignment_id
+    )
+    try:
+        assignment = load_assignment_config(config_path)
+    except (OSError, AssignmentConfigError) as error:
+        raise ReviewTagError(f"Could not load assignment config: {error}") from error
+    if assignment["assignment_id"] != assignment_id:
+        raise ReviewTagError(
+            "Assignment config assignment_id is "
+            f"{assignment['assignment_id']!r}, expected {assignment_id!r}."
+        )
+    if class_id not in assignment["class_ids"]:
+        raise ReviewTagError(
+            f"Assignment config does not include class_id {class_id!r}."
+        )
+
+    profile_id = assignment["standards_profile_id"]
+    profile_path = workspace_root / "shared" / "standards" / f"{profile_id}.json"
+    try:
+        profile = load_standards_profile(profile_path)
+    except (OSError, StandardsProfileError) as error:
+        raise ReviewTagError(f"Could not load standards profile: {error}") from error
+    if profile["profile_id"] != profile_id:
+        raise ReviewTagError(
+            f"Standards profile ID is {profile['profile_id']!r}, "
+            f"expected {profile_id!r}."
+        )
+
+    standards = {standard["code"]: standard for standard in profile["standards"]}
+    if standard_code not in standards:
+        raise ReviewTagError(
+            f"standard_code {standard_code!r} does not exist in standards "
+            f"profile {profile_id!r}."
+        )
+    if comment_id is None:
+        return severity
+
+    comments = {
+        comment["comment_id"]: comment
+        for comment in standards[standard_code]["comments"]
+    }
+    if comment_id not in comments:
+        raise ReviewTagError(
+            f"comment_id {comment_id!r} does not exist under standard "
+            f"{standard_code!r}."
+        )
+    comment = comments[comment_id]
+    if label != comment["label"]:
+        raise ReviewTagError(
+            f"label {label!r} does not match profile comment label "
+            f"{comment['label']!r}."
+        )
+    if polarity != comment["polarity"]:
+        raise ReviewTagError(
+            f"polarity {polarity!r} does not match profile comment polarity "
+            f"{comment['polarity']!r}."
+        )
+    if severity is None:
+        return cast(int | None, comment.get("severity_default"))
+    return severity
+
+
+def _next_tag_id(tags: list[dict[str, Any]]) -> str:
+    existing_ids = {tag["tag_id"] for tag in tags}
+    highest = max(
+        (
+            int(match.group(1))
+            for tag_id in existing_ids
+            if (match := _SEQUENTIAL_TAG_ID.fullmatch(tag_id))
+        ),
+        default=0,
+    )
+    candidate_number = highest + 1
+    while True:
+        candidate = f"tag_{candidate_number:04d}"
+        if candidate not in existing_ids:
+            return candidate
+        candidate_number += 1
+
+
+def _workspace_relative_path(
+    path: Path,
+    workspace_root: Path,
+    description: str,
+) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewTagError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error

--- a/tests/test_cli_review_tags.py
+++ b/tests/test_cli_review_tags.py
@@ -1,0 +1,172 @@
+"""CLI tests for structured teacher review tags."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.review_record_paths import review_record_path
+from tests.test_review_tags import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STUDENT_ID,
+    _manifest,
+    _review,
+    _write_manifest,
+    _write_review,
+)
+
+
+def test_cli_success_creates_tag_and_prints_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "add-tag",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--label",
+            "Evidence needs explanation",
+            "--polarity",
+            "developing",
+            "--severity",
+            "2",
+            "--note",
+            "Explain the connection.",
+            "--page",
+            "1",
+            "--evidence-id",
+            "evidence_001",
+            "--location-type",
+            "paragraph",
+            "--location-value",
+            "2",
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Added review tag:" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Tag: tag_0001" in output
+    assert "Polarity: developing" in output
+    assert "Review state: in_progress" in output
+    assert (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/review.json"
+    ) in output
+    written = json.loads(
+        review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert written["tags"][0]["location"] == {
+        "type": "paragraph",
+        "value": 2,
+    }
+    assert written["tags"][0]["evidence_id"] == "evidence_001"
+
+
+@pytest.mark.parametrize(
+    ("prepare_submission", "label", "polarity"),
+    [
+        (True, " ", "neutral"),
+        (True, "A tag", "mixed"),
+        (False, "A tag", "neutral"),
+    ],
+)
+def test_cli_handled_failure_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    prepare_submission: bool,
+    label: str,
+    polarity: str,
+) -> None:
+    if prepare_submission:
+        _write_manifest(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    result = main(
+        [
+            "add-tag",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--label",
+            label,
+            "--polarity",
+            polarity,
+        ]
+    )
+
+    assert result == 1
+    assert "Error: could not add review tag:" in capsys.readouterr().out
+
+
+def test_cli_append_preserves_existing_sections(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_manifest(tmp_path)
+    original = _review("ready_for_export")
+    path = _write_review(tmp_path, copy.deepcopy(original))
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "add-tag",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--label",
+            "CLI append",
+            "--polarity",
+            "positive",
+            "--location-type",
+            "whole_submission",
+        ]
+    ) == 0
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    for field in ("notes", "scores", "comments", "module_details"):
+        assert written[field] == original[field]
+    assert written["tags"][:-1] == original["tags"]
+    assert written["review_state"] == "ready_for_export"
+
+
+def test_cli_does_not_mutate_submission_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = _write_manifest(tmp_path, _manifest())
+    original = manifest_path.read_bytes()
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "add-tag",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--label",
+            "Page tag",
+            "--polarity",
+            "neutral",
+            "--page",
+            "2",
+        ]
+    ) == 0
+    assert manifest_path.read_bytes() == original

--- a/tests/test_review_tags.py
+++ b/tests/test_review_tags.py
@@ -1,0 +1,768 @@
+"""Tests for teacher-entered structured review tags."""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.review_tags import (
+    AddedReviewTag,
+    ReviewTagError,
+    add_review_tag,
+)
+from quillan.storage import assignment_config_path
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+PROFILE_ID = "english_12_njsls_synthetic"
+STANDARD_CODE = "W.AW.11-12.1"
+ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
+FIRST_TAG_TIMESTAMP = "2026-06-22T13:35:00-04:00"
+SECOND_TAG_TIMESTAMP = "2026-06-22T14:00:00-04:00"
+
+
+def _manifest() -> dict[str, Any]:
+    def evidence(evidence_id: str, page_number: int) -> dict[str, Any]:
+        return {
+            "evidence_id": evidence_id,
+            "routed_evidence_path": (
+                f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+                f"response_00107_pg_{page_number:03d}.pdf"
+            ),
+            "evidence_role": "selected",
+            "evidence_state": "active",
+            "duplicate_number": None,
+            "created_at": ORIGINAL_TIMESTAMP,
+            "retained_source": {
+                "source_scan_id": f"scan_{page_number:03d}",
+                "source_filename": f"source_{page_number}.pdf",
+                "source_sha256": str(page_number) * 64,
+                "retained_source_path": (
+                    f"routing/source_scans/scan_{page_number:03d}/"
+                    f"source_{page_number}.pdf"
+                ),
+                "source_page_number": page_number,
+            },
+            "module_details": {},
+        }
+
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 2,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": page_number,
+                "page_state": "present",
+                "selected_evidence_id": f"evidence_{page_number:03d}",
+                "evidence": [evidence(f"evidence_{page_number:03d}", page_number)],
+            }
+            for page_number in (1, 2)
+        ],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {"preserve": True},
+    }
+
+
+def _review(state: str = "not_started") -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": state,
+        "notes": [
+            {
+                "note_id": "note_0001",
+                "text": "Existing note.",
+                "created_at": ORIGINAL_TIMESTAMP,
+                "updated_at": ORIGINAL_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "tags": [
+            {
+                "tag_id": "tag_0001",
+                "label": "Existing tag",
+                "polarity": "neutral",
+                "created_at": ORIGINAL_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "scores": [
+            {
+                "score_id": "score_0001",
+                "criterion_id": "evidence",
+                "label": "Evidence",
+                "score": 3,
+                "max_score": 4,
+                "updated_at": ORIGINAL_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "comments": [
+            {
+                "comment_record_id": "comment_0001",
+                "label": "Existing comment",
+                "text": "Existing selected language.",
+                "source": "custom",
+                "include_in_feedback": True,
+                "created_at": ORIGINAL_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {"preserve": True},
+    }
+
+
+def _assignment() -> dict[str, Any]:
+    return {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": PROFILE_ID,
+        "tagging_mode": "focus",
+        "focus_standards": [STANDARD_CODE],
+        "basic_requirements": {},
+        "rubric_id": "argument_4pt",
+    }
+
+
+def _profile() -> dict[str, Any]:
+    return {
+        "profile_id": PROFILE_ID,
+        "subject": "English",
+        "course": "English 12",
+        "standards": [
+            {
+                "code": STANDARD_CODE,
+                "short_name": "Argument Writing",
+                "description": "Use claims, reasoning, and evidence.",
+                "comments": [
+                    {
+                        "comment_id": "evidence_needs_explanation",
+                        "label": "Evidence needs more explanation",
+                        "polarity": "developing",
+                        "severity_default": 2,
+                    }
+                ],
+            },
+            {
+                "code": "W.WP.11-12.4",
+                "short_name": "Writing Process",
+                "description": "Develop and strengthen writing.",
+                "comments": [],
+            },
+        ],
+    }
+
+
+def _write_json(path: Path, value: Any) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def _write_manifest(
+    workspace: Path, manifest: dict[str, Any] | None = None
+) -> Path:
+    path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    return write_submission_manifest(
+        path, _manifest() if manifest is None else manifest
+    )
+
+
+def _write_review(workspace: Path, review: dict[str, Any]) -> Path:
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    return write_review_record(path, review)
+
+
+def _write_profile_context(workspace: Path) -> None:
+    _write_json(
+        assignment_config_path(workspace, CLASS_ID, ASSIGNMENT_ID),
+        _assignment(),
+    )
+    _write_json(
+        workspace / "shared" / "standards" / f"{PROFILE_ID}.json",
+        _profile(),
+    )
+
+
+def test_creates_structured_tag_without_mutating_submission_or_evidence(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    evidence_path = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_00107_pg_001.pdf"
+    )
+    retained_path = (
+        tmp_path / "routing" / "source_scans" / "scan_001" / "source_1.pdf"
+    )
+    evidence_path.parent.mkdir(parents=True)
+    retained_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"routed evidence")
+    retained_path.write_bytes(b"retained source")
+    original_manifest = manifest_path.read_bytes()
+
+    result = add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="  Clear central claim  ",
+        polarity="positive",
+        page_number=1,
+        evidence_id="evidence_001",
+        location_type="paragraph",
+        location_value=2,
+        created_at=FIRST_TAG_TIMESTAMP,
+    )
+
+    expected_relative_path = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/review.json"
+    )
+    assert result == AddedReviewTag(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        review_record_path=review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ),
+        review_record_relative_path=expected_relative_path,
+        tag_id="tag_0001",
+        polarity="positive",
+        review_state="in_progress",
+        created_at=FIRST_TAG_TIMESTAMP,
+    )
+    written = json.loads(result.review_record_path.read_text(encoding="utf-8"))
+    assert written["submission_manifest_path"] == expected_relative_path.replace(
+        "review.json", "submission.json"
+    )
+    assert written["review_state"] == "in_progress"
+    assert written["notes"] == written["scores"] == written["comments"] == []
+    assert written["created_at"] == written["updated_at"] == FIRST_TAG_TIMESTAMP
+    assert written["tags"] == [
+        {
+            "tag_id": "tag_0001",
+            "label": "Clear central claim",
+            "polarity": "positive",
+            "created_at": FIRST_TAG_TIMESTAMP,
+            "module_details": {},
+            "page_number": 1,
+            "evidence_id": "evidence_001",
+            "location": {"type": "paragraph", "value": 2},
+        }
+    ]
+    assert manifest_path.read_bytes() == original_manifest
+    assert evidence_path.read_bytes() == b"routed evidence"
+    assert retained_path.read_bytes() == b"retained source"
+
+
+def test_appends_tag_and_preserves_existing_review_sections(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    original = _review()
+    path = _write_review(tmp_path, copy.deepcopy(original))
+
+    result = add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Second tag",
+        polarity="neutral",
+        created_at=SECOND_TAG_TIMESTAMP,
+    )
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert result.tag_id == "tag_0002"
+    assert written["tags"][:-1] == original["tags"]
+    for field in ("notes", "scores", "comments", "module_details"):
+        assert written[field] == original[field]
+    assert written["created_at"] == original["created_at"]
+    assert written["updated_at"] == SECOND_TAG_TIMESTAMP
+    assert written["review_state"] == "in_progress"
+
+
+@pytest.mark.parametrize(
+    ("initial_state", "expected_state"),
+    [
+        ("not_started", "in_progress"),
+        ("in_progress", "in_progress"),
+        ("ready_for_export", "ready_for_export"),
+        ("exported", "exported"),
+    ],
+)
+def test_append_uses_narrow_review_state_transition(
+    tmp_path: Path,
+    initial_state: str,
+    expected_state: str,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_review(tmp_path, _review(initial_state))
+
+    result = add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="State tag",
+        polarity="neutral",
+        created_at=SECOND_TAG_TIMESTAMP,
+    )
+
+    assert result.review_state == expected_state
+
+
+def test_tag_id_uses_highest_conforming_sequence(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    review = _review()
+    review["tags"].extend(
+        [
+            {
+                "tag_id": "custom-tag",
+                "label": "Custom",
+                "polarity": "neutral",
+                "created_at": ORIGINAL_TIMESTAMP,
+                "module_details": {},
+            },
+            {
+                "tag_id": "tag_0004",
+                "label": "Later",
+                "polarity": "neutral",
+                "created_at": ORIGINAL_TIMESTAMP,
+                "module_details": {},
+            },
+        ]
+    )
+    _write_review(tmp_path, review)
+
+    result = add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Next",
+        polarity="neutral",
+        created_at=SECOND_TAG_TIMESTAMP,
+    )
+
+    assert result.tag_id == "tag_0005"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"label": " "}, "label"),
+        ({"polarity": "mixed"}, "polarity"),
+        ({"severity": -1}, "severity"),
+        ({"severity": True}, "severity"),
+        ({"teacher_note": " "}, "teacher_note"),
+        ({"page_number": 0}, "page_number"),
+        ({"evidence_id": " "}, "evidence_id"),
+        ({"location_type": "word", "location_value": 1}, "location_type"),
+        ({"location_value": 1}, "requires location_type"),
+        (
+            {"location_type": "paragraph", "location_value": "two"},
+            "positive integer",
+        ),
+        (
+            {"location_type": "whole_submission", "location_value": 1},
+            "must be omitted",
+        ),
+        (
+            {
+                "location_type": "page",
+                "location_value": 2,
+                "page_number": 1,
+            },
+            "agree",
+        ),
+        (
+            {"location_type": "page", "location_value": 3},
+            "does not exist",
+        ),
+    ],
+)
+def test_invalid_tag_input_is_rejected_without_writing(
+    tmp_path: Path,
+    kwargs: dict[str, Any],
+    message: str,
+) -> None:
+    _write_manifest(tmp_path)
+    arguments: dict[str, Any] = {
+        "label": "Valid label",
+        "polarity": "neutral",
+        "created_at": FIRST_TAG_TIMESTAMP,
+    }
+    arguments.update(kwargs)
+
+    with pytest.raises(ReviewTagError, match=message):
+        add_review_tag(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            **arguments,
+        )
+
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+
+
+@pytest.mark.parametrize(
+    ("page_number", "evidence_id", "message"),
+    [
+        (3, None, "does not exist"),
+        (None, "missing", "does not exist"),
+        (1, "evidence_002", "occurs on page 2"),
+    ],
+)
+def test_invalid_manifest_reference_is_rejected(
+    tmp_path: Path,
+    page_number: int | None,
+    evidence_id: str | None,
+    message: str,
+) -> None:
+    _write_manifest(tmp_path)
+
+    with pytest.raises(ReviewTagError, match=message):
+        add_review_tag(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            label="Reference tag",
+            polarity="neutral",
+            page_number=page_number,
+            evidence_id=evidence_id,
+            created_at=FIRST_TAG_TIMESTAMP,
+        )
+
+
+@pytest.mark.parametrize(
+    ("page_number", "evidence_id"),
+    [(1, None), (None, "evidence_002")],
+)
+def test_individual_valid_manifest_reference_is_accepted(
+    tmp_path: Path,
+    page_number: int | None,
+    evidence_id: str | None,
+) -> None:
+    _write_manifest(tmp_path)
+
+    add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Reference tag",
+        polarity="neutral",
+        page_number=page_number,
+        evidence_id=evidence_id,
+        created_at=FIRST_TAG_TIMESTAMP,
+    )
+
+
+def test_whole_submission_and_named_location_are_accepted(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Whole submission",
+        polarity="positive",
+        location_type="whole_submission",
+        created_at=FIRST_TAG_TIMESTAMP,
+    )
+    add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Conclusion",
+        polarity="developing",
+        location_type="section",
+        location_value=" conclusion ",
+        created_at=SECOND_TAG_TIMESTAMP,
+    )
+    written = json.loads(
+        review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert written["tags"][0]["location"]["value"] is None
+    assert written["tags"][1]["location"]["value"] == "conclusion"
+
+
+def test_profile_standard_and_comment_are_validated_with_default_severity(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_profile_context(tmp_path)
+
+    add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Evidence needs more explanation",
+        polarity="developing",
+        standard_code=STANDARD_CODE,
+        comment_id="evidence_needs_explanation",
+        created_at=FIRST_TAG_TIMESTAMP,
+    )
+
+    written = json.loads(
+        review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert written["tags"][0]["severity"] == 2
+
+
+def test_profile_allows_non_focus_standard(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    _write_profile_context(tmp_path)
+
+    add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Revision observation",
+        polarity="neutral",
+        standard_code="W.WP.11-12.4",
+        created_at=FIRST_TAG_TIMESTAMP,
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"standard_code": "missing"}, "does not exist"),
+        ({"comment_id": "comment"}, "requires standard_code"),
+        (
+            {
+                "standard_code": STANDARD_CODE,
+                "comment_id": "missing",
+            },
+            "does not exist",
+        ),
+        (
+            {
+                "standard_code": STANDARD_CODE,
+                "comment_id": "evidence_needs_explanation",
+                "label": "Different label",
+            },
+            "does not match",
+        ),
+        (
+            {
+                "standard_code": STANDARD_CODE,
+                "comment_id": "evidence_needs_explanation",
+                "polarity": "positive",
+            },
+            "does not match",
+        ),
+    ],
+)
+def test_invalid_profile_reference_is_rejected(
+    tmp_path: Path,
+    kwargs: dict[str, Any],
+    message: str,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_profile_context(tmp_path)
+    arguments: dict[str, Any] = {
+        "label": "Evidence needs more explanation",
+        "polarity": "developing",
+        "created_at": FIRST_TAG_TIMESTAMP,
+    }
+    arguments.update(kwargs)
+
+    with pytest.raises(ReviewTagError, match=message):
+        add_review_tag(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            **arguments,
+        )
+
+
+def test_standard_reference_requires_assignment_and_profile(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    with pytest.raises(ReviewTagError, match="assignment config"):
+        add_review_tag(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            label="Standard tag",
+            polarity="neutral",
+            standard_code=STANDARD_CODE,
+            created_at=FIRST_TAG_TIMESTAMP,
+        )
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "not-a-time",
+        "2026-06-22T13:30:00",
+        datetime(2026, 6, 22, 13, 30),
+        123,
+    ],
+)
+def test_invalid_timestamp_is_rejected(tmp_path: Path, timestamp: object) -> None:
+    _write_manifest(tmp_path)
+    with pytest.raises(ReviewTagError, match="timezone-aware"):
+        add_review_tag(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            label="Timestamp tag",
+            polarity="neutral",
+            created_at=timestamp,  # type: ignore[arg-type]
+        )
+
+
+def test_timezone_aware_datetime_is_normalized(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    timestamp = datetime(2026, 6, 22, 17, 30, tzinfo=timezone.utc)
+    result = add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Timestamp tag",
+        polarity="neutral",
+        created_at=timestamp,
+    )
+    assert result.created_at == timestamp.isoformat()
+
+
+def test_missing_submission_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ReviewTagError, match="does not exist"):
+        add_review_tag(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            label="Missing",
+            polarity="neutral",
+            created_at=FIRST_TAG_TIMESTAMP,
+        )
+
+
+@pytest.mark.parametrize("record_kind", ["submission", "review"])
+def test_invalid_existing_record_is_rejected_without_review_write(
+    tmp_path: Path, record_kind: str
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    record_path = review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    if record_kind == "submission":
+        manifest_path.write_text("{", encoding="utf-8")
+    else:
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.write_text("{", encoding="utf-8")
+    original = record_path.read_bytes() if record_path.exists() else None
+
+    with pytest.raises(ReviewTagError, match="not valid JSON"):
+        add_review_tag(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            label="Invalid record",
+            polarity="neutral",
+            created_at=FIRST_TAG_TIMESTAMP,
+        )
+
+    assert (
+        record_path.read_bytes() if record_path.exists() else None
+    ) == original
+
+
+@pytest.mark.parametrize(
+    ("record_kind", "field", "value"),
+    [
+        ("submission", "class_id", "other_class"),
+        ("submission", "assignment_id", "other_assignment"),
+        ("submission", "student_id", "00108"),
+        ("review", "class_id", "other_class"),
+        ("review", "assignment_id", "other_assignment"),
+        ("review", "student_id", "00108"),
+    ],
+)
+def test_identity_mismatch_is_rejected(
+    tmp_path: Path,
+    record_kind: str,
+    field: str,
+    value: str,
+) -> None:
+    manifest = _manifest()
+    review = _review()
+    if record_kind == "submission":
+        manifest[field] = value
+    else:
+        review[field] = value
+        review["submission_manifest_path"] = (
+            f"classes/{review['class_id']}/assignments/"
+            f"{review['assignment_id']}/submissions/{review['student_id']}/"
+            "submission.json"
+        )
+    _write_manifest(tmp_path, manifest)
+    if record_kind == "review":
+        _write_review(tmp_path, review)
+
+    with pytest.raises(ReviewTagError, match=field):
+        add_review_tag(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            label="Mismatch",
+            polarity="neutral",
+            created_at=FIRST_TAG_TIMESTAMP,
+        )


### PR DESCRIPTION
## Summary

Adds structured teacher tags for Quillan v0.7 review records.

This PR introduces a teacher-controlled tagging workflow built on the canonical `review.json` infrastructure:

```powershell
quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
```

Tags are appended to the `tags` array of `review.json`. They may reference standards, reusable profile comments, pages, evidence IDs, and structured locations, but they do not calculate scores, imply standard mastery, generate feedback, or analyze student writing.

## Changes

* Added `quillan/review_tags.py`

  * `ReviewTagError`
  * `AddedReviewTag`
  * `add_review_tag(...)`
  * teacher-facing input validation
  * sequential `tag_NNNN` IDs
  * timestamp normalization
  * page and evidence reference validation against `submission.json`
  * location validation
  * standard/comment validation through `shared/standards/<profile_id>.json`
  * narrow review-state transition behavior
  * safe append behavior for canonical `review.json`

* Added CLI support:

  ```powershell
  quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
  ```

* Added CLI options for:

  * `--label`
  * `--polarity`
  * `--standard`
  * `--comment-id`
  * `--severity`
  * `--note`
  * `--page`
  * `--evidence-id`
  * `--location-type`
  * `--location-value`

* Added teacher-facing success output showing:

  * class
  * assignment
  * student
  * tag ID
  * polarity
  * review state
  * review-record path

* Added tests covering:

  * new `review.json` creation
  * append behavior
  * sequential tag IDs
  * preservation of notes, existing tags, scores, comments, and module details
  * review-state transition behavior
  * timestamp validation
  * page validation
  * evidence validation
  * page/evidence mismatch rejection
  * location validation
  * standard validation
  * comment validation
  * profile-backed severity defaults
  * CLI success behavior
  * CLI handled failures
  * non-mutation of `submission.json`

* Updated README, review-record contract documentation, teacher-review model documentation, and changelog.

## Review-State Behavior

This PR applies the same narrow review-state policy used by quick notes:

* new review record: `in_progress`
* existing `not_started`: advances to `in_progress`
* existing `in_progress`: remains `in_progress`
* existing `ready_for_export`: preserved
* existing `exported`: preserved

The command does not update `submission_state` in `submission.json`.

## Validation Behavior

Structured tags are validated before writing.

The implementation rejects:

* blank labels
* invalid polarities
* invalid severity values
* blank teacher notes
* invalid timestamps
* missing or invalid `submission.json`
* identity mismatches
* invalid existing `review.json`
* missing pages
* invalid evidence IDs
* evidence IDs on the wrong page
* invalid locations
* invalid standard references
* invalid comment references under a standard
* profile comment label/polarity mismatches

## Non-Mutation Guarantees

This PR does not mutate:

* `submission.json`
* routed evidence files
* retained source scans
* existing notes
* existing tags
* existing scores
* existing comments
* existing module details

Existing review data is preserved when a tag is appended.

## Non-Goals

This PR does not implement:

* tag editing
* tag deletion
* batch tagging
* automatic tag generation
* automatic standard detection
* rubric scores
* note editing or deletion
* reusable comment selection into the `comments` array
* full comment-bank management
* feedback export
* class summary CSV export
* standards summary CSV export
* terminal-menu review workflow
* AI scoring
* AI feedback
* OCR
* automatic grading
* `tags.json` or `scores.json` generation

Those remain separate v0.7 sub-issues.

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

705 tests passed.

Closes #97
