### PR TITLE
feat: add comment bank provenance to review comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ planning and do not by themselves represent releases.
 
 ### Changed
 
+- Added explicit shared-bank provenance to selected version `1` review
+  comments. `comment_bank` snapshots now require a valid `bank_id` and
+  `comment_id`; standards-profile snapshots require `standard_code` and
+  `comment_id`; and custom comments reject source identifiers. Bank provenance
+  does not perform lookup or turn snapshotted label and text into live
+  references.
 - Defined the v0.7 canonical `review.json` contract, separating
   teacher-entered notes, tags, criterion scores, selected comments, and
   `review_state` from the `submission.json` evidence manifest.

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -303,23 +303,24 @@ The bank and the review record serve different purposes:
   with one student submission.
 
 A future selection operation should copy the selected `label` and `text`,
-set `source` to `"comment_bank"`, preserve the source `comment_id`, apply the
-teacher's `include_in_feedback` choice, and create a new local
-`comment_record_id` and timestamp. Copying display language is essential:
-later edits to a shared bank must not silently change an existing student's
-review or exported feedback.
+set `source` to `"comment_bank"`, preserve the source `bank_id` and
+`comment_id`, apply the teacher's `include_in_feedback` choice, and create a
+new local `comment_record_id` and timestamp. A `comment_id` is unique only
+within its bank, so `bank_id + comment_id` identifies the reusable source
+comment. Copying display language is essential: provenance is not a live
+reference, and later edits to a shared bank must not silently change an
+existing student's review or exported feedback.
 
 Source `standard_codes` and `criterion_ids` are filtering and alignment
 metadata. A future workflow may copy the specifically applicable
 `standard_code`, but it must not treat either reference as a score or mastery
 decision.
 
-The current strict version `1` `review.json.comments` shape supports
-`comment_id`, optional `standard_code`, snapshotted `label` and `text`,
-`source`, `include_in_feedback`, `created_at`, and `module_details`. It does
-not yet contain `bank_id`. Adding first-class bank provenance to selected
-comments requires an explicit later review-contract change or version; this
-contract does not silently extend `review.json`.
+The strict version `1` `review.json.comments` shape requires `bank_id` and
+`comment_id` for `source: "comment_bank"`, along with snapshotted `label` and
+`text`, `include_in_feedback`, `created_at`, and `module_details`. The
+`bank_id` records provenance at `shared/comment_banks/<bank_id>.json`; review
+validation does not load that file or perform selection.
 
 Standards-profile comments remain a separate reusable source with
 `source: "standards_profile"`. Teacher-entered language uses

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -195,7 +195,9 @@ grade work, and do not generate feedback by themselves.
 
 Future assignments may optionally activate banks through
 `comment_bank_ids`. Future selection should copy the chosen language into
-`review.json.comments` with `source: "comment_bank"` so the student review is
+`review.json.comments` with `source: "comment_bank"`, `bank_id`, and
+`comment_id`. Because comment IDs are unique only within a bank, the pair
+preserves source provenance. The copied label and text make the student review
 a stable snapshot rather than a live reference. The complete version `1`
 shape and validation rules are defined in
 [`comment_bank_contract.md`](comment_bank_contract.md). Runtime validation,

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -359,32 +359,42 @@ Required comment fields are:
 
 Optional comment fields are:
 
+* `bank_id`;
 * `comment_id`; and
 * `standard_code`.
 
 Comment field rules are:
 
 * `comment_record_id` is unique within `comments`.
-* `comment_id` may identify reusable language in a standards profile or
-  comment bank.
-* `standard_code` may identify the associated profile standard.
+* `bank_id`, when present, is a valid shared identifier naming the source at
+  `shared/comment_banks/<bank_id>.json`.
+* `comment_id` identifies reusable language within its source bank or
+  standards profile; it is not globally unique across comment banks.
+* `standard_code` identifies the associated profile standard.
 * `label` and `text` are non-empty strings.
 * `source` is one of `standards_profile`, `comment_bank`, or `custom`.
 * `include_in_feedback` is a boolean expressing the teacher's export choice.
 * `module_details` is an object.
+
+Source-specific rules are:
+
+* `comment_bank` comments require both `bank_id` and `comment_id`;
+  `bank_id + comment_id` identifies the reusable source comment.
+* `standards_profile` comments require `comment_id` and `standard_code` and
+  must omit `bank_id`.
+* `custom` comments must omit `bank_id`, `comment_id`, and `standard_code`.
 
 Comments are teacher-selected or teacher-entered; they are not generated from
 student writing or supplied as AI judgments. Comments are append-only for the
 MVP. Editing, deletion, and toggling export inclusion are reserved for future
 explicit workflows, which must not silently erase other comment records.
 
