### PR TITLE
feat: add criterion review scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan set-score` and a focused criterion-score API for setting
+  teacher-entered scores in canonical `review.json` records. New criteria
+  receive stable sequential IDs; existing criteria update in place by
+  `criterion_id` while preserving their IDs and unrelated review data.
+  Inputs, timestamps, identities, and complete proposed records validate
+  before atomic writes. The workflow does not infer scores, calculate an
+  overall score, validate against a rubric profile, or mutate submission
+  manifests or evidence.
 - Added `quillan add-tag` and a focused structured-tag API for appending
   teacher-entered tags to canonical `review.json` records. The workflow
   validates tag fields, timestamps, pages, evidence IDs, locations, assignment

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ The supported teacher/developer sequence is:
    `review.json`.
 10. `add-tag` appends a teacher-entered structured observation to that review
     record.
-11. `set-review-state` records lightweight submission-manifest progress when
+11. `set-score` sets or updates one explicitly teacher-entered criterion score.
+12. `set-review-state` records lightweight submission-manifest progress when
     the teacher chooses.
 
 Opening evidence and updating review state are separate teacher-controlled
@@ -150,6 +151,7 @@ quillan open-evidence <workspace-relative-evidence-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
+quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
@@ -174,6 +176,10 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   may reference a validated standard, reusable profile comment, page,
   evidence ID, or writing location, but they do not score work, prove mastery,
   or generate feedback.
+- `set-score` sets one teacher-entered criterion score in `review.json`.
+  Existing criteria update by `criterion_id`; unrelated review data is
+  preserved. Criterion IDs are not yet validated against rubric profiles, and
+  no overall score is calculated.
 - `set-review-state` updates only the manifest's `submission_state` and
   `updated_at`; it does not inspect evidence or make a review decision.
 
@@ -431,6 +437,25 @@ Tags remain teacher-entered review artifacts. Adding one does not mutate the
 submission manifest or evidence, calculate a score, establish standard
 mastery, analyze writing, or generate feedback.
 
+Set or update one teacher-entered criterion score:
+
+```powershell
+quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
+```
+
+Scores are stored in the `scores` array of the student's canonical
+`review.json`. A missing review record is created only when the adjacent
+`submission.json` validates and matches the requested identity. Repeating the
+command for the same `criterion_id` preserves its score ID, updates that
+criterion, and preserves unrelated notes, tags, scores, comments, and
+metadata. Optional `--scale` and `--note` values describe the latest explicit
+teacher input; omitting them during an update removes stale prior values.
+
+Quillan does not derive scores from student writing, tags, notes, comments,
+requirements, standards references, or evidence metadata. This command does
+not calculate totals, weighted scores, percentages, grades, mastery, or any
+other overall score. Rubric-profile criterion validation is future work.
+
 Validate a standards profile:
 
 ```powershell
@@ -507,6 +532,7 @@ quillan open-evidence <workspace-relative-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
+quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan workspace show
 quillan menu

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -374,6 +374,25 @@ review state, and workspace-relative review-record path. The command never
 mutates the submission manifest, routed evidence, or retained source scans,
 and it does not score, analyze, or generate feedback.
 
+## Criterion Scores
+
+```powershell
+quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
+```
+
+This direct command sets or updates one explicitly teacher-entered criterion
+score in canonical `review.json`. Optional flags are `--scale` and `--note`.
+The command creates a missing review record only when the adjacent
+`submission.json` validates and matches the requested identity.
+
+Success returns `0` and reports the class, assignment, student, criterion,
+score and maximum, score ID, created-or-updated action, review state, and
+workspace-relative review-record path. Handled workspace, score, and record
+failures return `1`. Updating by `criterion_id` preserves the existing score
+ID and unrelated review sections. The command does not validate criteria
+against a rubric profile, calculate an overall score, infer scores, or mutate
+the submission manifest or evidence.
+
 ## Output and Error Handling
 
 Human-readable command results are the current output contract. Quillan does

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -302,8 +302,8 @@ Optional score fields are:
 Score field rules are:
 
 * `score_id` is unique within `scores`.
-* `criterion_id` is non-empty and unique within `scores`. When a rubric is
-  available, it should reference one rubric criterion.
+* `criterion_id` is non-empty and unique within `scores`. Schema version `1`
+  validates this field intrinsically; rubric-profile lookup is future work.
 * `label` is a non-empty, teacher-readable string.
 * `score` is a finite number greater than or equal to zero.
 * `max_score` is a finite number greater than zero.
@@ -316,11 +316,13 @@ Scores are teacher-entered or teacher-confirmed decisions. Quillan must not
 infer a score from student writing, tags, requirements, comments, or other
 records.
 
-Scores are mutable by `criterion_id` for the MVP. A later set-score workflow
+Scores are mutable by `criterion_id` for the MVP. The `set-score` workflow
 updates the matching criterion record and its `updated_at`, preserves its
 `score_id`, and updates top-level `updated_at`. It appends a new score only
