### PR TITLE
docs: define shared comment bank contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Defined the version `1` shared reusable comment bank contract at
+  `shared/comment_banks/<bank_id>.json`, including writing-type filters,
+  categories, standards and criterion links, polarity, severity defaults,
+  search metadata, student-facing controls, future assignment activation,
+  and snapshot semantics for selected `review.json.comments`. Added a
+  synthetic multi-category example without implementing runtime loading,
+  selection, export, grading, or AI behavior.
 - Added `quillan set-score` and a focused criterion-score API for setting
   teacher-entered scores in canonical `review.json` records. New criteria
   receive stable sequential IDs; existing criteria update in place by

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Quillan currently supports:
 - standards profile loading and validation;
 - validation of the legacy text-oriented submission metadata shape;
 - documented writing-evidence and teacher-review data contracts;
+- a documented shared reusable comment bank contract with a synthetic
+  example; runtime bank activation and comment selection remain future work;
 - loading and validation for the version `1` reviewable-evidence submission
   manifest through the distinct `quillan.submission_manifest` module;
 - assembly of new version `1` submission manifests from caller-provided routed
@@ -308,6 +310,13 @@ generates one combined class packet at:
 Replacing an existing packet requires exact `OVERWRITE` confirmation.
 Generation does not alter the roster or assignment config. Generated PDFs are
 local workspace artifacts and should not be committed.
