### PR TITLE
feat: add student feedback export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan export-feedback` and a focused read-only API for generating
+  `submissions/<student_id>/exports/feedback.md` from valid matching
+  `submission.json` and `review.json` records. The Markdown includes ordered
+  teacher-entered criterion scores and snapshotted comments marked for
+  feedback, excludes private notes, tags, score notes, excluded comments, and
+  provenance, and never reads source comment banks. Existing exports require
+  `--overwrite`; canonical records, evidence, timestamps, and `review_state`
+  remain unchanged.
 - Added `quillan add-comment` and a focused reusable-comment selection API.
   Shared comment banks are fully validated before selection; student-facing
   comments are appended to `review.json.comments` with sequential local IDs,

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ The supported teacher/developer sequence is:
 11. `add-comment` selects student-facing teacher-authored language from a
     shared comment bank into that review record as a stable snapshot.
 12. `set-score` sets or updates one explicitly teacher-entered criterion score.
-13. `set-review-state` records lightweight submission-manifest progress when
+13. `export-feedback` writes selected comments and criterion scores to a
+    student-facing Markdown file.
+14. `set-review-state` records lightweight submission-manifest progress when
     the teacher chooses.
 
 Opening evidence and updating review state are separate teacher-controlled
@@ -157,6 +159,7 @@ quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
 quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
 quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
+quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
@@ -191,6 +194,14 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   Existing criteria update by `criterion_id`; unrelated review data is
   preserved. Criterion IDs are not yet validated against rubric profiles, and
   no overall score is calculated.
+- `export-feedback` reads a valid matching `submission.json` and `review.json`,
+  then writes
+  `submissions/<student_id>/exports/feedback.md`. It includes criterion scores
+  and only snapshotted comments marked `include_in_feedback: true`, without
+  reading source comment banks. Private notes, score notes, tags, and comment
+  provenance are excluded. Existing feedback is protected unless
+  `--overwrite` is supplied, and export does not mutate canonical records,
+  evidence, timestamps, or review state.
 - `set-review-state` updates only the manifest's `submission_state` and
   `updated_at`; it does not inspect evidence or make a review decision.
 
@@ -201,8 +212,8 @@ teacher explicitly requests it.
 Quillan does not perform OCR, handwriting recognition, PDF text
 extraction, AI scoring, AI feedback, AI suggestions, automatic grading,
 automatic review-state updates, automatic evidence selection among duplicates,
-rubric scoring, feedback export, or
-report generation. Quick notes and structured tags are teacher-entered
+rubric scoring, automatic feedback generation, or report generation. Quick
+notes and structured tags are teacher-entered
 records; they do not score or generate feedback by themselves.
 The teacher remains responsible for reading and evaluating student work.
 
@@ -551,6 +562,7 @@ quillan open-submission <class_id> <assignment_id> <student_id>
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
 quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
+quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan workspace show
 quillan menu

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -48,6 +48,7 @@ quillan
 quillan --help
 quillan validate-standards <path>
 quillan validate-assignment <path>
+quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan workspace show
 quillan workspace set <path>
 quillan workspace validate
@@ -392,6 +393,26 @@ failures return `1`. Updating by `criterion_id` preserves the existing score
 ID and unrelated review sections. The command does not validate criteria
 against a rubric profile, calculate an overall score, infer scores, or mutate
 the submission manifest or evidence.
+
+## Student Feedback Export
+
+```powershell
+quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
+```
+
+This direct command requires valid matching canonical `submission.json` and
+`review.json` records, then writes the derived
+`submissions/<student_id>/exports/feedback.md` artifact. It includes ordered
+criterion scores and snapshotted comments marked `include_in_feedback: true`.
+It excludes private notes, score notes, structured tags, excluded comments,
+and comment source/provenance fields, and it does not read source comment
+banks.
+
+Success returns `0` and reports the identity, included-comment count, score
+count, overwrite status, and workspace-relative feedback path. Handled
+workspace, validation, missing-record, and overwrite failures return `1`.
+Without `--overwrite`, an existing feedback file is preserved. The command
+does not mutate review state, timestamps, canonical records, or evidence.
 
 ## Output and Error Handling
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -673,41 +673,27 @@ Example:
 
 ## Feedback File (Derived Export)
 
-A future feedback file may store exported student-readable teacher
-communication. It may draw on
-teacher-reviewed tags, notes, score records, requirements checks, and
-teacher-approved standards profile comments. Any future drafting or formatting
-support must remain teacher-reviewed and teacher-controlled.
+The feedback file stores student-readable teacher communication derived from a
+valid matching canonical `review.json`. Unlike the historical `tags.json` and
+`scores.json` concepts, it is not a canonical review record and must not
+replace `review.json`.
 
-Unlike the historical `tags.json` and `scores.json` concepts, `feedback.md`
-may remain a derived export path. It is not the canonical review record and
-must not replace `review.json`.
-
-Reserved export path:
+Canonical export path:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/feedback.md
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
-Example:
+The Markdown contains class, assignment, student, generation timestamp,
+teacher-entered criterion scores, and snapshotted text for comments marked
+`include_in_feedback: true`. Score and included-comment order follow
+`review.json`.
 
-```markdown
-# Feedback — Villainy Final Essay
-
-## Strengths
-
-- Your essay has a clear central claim.
-- You chose relevant evidence from the texts and films.
-
-## Areas for Growth
-
-- Some evidence needs more explanation.
-- Several comparisons would be stronger if you explained the moral significance of each example.
-
-## Teacher Summary
-
-The essay has a clear central claim and relevant evidence, but several body paragraphs need stronger explanation.
-```
+The export excludes private notes, score `teacher_note` values, structured
+tags, excluded comments, and comment source/provenance metadata. It does not
+read source comment banks, mutate canonical records or evidence, change
+`review_state`, or mark a review exported. Replacing an existing feedback file
+requires explicit overwrite approval.
 
 ## Standards Summary Report
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -558,13 +558,25 @@ Those names are historical design background, not alternate active v0.7
 contracts. Implementations must not split or mirror canonical review data
 across those files.
 
-`feedback.md`, `reports/class_summary.csv`, and
+`submissions/<student_id>/exports/feedback.md`,
+`reports/class_summary.csv`, and
 `reports/standards_summary.csv` are derived export artifacts. They may be
-generated from teacher-controlled review records in later issues, but they do
+generated from teacher-controlled review records, but they do
 not replace `review.json` and are not authoritative independent evidence.
 `requirements.json` remains a separate reserved structural-check record
 because requirements checks are not teacher evaluation artifacts in this
 schema.
+
+The Markdown feedback export requires valid matching canonical
+`submission.json` and `review.json` records and uses only snapshotted review
+content. It includes criterion scores and comments whose
+`include_in_feedback` value is `true`; it excludes notes, tags, score
+`teacher_note` values, excluded comments, and source/provenance fields. Source
+comment banks are neither required nor read.
+
+Export does not mutate the review record, update timestamps, or advance
+`review_state` to `exported`. It writes only the derived feedback file and
+refuses to replace an existing file unless overwrite is explicitly requested.
 
 ## Synthetic Example
 
@@ -579,7 +591,7 @@ This contract does not implement:
 * rubric-profile loading, validation, or criterion lookup;
 * overall, weighted, percentage, grade, or mastery score calculation;
 * standalone comment-bank lookup or reusable-comment management;
-* feedback, class-summary, or standards-summary export;
+* class-summary or standards-summary export;
 * terminal-menu review workflows or review CLI commands beyond those listed;
 * editing or deletion of append-only review artifacts;
 * AI scoring, feedback, comments, suggestions, or automated grading;

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -157,12 +157,23 @@ Feedback is student-readable teacher communication. It may draw on:
 * requirements checks; and
 * teacher-approved standards profile or shared comment bank comments.
 
-Feedback remains teacher-controlled. Future tooling may help select
-teacher-approved language, draft text, or format a feedback file, but the
-teacher must review and confirm the communication before it is treated as a
-teacher export. Selected reusable or custom comments are stored in
-`review.json`; a rendered `feedback.md` remains a derived artifact. Quillan
-must not present authoritative AI-generated feedback.
+Feedback remains teacher-controlled. The direct `export-feedback` workflow
+formats already-selected teacher-authored comments and teacher-entered
+criterion scores as Markdown; it does not draft, infer, select, or grade
+anything. Selected reusable or custom comments are stored in `review.json`;
+the rendered `submissions/<student_id>/exports/feedback.md` is derived.
+
+The export preserves score and included-comment order. It includes only
+comments marked `include_in_feedback: true` and uses their snapshotted text,
+without reading source comment banks or standards profiles. Private notes,
+score `teacher_note` values, structured tags, excluded comments, and comment
+provenance are omitted.
+
+Export does not change `review_state`, mark a review `exported`, update
+timestamps, or mutate `review.json`, `submission.json`, evidence, retained
+scans, or source banks. Existing feedback is protected unless the teacher
+explicitly supplies `--overwrite`. Quillan must not present authoritative
+AI-generated feedback.
 
 Shared comment banks are reusable teacher-authored source data stored at
 `shared/comment_banks/<bank_id>.json`. They are not student records and do
@@ -174,7 +185,7 @@ language into
 identifies the reusable source comment. The copied label and text remain
 stable if the bank later changes; provenance does not create a live reference.
 The bank feedback default may be overridden by the teacher at selection time.
-Teacher-only bank comments are rejected, and selection does not export
+Teacher-only bank comments are rejected, and selection does not itself export
 feedback.
 The source contract and future assignment-activation design are defined in
 [`comment_bank_contract.md`](comment_bank_contract.md).

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -29,6 +29,11 @@ from quillan.evidence_filing import (
     file_routed_response_evidence,
 )
 from quillan.evidence_opening import EvidenceOpeningError, open_workspace_evidence
+from quillan.feedback_export import (
+    ExportedFeedback,
+    FeedbackExportError,
+    export_student_feedback,
+)
 from quillan.menu import launch_menu
 from quillan.route_planning import (
     DecodedResponsePage,
@@ -185,6 +190,14 @@ def main(argv: list[str] | None = None) -> int:
             max_score=args.max_score,
             scale=args.scale,
             teacher_note=args.note,
+        )
+
+    if args.command == "export-feedback":
+        return _handle_export_feedback(
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            overwrite=args.overwrite,
         )
 
     if args.command == "workspace" and args.workspace_command == "show":
@@ -501,6 +514,28 @@ def _build_parser() -> argparse.ArgumentParser:
     set_score_parser.add_argument(
         "--note",
         help="Optional teacher note for this criterion score.",
+    )
+
+    export_feedback_parser = subparsers.add_parser(
+        "export-feedback",
+        help="Export student-facing feedback from one review record.",
+        description=(
+            "Generate a student-facing Markdown feedback file from the "
+            "canonical review.json for one student submission. The export "
+            "includes selected feedback comments and teacher-entered criterion "
+            "scores. It does not mutate the review record, submission manifest, "
+            "evidence files, or source comment banks."
+        ),
+    )
+    export_feedback_parser.add_argument("class_id", help="Class identifier.")
+    export_feedback_parser.add_argument(
+        "assignment_id", help="Assignment identifier."
+    )
+    export_feedback_parser.add_argument("student_id", help="Student identifier.")
+    export_feedback_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing exports/feedback.md file.",
     )
 
     workspace_parser = subparsers.add_parser(
@@ -962,6 +997,43 @@ def _print_updated_review_score(updated: UpdatedReviewScore) -> None:
     print(f"Action: {'created' if updated.was_created else 'updated'}")
     print(f"Review state: {updated.review_state}")
     print(f"Review record: {updated.review_record_relative_path}")
+
+
+def _handle_export_feedback(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    overwrite: bool,
+) -> int:
+    """Export one student-facing Markdown feedback artifact."""
+    try:
+        workspace_root = resolve_workspace_root()
+        exported = export_student_feedback(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            overwrite=overwrite,
+        )
+    except (WorkspaceRootError, FeedbackExportError) as error:
+        print(f"Error: could not export student feedback: {error}")
+        return 1
+
+    _print_exported_feedback(exported)
+    return 0
+
+
+def _print_exported_feedback(exported: ExportedFeedback) -> None:
+    """Print a concise student-feedback export summary."""
+    print("Exported student feedback:")
+    print(f"Class: {exported.class_id}")
+    print(f"Assignment: {exported.assignment_id}")
+    print(f"Student: {exported.student_id}")
+    print(f"Included comments: {exported.included_comment_count}")
+    print(f"Scores: {exported.score_count}")
+    print(f"Overwrote existing: {_format_bool(exported.overwrote_existing)}")
+    print(f"Feedback file: {exported.feedback_relative_path}")
 
 
 def _print_assignment_submission_status(

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -1,0 +1,323 @@
+"""Student-facing Markdown export from canonical Quillan review records."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.review_record_paths import ReviewRecordPathError, review_record_path
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_dir,
+    submission_manifest_path,
+)
+
+
+class FeedbackExportError(Exception):
+    """Raised when student-facing feedback cannot be exported safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExportedFeedback:
+    """Information about one generated student-facing feedback artifact."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    feedback_path: Path
+    feedback_relative_path: str
+    included_comment_count: int
+    score_count: int
+    created_at: str
+    overwrote_existing: bool
+
+
+def feedback_export_path(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the canonical student-facing Markdown feedback export path."""
+    return (
+        submission_dir(workspace_root, class_id, assignment_id, student_id)
+        / "exports"
+        / "feedback.md"
+    )
+
+
+def export_student_feedback(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    overwrite: bool = False,
+    created_at: datetime | str | None = None,
+) -> ExportedFeedback:
+    """Generate student-facing Markdown from one canonical review record."""
+    normalized_created_at = _normalize_timestamp(created_at)
+    try:
+        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_workspace_root, class_id, assignment_id, student_id
+        )
+        record_path = review_record_path(
+            resolved_workspace_root, class_id, assignment_id, student_id
+        )
+        output_path = feedback_export_path(
+            resolved_workspace_root, class_id, assignment_id, student_id
+        )
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise FeedbackExportError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise FeedbackExportError(
+            "Submission manifest does not exist for "
+            f"class={class_id}, assignment={assignment_id}, student={student_id}."
+        )
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise FeedbackExportError(
+            f"Could not load submission manifest: {error}"
+        ) from error
+    _validate_identity(
+        manifest,
+        record_name="Submission manifest",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+
+    if not record_path.exists():
+        raise FeedbackExportError(
+            "Review record does not exist for "
+            f"class={class_id}, assignment={assignment_id}, student={student_id}."
+        )
+    try:
+        review = load_review_record(record_path)
+    except (OSError, ReviewRecordError) as error:
+        raise FeedbackExportError(f"Could not load review record: {error}") from error
+    _validate_identity(
+        review,
+        record_name="Review record",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+
+    included_comments = [
+        comment
+        for comment in review["comments"]
+        if comment["include_in_feedback"]
+    ]
+    markdown = _render_markdown(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        created_at=normalized_created_at,
+        scores=review["scores"],
+        comments=included_comments,
+    )
+    overwrote_existing = output_path.exists()
+    if overwrote_existing and not overwrite:
+        raise FeedbackExportError(
+            f"Feedback export already exists: {output_path}. "
+            "Use --overwrite to replace it."
+        )
+
+    _write_feedback(output_path, markdown, overwrite=overwrite)
+    return ExportedFeedback(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=record_path,
+        review_record_relative_path=_workspace_relative_path(
+            record_path, resolved_workspace_root, "review record"
+        ),
+        feedback_path=output_path,
+        feedback_relative_path=_workspace_relative_path(
+            output_path, resolved_workspace_root, "feedback"
+        ),
+        included_comment_count=len(included_comments),
+        score_count=len(review["scores"]),
+        created_at=normalized_created_at,
+        overwrote_existing=overwrote_existing,
+    )
+
+
+def _render_markdown(
+    *,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    created_at: str,
+    scores: list[dict[str, Any]],
+    comments: list[dict[str, Any]],
+) -> str:
+    lines = [
+        "# Feedback",
+        "",
+        f"Class: {_plain_text(class_id)}",
+        f"Assignment: {_plain_text(assignment_id)}",
+        f"Student: {_plain_text(student_id)}",
+        f"Generated: {_plain_text(created_at)}",
+        "",
+        "## Scores",
+        "",
+    ]
+    if scores:
+        for score in scores:
+            rendered = (
+                f"- {_plain_text(score['label'])}: "
+                f"{_format_number(score['score'])} / "
+                f"{_format_number(score['max_score'])}"
+            )
+            if "scale" in score:
+                rendered += f" ({_plain_text(score['scale'])})"
+            lines.append(rendered)
+    else:
+        lines.append("No scores recorded.")
+
+    lines.extend(["", "## Feedback Comments", ""])
+    if comments:
+        lines.extend(f"- {_plain_text(comment['text'])}" for comment in comments)
+    else:
+        lines.append("No feedback comments selected.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _write_feedback(path: Path, content: str, *, overwrite: bool) -> None:
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise FeedbackExportError(
+            f"Could not create feedback export directory {parent}: {error}"
+        ) from error
+    if not parent.is_dir():
+        raise FeedbackExportError(
+            f"Feedback export parent is not a directory: {parent}"
+        )
+
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=parent,
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            temporary_file.write(content)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        if overwrite:
+            os.replace(temporary_path, path)
+        else:
+            os.link(temporary_path, path)
+            temporary_path.unlink()
+        temporary_path = None
+    except FileExistsError as error:
+        raise FeedbackExportError(
+            f"Feedback export already exists: {path}. "
+            "Use --overwrite to replace it."
+        ) from error
+    except OSError as error:
+        raise FeedbackExportError(
+            f"Could not write feedback export {path}: {error}"
+        ) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise FeedbackExportError("created_at datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise FeedbackExportError(
+            "created_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise FeedbackExportError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise FeedbackExportError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    *,
+    record_name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    requested = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+    for field, expected in requested.items():
+        actual = record[field]
+        if actual != expected:
+            raise FeedbackExportError(
+                f"{record_name} {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _plain_text(value: object) -> str:
+    return re.sub(r"\s+", " ", str(value)).strip()
+
+
+def _format_number(value: int | float) -> str:
+    if isinstance(value, int):
+        return str(value)
+    return format(value, "g")
+
+
+def _workspace_relative_path(
+    path: Path, workspace_root: Path, description: str
+) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise FeedbackExportError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error

--- a/tests/test_cli_feedback_export.py
+++ b/tests/test_cli_feedback_export.py
@@ -1,0 +1,101 @@
+"""CLI tests for student-facing feedback export."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.feedback_export import feedback_export_path
+from tests.test_review_scores import _write_manifest, _write_review
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID, _review
+
+
+def test_cli_exports_feedback_and_prints_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    review = _review()
+    review["comments"].append(
+        {
+            "comment_record_id": "comment_0002",
+            "label": "Private",
+            "text": "Excluded comment.",
+            "source": "custom",
+            "include_in_feedback": False,
+            "created_at": review["created_at"],
+            "module_details": {},
+        }
+    )
+    review_path = _write_review(tmp_path, review)
+    review_before = review_path.read_bytes()
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        ["export-feedback", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Exported student feedback:" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Included comments: 1" in output
+    assert "Scores: 1" in output
+    assert "Overwrote existing: no" in output
+    relative = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/exports/feedback.md"
+    )
+    assert f"Feedback file: {relative}" in output
+    content = feedback_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).read_text(encoding="utf-8")
+    assert "Existing selected language." in content
+    assert "Excluded comment." not in content
+    assert "- Evidence: 3 / 4" in content
+    assert review_path.read_bytes() == review_before
+
+
+def test_cli_missing_review_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    assert main(
+        ["export-feedback", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    ) == 1
+    assert "Review record does not exist" in capsys.readouterr().out
+
+
+def test_cli_overwrite_flag_controls_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    review_path = _write_review(tmp_path, _review())
+    review_before = review_path.read_bytes()
+    output_path = feedback_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    output_path.parent.mkdir(parents=True)
+    output_path.write_text("manual edit", encoding="utf-8")
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    command = ["export-feedback", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+
+    assert main(command) == 1
+    assert output_path.read_text(encoding="utf-8") == "manual edit"
+    assert main([*command, "--overwrite"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Use --overwrite" in output
+    assert "Overwrote existing: yes" in output
+    assert output_path.read_text(encoding="utf-8").startswith("# Feedback")
+    assert review_path.read_bytes() == review_before

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -1,0 +1,318 @@
+"""Tests for student-facing Markdown feedback export."""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from quillan.feedback_export import (
+    ExportedFeedback,
+    FeedbackExportError,
+    export_student_feedback,
+    feedback_export_path,
+)
+from tests.test_review_scores import _write_manifest, _write_review
+from tests.test_review_tags import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STUDENT_ID,
+    _manifest,
+    _review,
+)
+
+TIMESTAMP = "2026-06-23T12:30:00+00:00"
+
+
+def test_exports_ordered_student_content_without_mutating_sources(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    review = _review("ready_for_export")
+    review["notes"][0]["text"] = "PRIVATE TEACHER NOTE"
+    review["tags"][0]["label"] = "PRIVATE STRUCTURED TAG"
+    review["scores"][0]["teacher_note"] = "PRIVATE SCORE NOTE"
+    review["scores"][0]["scale"] = "4 point"
+    review["scores"].append(
+        {
+            "score_id": "score_0002",
+            "criterion_id": "organization",
+            "label": "Organization",
+            "score": 3.5,
+            "max_score": 4,
+            "updated_at": review["updated_at"],
+            "module_details": {"private": "score metadata"},
+        }
+    )
+    review["comments"][0].update(
+        {
+            "text": "First student comment.\nWith a second line.",
+            "source": "comment_bank",
+            "bank_id": "private_bank",
+            "comment_id": "private_comment_id",
+            "standard_code": "PRIVATE.STANDARD",
+            "module_details": {"private": "comment metadata"},
+        }
+    )
+    review["comments"].extend(
+        [
+            {
+                "comment_record_id": "comment_0002",
+                "label": "Excluded",
+                "text": "EXCLUDED COMMENT",
+                "source": "custom",
+                "include_in_feedback": False,
+                "created_at": review["created_at"],
+                "module_details": {},
+            },
+            {
+                "comment_record_id": "comment_0003",
+                "label": "Second",
+                "text": "Second student comment.",
+                "source": "custom",
+                "include_in_feedback": True,
+                "created_at": review["created_at"],
+                "module_details": {},
+            },
+        ]
+    )
+    review_path = _write_review(tmp_path, review)
+    evidence_path = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_00107_pg_001.pdf"
+    )
+    retained_path = (
+        tmp_path / "routing" / "source_scans" / "scan_001" / "source_1.pdf"
+    )
+    evidence_path.parent.mkdir(parents=True)
+    retained_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"evidence")
+    retained_path.write_bytes(b"source")
+    originals = {
+        manifest_path: manifest_path.read_bytes(),
+        review_path: review_path.read_bytes(),
+        evidence_path: evidence_path.read_bytes(),
+        retained_path: retained_path.read_bytes(),
+    }
+
+    result = export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=TIMESTAMP,
+    )
+
+    expected_path = feedback_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    assert result == ExportedFeedback(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        review_record_path=review_path,
+        review_record_relative_path=(
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/review.json"
+        ),
+        feedback_path=expected_path,
+        feedback_relative_path=(
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/exports/feedback.md"
+        ),
+        included_comment_count=2,
+        score_count=2,
+        created_at=TIMESTAMP,
+        overwrote_existing=False,
+    )
+    content = expected_path.read_text(encoding="utf-8")
+    assert f"Class: {CLASS_ID}" in content
+    assert f"Assignment: {ASSIGNMENT_ID}" in content
+    assert f"Student: {STUDENT_ID}" in content
+    assert f"Generated: {TIMESTAMP}" in content
+    assert content.index("- Evidence: 3 / 4 (4 point)") < content.index(
+        "- Organization: 3.5 / 4"
+    )
+    assert content.index(
+        "- First student comment. With a second line."
+    ) < content.index("- Second student comment.")
+    for private_text in (
+        "PRIVATE TEACHER NOTE",
+        "PRIVATE STRUCTURED TAG",
+        "PRIVATE SCORE NOTE",
+        "EXCLUDED COMMENT",
+        "private_bank",
+        "private_comment_id",
+        "PRIVATE.STANDARD",
+        "comment metadata",
+        "score metadata",
+    ):
+        assert private_text not in content
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+def test_empty_scores_and_comments_have_clear_messages(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    review = _review()
+    review["scores"] = []
+    review["comments"][0]["include_in_feedback"] = False
+    _write_review(tmp_path, review)
+
+    result = export_student_feedback(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+
+    content = result.feedback_path.read_text(encoding="utf-8")
+    assert "No scores recorded." in content
+    assert "No feedback comments selected." in content
+
+
+@pytest.mark.parametrize("record_kind", ["submission", "review"])
+def test_missing_record_is_rejected(tmp_path: Path, record_kind: str) -> None:
+    if record_kind == "review":
+        _write_manifest(tmp_path)
+    with pytest.raises(FeedbackExportError, match="does not exist"):
+        export_student_feedback(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+
+@pytest.mark.parametrize("record_kind", ["submission", "review"])
+def test_invalid_record_is_rejected(tmp_path: Path, record_kind: str) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    if record_kind == "submission":
+        manifest_path.write_text("{", encoding="utf-8")
+    else:
+        review_path = feedback_export_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).parent.parent / "review.json"
+        review_path.write_text("{", encoding="utf-8")
+    with pytest.raises(FeedbackExportError, match="not valid JSON"):
+        export_student_feedback(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+
+@pytest.mark.parametrize(
+    ("record_kind", "field", "value"),
+    [
+        ("submission", "class_id", "other_class"),
+        ("submission", "assignment_id", "other_assignment"),
+        ("submission", "student_id", "00108"),
+        ("review", "class_id", "other_class"),
+        ("review", "assignment_id", "other_assignment"),
+        ("review", "student_id", "00108"),
+    ],
+)
+def test_identity_mismatch_is_rejected(
+    tmp_path: Path, record_kind: str, field: str, value: str
+) -> None:
+    manifest = _manifest()
+    review = _review()
+    if record_kind == "submission":
+        manifest[field] = value
+    else:
+        review[field] = value
+        review["submission_manifest_path"] = (
+            f"classes/{review['class_id']}/assignments/"
+            f"{review['assignment_id']}/submissions/{review['student_id']}/"
+            "submission.json"
+        )
+    _write_manifest(tmp_path, manifest)
+    if record_kind == "review":
+        _write_review(tmp_path, review)
+    with pytest.raises(FeedbackExportError, match=field):
+        export_student_feedback(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+
+def test_overwrite_policy(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    review_path = _write_review(tmp_path, _review())
+    original_review = review_path.read_bytes()
+    first = export_student_feedback(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+    first.feedback_path.write_text("manually edited", encoding="utf-8")
+
+    with pytest.raises(FeedbackExportError, match="--overwrite"):
+        export_student_feedback(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+    assert first.feedback_path.read_text(encoding="utf-8") == "manually edited"
+
+    second = export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        overwrite=True,
+        created_at=TIMESTAMP,
+    )
+    assert second.overwrote_existing is True
+    assert second.feedback_path.read_text(encoding="utf-8").startswith("# Feedback")
+    assert review_path.read_bytes() == original_review
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "not-a-time",
+        "2026-06-23T12:30:00",
+        datetime(2026, 6, 23, 12, 30),
+        123,
+    ],
+)
+def test_invalid_timestamp_is_rejected(
+    tmp_path: Path, timestamp: object
+) -> None:
+    with pytest.raises(FeedbackExportError, match="timezone-aware"):
+        export_student_feedback(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            created_at=timestamp,  # type: ignore[arg-type]
+        )
+
+
+def test_aware_datetime_is_normalized(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    _write_review(tmp_path, copy.deepcopy(_review()))
+    timestamp = datetime(2026, 6, 23, 12, 30, tzinfo=timezone.utc)
+    result = export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=timestamp,
+    )
+    assert result.created_at == timestamp.isoformat()
+
+
+def test_source_comment_bank_is_not_read(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    review = _review()
+    review["comments"][0].update(
+        {
+            "source": "comment_bank",
+            "bank_id": "missing_bank",
+            "comment_id": "missing_comment",
+        }
+    )
+    _write_review(tmp_path, review)
+    result = export_student_feedback(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+    assert "Existing selected language." in result.feedback_path.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
## Summary

Adds student-facing Markdown feedback export from canonical Quillan review records.

This PR adds a read-only export workflow:

`quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]`

The command writes:

`classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md`

## Changes

* Added `quillan/feedback_export.py`

  * `FeedbackExportError`
  * `ExportedFeedback`
  * `feedback_export_path(...)`
  * `export_student_feedback(...)`
  * atomic Markdown file writing
  * overwrite protection
  * timestamp validation
  * identity validation for matching `submission.json` and `review.json`

* Added CLI support:

  * `quillan export-feedback <class_id> <assignment_id> <student_id>`
  * optional `--overwrite`

* Updated documentation:

  * README
  * CLI contract
  * data contracts
  * review record contract
  * teacher review model
  * changelog

* Added focused tests for:

  * core export behavior
  * CLI export behavior
  * overwrite behavior
  * missing record handling
  * invalid record handling
  * identity mismatch handling
  * timestamp validation
  * non-mutation guarantees
  * exclusion of private/internal review data
  * source comment bank independence

## Export Behavior

The generated Markdown includes:

* class ID
* assignment ID
* student ID
* generated timestamp
* ordered teacher-entered criterion scores
* ordered snapshotted comments where `include_in_feedback == true`

The generated Markdown excludes:

* private teacher notes
* structured tags
* score `teacher_note` values
* comments where `include_in_feedback == false`
* comment source/provenance fields
* score/comment module metadata

## Output Path

Feedback is written as a derived artifact at:

`submissions/<student_id>/exports/feedback.md`

The export is not canonical review data and does not replace `review.json`.

## Overwrite Policy

Existing feedback files are protected by default.

* Without `--overwrite`, existing feedback causes a handled failure.
* With `--overwrite`, the feedback file is replaced.

## Read-Only Review-State Policy

This PR does not mutate canonical records.

It does not:

* change `review_state`
* mark a review as `exported`
* update review timestamps
* update `submission.json`
* update evidence files
* read or update source comment banks

Feedback export uses the snapshotted content already stored in `review.json`.

## Non-Goals

This PR does not implement:

* automatic `review_state = exported`
* `--mark-exported`
* feedback editing
* feedback email export
* PDF export
* batch class export
* class summary export
* standards summary export
* report generation
* parent/guardian email text
* LMS integration
* comment bank lookup during export
* standards-profile lookup during export
* automatic comment selection
* AI feedback
* AI revision suggestions
* AI grading
* automatic scoring
* mastery calculation
* tag-to-feedback conversion
* private note export
* mutation of source evidence
* mutation of canonical review records

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

836 tests passed.

Closes #100
