### PR TITLE
feat: add reusable comment selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan add-comment` and a focused reusable-comment selection API.
+  Shared comment banks are fully validated before selection; student-facing
+  comments are appended to `review.json.comments` with sequential local IDs,
+  `bank_id + comment_id` provenance, snapshotted label and text, optional
+  standard selection, and bank-default or teacher-overridden feedback
+  inclusion. Existing review content and later review states are preserved,
+  while comment banks, submission manifests, and evidence remain unchanged.
 - Defined the version `1` shared reusable comment bank contract at
   `shared/comment_banks/<bank_id>.json`, including writing-type filters,
   categories, standards and criterion links, polarity, severity defaults,

--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ The supported teacher/developer sequence is:
    `review.json`.
 10. `add-tag` appends a teacher-entered structured observation to that review
     record.
-11. `set-score` sets or updates one explicitly teacher-entered criterion score.
-12. `set-review-state` records lightweight submission-manifest progress when
+11. `add-comment` selects student-facing teacher-authored language from a
+    shared comment bank into that review record as a stable snapshot.
+12. `set-score` sets or updates one explicitly teacher-entered criterion score.
+13. `set-review-state` records lightweight submission-manifest progress when
     the teacher chooses.
 
 Opening evidence and updating review state are separate teacher-controlled
@@ -153,6 +155,7 @@ quillan open-evidence <workspace-relative-evidence-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
+quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
 quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
@@ -178,6 +181,12 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   may reference a validated standard, reusable profile comment, page,
   evidence ID, or writing location, but they do not score work, prove mastery,
   or generate feedback.
+- `add-comment` validates a shared bank and appends one student-facing source
+  comment to `review.json.comments`. The selected record stores
+  `bank_id + comment_id` provenance and copies label and text, so later bank
+  edits do not change an existing review. Feedback inclusion uses the bank
+  default unless explicitly included or excluded; this command does not
+  export feedback.
 - `set-score` sets one teacher-entered criterion score in `review.json`.
   Existing criteria update by `criterion_id`; unrelated review data is
   preserved. Criterion IDs are not yet validated against rubric profiles, and
@@ -192,7 +201,7 @@ teacher explicitly requests it.
 Quillan does not perform OCR, handwriting recognition, PDF text
 extraction, AI scoring, AI feedback, AI suggestions, automatic grading,
 automatic review-state updates, automatic evidence selection among duplicates,
-rubric scoring, reusable comment selection into feedback, feedback export, or
+rubric scoring, feedback export, or
 report generation. Quick notes and structured tags are teacher-entered
 records; they do not score or generate feedback by themselves.
 The teacher remains responsible for reading and evaluating student work.

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -23,9 +23,10 @@ submission evidence, review records, grades, or generated feedback. A bank
 does not evaluate writing, imply standards mastery, or place a comment in a
 student's review by itself.
 
-This document defines comment bank schema version `1`. It does not implement
-bank loading, editing, assignment activation, comment selection, feedback
-export, automatic suggestions, or AI-generated comments.
+This document defines comment bank schema version `1`. Runtime loading,
+validation, and direct student-facing selection are implemented; bank editing,
+assignment activation, menus, feedback export, automatic suggestions, and
+AI-generated comments are not.
 
 ## Top-Level Structure
 
@@ -302,7 +303,7 @@ The bank and the review record serve different purposes:
 * a `review.json.comments` item is a teacher-selected snapshot associated
   with one student submission.
 
-A future selection operation should copy the selected `label` and `text`,
+The direct selection operation copies the selected `label` and `text`,
 set `source` to `"comment_bank"`, preserve the source `bank_id` and
 `comment_id`, apply the teacher's `include_in_feedback` choice, and create a
 new local `comment_record_id` and timestamp. A `comment_id` is unique only
@@ -312,9 +313,9 @@ reference, and later edits to a shared bank must not silently change an
 existing student's review or exported feedback.
 
 Source `standard_codes` and `criterion_ids` are filtering and alignment
-metadata. A future workflow may copy the specifically applicable
-`standard_code`, but it must not treat either reference as a score or mastery
-decision.
+metadata. Selection copies a sole standard automatically, stores an explicitly
+requested source standard, and otherwise omits `standard_code`; it does not
+treat either reference as a score or mastery decision.
 
 The strict version `1` `review.json.comments` shape requires `bank_id` and
 `comment_id` for `source: "comment_bank"`, along with snapshotted `label` and
@@ -345,13 +346,24 @@ Future tools should be able to filter or order bank comments by:
 These fields support fast teacher lookup. They do not authorize automatic
 selection, automatic feedback, automatic standards detection, or scoring.
 
+## Runtime Selection
+
+```powershell
+quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
+```
+
+Optional `--standard`, `--include-in-feedback`, and
+`--exclude-from-feedback` flags refine the selected snapshot. Include and
+exclude are mutually exclusive. Only comments with `student_facing: true` are
+selectable in this MVP; teacher-only language is rejected. The source bank,
+submission manifest, routed evidence, and retained source scans are never
+mutated. No feedback export is performed.
+
 ## Scope and Non-Goals
 
-Schema version `1` establishes a reusable source-data contract only. It does
-not implement:
+Schema version `1` and the first runtime workflow do not implement:
 
-* `quillan add-comment` or any other comment-selection command;
-* comment bank loading, validation, editing, menus, or UI;
+* comment bank editing, menus, search, or UI;
 * mutation of `review.json`, `submission.json`, or evidence files;
 * assignment-local merge or override behavior;
 * feedback, email, LMS, or PDF export;

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -194,7 +194,7 @@ metadata, and student-facing controls. Banks are not student records, do not
 grade work, and do not generate feedback by themselves.
 
 Future assignments may optionally activate banks through
-`comment_bank_ids`. Future selection should copy the chosen language into
+`comment_bank_ids`. Direct shared-bank selection copies the chosen language into
 `review.json.comments` with `source: "comment_bank"`, `bank_id`, and
 `comment_id`. Because comment IDs are unique only within a bank, the pair
 preserves source provenance. The copied label and text make the student review

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -396,6 +396,13 @@ live display reference. The selected record is a submission-specific snapshot,
 so later edits to the shared bank cannot silently alter an existing review or
 export.
 
+The direct `add-comment` workflow validates the source bank first and accepts
+only `student_facing: true` comments. It uses the bank's
+`include_in_feedback_default` unless the teacher explicitly includes or
+excludes the selected comment. A sole source `standard_code` is copied
+automatically; with multiple source standards, one is stored only when the
+teacher specifies it.
+
 ## Timestamp Policy
 
 Every timestamp is an ISO 8601 string with an explicit timezone offset, for

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -166,12 +166,16 @@ must not present authoritative AI-generated feedback.
 
 Shared comment banks are reusable teacher-authored source data stored at
 `shared/comment_banks/<bank_id>.json`. They are not student records and do
-not grade, evaluate, or generate feedback by themselves. A future selection
-workflow should copy a comment's teacher-approved language into
+not grade, evaluate, or generate feedback by themselves. The direct
+`add-comment` workflow copies a student-facing comment's teacher-approved
+language into
 `review.json.comments` as a snapshot with `source: "comment_bank"`, the source
 `bank_id`, and the source `comment_id`. Comment IDs are bank-local, so the pair
 identifies the reusable source comment. The copied label and text remain
 stable if the bank later changes; provenance does not create a live reference.
+The bank feedback default may be overridden by the teacher at selection time.
+Teacher-only bank comments are rejected, and selection does not export
+feedback.
 The source contract and future assignment-activation design are defined in
 [`comment_bank_contract.md`](comment_bank_contract.md).
 

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -47,6 +47,11 @@ from quillan.review_notes import (
     ReviewNoteError,
     add_review_note,
 )
+from quillan.review_comments import (
+    AddedReviewComment,
+    ReviewCommentError,
+    add_review_comment,
+)
 from quillan.review_scores import (
     ReviewScoreError,
     UpdatedReviewScore,
@@ -156,6 +161,17 @@ def main(argv: list[str] | None = None) -> int:
             evidence_id=args.evidence_id,
             location_type=args.location_type,
             location_value=args.location_value,
+        )
+
+    if args.command == "add-comment":
+        return _handle_add_comment(
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            bank_id=args.bank,
+            comment_id=args.comment_id,
+            standard_code=args.standard,
+            include_in_feedback=args.include_in_feedback,
         )
 
     if args.command == "set-score":
@@ -401,6 +417,47 @@ def _build_parser() -> argparse.ArgumentParser:
         "--location-value",
         type=_location_value_argument,
         help="Optional positive integer or non-empty location value.",
+    )
+
+    add_comment_parser = subparsers.add_parser(
+        "add-comment",
+        help="Select one reusable comment-bank comment for a student review record.",
+        description=(
+            "Append one teacher-selected reusable comment from a shared comment "
+            "bank to the canonical review.json for a student submission. The "
+            "selected comment snapshots label and text so later bank edits do "
+            "not alter existing reviews."
+        ),
+    )
+    add_comment_parser.add_argument("class_id", help="Class identifier.")
+    add_comment_parser.add_argument(
+        "assignment_id", help="Assignment identifier."
+    )
+    add_comment_parser.add_argument("student_id", help="Student identifier.")
+    add_comment_parser.add_argument(
+        "--bank", required=True, help="Shared comment-bank identifier."
+    )
+    add_comment_parser.add_argument(
+        "--comment-id", required=True, help="Reusable source comment identifier."
+    )
+    add_comment_parser.add_argument(
+        "--standard", help="Optional standard code from the source comment."
+    )
+    feedback_group = add_comment_parser.add_mutually_exclusive_group()
+    feedback_group.add_argument(
+        "--include-in-feedback",
+        dest="include_in_feedback",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Include the selected comment in future feedback.",
+    )
+    feedback_group.add_argument(
+        "--exclude-from-feedback",
+        dest="include_in_feedback",
+        action="store_const",
+        const=False,
+        help="Exclude the selected comment from future feedback.",
     )
 
     set_score_parser = subparsers.add_parser(
@@ -806,6 +863,51 @@ def _print_added_review_tag(added: AddedReviewTag) -> None:
     print(f"Student: {added.student_id}")
     print(f"Tag: {added.tag_id}")
     print(f"Polarity: {added.polarity}")
+    print(f"Review state: {added.review_state}")
+    print(f"Review record: {added.review_record_relative_path}")
+
+
+def _handle_add_comment(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    bank_id: str,
+    comment_id: str,
+    standard_code: str | None,
+    include_in_feedback: bool | None,
+) -> int:
+    """Select one shared-bank comment into a canonical review record."""
+    try:
+        workspace_root = resolve_workspace_root()
+        added = add_review_comment(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            bank_id=bank_id,
+            comment_id=comment_id,
+            standard_code=standard_code,
+            include_in_feedback=include_in_feedback,
+        )
+    except (WorkspaceRootError, ReviewCommentError) as error:
+        print(f"Error: could not select review comment: {error}")
+        return 1
+
+    _print_added_review_comment(added)
+    return 0
+
+
+def _print_added_review_comment(added: AddedReviewComment) -> None:
+    """Print a concise teacher-facing selected-comment summary."""
+    print("Selected review comment:")
+    print(f"Class: {added.class_id}")
+    print(f"Assignment: {added.assignment_id}")
+    print(f"Student: {added.student_id}")
+    print(f"Bank: {added.bank_id}")
+    print(f"Source comment: {added.comment_id}")
+    print(f"Review comment: {added.comment_record_id}")
+    print(f"Include in feedback: {_format_bool(added.include_in_feedback)}")
     print(f"Review state: {added.review_state}")
     print(f"Review record: {added.review_record_relative_path}")
 

--- a/quillan/comment_banks.py
+++ b/quillan/comment_banks.py
@@ -1,0 +1,371 @@
+"""Loading, canonical paths, and validation for shared comment banks."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+REQUIRED_BANK_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "module",
+        "record_type",
+        "bank_id",
+        "title",
+        "description",
+        "scope",
+        "writing_types",
+        "categories",
+        "comments",
+        "created_at",
+        "updated_at",
+        "module_details",
+    }
+)
+REQUIRED_CATEGORY_FIELDS: Final[frozenset[str]] = frozenset(
+    {"category_id", "label"}
+)
+OPTIONAL_CATEGORY_FIELDS: Final[frozenset[str]] = frozenset(
+    {"description", "sort_order", "module_details"}
+)
+REQUIRED_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "comment_id",
+        "label",
+        "text",
+        "category_id",
+        "polarity",
+        "include_in_feedback_default",
+        "student_facing",
+        "module_details",
+    }
+)
+OPTIONAL_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "short_text",
+        "subcategory",
+        "writing_types",
+        "standard_codes",
+        "criterion_ids",
+        "severity_default",
+        "tags",
+        "hotwords",
+        "teacher_note",
+        "follow_up_prompt",
+        "revision_action",
+        "sort_order",
+        "created_at",
+        "updated_at",
+    }
+)
+ALLOWED_SCOPES: Final[frozenset[str]] = frozenset(
+    {"shared", "assignment_local", "district", "system"}
+)
+ALLOWED_POLARITIES: Final[frozenset[str]] = frozenset(
+    {"positive", "developing", "negative", "neutral"}
+)
+
+
+class CommentBankError(ValueError):
+    """Raised when a shared comment bank is missing or invalid."""
+
+
+def comment_bank_path(workspace_root: str | Path, bank_id: str) -> Path:
+    """Return the canonical path for one shared comment bank."""
+    _validate_identifier(bank_id, "bank_id")
+    return Path(workspace_root) / "shared" / "comment_banks" / f"{bank_id}.json"
+
+
+def load_comment_bank(path: str | Path) -> dict[str, Any]:
+    """Load and validate a version 1 shared comment bank."""
+    bank_path = Path(path)
+    try:
+        with bank_path.open("r", encoding="utf-8") as file:
+            value = json.load(file)
+    except FileNotFoundError as error:
+        raise CommentBankError(f"Comment bank not found: {bank_path}") from error
+    except json.JSONDecodeError as error:
+        raise CommentBankError(
+            f"Comment bank is not valid JSON: {bank_path}"
+        ) from error
+    except OSError as error:
+        raise CommentBankError(
+            f"Could not read comment bank {bank_path}: {error}"
+        ) from error
+
+    if not isinstance(value, dict):
+        raise CommentBankError(f"Comment bank must be a JSON object: {bank_path}")
+    bank = cast(dict[str, Any], value)
+    validate_comment_bank(bank)
+    if bank["bank_id"] != bank_path.stem:
+        raise CommentBankError(
+            f"Comment bank bank_id is {bank['bank_id']!r}, expected "
+            f"{bank_path.stem!r} from its filename."
+        )
+    return bank
+
+
+def validate_comment_bank(bank: dict[str, Any]) -> None:
+    """Validate the intrinsic version 1 shared comment-bank contract."""
+    if not isinstance(bank, dict):
+        raise CommentBankError("Comment bank must be an object.")
+    _validate_fields(bank, REQUIRED_BANK_FIELDS, frozenset(), "comment bank")
+    _validate_exact(bank["schema_version"], "schema_version", "1")
+    _validate_exact(bank["module"], "module", "quillan")
+    _validate_exact(bank["record_type"], "record_type", "comment_bank")
+    _validate_identifier(bank["bank_id"], "bank_id")
+    _validate_non_empty_string(bank["title"], "title")
+    _validate_string(bank["description"], "description")
+    _validate_allowed(bank["scope"], "scope", ALLOWED_SCOPES)
+    writing_types = _validate_unique_strings(
+        bank["writing_types"], "writing_types", require_non_empty=True
+    )
+    category_ids = _validate_categories(bank["categories"])
+    _validate_comments(bank["comments"], category_ids, set(writing_types))
+    created_at = _validate_timestamp(bank["created_at"], "created_at")
+    updated_at = _validate_timestamp(bank["updated_at"], "updated_at")
+    if updated_at < created_at:
+        raise CommentBankError(
+            "Field 'updated_at' must not precede field 'created_at'."
+        )
+    _validate_object(bank["module_details"], "module_details")
+
+
+def _validate_categories(value: Any) -> set[str]:
+    categories = _validate_list(value, "categories")
+    seen: set[str] = set()
+    for index, value_item in enumerate(categories):
+        context = f"categories[{index}]"
+        item = _validate_record(value_item, context)
+        _validate_fields(
+            item, REQUIRED_CATEGORY_FIELDS, OPTIONAL_CATEGORY_FIELDS, context
+        )
+        category_id = _validate_identifier(
+            item["category_id"], f"{context}.category_id"
+        )
+        if category_id in seen:
+            raise CommentBankError(f"Duplicate category_id '{category_id}'.")
+        seen.add(category_id)
+        _validate_non_empty_string(item["label"], f"{context}.label")
+        if "description" in item:
+            _validate_string(item["description"], f"{context}.description")
+        if "sort_order" in item:
+            _validate_integer(item["sort_order"], f"{context}.sort_order")
+        if "module_details" in item:
+            _validate_object(item["module_details"], f"{context}.module_details")
+    return seen
+
+
+def _validate_comments(
+    value: Any, category_ids: set[str], bank_writing_types: set[str]
+) -> None:
+    comments = _validate_list(value, "comments")
+    if not comments:
+        raise CommentBankError("Field 'comments' must be a non-empty list.")
+    seen: set[str] = set()
+    for index, value_item in enumerate(comments):
+        context = f"comments[{index}]"
+        item = _validate_record(value_item, context)
+        _validate_fields(
+            item, REQUIRED_COMMENT_FIELDS, OPTIONAL_COMMENT_FIELDS, context
+        )
+        comment_id = _validate_identifier(
+            item["comment_id"], f"{context}.comment_id"
+        )
+        if comment_id in seen:
+            raise CommentBankError(f"Duplicate comment_id '{comment_id}'.")
+        seen.add(comment_id)
+        for field in ("label", "text"):
+            _validate_non_empty_string(item[field], f"{context}.{field}")
+        category_id = _validate_identifier(
+            item["category_id"], f"{context}.category_id"
+        )
+        if category_id not in category_ids:
+            raise CommentBankError(
+                f"Field '{context}.category_id' references unknown category "
+                f"'{category_id}'."
+            )
+        _validate_allowed(
+            item["polarity"], f"{context}.polarity", ALLOWED_POLARITIES
+        )
+        for field in ("include_in_feedback_default", "student_facing"):
+            if not isinstance(item[field], bool):
+                raise CommentBankError(
+                    f"Field '{context}.{field}' must be a boolean."
+                )
+        _validate_object(item["module_details"], f"{context}.module_details")
+
+        for field in (
+            "short_text",
+            "subcategory",
+            "teacher_note",
+            "follow_up_prompt",
+            "revision_action",
+        ):
+            if field in item:
+                _validate_non_empty_string(item[field], f"{context}.{field}")
+        if "writing_types" in item:
+            values = _validate_unique_strings(
+                item["writing_types"],
+                f"{context}.writing_types",
+                require_non_empty=True,
+            )
+            outside = set(values) - bank_writing_types
+            if outside:
+                raise CommentBankError(
+                    f"Field '{context}.writing_types' contains value outside "
+                    f"bank writing_types: {sorted(outside)[0]!r}."
+                )
+        for field in ("standard_codes", "criterion_ids", "tags", "hotwords"):
+            if field in item:
+                _validate_unique_strings(item[field], f"{context}.{field}")
+        if "severity_default" in item:
+            value_severity = item["severity_default"]
+            if (
+                isinstance(value_severity, bool)
+                or not isinstance(value_severity, int)
+                or value_severity < 0
+            ):
+                raise CommentBankError(
+                    f"Field '{context}.severity_default' must be a "
+                    "non-negative integer."
+                )
+        if "sort_order" in item:
+            _validate_integer(item["sort_order"], f"{context}.sort_order")
+        created_at = (
+            _validate_timestamp(item["created_at"], f"{context}.created_at")
+            if "created_at" in item
+            else None
+        )
+        updated_at = (
+            _validate_timestamp(item["updated_at"], f"{context}.updated_at")
+            if "updated_at" in item
+            else None
+        )
+        if (
+            created_at is not None
+            and updated_at is not None
+            and updated_at < created_at
+        ):
+            raise CommentBankError(
+                f"Field '{context}.updated_at' must not precede "
+                f"field '{context}.created_at'."
+            )
+
+
+def _validate_fields(
+    data: dict[str, Any],
+    required: frozenset[str],
+    optional: frozenset[str],
+    context: str,
+) -> None:
+    missing = required - data.keys()
+    if missing:
+        raise CommentBankError(
+            f"Missing required field '{sorted(missing)[0]}' in {context}."
+        )
+    unknown = data.keys() - required - optional
+    if unknown:
+        raise CommentBankError(
+            f"Unknown field '{sorted(unknown)[0]}' in {context}."
+        )
+
+
+def _validate_record(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise CommentBankError(f"{context} must be an object.")
+    return cast(dict[str, Any], value)
+
+
+def _validate_list(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise CommentBankError(f"Field '{field}' must be a list.")
+    return value
+
+
+def _validate_unique_strings(
+    value: Any, field: str, *, require_non_empty: bool = False
+) -> list[str]:
+    values = _validate_list(value, field)
+    if require_non_empty and not values:
+        raise CommentBankError(f"Field '{field}' must be a non-empty list.")
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in values:
+        text = _validate_non_empty_string(item, field)
+        if text in seen:
+            raise CommentBankError(f"Field '{field}' contains duplicate {text!r}.")
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _validate_identifier(value: Any, field: str) -> str:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise CommentBankError(str(error)) from error
+    return cast(str, value)
+
+
+def _validate_non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CommentBankError(f"Field '{field}' must be a non-empty string.")
+    return value
+
+
+def _validate_string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise CommentBankError(f"Field '{field}' must be a string.")
+    return value
+
+
+def _validate_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CommentBankError(f"Field '{field}' must be an integer.")
+    return value
+
+
+def _validate_object(value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        raise CommentBankError(f"Field '{field}' must be an object.")
+
+
+def _validate_exact(value: Any, field: str, expected: str) -> None:
+    if value != expected:
+        raise CommentBankError(
+            f"Field '{field}' must be the string '{expected}'."
+        )
+
+
+def _validate_allowed(
+    value: Any, field: str, allowed_values: frozenset[str]
+) -> str:
+    if not isinstance(value, str) or value not in allowed_values:
+        allowed = ", ".join(sorted(allowed_values))
+        raise CommentBankError(
+            f"Invalid {field} {value!r}. Allowed values: {allowed}."
+        )
+    return value
+
+
+def _validate_timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise CommentBankError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise CommentBankError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CommentBankError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    return parsed

--- a/quillan/review_comments.py
+++ b/quillan/review_comments.py
@@ -1,0 +1,347 @@
+"""Selection of reusable shared-bank comments into submission reviews."""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.comment_banks import (
+    CommentBankError,
+    comment_bank_path,
+    load_comment_bank,
+)
+from quillan.review_record import (
+    ReviewRecordError,
+    load_review_record,
+    validate_review_record,
+)
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+_SEQUENTIAL_COMMENT_ID = re.compile(r"^comment_record_(\d{4})$")
+
+
+class ReviewCommentError(Exception):
+    """Raised when a reusable comment cannot be selected safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class AddedReviewComment:
+    """Information about one reusable comment appended to a review."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    comment_record_id: str
+    bank_id: str
+    comment_id: str
+    label: str
+    include_in_feedback: bool
+    review_state: str
+    created_at: str
+
+
+def add_review_comment(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    bank_id: str,
+    comment_id: str,
+    standard_code: str | None = None,
+    include_in_feedback: bool | None = None,
+    created_at: datetime | str | None = None,
+) -> AddedReviewComment:
+    """Append one snapshotted shared-bank comment to a review record."""
+    normalized_bank_id = _normalize_identifier(bank_id, "bank_id")
+    normalized_comment_id = _normalize_identifier(comment_id, "comment_id")
+    normalized_standard = _normalize_optional_string(
+        standard_code, "standard_code"
+    )
+    if include_in_feedback is not None and not isinstance(
+        include_in_feedback, bool
+    ):
+        raise ReviewCommentError("include_in_feedback must be a boolean or None.")
+    normalized_created_at = _normalize_timestamp(created_at)
+    resolved_root = Path(workspace_root).resolve(strict=False)
+
+    try:
+        bank_path = comment_bank_path(resolved_root, normalized_bank_id)
+        manifest_path = submission_manifest_path(
+            resolved_root, class_id, assignment_id, student_id
+        )
+        record_path = review_record_path(
+            resolved_root, class_id, assignment_id, student_id
+        )
+    except (
+        OSError,
+        RuntimeError,
+        CommentBankError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewCommentError(str(error)) from error
+
+    try:
+        bank = load_comment_bank(bank_path)
+    except (OSError, CommentBankError) as error:
+        raise ReviewCommentError(f"Could not load comment bank: {error}") from error
+    if bank["bank_id"] != normalized_bank_id:
+        raise ReviewCommentError(
+            f"Comment bank bank_id is {bank['bank_id']!r}, expected "
+            f"{normalized_bank_id!r}."
+        )
+    matches = [
+        item
+        for item in bank["comments"]
+        if item["comment_id"] == normalized_comment_id
+    ]
+    if not matches:
+        raise ReviewCommentError(
+            f"Comment bank '{normalized_bank_id}' has no comment "
+            f"'{normalized_comment_id}'."
+        )
+    if len(matches) > 1:
+        raise ReviewCommentError(
+            f"Comment bank '{normalized_bank_id}' has multiple comments "
+            f"named '{normalized_comment_id}'."
+        )
+    source_comment = matches[0]
+    if not source_comment["student_facing"]:
+        raise ReviewCommentError(
+            f"Comment '{normalized_comment_id}' is not student-facing and "
+            "cannot be selected into review comments."
+        )
+    selected_standard = _select_standard(source_comment, normalized_standard)
+    selected_include = (
+        source_comment["include_in_feedback_default"]
+        if include_in_feedback is None
+        else include_in_feedback
+    )
+
+    if not manifest_path.exists():
+        raise ReviewCommentError(
+            "Submission manifest does not exist for "
+            f"class={class_id}, assignment={assignment_id}, student={student_id}."
+        )
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise ReviewCommentError(
+            f"Could not load submission manifest: {error}"
+        ) from error
+    _validate_identity(
+        manifest, "Submission manifest", class_id, assignment_id, student_id
+    )
+
+    if record_path.exists():
+        try:
+            review = load_review_record(record_path)
+        except (OSError, ReviewRecordError) as error:
+            raise ReviewCommentError(
+                f"Could not load review record: {error}"
+            ) from error
+        _validate_identity(
+            review, "Review record", class_id, assignment_id, student_id
+        )
+        updated_review = copy.deepcopy(review)
+        if updated_review["review_state"] == "not_started":
+            updated_review["review_state"] = "in_progress"
+    else:
+        updated_review = {
+            "schema_version": "1",
+            "module": "quillan",
+            "record_type": "submission_review",
+            "class_id": class_id,
+            "assignment_id": assignment_id,
+            "student_id": student_id,
+            "submission_manifest_path": _workspace_relative_path(
+                manifest_path, resolved_root, "submission manifest"
+            ),
+            "review_state": "in_progress",
+            "notes": [],
+            "tags": [],
+            "scores": [],
+            "comments": [],
+            "created_at": normalized_created_at,
+            "updated_at": normalized_created_at,
+            "module_details": {},
+        }
+
+    comment_record_id = _next_comment_record_id(updated_review["comments"])
+    selected_comment = {
+        "comment_record_id": comment_record_id,
+        "source": "comment_bank",
+        "bank_id": normalized_bank_id,
+        "comment_id": normalized_comment_id,
+        "label": source_comment["label"],
+        "text": source_comment["text"],
+        "include_in_feedback": selected_include,
+        "created_at": normalized_created_at,
+        "module_details": {},
+    }
+    if selected_standard is not None:
+        selected_comment["standard_code"] = selected_standard
+    updated_review["comments"].append(selected_comment)
+    updated_review["updated_at"] = normalized_created_at
+
+    try:
+        validate_review_record(updated_review)
+        write_review_record(
+            record_path, updated_review, overwrite=record_path.exists()
+        )
+        relative_path = _workspace_relative_path(
+            record_path, resolved_root, "review record"
+        )
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        ReviewRecordError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewCommentError(
+            f"Could not write review record: {error}"
+        ) from error
+
+    return AddedReviewComment(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=record_path,
+        review_record_relative_path=relative_path,
+        comment_record_id=comment_record_id,
+        bank_id=normalized_bank_id,
+        comment_id=normalized_comment_id,
+        label=source_comment["label"],
+        include_in_feedback=selected_include,
+        review_state=updated_review["review_state"],
+        created_at=normalized_created_at,
+    )
+
+
+def _select_standard(
+    source_comment: dict[str, Any], requested: str | None
+) -> str | None:
+    standards = cast(list[str], source_comment.get("standard_codes", []))
+    if requested is not None:
+        if requested not in standards:
+            raise ReviewCommentError(
+                f"Standard code {requested!r} is not available on comment "
+                f"{source_comment['comment_id']!r}."
+            )
+        return requested
+    if len(standards) == 1:
+        return standards[0]
+    return None
+
+
+def _normalize_identifier(value: str, field: str) -> str:
+    if not isinstance(value, str):
+        raise ReviewCommentError(f"{field} must be a valid identifier.")
+    normalized = value.strip()
+    try:
+        validate_identifier(normalized, field)
+    except IdentifierValidationError as error:
+        raise ReviewCommentError(str(error)) from error
+    return normalized
+
+
+def _normalize_optional_string(value: str | None, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewCommentError(f"{field} must be a non-empty string.")
+    return value.strip()
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReviewCommentError("created_at datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise ReviewCommentError(
+            "created_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ReviewCommentError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewCommentError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    record_name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    for field, expected in {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }.items():
+        if record[field] != expected:
+            raise ReviewCommentError(
+                f"{record_name} {field} is {record[field]!r}, "
+                f"expected {expected!r}."
+            )
+
+
+def _next_comment_record_id(comments: list[dict[str, Any]]) -> str:
+    existing_ids = {comment["comment_record_id"] for comment in comments}
+    highest = max(
+        (
+            int(match.group(1))
+            for comment_id in existing_ids
+            if (match := _SEQUENTIAL_COMMENT_ID.fullmatch(comment_id))
+        ),
+        default=0,
+    )
+    candidate_number = highest + 1
+    while True:
+        candidate = f"comment_record_{candidate_number:04d}"
+        if candidate not in existing_ids:
+            return candidate
+        candidate_number += 1
+
+
+def _workspace_relative_path(
+    path: Path, workspace_root: Path, description: str
+) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewCommentError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error

--- a/tests/test_cli_review_comments.py
+++ b/tests/test_cli_review_comments.py
@@ -1,0 +1,90 @@
+"""CLI tests for reusable shared-bank comment selection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.review_record_paths import review_record_path
+from tests.test_review_comments import BANK_ID, _write_bank
+from tests.test_review_scores import _write_manifest
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID
+
+
+def test_cli_selects_comment_and_prints_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "add-comment",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--bank",
+            BANK_ID,
+            "--comment-id",
+            "evidence_needs_explanation",
+            "--exclude-from-feedback",
+            "--standard",
+            "W.AW.11-12.1",
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    for expected in (
+        "Selected review comment:",
+        f"Class: {CLASS_ID}",
+        f"Assignment: {ASSIGNMENT_ID}",
+        f"Student: {STUDENT_ID}",
+        f"Bank: {BANK_ID}",
+        "Source comment: evidence_needs_explanation",
+        "Review comment: comment_record_0001",
+        "Include in feedback: no",
+        "Review state: in_progress",
+        "review.json",
+    ):
+        assert expected in output
+    written = json.loads(
+        review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert written["comments"][0]["include_in_feedback"] is False
+    assert written["comments"][0]["standard_code"] == "W.AW.11-12.1"
+
+
+def test_cli_handled_failure_returns_one_without_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "add-comment",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--bank",
+            BANK_ID,
+            "--comment-id",
+            "missing",
+        ]
+    ) == 1
+    assert "could not select review comment" in capsys.readouterr().out
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()

--- a/tests/test_comment_banks.py
+++ b/tests/test_comment_banks.py
@@ -1,0 +1,129 @@
+"""Tests for shared comment-bank loading and validation."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from quillan.comment_banks import (
+    CommentBankError,
+    comment_bank_path,
+    load_comment_bank,
+    validate_comment_bank,
+)
+
+EXAMPLE_PATH = (
+    Path(__file__).parents[1]
+    / "examples"
+    / "comment_banks"
+    / "general_writing_synthetic.json"
+)
+
+
+def _bank() -> dict[str, Any]:
+    return cast(
+        dict[str, Any], json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
+    )
+
+
+def test_valid_synthetic_bank_loads() -> None:
+    bank = load_comment_bank(EXAMPLE_PATH)
+    assert bank["bank_id"] == "general_writing_synthetic"
+    assert len(bank["comments"]) > 1
+
+
+def test_canonical_path_validates_identifier(tmp_path: Path) -> None:
+    assert comment_bank_path(tmp_path, "general_writing") == (
+        tmp_path / "shared" / "comment_banks" / "general_writing.json"
+    )
+    with pytest.raises(CommentBankError, match="bank_id"):
+        comment_bank_path(tmp_path, "../unsafe")
+
+
+def test_missing_invalid_json_and_non_object_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(CommentBankError, match="not found"):
+        load_comment_bank(tmp_path / "missing.json")
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{", encoding="utf-8")
+    with pytest.raises(CommentBankError, match="not valid JSON"):
+        load_comment_bank(invalid)
+    invalid.write_text("[]", encoding="utf-8")
+    with pytest.raises(CommentBankError, match="JSON object"):
+        load_comment_bank(invalid)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", "2"),
+        ("module", "other"),
+        ("record_type", "other"),
+        ("bank_id", "../unsafe"),
+        ("title", " "),
+        ("scope", "private"),
+    ],
+)
+def test_invalid_top_level_values_are_rejected(field: str, value: Any) -> None:
+    bank = _bank()
+    bank[field] = value
+    with pytest.raises(CommentBankError, match=field):
+        validate_comment_bank(bank)
+
+
+def test_filename_bank_id_mismatch_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "different.json"
+    path.write_text(json.dumps(_bank()), encoding="utf-8")
+    with pytest.raises(CommentBankError, match="filename"):
+        load_comment_bank(path)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("duplicate_writing_type", "duplicate"),
+        ("duplicate_category", "Duplicate category_id"),
+        ("duplicate_comment", "Duplicate comment_id"),
+        ("unknown_category", "unknown category"),
+        ("invalid_polarity", "polarity"),
+        ("invalid_feedback_default", "include_in_feedback_default"),
+        ("invalid_student_facing", "student_facing"),
+        ("invalid_severity", "severity_default"),
+        ("duplicate_tags", "duplicate"),
+        ("outside_writing_type", "outside"),
+        ("invalid_timestamp", "created_at"),
+    ],
+)
+def test_nested_contract_failures_are_rejected(
+    mutation: str, message: str
+) -> None:
+    bank = copy.deepcopy(_bank())
+    comment = bank["comments"][0]
+    if mutation == "duplicate_writing_type":
+        bank["writing_types"].append(bank["writing_types"][0])
+    elif mutation == "duplicate_category":
+        bank["categories"].append(copy.deepcopy(bank["categories"][0]))
+    elif mutation == "duplicate_comment":
+        bank["comments"].append(copy.deepcopy(comment))
+    elif mutation == "unknown_category":
+        comment["category_id"] = "missing"
+    elif mutation == "invalid_polarity":
+        comment["polarity"] = "mixed"
+    elif mutation == "invalid_feedback_default":
+        comment["include_in_feedback_default"] = 1
+    elif mutation == "invalid_student_facing":
+        comment["student_facing"] = "yes"
+    elif mutation == "invalid_severity":
+        comment["severity_default"] = True
+    elif mutation == "duplicate_tags":
+        comment["tags"].append(comment["tags"][0])
+    elif mutation == "outside_writing_type":
+        comment["writing_types"] = ["unknown"]
+    else:
+        bank["created_at"] = "2026-06-22T00:00:00"
+
+    with pytest.raises(CommentBankError, match=message):
+        validate_comment_bank(bank)

--- a/tests/test_review_comments.py
+++ b/tests/test_review_comments.py
@@ -1,0 +1,242 @@
+"""Tests for selecting shared-bank comments into review records."""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from quillan.review_comments import ReviewCommentError, add_review_comment
+from quillan.review_record_paths import review_record_path
+from tests.test_review_scores import _write_manifest, _write_review
+from tests.test_review_tags import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STUDENT_ID,
+    _review,
+)
+
+BANK_ID = "general_writing_synthetic"
+TIMESTAMP = "2026-06-22T15:00:00+00:00"
+EXAMPLE_PATH = (
+    Path(__file__).parents[1]
+    / "examples"
+    / "comment_banks"
+    / f"{BANK_ID}.json"
+)
+
+
+def _bank() -> dict[str, Any]:
+    return cast(
+        dict[str, Any], json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
+    )
+
+
+def _write_bank(workspace: Path, bank: dict[str, Any] | None = None) -> Path:
+    path = workspace / "shared" / "comment_banks" / f"{BANK_ID}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_bank() if bank is None else bank), encoding="utf-8")
+    return path
+
+
+def _add(workspace: Path, **overrides: Any) -> Any:
+    arguments: dict[str, Any] = {
+        "bank_id": BANK_ID,
+        "comment_id": "evidence_needs_explanation",
+        "created_at": TIMESTAMP,
+    }
+    arguments.update(overrides)
+    return add_review_comment(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, **arguments
+    )
+
+
+def test_creates_snapshotted_comment_without_mutating_sources(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    bank_path = _write_bank(tmp_path)
+    manifest_before = manifest_path.read_bytes()
+    bank_before = bank_path.read_bytes()
+
+    result = _add(tmp_path)
+
+    written = json.loads(result.review_record_path.read_text(encoding="utf-8"))
+    assert result.comment_record_id == "comment_record_0001"
+    assert result.include_in_feedback is True
+    assert written["review_state"] == "in_progress"
+    assert written["created_at"] == written["updated_at"] == TIMESTAMP
+    assert written["notes"] == written["tags"] == written["scores"] == []
+    assert written["comments"] == [
+        {
+            "comment_record_id": "comment_record_0001",
+            "source": "comment_bank",
+            "bank_id": BANK_ID,
+            "comment_id": "evidence_needs_explanation",
+            "label": "Evidence needs explanation",
+            "text": (
+                "Your evidence is relevant, but explain more clearly how it "
+                "supports your central idea."
+            ),
+            "include_in_feedback": True,
+            "created_at": TIMESTAMP,
+            "module_details": {},
+            "standard_code": "W.AW.11-12.1",
+        }
+    ]
+    assert manifest_path.read_bytes() == manifest_before
+    assert bank_path.read_bytes() == bank_before
+
+
+@pytest.mark.parametrize(
+    ("override", "expected"),
+    [(True, True), (False, False), (None, True)],
+)
+def test_feedback_inclusion_policy(
+    tmp_path: Path, override: bool | None, expected: bool
+) -> None:
+    _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+    result = _add(tmp_path, include_in_feedback=override)
+    assert result.include_in_feedback is expected
+
+
+def test_standard_selection_policy(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    bank = _bank()
+    bank["comments"][0]["standard_codes"] = []
+    bank["comments"][3]["standard_codes"] = ["A", "B"]
+    _write_bank(tmp_path, bank)
+
+    first = _add(tmp_path, comment_id="focus_is_clear")
+    second = _add(tmp_path, comment_id="sentence_boundaries_need_review")
+    third = _add(
+        tmp_path,
+        comment_id="sentence_boundaries_need_review",
+        standard_code="B",
+    )
+    comments = json.loads(
+        third.review_record_path.read_text(encoding="utf-8")
+    )["comments"]
+    assert "standard_code" not in comments[0]
+    assert "standard_code" not in comments[1]
+    assert comments[2]["standard_code"] == "B"
+    assert first.comment_record_id == "comment_record_0001"
+    assert second.comment_record_id == "comment_record_0002"
+
+
+def test_invalid_standard_and_teacher_only_comment_are_rejected(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+    with pytest.raises(ReviewCommentError, match="not available"):
+        _add(tmp_path, standard_code="missing")
+    with pytest.raises(ReviewCommentError, match="not student-facing"):
+        _add(tmp_path, comment_id="teacher_review_follow_up")
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+
+
+def test_append_preserves_review_and_uses_highest_conforming_id(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+    original = _review("ready_for_export")
+    original["comments"].extend(
+        [
+            {
+                "comment_record_id": "custom-id",
+                "label": "Custom",
+                "text": "Preserve me.",
+                "source": "custom",
+                "include_in_feedback": False,
+                "created_at": original["created_at"],
+                "module_details": {"preserve": True},
+            },
+            {
+                "comment_record_id": "comment_record_0004",
+                "label": "Older",
+                "text": "Also preserve me.",
+                "source": "custom",
+                "include_in_feedback": True,
+                "created_at": original["created_at"],
+                "module_details": {},
+            },
+        ]
+    )
+    path = _write_review(tmp_path, copy.deepcopy(original))
+
+    result = _add(tmp_path)
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert result.comment_record_id == "comment_record_0005"
+    assert result.review_state == "ready_for_export"
+    assert written["comments"][:-1] == original["comments"]
+    for field in ("notes", "tags", "scores", "module_details", "created_at"):
+        assert written[field] == original[field]
+    assert written["updated_at"] == TIMESTAMP
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("not_started", "in_progress"),
+        ("in_progress", "in_progress"),
+        ("ready_for_export", "ready_for_export"),
+        ("exported", "exported"),
+    ],
+)
+def test_narrow_review_state_transition(
+    tmp_path: Path, state: str, expected: str
+) -> None:
+    _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+    _write_review(tmp_path, _review(state))
+    assert _add(tmp_path).review_state == expected
+
+
+@pytest.mark.parametrize(
+    ("setup", "message"),
+    [
+        ("missing_bank", "not found"),
+        ("invalid_bank", "not valid JSON"),
+        ("missing_comment", "has no comment"),
+        ("missing_submission", "does not exist"),
+        ("invalid_review", "not valid JSON"),
+    ],
+)
+def test_failures_do_not_mutate_existing_review(
+    tmp_path: Path, setup: str, message: str
+) -> None:
+    if setup != "missing_submission":
+        _write_manifest(tmp_path)
+    if setup != "missing_bank":
+        bank_path = _write_bank(tmp_path)
+        if setup == "invalid_bank":
+            bank_path.write_text("{", encoding="utf-8")
+    path = review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    if setup == "invalid_review":
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{", encoding="utf-8")
+    before = path.read_bytes() if path.exists() else None
+    overrides = {"comment_id": "missing"} if setup == "missing_comment" else {}
+
+    with pytest.raises(ReviewCommentError, match=message):
+        _add(tmp_path, **overrides)
+    assert (path.read_bytes() if path.exists() else None) == before
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    ["bad", "2026-06-22T15:00:00", datetime(2026, 6, 22, 15), 123],
+)
+def test_invalid_timestamp_is_rejected(tmp_path: Path, timestamp: object) -> None:
+    _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+    with pytest.raises(ReviewCommentError, match="timezone-aware"):
+        _add(tmp_path, created_at=timestamp)


### PR DESCRIPTION
## Summary

Adds reusable shared-bank comment selection into Quillan review records.

This PR implements the first runtime workflow for selecting teacher-authored reusable comments from shared comment banks and appending them as snapshotted selected comments in a student’s canonical `review.json`.

The new CLI command is:

`quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>`

## Changes

* Added `quillan/comment_banks.py`

  * canonical shared comment-bank path helper
  * strict comment-bank loader
  * strict version `1` comment-bank validator
  * top-level bank validation
  * category validation
  * comment validation
  * duplicate ID checks
  * timestamp validation
  * writing-type subset checks
  * filename / `bank_id` consistency check

* Added `quillan/review_comments.py`

  * `ReviewCommentError`
  * `AddedReviewComment`
  * `add_review_comment(...)`
  * shared-bank comment lookup
  * selected-comment snapshot creation
  * `bank_id + comment_id` provenance
  * sequential `comment_record_NNNN` IDs
  * student-facing enforcement
  * standard-code selection policy
  * feedback-inclusion override/default policy
  * narrow review-state transition behavior
  * validation-before-write behavior
  * non-mutation guarantees

* Added CLI support:

  `quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>`

* Added CLI options:

  * `--bank`
  * `--comment-id`
  * `--standard`
  * `--include-in-feedback`
  * `--exclude-from-feedback`

* Added tests for:

  * comment-bank loading
  * comment-bank validation
  * canonical comment-bank paths
  * invalid bank files
  * malformed bank contracts
  * duplicate bank/category/comment values
  * selected comment snapshot behavior
  * `bank_id + comment_id` provenance
  * feedback-inclusion defaults and overrides
  * standard-code selection behavior
  * student-facing enforcement
  * sequential local comment IDs
  * repeated selection behavior
  * preservation of notes, tags, scores, existing comments, metadata, and review state
  * missing/invalid bank failures
  * missing comment failures
  * invalid submission/review failures
  * timestamp failures
  * CLI success and handled failure behavior
  * non-mutation of source bank, submission manifest, routed evidence, and retained source files

* Updated README, contracts, teacher-review model, and changelog.

## Selected Comment Behavior

A selected shared-bank comment is copied into `review.json.comments` as a stable snapshot.

The selected record includes:

* `comment_record_id`
* `source: "comment_bank"`
* `bank_id`
* `comment_id`
* snapshotted `label`
* snapshotted `text`
* optional `standard_code`
* `include_in_feedback`
* `created_at`
* `module_details`

`bank_id + comment_id` preserves source provenance, but the selected review comment is not a live reference. Later edits to the shared comment bank do not silently alter existing student review records.

## Standard-Code Policy

When `--standard` is supplied:

* the selected source comment must contain that standard code;
* the selected review comment stores that standard code.

When `--standard` is omitted:

* if the source comment has exactly one standard code, it is copied;
* if the source comment has zero standard codes, `standard_code` is omitted;
* if the source comment has multiple standard codes, `standard_code` is omitted.

No standards-profile lookup or standards-mastery inference is performed.

## Feedback-Inclusion Policy

The selected review comment stores `include_in_feedback`.

Behavior:

* `--include-in-feedback` stores `true`;
* `--exclude-from-feedback` stores `false`;
* if neither flag is supplied, the source comment’s `include_in_feedback_default` is used.

This PR does not implement feedback export.

## Student-Facing Policy

This MVP only allows selecting source comments with:

`student_facing: true`

Teacher-only/internal bank comments are rejected for selection into `review.json.comments`.

## Review-State Behavior

The workflow follows the established narrow review-state policy:

* new review record: `in_progress`
* existing `not_started`: advances to `in_progress`
* existing `in_progress`: remains `in_progress`
* existing `ready_for_export`: preserved
* existing `exported`: preserved

`submission.json` is not mutated.

## Non-Mutation Guarantees

This PR does not mutate:

* source comment banks
* `submission.json`
* routed evidence files
* retained source scans
* existing notes
* existing tags
* existing scores
* existing comments
* unrelated review metadata

## Non-Goals

This PR does not implement:

* custom one-off comment entry
* standards-profile comment selection
* assignment activation through `comment_bank_ids`
* default bank selection from assignment `writing_type`
* assignment-local comment banks
* comment bank editing
* menu browsing
* comment search UI
* feedback export
* report generation
* email export
* PDF export
* LMS integration
* AI suggestions
* AI feedback
* AI comment generation
* automatic standard detection
* automatic scoring
* standards mastery inference
* migration tooling

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

814 tests passed.

Closes #99