+
+Reusable teacher-authored comment banks are designed to live at
+`shared/comment_banks/<bank_id>.json`. The version `1` source-data contract,
+category and comment shapes, future assignment activation, and snapshot
+boundary with `review.json.comments` are documented in
+[`docs/comment_bank_contract.md`](docs/comment_bank_contract.md). Quillan does
+not yet load banks or select comments from them.
 
 Quillan also consumes the shared PDS1 payload conventions and helpers from
 `pds-core`. Each generated response page embeds a QR code containing a

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -1,0 +1,365 @@
+# Quillan Shared Comment Bank Contract
+
+## Purpose and Boundary
+
+A comment bank is reusable, teacher-authored source data for selecting
+feedback language across classes and assignments. The canonical shared
+workspace-relative path is:
+
+```text
+shared/comment_banks/<bank_id>.json
+```
+
+For example:
+
+```text
+shared/comment_banks/general_writing.json
+shared/comment_banks/argument_writing.json
+shared/comment_banks/literary_analysis.json
+```
+
+Comment banks are local workspace artifacts. They are not student records,
+submission evidence, review records, grades, or generated feedback. A bank
+does not evaluate writing, imply standards mastery, or place a comment in a
+student's review by itself.
+
+This document defines comment bank schema version `1`. It does not implement
+bank loading, editing, assignment activation, comment selection, feedback
+export, automatic suggestions, or AI-generated comments.
+
+## Top-Level Structure
+
+Every version `1` comment bank contains:
+
+```json
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "comment_bank",
+  "bank_id": "argument_writing",
+  "title": "Argument Writing Comments",
+  "description": "Reusable comments for claims, evidence, reasoning, organization, and style.",
+  "scope": "shared",
+  "writing_types": ["argument", "literary_analysis"],
+  "categories": [
+    {
+      "category_id": "evidence",
+      "label": "Evidence",
+      "description": "Quotation choice, relevance, integration, and explanation.",
+      "sort_order": 30,
+      "module_details": {}
+    }
+  ],
+  "comments": [
+    {
+      "comment_id": "evidence_needs_explanation",
+      "label": "Evidence needs explanation",
+      "text": "Your evidence is relevant, but explain more clearly how it supports your claim.",
+      "category_id": "evidence",
+      "subcategory": "analysis",
+      "writing_types": ["argument", "literary_analysis"],
+      "standard_codes": ["W.AW.11-12.1"],
+      "criterion_ids": ["evidence"],
+      "polarity": "developing",
+      "severity_default": 2,
+      "include_in_feedback_default": true,
+      "student_facing": true,
+      "tags": ["evidence", "analysis", "quotation"],
+      "hotwords": ["because", "shows", "suggests"],
+      "teacher_note": "Use when the quotation is relevant but its explanation is thin.",
+      "module_details": {}
+    }
+  ],
+  "created_at": "2026-06-22T00:00:00+00:00",
+  "updated_at": "2026-06-22T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+All top-level fields shown above are required.
+
+* `schema_version` must be the string `"1"`.
+* `module` must be the string `"quillan"`.
+* `record_type` must be the string `"comment_bank"`.
+* `bank_id` must be a valid shared `pds-core` identifier. It must match the
+  filename stem at the canonical shared path.
+* `title` must be a non-empty, teacher-readable string.
+* `description` must be a string and may be empty.
+* `scope` must be one of `shared`, `assignment_local`, `district`, or
+  `system`. Schema version `1` defines all four values for forward
+  compatibility, but `shared` is the supported MVP storage scope.
+* `writing_types` must be an array of non-empty strings.
+* `categories` must be an array of category records. Because every comment
+  requires a category, a conforming non-empty bank will have categories.
+* `comments` must be a non-empty array of comment records.
+* `created_at` and `updated_at` must be timezone-aware ISO 8601 strings.
+  `updated_at` must not precede `created_at`.
+* `module_details` must be an object.
+
+Fields not defined by this contract are not part of schema version `1`.
+Compatible extensions belong in `module_details`; changes to required fields
+or existing field meaning require a later schema version.
+
+## Writing Types
+
+Writing types are open, non-empty strings rather than a closed enum. This
+allows Quillan to support new assignment forms without revising the schema.
+Recommended values include:
+
+* `argument`
+* `literary_analysis`
+* `informational`
+* `narrative`
+* `creative_writing`
+* `journal`
+* `reflection`
+* `short_response`
+* `research`
+* `compare_contrast`
+* `rhetorical_analysis`
+* `poetry`
+* `personal_narrative`
+* `open_response`
+* `general`
+
+Lowercase snake case is recommended for stable filtering, but schema version
+`1` validates only that each value is a non-empty string. Values are
+case-sensitive. Duplicate exact values should be rejected.
+
+Bank-level `writing_types` describes the bank's intended coverage. A
+comment-level `writing_types` array narrows that coverage and therefore must
+be a subset of the bank-level values. When the comment field is absent, the
+comment inherits all bank-level writing types. The value `general` is an
+ordinary writing-type label, not a wildcard.
+
+## Category Records
+
+Categories divide a bank into teacher-scannable sections and avoid one large
+flat comment list. Each category requires:
+
+* `category_id`;
+* `label`.
+
+Optional category fields are:
+
+* `description`;
+* `sort_order`; and
+* `module_details`.
+
+Example:
+
+```json
+{
+  "category_id": "evidence",
+  "label": "Evidence",
+  "description": "Quotation choice, relevance, integration, and explanation.",
+  "sort_order": 30,
+  "module_details": {}
+}
+```
+
+Category field rules are:
+
+* `category_id` must be a valid shared identifier and unique within the bank.
+* `label` must be a non-empty, teacher-readable string.
+* `description`, when present, must be a string and may be empty.
+* `sort_order`, when present, must be an integer. Consumers should sort by
+  `sort_order` first and preserve file order as the stable tie-breaker.
+* `module_details`, when present, must be an object.
+
+Banks choose the categories useful to their own content; they are not
+required to share one global category list. Useful starting values include
+`claim`, `thesis`, `focus`, `evidence`, `analysis`, `organization`,
+`development`, `style`, `voice`, `conventions`, `grammar`, `mechanics`,
+`creativity`, `reflection`, `revision`, `process`, `strength`, `next_step`,
+and `general`.
+
+## Comment Records
+
+Each comment is one stable, teacher-selectable unit of reusable language.
+Required fields are:
+
+* `comment_id`;
+* `label`;
+* `text`;
+* `category_id`;
+* `polarity`;
+* `include_in_feedback_default`;
+* `student_facing`; and
+* `module_details`.
+
+Optional fields are:
+
+* `short_text`;
+* `subcategory`;
+* `writing_types`;
+* `standard_codes`;
+* `criterion_ids`;
+* `severity_default`;
+* `tags`;
+* `hotwords`;
+* `teacher_note`;
+* `follow_up_prompt`;
+* `revision_action`;
+* `sort_order`;
+* `created_at`; and
+* `updated_at`.
+
+Example:
+
+```json
+{
+  "comment_id": "claim_is_clear",
+  "label": "Clear claim",
+  "short_text": "Clear claim.",
+  "text": "Your central claim is clear and gives the response a strong direction.",
+  "category_id": "claim",
+  "subcategory": "strength",
+  "writing_types": ["argument", "literary_analysis"],
+  "standard_codes": ["W.AW.11-12.1"],
+  "criterion_ids": ["thesis"],
+  "polarity": "positive",
+  "severity_default": 0,
+  "include_in_feedback_default": true,
+  "student_facing": true,
+  "tags": ["claim", "thesis", "focus"],
+  "hotwords": ["claim", "argument", "position"],
+  "teacher_note": "Use when the student has a clear controlling idea.",
+  "module_details": {}
+}
+```
+
+Comment field rules are:
+
+* `comment_id` must be a valid shared identifier and unique within the bank.
+  It is a stable source identifier and should not be renamed once selected
+  into review records.
+* `label` and `text` must be non-empty strings. `label` is concise,
+  teacher-facing selection text; `text` is the full reusable language that a
+  future workflow may snapshot into a review.
+* `short_text`, `subcategory`, `teacher_note`, `follow_up_prompt`, and
+  `revision_action`, when present, must be non-empty strings.
+* `category_id` must reference a category in the same bank.
+* `writing_types`, when present, must be a non-empty array of non-empty
+  strings, contain no duplicate exact values, and be a subset of the bank's
+  `writing_types`.
+* `standard_codes` and `criterion_ids`, when present, must be arrays of
+  non-empty strings with no duplicate exact values. They are optional lookup
+  metadata: the bank remains valid without an available standards or rubric
+  profile, and their presence does not establish mastery or a score.
+* `polarity` must be one of `positive`, `developing`, `negative`, or
+  `neutral`.
+* `severity_default`, when present, must be a non-negative integer. It is a
+  triage and organization default, not a score.
+* `include_in_feedback_default` must be a boolean. It is the initial
+  preference for a future selection workflow, not an instruction to export
+  the source comment automatically.
+* `student_facing` must be a boolean. `false` marks language or guidance that
+  is not appropriate to copy directly into student-facing feedback.
+* `tags` and `hotwords`, when present, must be arrays of non-empty strings
+  with no duplicate exact values. Tags support broad keyword filtering;
+  hotwords support quick search terms and phrases.
+* `sort_order`, when present, must be an integer. Consumers should sort by
+  category order, then comment `sort_order`, and then preserve file order as
+  a stable tie-breaker.
+* `created_at` and `updated_at`, when present, must be timezone-aware ISO 8601
+  strings. When both are present, `updated_at` must not precede `created_at`.
+* `module_details` must be an object.
+
+## Assignment Activation
+
+A future assignment contract may add an optional `comment_bank_ids` field:
+
+```json
+{
+  "assignment_id": "villainy_essay",
+  "writing_type": "argument",
+  "comment_bank_ids": [
+    "general_writing",
+    "argument_writing",
+    "literary_analysis"
+  ]
+}
+```
+
+Each item should be a valid, unique shared identifier resolving to
+`shared/comment_banks/<bank_id>.json`.
+
+For backward compatibility, `comment_bank_ids` should remain optional. A
+future consumer may choose defaults based on `writing_type` when the field is
+absent. When it is present, the assignment should activate only the listed
+shared banks plus any future assignment-local supplemental bank.
+
+This field is design guidance only in issue #109. The current assignment
+validator does not accept or act on `comment_bank_ids`, and schema version
+`1` does not define assignment-local merge or override behavior.
+
+## Relationship to `review.json.comments`
+
+The bank and the review record serve different purposes:
+
+* a bank comment is reusable source data shared across reviews;
+* a `review.json.comments` item is a teacher-selected snapshot associated
+  with one student submission.
+
+A future selection operation should copy the selected `label` and `text`,
+set `source` to `"comment_bank"`, preserve the source `comment_id`, apply the
+teacher's `include_in_feedback` choice, and create a new local
+`comment_record_id` and timestamp. Copying display language is essential:
+later edits to a shared bank must not silently change an existing student's
+review or exported feedback.
+
+Source `standard_codes` and `criterion_ids` are filtering and alignment
+metadata. A future workflow may copy the specifically applicable
+`standard_code`, but it must not treat either reference as a score or mastery
+decision.
+
+The current strict version `1` `review.json.comments` shape supports
+`comment_id`, optional `standard_code`, snapshotted `label` and `text`,
+`source`, `include_in_feedback`, `created_at`, and `module_details`. It does
+not yet contain `bank_id`. Adding first-class bank provenance to selected
+comments requires an explicit later review-contract change or version; this
+contract does not silently extend `review.json`.
+
+Standards-profile comments remain a separate reusable source with
+`source: "standards_profile"`. Teacher-entered language uses
+`source: "custom"`.
+
+## Selection and Search Expectations
+
+Future tools should be able to filter or order bank comments by:
+
+* active bank;
+* assignment and comment writing type;
+* category and subcategory;
+* standard code;
+* criterion ID;
+* polarity;
+* default severity;
+* tags and hotwords;
+* student-facing status;
+* feedback-inclusion default; and
+* stable category and comment sort order.
+
+These fields support fast teacher lookup. They do not authorize automatic
+selection, automatic feedback, automatic standards detection, or scoring.
+
+## Scope and Non-Goals
+
+Schema version `1` establishes a reusable source-data contract only. It does
+not implement:
+
+* `quillan add-comment` or any other comment-selection command;
+* comment bank loading, validation, editing, menus, or UI;
+* mutation of `review.json`, `submission.json`, or evidence files;
+* assignment-local merge or override behavior;
+* feedback, email, LMS, or PDF export;
+* reports or standard-mastery conclusions;
+* automatic suggestions, standard detection, scoring, or grading;
+* AI feedback or AI comment generation;
+* district synchronization, cloud sharing, or system-bank distribution.
+
+The repository example at
+[`../examples/comment_banks/general_writing_synthetic.json`](../examples/comment_banks/general_writing_synthetic.json)
+contains synthetic teacher language only and demonstrates the version `1`
+shape.

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -3,8 +3,8 @@
 Quillan stores structured evidence about student writing using local files.
 
 These contracts describe the expected file formats for standards profiles,
-assignments, submissions, teacher review, requirements checks, feedback
-exports, and reports.
+shared comment banks, assignments, submissions, teacher review, requirements
+checks, feedback exports, and reports.
 
 Standards profiles, assignment configurations, the legacy text-oriented
 submission metadata shape, and the reviewable-evidence submission manifest
@@ -26,6 +26,11 @@ scores, feedback, and reports, see
 For the canonical v0.7 `review.json` schema, including notes, tags, scores,
 comments, state, paths, timestamps, and mutation policy, see
 [`review_record_contract.md`](review_record_contract.md).
+
+For reusable teacher-authored feedback language stored at
+`shared/comment_banks/<bank_id>.json`, including categories, writing-type
+filters, standards and criterion links, and future assignment activation, see
+[`comment_bank_contract.md`](comment_bank_contract.md).
 
 For the required structure and human-readable elements of a printable
 writing-response page, see
@@ -174,6 +179,27 @@ Example:
   ]
 }
 ```