-when the criterion is not already present. It must not replace the entire
-`scores` array or erase unrelated criteria.
+when the criterion is not already present. It does not replace the entire
+`scores` array or erase unrelated criteria. Omitting optional `scale` or
+`teacher_note` values removes prior values from the updated criterion so the
+record reflects the latest explicit teacher input.
 
 ## Comments
 
@@ -493,6 +495,32 @@ record validation, safe-write, preservation, and non-mutation policies as
 quick notes. Tags organize teacher judgment only; they do not calculate
 scores, prove mastery, analyze student writing, or generate feedback.
 
+## Teacher-Entered Criterion Scores
+
+The direct score command is:
+
+```powershell
+quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
+```
+
+Optional `--scale` and `--note` values are descriptive teacher-entered
+metadata. A new criterion receives the next stable local ID such as
+`score_0001`. An existing criterion updates in place by `criterion_id`,
+preserves its `score_id`, and does not move or replace unrelated scores.
+
+The workflow requires a valid matching adjacent `submission.json`, creates a
+missing review record in `in_progress`, advances only `not_started` to
+`in_progress`, and preserves `ready_for_export` and `exported`. It preserves
+unrelated notes, tags, scores, comments, top-level metadata, and
+`created_at`; validates the complete proposed record before an atomic write;
+and never mutates submission manifests, routed evidence, or retained scans.
+
+Criterion IDs are validated only as non-empty local identifiers in this
+workflow. The assignment's `rubric_id` does not provide a criterion contract;
+rubric-profile loading and criterion lookup remain future work. Quillan does
+not infer criterion scores or calculate an overall, weighted, percentage,
+grade, or mastery score.
+
 ## Derived Artifacts and Historical Names
 
 `review.json` is the canonical active v0.7 teacher-review record for notes,
@@ -521,7 +549,8 @@ selected comment is stored in
 
 This contract does not implement:
 
-* `set-score` or other review commands beyond `add-note` and `add-tag`;
+* rubric-profile loading, validation, or criterion lookup;
+* overall, weighted, percentage, grade, or mastery score calculation;
 * standalone comment-bank lookup or reusable-comment management;
 * feedback, class-summary, or standards-summary export;
 * terminal-menu review workflows or review CLI commands beyond those listed;

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -140,6 +140,13 @@ Tags and requirements results may inform a score, but they do not calculate
 or compel one. Quillan must not automatically determine or generate scores. A
 score record represents teacher judgment, not software judgment.
 
+Quillan's direct `set-score` workflow records one criterion at a time in the
+canonical `review.json`. It updates an existing record by `criterion_id` or
+appends a new one without disturbing unrelated review data. Criterion IDs are
+accepted as explicit teacher input; rubric-profile lookup is not yet
+implemented. The workflow does not calculate an overall score, percentage,
+grade, weighted result, or mastery result.
+
 ## Feedback Philosophy
 
 Feedback is student-readable teacher communication. It may draw on:

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -46,6 +47,11 @@ from quillan.review_notes import (
     ReviewNoteError,
     add_review_note,
 )