-For a future shared-bank selection, `source` must be `"comment_bank"`.
+For a shared-bank selection, `source` must be `"comment_bank"`. `bank_id` is
+provenance metadata only: validation does not load or look up the bank file.
 `label` and `text` must be copied into this record rather than resolved as a
-live display reference. The selected record is a submission-specific
-snapshot, so later edits to the shared bank cannot silently alter an existing
-review or export. The current strict version `1` comment record does not
-contain `bank_id`; first-class bank provenance requires an explicit later
-review-contract change rather than an undeclared field.
+live display reference. The selected record is a submission-specific snapshot,
+so later edits to the shared bank cannot silently alter an existing review or
+export.
 
 ## Timestamp Policy
 

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -168,8 +168,10 @@ Shared comment banks are reusable teacher-authored source data stored at
 `shared/comment_banks/<bank_id>.json`. They are not student records and do
 not grade, evaluate, or generate feedback by themselves. A future selection
 workflow should copy a comment's teacher-approved language into
-`review.json.comments` as a snapshot with `source: "comment_bank"`. This
-prevents later bank edits from silently changing an existing student review.
+`review.json.comments` as a snapshot with `source: "comment_bank"`, the source
+`bank_id`, and the source `comment_id`. Comment IDs are bank-local, so the pair
+identifies the reusable source comment. The copied label and text remain
+stable if the bank later changes; provenance does not create a live reference.
 The source contract and future assignment-activation design are defined in
 [`comment_bank_contract.md`](comment_bank_contract.md).
 

--- a/quillan/review_record.py
+++ b/quillan/review_record.py
@@ -73,7 +73,7 @@ REQUIRED_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
     }
 )
 OPTIONAL_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