+
+## Shared Comment Bank
+
+A shared comment bank is reusable teacher-authored source data stored at:
+
+```text
+shared/comment_banks/<bank_id>.json
+```
+
+It organizes comments with writing types, categories, subcategories,
+standards and criterion references, polarity, severity defaults, search
+metadata, and student-facing controls. Banks are not student records, do not
+grade work, and do not generate feedback by themselves.
+
+Future assignments may optionally activate banks through
+`comment_bank_ids`. Future selection should copy the chosen language into
+`review.json.comments` with `source: "comment_bank"` so the student review is
+a stable snapshot rather than a live reference. The complete version `1`
+shape and validation rules are defined in
+[`comment_bank_contract.md`](comment_bank_contract.md). Runtime validation,
+assignment activation, and selection are not implemented.
 
 ## Assignment
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -327,7 +327,9 @@ record reflects the latest explicit teacher input.
 ## Comments
 
 `comments` contains teacher-selected reusable language or teacher-entered
-custom language intended for possible feedback export.
+custom language intended for possible feedback export. Reusable source
+comments may come from a standards profile or from a shared comment bank
+defined by [`comment_bank_contract.md`](comment_bank_contract.md).
 
 Each comment contains:
 
@@ -375,6 +377,14 @@ Comments are teacher-selected or teacher-entered; they are not generated from
 student writing or supplied as AI judgments. Comments are append-only for the
 MVP. Editing, deletion, and toggling export inclusion are reserved for future
 explicit workflows, which must not silently erase other comment records.