+from quillan.review_scores import (
+    ReviewScoreError,
+    UpdatedReviewScore,
+    set_review_score,
+)
 from quillan.review_tags import (
     AddedReviewTag,
     ReviewTagError,
@@ -70,10 +76,18 @@ from quillan.submission_review_state import (
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
 
 
+class _ScoreArgumentError(Exception):
+    """Raised for handled set-score numeric argument failures."""
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the Quillan command-line interface."""
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    try:
+        args = parser.parse_args(argv)
+    except _ScoreArgumentError as error:
+        print(f"Error: could not set review score: {error}")
+        return 1
 
     if args.command == "validate-standards":
         _handle_validate_standards(args.path)
@@ -142,6 +156,19 @@ def main(argv: list[str] | None = None) -> int:
             evidence_id=args.evidence_id,
             location_type=args.location_type,
             location_value=args.location_value,
+        )
+
+    if args.command == "set-score":
+        return _handle_set_score(
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            criterion_id=args.criterion,
+            label=args.label,
+            score=args.score,
+            max_score=args.max_score,
+            scale=args.scale,
+            teacher_note=args.note,
         )
 
     if args.command == "workspace" and args.workspace_command == "show":
@@ -374,6 +401,49 @@ def _build_parser() -> argparse.ArgumentParser:
         "--location-value",
         type=_location_value_argument,
         help="Optional positive integer or non-empty location value.",
+    )
+
+    set_score_parser = subparsers.add_parser(
+        "set-score",
+        help="Set one teacher-entered criterion score in a student review record.",
+        description=(
+            "Set or update one teacher-entered criterion score in the canonical "
+            "review.json for a student submission. Creates review.json when "
+            "the adjacent submission.json exists and validates."
+        ),
+    )
+    set_score_parser.add_argument("class_id", help="Class identifier.")
+    set_score_parser.add_argument("assignment_id", help="Assignment identifier.")
+    set_score_parser.add_argument("student_id", help="Student identifier.")
+    set_score_parser.add_argument(
+        "--criterion",
+        required=True,
+        help="Non-empty criterion identifier.",
+    )
+    set_score_parser.add_argument(
+        "--label",
+        required=True,
+        help="Teacher-readable criterion label.",
+    )
+    set_score_parser.add_argument(
+        "--score",
+        required=True,
+        type=_non_negative_number_argument,
+        help="Finite criterion score greater than or equal to zero.",
+    )
+    set_score_parser.add_argument(
+        "--max-score",
+        required=True,
+        type=_positive_number_argument,
+        help="Finite maximum criterion score greater than zero.",
+    )
+    set_score_parser.add_argument(
+        "--scale",
+        help="Optional descriptive score scale.",
+    )
+    set_score_parser.add_argument(
+        "--note",
+        help="Optional teacher note for this criterion score.",
     )
 
     workspace_parser = subparsers.add_parser(
@@ -740,6 +810,58 @@ def _print_added_review_tag(added: AddedReviewTag) -> None:
     print(f"Review record: {added.review_record_relative_path}")
 
 
+def _handle_set_score(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    criterion_id: str,
+    label: str,
+    score: int | float,
+    max_score: int | float,
+    scale: str | None,
+    teacher_note: str | None,
+) -> int:
+    """Set one teacher-entered criterion score in a review record."""
+    try:
+        workspace_root = resolve_workspace_root()
+        updated = set_review_score(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            criterion_id=criterion_id,
+            label=label,
+            score=score,
+            max_score=max_score,
+            scale=scale,
+            teacher_note=teacher_note,
+        )
+    except (WorkspaceRootError, ReviewScoreError) as error:
+        print(f"Error: could not set review score: {error}")
+        return 1
+
+    _print_updated_review_score(updated)
+    return 0
+
+
+def _print_updated_review_score(updated: UpdatedReviewScore) -> None:
+    """Print a concise teacher-facing criterion-score summary."""
+    print("Set review score:")
+    print(f"Class: {updated.class_id}")
+    print(f"Assignment: {updated.assignment_id}")
+    print(f"Student: {updated.student_id}")
+    print(f"Criterion: {updated.criterion_id}")
+    print(
+        f"Score: {_format_number(updated.score)} / "
+        f"{_format_number(updated.max_score)}"
+    )
+    print(f"Score record: {updated.score_id}")
+    print(f"Action: {'created' if updated.was_created else 'updated'}")
+    print(f"Review state: {updated.review_state}")
+    print(f"Review record: {updated.review_record_relative_path}")
+
+
 def _print_assignment_submission_status(
     result: AssignmentSubmissionStatus,
     workspace_root: Path,
@@ -999,6 +1121,44 @@ def _location_value_argument(value: str) -> int | str:
         return int(stripped)
     except ValueError:
         return stripped
+
+
+def _non_negative_number_argument(value: str) -> int | float:
+    try:
+        parsed = _finite_number_argument(value)
+    except argparse.ArgumentTypeError as error:
+        raise _ScoreArgumentError(str(error)) from error
+    if parsed < 0:
+        raise _ScoreArgumentError(
+            "must be a finite number greater than or equal to zero"
+        )
+    return parsed
+
+
+def _positive_number_argument(value: str) -> int | float:
+    try:
+        parsed = _finite_number_argument(value)
+    except argparse.ArgumentTypeError as error:
+        raise _ScoreArgumentError(str(error)) from error
+    if parsed <= 0:
+        raise _ScoreArgumentError(
+            "must be a finite number greater than zero"
+        )
+    return parsed
+
+
+def _finite_number_argument(value: str) -> int | float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a finite number") from error
+    if not math.isfinite(parsed):
+        raise argparse.ArgumentTypeError("must be a finite number")
+    return int(parsed) if parsed.is_integer() else parsed
+
+
+def _format_number(value: int | float) -> str:
+    return f"{value:g}"
 
 
 def _validate_route_scan_source_file(source_file: Path) -> bool:

--- a/quillan/review_scores.py
+++ b/quillan/review_scores.py
@@ -1,0 +1,345 @@
+"""Teacher-entered criterion scores for submission review records."""
+
+from __future__ import annotations
+
+import copy
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.review_record import (
+    ReviewRecordError,
+    load_review_record,
+    validate_review_record,
+)
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+_SEQUENTIAL_SCORE_ID = re.compile(r"^score_(\d{4})$")
+
+
+class ReviewScoreError(Exception):
+    """Raised when a teacher score cannot be set safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class UpdatedReviewScore:
+    """Information about a criterion score set in a review record."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    score_id: str
+    criterion_id: str
+    score: int | float
+    max_score: int | float
+    review_state: str
+    updated_at: str
+    was_created: bool
+
+
+def set_review_score(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    criterion_id: str,
+    label: str,
+    score: int | float,
+    max_score: int | float,
+    scale: str | None = None,
+    teacher_note: str | None = None,
+    updated_at: datetime | str | None = None,
+) -> UpdatedReviewScore:
+    """Set or update one teacher-entered criterion score."""
+    normalized_criterion_id = _normalize_required_string(
+        criterion_id, "criterion_id"
+    )
+    normalized_label = _normalize_required_string(label, "label")
+    normalized_score = _normalize_number(score, "score", minimum=0)
+    normalized_max_score = _normalize_number(
+        max_score, "max_score", minimum=0, exclusive_minimum=True
+    )
+    if normalized_score > normalized_max_score:
+        raise ReviewScoreError("score must be less than or equal to max_score.")
+    normalized_scale = _normalize_optional_string(scale, "scale")
+    normalized_teacher_note = _normalize_optional_string(
+        teacher_note, "teacher_note"
+    )
+    normalized_updated_at = _normalize_timestamp(updated_at)
+
+    try:
+        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        record_path = review_record_path(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewScoreError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise ReviewScoreError(
+            "Submission manifest does not exist for "
+            f"class={class_id}, assignment={assignment_id}, student={student_id}."
+        )
+
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise ReviewScoreError(
+            f"Could not load submission manifest: {error}"
+        ) from error
+    _validate_identity(
+        manifest,
+        record_name="Submission manifest",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+
+    if record_path.exists():
+        try:
+            review = load_review_record(record_path)
+        except (OSError, ReviewRecordError) as error:
+            raise ReviewScoreError(
+                f"Could not load review record: {error}"
+            ) from error
+        _validate_identity(
+            review,
+            record_name="Review record",
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+        )
+        updated_review = copy.deepcopy(review)
+        if updated_review["review_state"] == "not_started":
+            updated_review["review_state"] = "in_progress"
+    else:
+        manifest_relative_path = _workspace_relative_path(
+            manifest_path, resolved_workspace_root, "submission manifest"
+        )
+        updated_review = {
+            "schema_version": "1",
+            "module": "quillan",
+            "record_type": "submission_review",
+            "class_id": class_id,
+            "assignment_id": assignment_id,
+            "student_id": student_id,
+            "submission_manifest_path": manifest_relative_path,
+            "review_state": "in_progress",
+            "notes": [],
+            "tags": [],
+            "scores": [],
+            "comments": [],
+            "created_at": normalized_updated_at,
+            "updated_at": normalized_updated_at,
+            "module_details": {},
+        }
+
+    existing_score = next(
+        (
+            candidate
+            for candidate in updated_review["scores"]
+            if candidate["criterion_id"] == normalized_criterion_id
+        ),
+        None,
+    )
+    was_created = existing_score is None
+    if existing_score is None:
+        score_id = _next_score_id(updated_review["scores"])
+        existing_score = {"score_id": score_id}
+        updated_review["scores"].append(existing_score)
+    else:
+        score_id = existing_score["score_id"]
+
+    existing_score.clear()
+    existing_score.update(
+        {
+            "score_id": score_id,
+            "criterion_id": normalized_criterion_id,
+            "label": normalized_label,
+            "score": normalized_score,
+            "max_score": normalized_max_score,
+            "updated_at": normalized_updated_at,
+            "module_details": {},
+        }
+    )
+    if normalized_scale is not None:
+        existing_score["scale"] = normalized_scale
+    if normalized_teacher_note is not None:
+        existing_score["teacher_note"] = normalized_teacher_note
+    updated_review["updated_at"] = normalized_updated_at
+
+    try:
+        validate_review_record(updated_review)
+        write_review_record(
+            record_path,
+            updated_review,
+            overwrite=record_path.exists(),
+        )
+        record_relative_path = _workspace_relative_path(
+            record_path, resolved_workspace_root, "review record"
+        )
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        ReviewRecordError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewScoreError(f"Could not write review record: {error}") from error
+
+    return UpdatedReviewScore(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=record_path,
+        review_record_relative_path=record_relative_path,
+        score_id=score_id,
+        criterion_id=normalized_criterion_id,
+        score=normalized_score,
+        max_score=normalized_max_score,
+        review_state=updated_review["review_state"],
+        updated_at=normalized_updated_at,
+        was_created=was_created,
+    )
+
+
+def _normalize_required_string(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewScoreError(f"{field} must be a non-empty string.")
+    return value.strip()
+
+
+def _normalize_optional_string(value: str | None, field: str) -> str | None:
+    if value is None:
+        return None
+    return _normalize_required_string(value, field)
+
+
+def _normalize_number(
+    value: int | float,
+    field: str,
+    *,
+    minimum: int,
+    exclusive_minimum: bool = False,
+) -> int | float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+    ):
+        raise ReviewScoreError(f"{field} must be a finite number.")
+    if exclusive_minimum and value <= minimum:
+        raise ReviewScoreError(f"{field} must be greater than {minimum}.")
+    if not exclusive_minimum and value < minimum:
+        raise ReviewScoreError(
+            f"{field} must be greater than or equal to {minimum}."
+        )
+    return value
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReviewScoreError("updated_at datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise ReviewScoreError(
+            "updated_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ReviewScoreError(
+            "updated_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewScoreError(
+            "updated_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    *,
+    record_name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    requested = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+    for field, expected in requested.items():
+        actual = record[field]
+        if actual != expected:
+            raise ReviewScoreError(
+                f"{record_name} {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _next_score_id(scores: list[dict[str, Any]]) -> str:
+    existing_ids = {score["score_id"] for score in scores}
+    highest = max(
+        (
+            int(match.group(1))
+            for score_id in existing_ids
+            if (match := _SEQUENTIAL_SCORE_ID.fullmatch(score_id))
+        ),
+        default=0,
+    )
+    candidate_number = highest + 1
+    while True:
+        candidate = f"score_{candidate_number:04d}"
+        if candidate not in existing_ids:
+            return candidate
+        candidate_number += 1
+
+
+def _workspace_relative_path(
+    path: Path,
+    workspace_root: Path,
+    description: str,
+) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewScoreError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error

--- a/tests/test_cli_review_scores.py
+++ b/tests/test_cli_review_scores.py
@@ -1,0 +1,221 @@
+"""CLI tests for teacher-entered criterion review scores."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.review_record_paths import review_record_path
+from tests.test_review_scores import _write_manifest, _write_review
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID, _review
+
+
+def test_cli_success_creates_score_and_prints_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "set-score",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--criterion",
+            "evidence",
+            "--label",
+            "Evidence",
+            "--score",
+            "3",
+            "--max-score",
+            "4",
+            "--scale",
+            "4_point",
+            "--note",
+            "Relevant but not fully explained.",
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Set review score:" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Criterion: evidence" in output
+    assert "Score: 3 / 4" in output
+    assert "Score record: score_0001" in output
+    assert "Action: created" in output
+    assert "Review state: in_progress" in output
+    assert (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/review.json"
+    ) in output
+    written = json.loads(
+        review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert written["scores"][0]["criterion_id"] == "evidence"
+    assert written["scores"][0]["scale"] == "4_point"
+
+
+def test_cli_update_replaces_matching_criterion_and_preserves_other_data(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    original = _review("exported")
+    original["scores"].append(
+        {
+            "score_id": "score_0002",
+            "criterion_id": "organization",
+            "label": "Organization",
+            "score": 2,
+            "max_score": 4,
+            "updated_at": original["updated_at"],
+            "module_details": {"preserve": True},
+        }
+    )
+    path = _write_review(tmp_path, copy.deepcopy(original))
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "set-score",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--criterion",
+            "evidence",
+            "--label",
+            "Use of Evidence",
+            "--score",
+            "4",
+            "--max-score",
+            "5",
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Score record: score_0001" in output
+    assert "Action: updated" in output
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert [item["criterion_id"] for item in written["scores"]].count("evidence") == 1
+    assert written["scores"][0]["score_id"] == "score_0001"
+    assert written["scores"][0]["score"] == 4
+    assert written["scores"][1] == original["scores"][1]
+    for field in ("notes", "tags", "comments", "module_details"):
+        assert written[field] == original[field]
+    assert written["review_state"] == "exported"
+
+
+@pytest.mark.parametrize(
+    ("score", "max_score"),
+    [
+        ("-1", "4"),
+        ("nan", "4"),
+        ("inf", "4"),
+        ("not-a-number", "4"),
+        ("3", "0"),
+        ("3", "-1"),
+        ("3", "nan"),
+        ("3", "not-a-number"),
+        ("5", "4"),
+    ],
+)
+def test_cli_invalid_score_returns_one_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    score: str,
+    max_score: str,
+) -> None:
+    _write_manifest(tmp_path)
+    path = _write_review(tmp_path, _review())
+    original = path.read_bytes()
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "set-score",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--criterion",
+            "evidence",
+            "--label",
+            "Evidence",
+            "--score",
+            score,
+            "--max-score",
+            max_score,
+        ]
+    ) == 1
+
+    assert "Error: could not set review score:" in capsys.readouterr().out
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize(("criterion", "label"), [(" ", "Evidence"), ("evidence", " ")])
+def test_cli_blank_text_and_missing_submission_return_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    criterion: str,
+    label: str,
+) -> None:
+    _write_manifest(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "set-score",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--criterion",
+            criterion,
+            "--label",
+            label,
+            "--score",
+            "3",
+            "--max-score",
+            "4",
+        ]
+    ) == 1
+    assert "Error: could not set review score:" in capsys.readouterr().out
+
+
+def test_cli_missing_submission_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "set-score",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--criterion",
+            "evidence",
+            "--label",
+            "Evidence",
+            "--score",
+            "3",
+            "--max-score",
+            "4",
+        ]
+    ) == 1
+    assert "does not exist" in capsys.readouterr().out