-    {"comment_id", "standard_code"}
+    {"bank_id", "comment_id", "standard_code"}
 )
 
 ALLOWED_REVIEW_STATES: Final[frozenset[str]] = frozenset(
@@ -346,15 +346,52 @@ def _validate_comments(value: Any) -> None:
         for field in ("comment_id", "standard_code"):
             if field in item:
                 _validate_non_empty_string(item[field], f"{context}.{field}")
-        _validate_allowed_value(
+        if "bank_id" in item:
+            _validate_identifier(item["bank_id"], f"{context}.bank_id")
+        source = _validate_allowed_value(
             item["source"], f"{context}.source", ALLOWED_COMMENT_SOURCES
         )
+        _validate_comment_provenance(item, source, context)
         if not isinstance(item["include_in_feedback"], bool):
             raise ReviewRecordError(
                 f"Field '{context}.include_in_feedback' must be a boolean."
             )
         _validate_timestamp(item["created_at"], f"{context}.created_at")
         _validate_json_object(item["module_details"], f"{context}.module_details")
+
+
+def _validate_comment_provenance(
+    item: dict[str, Any], source: str, context: str
+) -> None:
+    if source == "comment_bank":
+        for field in ("bank_id", "comment_id"):
+            if field not in item:
+                raise ReviewRecordError(
+                    f"Field '{context}.{field}' is required when "
+                    f"'{context}.source' is 'comment_bank'."
+                )
+        return
+
+    if source == "standards_profile":
+        if "bank_id" in item:
+            raise ReviewRecordError(
+                f"Field '{context}.bank_id' must be absent when "
+                f"'{context}.source' is 'standards_profile'."
+            )
+        for field in ("comment_id", "standard_code"):
+            if field not in item:
+                raise ReviewRecordError(
+                    f"Field '{context}.{field}' is required when "
+                    f"'{context}.source' is 'standards_profile'."
+                )
+        return
+
+    for field in ("bank_id", "comment_id", "standard_code"):
+        if field in item:
+            raise ReviewRecordError(
+                f"Field '{context}.{field}' must be absent when "
+                f"'{context}.source' is 'custom'."
+            )
 
 
 def _validate_workspace_relative_path(value: Any, field: str) -> None:

--- a/tests/test_review_record.py
+++ b/tests/test_review_record.py
@@ -96,6 +96,30 @@ def _comment(comment_record_id: str = "comment_0001") -> dict[str, Any]:
     }
 
 
+def _comment_bank_comment() -> dict[str, Any]:
+    comment = _comment()
+    comment.update(
+        {
+            "source": "comment_bank",
+            "bank_id": "general_writing",
+            "comment_id": "evidence_needs_explanation",
+        }
+    )
+    return comment
+
+
+def _standards_profile_comment() -> dict[str, Any]:
+    comment = _comment()
+    comment.update(
+        {
+            "source": "standards_profile",
+            "comment_id": "evidence_needs_explanation",
+            "standard_code": "W.AW.11-12.1",
+        }
+    )
+    return comment
+
+
 def _write_json(path: Path, value: Any) -> Path:
     path.write_text(json.dumps(value), encoding="utf-8")
     return path
@@ -399,6 +423,73 @@ def test_invalid_comment_source_is_rejected() -> None:
     record["comments"] = [comment]
 
     with pytest.raises(ReviewRecordError, match="source"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    "comment_factory",
+    [_comment_bank_comment, _standards_profile_comment, _comment],
+)
+def test_valid_comment_source_provenance_is_accepted(
+    comment_factory: Any,
+) -> None:
+    record = _record()
+    record["comments"] = [comment_factory()]
+
+    validate_review_record(record)
+
+
+@pytest.mark.parametrize("field", ["bank_id", "comment_id"])
+def test_comment_bank_requires_source_identifiers(field: str) -> None:
+    record = _record()
+    comment = _comment_bank_comment()
+    del comment[field]
+    record["comments"] = [comment]
+
+    with pytest.raises(ReviewRecordError, match=field):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize("bank_id", ["", " ", "General Writing", "../unsafe"])
+def test_comment_bank_rejects_invalid_bank_id(bank_id: str) -> None:
+    record = _record()
+    comment = _comment_bank_comment()
+    comment["bank_id"] = bank_id
+    record["comments"] = [comment]
+
+    with pytest.raises(ReviewRecordError, match="bank_id"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize("field", ["comment_id", "standard_code"])
+def test_standards_profile_requires_source_identifiers(field: str) -> None:
+    record = _record()
+    comment = _standards_profile_comment()
+    del comment[field]
+    record["comments"] = [comment]
+
+    with pytest.raises(ReviewRecordError, match=field):
+        validate_review_record(record)
+
+
+def test_standards_profile_rejects_bank_id() -> None:
+    record = _record()
+    comment = _standards_profile_comment()
+    comment["bank_id"] = "general_writing"
+    record["comments"] = [comment]
+
+    with pytest.raises(ReviewRecordError, match="bank_id"):
+        validate_review_record(record)
+
+
+@pytest.mark.parametrize("field", ["bank_id", "comment_id", "standard_code"])
+def test_custom_comment_rejects_source_identifiers(field: str) -> None:
+    record = _record()
+    comment = _comment()
+    comment[field] = "general_writing"
+    record["comments"] = [comment]
+
+    with pytest.raises(ReviewRecordError, match=field):
         validate_review_record(record)
 
 


### PR DESCRIPTION
## Summary

Adds explicit shared comment-bank provenance to selected review comment records.

Selected comments with `source: "comment_bank"` now require both:

* `bank_id`
* `comment_id`

This allows `bank_id + comment_id` to identify the reusable source comment while preserving the selected review comment as a stable snapshot.

## Changes

* Updated `review.json.comments` validation:

  * added optional `bank_id` field
  * validates `bank_id` as a shared identifier when present
  * requires `bank_id` and `comment_id` for `source: "comment_bank"`
  * requires `standard_code` and `comment_id` for `source: "standards_profile"`
  * rejects `bank_id` for `source: "standards_profile"`
  * rejects `bank_id`, `comment_id`, and `standard_code` for `source: "custom"`

* Updated review-record provenance tests:

  * valid comment-bank provenance
  * missing comment-bank identifiers
  * invalid `bank_id`
  * valid standards-profile provenance
  * missing standards-profile identifiers
  * invalid standards-profile `bank_id`
  * valid custom comments
  * invalid custom source identifiers

* Updated documentation:

  * comment bank contract
  * review record contract
  * teacher review model
  * data contracts
  * changelog

## Design Notes

`comment_id` is bank-local, not globally unique. Multiple shared banks may reasonably use the same `comment_id`.

For comment-bank selections, `bank_id + comment_id` identifies the reusable source comment at:

`shared/comment_banks/<bank_id>.json`

The selected review comment still snapshots `label` and `text`. Bank provenance does not create a live reference, and later edits to a shared bank must not silently alter existing student review records or exported feedback.

## Non-Goals

This PR does not implement:

* comment bank lookup
* comment bank validation
* comment selection
* `quillan add-comment`
* assignment activation through `comment_bank_ids`
* feedback export
* report generation
* AI suggestions
* automatic comments
* grading behavior
* migration tooling

This is only a review-record contract and validation update.

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

771 tests passed.

Closes #111