+
+For a future shared-bank selection, `source` must be `"comment_bank"`.
+`label` and `text` must be copied into this record rather than resolved as a
+live display reference. The selected record is a submission-specific
+snapshot, so later edits to the shared bank cannot silently alter an existing
+review or export. The current strict version `1` comment record does not
+contain `bank_id`; first-class bank provenance requires an explicit later
+review-contract change rather than an undeclared field.
 
 ## Timestamp Policy
 

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -155,7 +155,7 @@ Feedback is student-readable teacher communication. It may draw on:
 * teacher notes;
 * score records;
 * requirements checks; and
-* standards profile comments.
+* teacher-approved standards profile or shared comment bank comments.
 
 Feedback remains teacher-controlled. Future tooling may help select
 teacher-approved language, draft text, or format a feedback file, but the
@@ -163,6 +163,15 @@ teacher must review and confirm the communication before it is treated as a
 teacher export. Selected reusable or custom comments are stored in
 `review.json`; a rendered `feedback.md` remains a derived artifact. Quillan
 must not present authoritative AI-generated feedback.
+
+Shared comment banks are reusable teacher-authored source data stored at
+`shared/comment_banks/<bank_id>.json`. They are not student records and do
+not grade, evaluate, or generate feedback by themselves. A future selection
+workflow should copy a comment's teacher-approved language into
+`review.json.comments` as a snapshot with `source: "comment_bank"`. This
+prevents later bank edits from silently changing an existing student review.
+The source contract and future assignment-activation design are defined in
+[`comment_bank_contract.md`](comment_bank_contract.md).
 
 ## Report Philosophy
 