--- a/tests/test_review_scores.py
+++ b/tests/test_review_scores.py
@@ -1,0 +1,453 @@
+"""Tests for teacher-entered criterion review scores."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.review_scores import (
+    ReviewScoreError,
+    UpdatedReviewScore,
+    set_review_score,
+)
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+from tests.test_review_tags import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    ORIGINAL_TIMESTAMP,
+    STUDENT_ID,
+    _manifest,
+    _review,
+)
+
+FIRST_SCORE_TIMESTAMP = "2026-06-22T14:20:00-04:00"
+SECOND_SCORE_TIMESTAMP = "2026-06-22T15:10:00-04:00"
+
+
+def _write_manifest(
+    workspace: Path, manifest: dict[str, Any] | None = None
+) -> Path:
+    path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    return write_submission_manifest(
+        path, _manifest() if manifest is None else manifest
+    )
+
+
+def _write_review(workspace: Path, review: dict[str, Any]) -> Path:
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    return write_review_record(path, review)
+
+
+def test_creates_score_without_mutating_submission_or_evidence(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    evidence_path = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_00107_pg_001.pdf"
+    )
+    retained_path = (
+        tmp_path / "routing" / "source_scans" / "scan_001" / "source_1.pdf"
+    )
+    evidence_path.parent.mkdir(parents=True)
+    retained_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"routed evidence")
+    retained_path.write_bytes(b"retained source")
+    original_manifest = manifest_path.read_bytes()
+
+    result = set_review_score(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        criterion_id=" evidence ",
+        label=" Evidence ",
+        score=3,
+        max_score=4,
+        scale=" 4_point ",
+        teacher_note=" Relevant but not fully explained. ",
+        updated_at=FIRST_SCORE_TIMESTAMP,
+    )
+
+    expected_relative_path = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/review.json"
+    )
+    assert result == UpdatedReviewScore(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        review_record_path=review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ),
+        review_record_relative_path=expected_relative_path,
+        score_id="score_0001",
+        criterion_id="evidence",
+        score=3,
+        max_score=4,
+        review_state="in_progress",
+        updated_at=FIRST_SCORE_TIMESTAMP,
+        was_created=True,
+    )
+    written = json.loads(result.review_record_path.read_text(encoding="utf-8"))
+    assert written["class_id"] == CLASS_ID
+    assert written["assignment_id"] == ASSIGNMENT_ID
+    assert written["student_id"] == STUDENT_ID
+    assert written["submission_manifest_path"] == expected_relative_path.replace(
+        "review.json", "submission.json"
+    )
+    assert written["review_state"] == "in_progress"
+    assert written["notes"] == written["tags"] == written["comments"] == []
+    assert written["created_at"] == written["updated_at"] == FIRST_SCORE_TIMESTAMP
+    assert written["scores"] == [
+        {
+            "score_id": "score_0001",
+            "criterion_id": "evidence",
+            "label": "Evidence",
+            "score": 3,
+            "max_score": 4,
+            "updated_at": FIRST_SCORE_TIMESTAMP,
+            "module_details": {},
+            "scale": "4_point",
+            "teacher_note": "Relevant but not fully explained.",
+        }
+    ]
+    assert manifest_path.read_bytes() == original_manifest
+    assert evidence_path.read_bytes() == b"routed evidence"
+    assert retained_path.read_bytes() == b"retained source"
+
+
+def test_appends_new_criterion_and_uses_highest_conforming_score_id(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    original = _review()
+    original["scores"].extend(
+        [
+            {
+                "score_id": "custom-score",
+                "criterion_id": "style",
+                "label": "Style",
+                "score": 2,
+                "max_score": 4,
+                "updated_at": ORIGINAL_TIMESTAMP,
+                "module_details": {},
+            },
+            {
+                "score_id": "score_0004",
+                "criterion_id": "conventions",
+                "label": "Conventions",
+                "score": 4,
+                "max_score": 4,
+                "updated_at": ORIGINAL_TIMESTAMP,
+                "module_details": {},
+            },
+        ]
+    )
+    path = _write_review(tmp_path, copy.deepcopy(original))
+
+    result = set_review_score(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        criterion_id="organization",
+        label="Organization",
+        score=3.5,
+        max_score=4,
+        updated_at=SECOND_SCORE_TIMESTAMP,
+    )
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert result.score_id == "score_0005"
+    assert result.was_created is True
+    assert written["scores"][:-1] == original["scores"]
+    assert written["scores"][-1]["criterion_id"] == "organization"
+
+
+def test_updates_matching_criterion_and_preserves_unrelated_review_data(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    original = _review("ready_for_export")
+    original["scores"][0]["scale"] = "old_scale"
+    original["scores"][0]["teacher_note"] = "Old note."
+    original["scores"].append(
+        {
+            "score_id": "score_0002",
+            "criterion_id": "organization",
+            "label": "Organization",
+            "score": 2,
+            "max_score": 4,
+            "updated_at": ORIGINAL_TIMESTAMP,
+            "module_details": {"preserve": True},
+        }
+    )
+    path = _write_review(tmp_path, copy.deepcopy(original))
+
+    result = set_review_score(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        criterion_id="evidence",
+        label="Use of Evidence",
+        score=4,
+        max_score=5,
+        updated_at=SECOND_SCORE_TIMESTAMP,
+    )
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert result.score_id == "score_0001"
+    assert result.was_created is False
+    assert result.review_state == "ready_for_export"
+    assert [item["criterion_id"] for item in written["scores"]].count("evidence") == 1
+    assert written["scores"][0] == {
+        "score_id": "score_0001",
+        "criterion_id": "evidence",
+        "label": "Use of Evidence",
+        "score": 4,
+        "max_score": 5,
+        "updated_at": SECOND_SCORE_TIMESTAMP,
+        "module_details": {},
+    }
+    assert written["scores"][1] == original["scores"][1]
+    for field in ("notes", "tags", "comments", "module_details"):
+        assert written[field] == original[field]
+    assert written["created_at"] == original["created_at"]
+    assert written["updated_at"] == SECOND_SCORE_TIMESTAMP
+
+
+@pytest.mark.parametrize(
+    ("initial_state", "expected_state"),
+    [
+        ("not_started", "in_progress"),
+        ("in_progress", "in_progress"),
+        ("ready_for_export", "ready_for_export"),
+        ("exported", "exported"),
+    ],
+)
+def test_score_uses_narrow_review_state_transition(
+    tmp_path: Path,
+    initial_state: str,
+    expected_state: str,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_review(tmp_path, _review(initial_state))
+
+    result = set_review_score(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        criterion_id="evidence",
+        label="Evidence",
+        score=3,
+        max_score=4,
+        updated_at=SECOND_SCORE_TIMESTAMP,
+    )
+
+    assert result.review_state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"criterion_id": " "}, "criterion_id"),
+        ({"label": " "}, "label"),
+        ({"score": -1}, "score"),
+        ({"score": True}, "score"),
+        ({"score": math.inf}, "score"),
+        ({"score": math.nan}, "score"),
+        ({"score": "3"}, "score"),
+        ({"max_score": 0}, "max_score"),
+        ({"max_score": -1}, "max_score"),
+        ({"max_score": True}, "max_score"),
+        ({"max_score": math.inf}, "max_score"),
+        ({"max_score": math.nan}, "max_score"),
+        ({"max_score": "4"}, "max_score"),
+        ({"score": 5}, "less than or equal"),
+        ({"scale": " "}, "scale"),
+        ({"teacher_note": " "}, "teacher_note"),
+    ],
+)
+def test_invalid_score_input_is_rejected_without_writing(
+    tmp_path: Path,
+    overrides: dict[str, Any],
+    message: str,
+) -> None:
+    _write_manifest(tmp_path)
+    arguments: dict[str, Any] = {
+        "criterion_id": "evidence",
+        "label": "Evidence",
+        "score": 3,
+        "max_score": 4,
+        "updated_at": FIRST_SCORE_TIMESTAMP,
+    }
+    arguments.update(overrides)
+
+    with pytest.raises(ReviewScoreError, match=message):
+        set_review_score(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            **arguments,
+        )
+
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "not-a-time",
+        "2026-06-22T14:20:00",
+        datetime(2026, 6, 22, 14, 20),
+        123,
+    ],
+)
+def test_invalid_timestamp_is_rejected(tmp_path: Path, timestamp: object) -> None:
+    _write_manifest(tmp_path)
+    with pytest.raises(ReviewScoreError, match="timezone-aware"):
+        set_review_score(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            criterion_id="evidence",
+            label="Evidence",
+            score=3,
+            max_score=4,
+            updated_at=timestamp,  # type: ignore[arg-type]
+        )
+
+
+def test_timezone_aware_datetime_is_normalized(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    timestamp = datetime(2026, 6, 22, 18, 20, tzinfo=timezone.utc)
+    result = set_review_score(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        criterion_id="evidence",
+        label="Evidence",
+        score=3,
+        max_score=4,
+        updated_at=timestamp,
+    )
+    assert result.updated_at == timestamp.isoformat()
+
+
+def test_missing_submission_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ReviewScoreError, match="does not exist"):
+        set_review_score(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            criterion_id="evidence",
+            label="Evidence",
+            score=3,
+            max_score=4,
+            updated_at=FIRST_SCORE_TIMESTAMP,
+        )
+
+
+@pytest.mark.parametrize("record_kind", ["submission", "review"])
+def test_invalid_existing_record_is_rejected_without_review_write(
+    tmp_path: Path, record_kind: str
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    record_path = review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    if record_kind == "submission":
+        manifest_path.write_text("{", encoding="utf-8")
+    else:
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.write_text("{", encoding="utf-8")
+    original = record_path.read_bytes() if record_path.exists() else None
+
+    with pytest.raises(ReviewScoreError, match="not valid JSON"):
+        set_review_score(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            criterion_id="evidence",
+            label="Evidence",
+            score=3,
+            max_score=4,
+            updated_at=FIRST_SCORE_TIMESTAMP,
+        )
+
+    assert (
+        record_path.read_bytes() if record_path.exists() else None
+    ) == original
+
+
+@pytest.mark.parametrize(
+    ("record_kind", "field", "value"),
+    [
+        ("submission", "class_id", "other_class"),
+        ("submission", "assignment_id", "other_assignment"),
+        ("submission", "student_id", "00108"),
+        ("review", "class_id", "other_class"),
+        ("review", "assignment_id", "other_assignment"),
+        ("review", "student_id", "00108"),
+    ],
+)
+def test_identity_mismatch_is_rejected(
+    tmp_path: Path,
+    record_kind: str,
+    field: str,
+    value: str,
+) -> None:
+    manifest = _manifest()
+    review = _review()
+    if record_kind == "submission":
+        manifest[field] = value
+    else:
+        review[field] = value
+        review["submission_manifest_path"] = (
+            f"classes/{review['class_id']}/assignments/"
+            f"{review['assignment_id']}/submissions/{review['student_id']}/"
+            "submission.json"
+        )
+    _write_manifest(tmp_path, manifest)
+    if record_kind == "review":
+        _write_review(tmp_path, review)
+
+    with pytest.raises(ReviewScoreError, match=field):
+        set_review_score(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            criterion_id="evidence",
+            label="Evidence",
+            score=3,
+            max_score=4,
+            updated_at=FIRST_SCORE_TIMESTAMP,
+        )


### PR DESCRIPTION
## Summary

Adds teacher-entered criterion score records for Quillan v0.7 review records.

This PR introduces a score-entry workflow built on the canonical `review.json` infrastructure:

```powershell id="zokdyo"
quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
```

Scores are explicitly teacher-entered. Quillan does not infer scores from student writing, tags, notes, comments, requirements, standards references, or evidence metadata.

## Changes

* Added `quillan/review_scores.py`

  * `ReviewScoreError`
  * `UpdatedReviewScore`
  * `set_review_score(...)`
  * criterion score creation
  * criterion score update by `criterion_id`
  * stable sequential `score_NNNN` IDs
  * preservation of existing `score_id` when updating a criterion
  * timestamp normalization
  * intrinsic score validation
  * optional `scale` and `teacher_note` support
  * optional-field removal when omitted during update
  * narrow review-state transition behavior
  * validation-before-write behavior for canonical `review.json`

* Added CLI support:

  ```powershell
  quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
  ```

* Added CLI options for:

  * `--criterion`
  * `--label`
  * `--score`
  * `--max-score`
  * `--scale`
  * `--note`

* Added teacher-facing success output showing:

  * class
  * assignment
  * student
  * criterion
  * score and max score
  * score record ID
  * whether the score was created or updated
  * review state
  * review-record path

* Added tests covering:

  * new `review.json` creation
  * criterion score append behavior
  * criterion score update behavior
  * stable score IDs
  * preservation of existing score IDs
  * prevention of duplicate criterion records
  * preservation of unrelated score records
  * preservation of notes, tags, comments, and module details
  * review-state transition behavior
  * timestamp validation
  * invalid score values
  * invalid max-score values
  * `score > max_score` rejection
  * blank criterion and label rejection
  * blank optional fields rejection
  * missing submission rejection
  * invalid submission rejection
  * invalid existing review-record rejection
  * identity mismatch rejection
  * CLI success behavior
  * CLI handled failures
  * non-mutation of `submission.json`
  * non-mutation of routed evidence and retained source files

* Updated README, review-record contract documentation, teacher-review model documentation, and changelog.

## Criterion Update Behavior

Scores are mutable by `criterion_id`.

When a criterion does not yet exist, this PR appends a new score record and assigns the next stable `score_NNNN` ID.

When a criterion already exists, this PR updates that criterion record in place:

* preserves the existing `score_id`
* updates `label`
* updates `score`
* updates `max_score`
* updates `updated_at`
* resets `module_details` to `{}`
* updates `scale` when supplied
* updates `teacher_note` when supplied
* removes optional `scale` and `teacher_note` when omitted

Unrelated score records are preserved.

## Review-State Behavior

This PR applies the same narrow review-state policy used by quick notes and structured tags:

* new review record: `in_progress`
* existing `not_started`: advances to `in_progress`
* existing `in_progress`: remains `in_progress`
* existing `ready_for_export`: preserved
* existing `exported`: preserved

The command does not update `submission_state` in `submission.json`.

## Score Policy

This PR does not calculate or store an overall score.

It does not implement:

* total score calculation
* weighted scoring
* percentage calculation
* grade calculation
* mastery calculation
* rubric aggregation
* score inference from tags
* score inference from notes
* score inference from comments
* score inference from requirements
* score inference from student writing

Each score is explicitly entered by the teacher.

## Non-Mutation Guarantees

This PR does not mutate:

* `submission.json`
* routed evidence files
* retained source scans
* existing notes
* existing tags
* existing comments
* unrelated score records
* unrelated module details

Existing review data is preserved when a criterion score is set.

## Non-Goals

This PR does not implement:

* rubric profile contract
* rubric profile loader
* rubric profile validator
* criterion lookup from `rubric_id`
* overall score calculation
* weighted scoring
* percentage calculation
* grade calculation
* mastery calculation
* score inference
* structured tag changes
* note changes
* reusable comment selection
* feedback export
* class summary CSV export
* standards summary CSV export
* terminal-menu review workflow
* AI scoring
* AI feedback
* OCR
* automatic grading
* `scores.json` generation

Those remain separate future issues.

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

756 tests passed.

Closes #98