@@ -188,6 +197,9 @@ the conceptual relationships among those records.
 [`review_record_contract.md`](review_record_contract.md) defines the canonical
 v0.7 `review.json` shape and its identity, state, timestamp, path, reference,
 and mutation rules.
+
+[`comment_bank_contract.md`](comment_bank_contract.md) defines reusable shared
+comment source data and its boundary from selected review comments.
 
 [`workspace_lifecycle.md`](workspace_lifecycle.md) defines where records live
 in the shared PDS workspace and how active records relate over time. It does

--- a/examples/comment_banks/general_writing_synthetic.json
+++ b/examples/comment_banks/general_writing_synthetic.json
@@ -1,0 +1,242 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "comment_bank",
+  "bank_id": "general_writing_synthetic",
+  "title": "General Writing Comments (Synthetic)",
+  "description": "Synthetic reusable comments demonstrating strengths, development, conventions, analysis, and revision support.",
+  "scope": "shared",
+  "writing_types": [
+    "general",
+    "argument",
+    "literary_analysis",
+    "informational",
+    "narrative",
+    "reflection",
+    "short_response"
+  ],
+  "categories": [
+    {
+      "category_id": "strength",
+      "label": "Strengths",
+      "description": "Comments that identify effective choices in the writing.",
+      "sort_order": 10,
+      "module_details": {}
+    },
+    {
+      "category_id": "evidence_analysis",
+      "label": "Evidence and Analysis",
+      "description": "Comments about support, explanation, and reasoning.",
+      "sort_order": 20,
+      "module_details": {}
+    },
+    {
+      "category_id": "conventions",
+      "label": "Grammar and Conventions",
+      "description": "Comments about sentence-level correctness and readability.",
+      "sort_order": 30,
+      "module_details": {}
+    },
+    {
+      "category_id": "revision",
+      "label": "Revision and Next Steps",
+      "description": "Comments that help plan a focused revision.",
+      "sort_order": 40,
+      "module_details": {}
+    },
+    {
+      "category_id": "general",
+      "label": "General Review",
+      "description": "Internal or neutral comments used to organize review.",
+      "sort_order": 50,
+      "module_details": {}
+    }
+  ],
+  "comments": [
+    {
+      "comment_id": "focus_is_clear",
+      "label": "Clear focus",
+      "short_text": "Clear, consistent focus.",
+      "text": "Your response maintains a clear focus and stays connected to its central idea.",
+      "category_id": "strength",
+      "subcategory": "focus",
+      "writing_types": [
+        "general",
+        "argument",
+        "literary_analysis",
+        "informational",
+        "narrative",
+        "reflection",
+        "short_response"
+      ],
+      "criterion_ids": ["focus"],
+      "polarity": "positive",
+      "severity_default": 0,
+      "include_in_feedback_default": true,
+      "student_facing": true,
+      "tags": ["focus", "clarity", "central idea"],
+      "hotwords": ["focus", "main idea"],
+      "teacher_note": "Use when the controlling idea remains clear throughout the response.",
+      "sort_order": 10,
+      "module_details": {}
+    },
+    {
+      "comment_id": "evidence_needs_explanation",
+      "label": "Evidence needs explanation",
+      "short_text": "Explain the evidence.",
+      "text": "Your evidence is relevant, but explain more clearly how it supports your central idea.",
+      "category_id": "evidence_analysis",
+      "subcategory": "analysis",
+      "writing_types": [
+        "argument",
+        "literary_analysis",
+        "informational",
+        "short_response"
+      ],
+      "standard_codes": ["W.AW.11-12.1"],
+      "criterion_ids": ["evidence", "analysis"],
+      "polarity": "developing",
+      "severity_default": 2,
+      "include_in_feedback_default": true,
+      "student_facing": true,
+      "tags": ["evidence", "analysis", "reasoning"],
+      "hotwords": ["because", "shows", "suggests", "this matters"],
+      "teacher_note": "Use when support is relevant but the reasoning remains implicit.",
+      "follow_up_prompt": "What does this evidence show, and why does that matter to your central idea?",
+      "revision_action": "Add two sentences that connect the evidence to the central idea.",
+      "sort_order": 10,
+      "created_at": "2026-06-22T00:00:00+00:00",
+      "updated_at": "2026-06-22T00:00:00+00:00",
+      "module_details": {}
+    },
+    {
+      "comment_id": "evidence_is_well_integrated",
+      "label": "Evidence is well integrated",
+      "text": "You introduce and integrate evidence smoothly so it supports the flow of your explanation.",
+      "category_id": "evidence_analysis",
+      "subcategory": "strength",
+      "writing_types": [
+        "argument",
+        "literary_analysis",
+        "informational"
+      ],
+      "standard_codes": ["W.AW.11-12.1"],
+      "criterion_ids": ["evidence"],
+      "polarity": "positive",
+      "severity_default": 0,
+      "include_in_feedback_default": true,
+      "student_facing": true,
+      "tags": ["evidence", "integration", "quotation"],
+      "hotwords": ["introduces", "quotation", "context"],
+      "sort_order": 20,
+      "module_details": {}
+    },
+    {
+      "comment_id": "sentence_boundaries_need_review",
+      "label": "Review sentence boundaries",
+      "short_text": "Check sentence boundaries.",
+      "text": "Review sentence boundaries and revise run-ons or fragments so each sentence is complete and easy to follow.",
+      "category_id": "conventions",
+      "subcategory": "grammar",
+      "writing_types": [
+        "general",
+        "argument",
+        "literary_analysis",
+        "informational",
+        "narrative",
+        "reflection",
+        "short_response"
+      ],
+      "criterion_ids": ["conventions"],
+      "polarity": "developing",
+      "severity_default": 2,
+      "include_in_feedback_default": true,
+      "student_facing": true,
+      "tags": ["grammar", "sentences", "run-on", "fragment"],
+      "hotwords": ["sentence boundary", "run-on", "fragment"],
+      "revision_action": "Read each sentence aloud and mark where one complete thought ends.",
+      "sort_order": 10,
+      "module_details": {}
+    },
+    {
+      "comment_id": "revise_one_priority_area",
+      "label": "Choose one revision priority",
+      "text": "Choose one high-impact area to revise first, then reread the full response to check how that change affects the whole piece.",
+      "category_id": "revision",
+      "subcategory": "next_step",
+      "writing_types": [
+        "general",
+        "argument",
+        "literary_analysis",
+        "informational",
+        "narrative",
+        "reflection"
+      ],
+      "standard_codes": ["W.WP.11-12.4"],
+      "criterion_ids": ["revision_process"],
+      "polarity": "neutral",
+      "severity_default": 1,
+      "include_in_feedback_default": true,
+      "student_facing": true,
+      "tags": ["revision", "priority", "next step"],
+      "hotwords": ["revise", "reread", "next step"],
+      "follow_up_prompt": "Which single change would most improve this draft for your reader?",
+      "revision_action": "Name and complete one high-impact revision before editing smaller details.",
+      "sort_order": 10,
+      "module_details": {}
+    },
+    {
+      "comment_id": "meaning_is_currently_unclear",
+      "label": "Meaning is unclear",
+      "text": "Several ideas are difficult to follow because key connections are missing or unclear.",
+      "category_id": "revision",
+      "subcategory": "clarity",
+      "writing_types": [
+        "general",
+        "argument",
+        "literary_analysis",
+        "informational",
+        "narrative",
+        "reflection",
+        "short_response"
+      ],
+      "polarity": "negative",
+      "severity_default": 3,
+      "include_in_feedback_default": true,
+      "student_facing": true,
+      "tags": ["clarity", "connections", "meaning"],
+      "hotwords": ["unclear", "connection", "reader"],
+      "revision_action": "Add the missing connection between each key idea before editing wording.",
+      "sort_order": 20,
+      "module_details": {}
+    },
+    {
+      "comment_id": "teacher_review_follow_up",
+      "label": "Teacher follow-up needed",
+      "text": "Revisit this response after checking the assignment-specific expectations and the student's earlier draft.",
+      "category_id": "general",
+      "subcategory": "internal",
+      "writing_types": [
+        "general",
+        "argument",
+        "literary_analysis",
+        "informational",
+        "narrative",
+        "reflection",
+        "short_response"
+      ],
+      "polarity": "neutral",
+      "severity_default": 1,
+      "include_in_feedback_default": false,
+      "student_facing": false,
+      "tags": ["teacher only", "follow-up", "context"],
+      "hotwords": ["check draft", "assignment expectations"],
+      "teacher_note": "Internal reminder only; do not copy directly into student feedback.",
+      "sort_order": 10,
+      "module_details": {}
+    }
+  ],
+  "created_at": "2026-06-22T00:00:00+00:00",
+  "updated_at": "2026-06-22T00:00:00+00:00",
+  "module_details": {}
+}


### PR DESCRIPTION
## Summary

Defines the Quillan shared comment bank contract for reusable teacher-authored feedback language.

This PR adds a forward-looking schema version `1` contract for reusable comment banks stored at:

`shared/comment_banks/<bank_id>.json`

Comment banks are reusable source data. They do not select comments into student reviews by themselves, generate feedback, grade writing, infer standards mastery, or mutate student records.

## Changes

* Added `docs/comment_bank_contract.md`

  * canonical shared comment bank location
  * top-level bank shape
  * writing-type strategy
  * category record shape
  * comment record shape
  * assignment activation guidance
  * relationship to `review.json.comments`
  * selection/search expectations
  * explicit runtime non-goals

* Added `examples/comment_banks/general_writing_synthetic.json`

  * synthetic reusable comments only
  * multiple writing types
  * multiple categories
  * positive, developing, negative, and neutral comments
  * standard-linked comments
  * criterion-linked comments
  * feedback-inclusion defaults
  * student-facing and teacher-only examples
  * search metadata such as tags and hotwords
  * revision-oriented metadata such as follow-up prompts and revision actions

* Updated README, changelog, teacher-review model, review-record contract, and data-contract documentation to reference the comment-bank contract.

## Contract Highlights

The contract supports:

* shared reusable comment banks across classes and assignments
* assignment-type filtering through open writing-type strings
* category and subcategory organization for fast teacher lookup
* standard-code metadata
* criterion-ID metadata
* polarity
* severity defaults
* feedback-inclusion defaults
* student-facing vs teacher-only language
* keyword/search metadata
* stable display ordering
* future assignment activation through `comment_bank_ids`

## Relationship to Review Records

The contract distinguishes source comments from selected review comments.

A bank comment is reusable source data.

A `review.json.comments` item is a teacher-selected snapshot associated with one student submission.

Future selection behavior should copy the selected label and text into `review.json.comments` so later edits to the shared bank do not silently change an existing student review or exported feedback.

The current `review.json.comments` contract does not yet include `bank_id`. Adding first-class bank provenance should be handled through an explicit later review-contract change or version.

## Non-Goals

This PR does not implement:

* `quillan add-comment`
* comment bank loading
* comment bank validation
* comment bank editing
* assignment activation behavior
* comment selection into `review.json.comments`
* feedback export
* reports
* grading
* standards mastery conclusions
* automatic suggestions
* AI feedback
* AI comment generation
* mutation of `review.json`
* mutation of `submission.json`
* mutation of evidence files

This is a contract and documentation PR only.

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

756 tests passed.

Closes #109
