### PR TITLE
feat: add class review summary export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan export-class-summary` and a focused read-only API for writing
+  assignment-level `exports/class_summary.csv`. The deterministic CSV includes
+  one row per discovered student directory, status rows for missing, invalid,
+  and identity-mismatched records, review/submission states, transparent
+  teacher-entered score totals, selected-comment, tag, and note counts, and
+  feedback-export existence. It does not read evidence or comment banks,
+  calculate grades or mastery, use a roster, or mutate canonical records.
 - Added `quillan export-feedback` and a focused read-only API for generating
   `submissions/<student_id>/exports/feedback.md` from valid matching
   `submission.json` and `review.json` records. The Markdown includes ordered

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ The supported teacher/developer sequence is:
 12. `set-score` sets or updates one explicitly teacher-entered criterion score.
 13. `export-feedback` writes selected comments and criterion scores to a
     student-facing Markdown file.
-14. `set-review-state` records lightweight submission-manifest progress when
+14. `export-class-summary` writes an assignment-level teacher review CSV.
+15. `set-review-state` records lightweight submission-manifest progress when
     the teacher chooses.
 
 Opening evidence and updating review state are separate teacher-controlled
@@ -160,6 +161,7 @@ quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity
 quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
 quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
+quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
@@ -202,6 +204,14 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   provenance are excluded. Existing feedback is protected unless
   `--overwrite` is supplied, and export does not mutate canonical records,
   evidence, timestamps, or review state.
+- `export-class-summary` discovers immediate student directories under the
+  assignment `submissions/` directory and writes
+  `assignments/<assignment_id>/exports/class_summary.csv`. Each student gets
+  one deterministic row, including status rows for missing, invalid, or
+  identity-mismatched records. Ready rows summarize states, teacher-entered
+  score totals, selected comments, tags, notes, and feedback-file existence.
+  The totals are transparent arithmetic, not grades. The export does not read
+  evidence or comment banks and does not mutate canonical records.
 - `set-review-state` updates only the manifest's `submission_state` and
   `updated_at`; it does not inspect evidence or make a review decision.
 
@@ -212,7 +222,8 @@ teacher explicitly requests it.
 Quillan does not perform OCR, handwriting recognition, PDF text
 extraction, AI scoring, AI feedback, AI suggestions, automatic grading,
 automatic review-state updates, automatic evidence selection among duplicates,
-rubric scoring, automatic feedback generation, or report generation. Quick
+rubric scoring, automatic feedback generation, standards reporting, or
+roster-aware missing-student reporting. Quick
 notes and structured tags are teacher-entered
 records; they do not score or generate feedback by themselves.
 The teacher remains responsible for reading and evaluating student work.
@@ -563,6 +574,7 @@ quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
 quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
+quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan workspace show
 quillan menu

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -49,6 +49,7 @@ quillan --help
 quillan validate-standards <path>
 quillan validate-assignment <path>
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
+quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 quillan workspace show
 quillan workspace set <path>
 quillan workspace validate
@@ -413,6 +414,32 @@ count, overwrite status, and workspace-relative feedback path. Handled
 workspace, validation, missing-record, and overwrite failures return `1`.
 Without `--overwrite`, an existing feedback file is preserved. The command
 does not mutate review state, timestamps, canonical records, or evidence.
+
+## Class Review Summary Export
+
+```powershell
+quillan export-class-summary <class_id> <assignment_id> [--overwrite]
+```
+
+This direct command discovers immediate student directories under the
+assignment's canonical `submissions/` directory and writes
+`assignments/<assignment_id>/exports/class_summary.csv`. Rows are sorted by
+`student_id`. Valid matching records produce `ready` rows with submission and
+review states, score counts and simple score/max-score totals, selected and
+included comment counts, tag and note counts, feedback-export existence, and
+workspace-relative paths.
+
+Missing, invalid, and identity-mismatched student records produce
+`missing_submission`, `invalid_submission`, `missing_review`,
+`invalid_review`, or `identity_mismatch` rows rather than aborting the whole
+export. A missing assignment submissions directory is a handled failure.
+Success returns `0` and prints row/status counts, overwrite status, and the
+summary path; handled failures return `1`.
+
+The export is read-only with respect to canonical records. It does not read
+evidence files or comment banks, use a roster, infer missing students,
+calculate percentages, grades, mastery, or weighted results, or generate a
+standards summary. Existing CSV files require `--overwrite`.
 
 ## Output and Error Handling
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -722,28 +722,35 @@ villainy_final_essay_synthetic,english12_period3_synthetic,W.AW.11-12.1,12,18,6,
 
 ## Class Summary Report
 
-A class summary aggregates teacher-reviewed submission-level results. It is a
-derived report for review and instructional planning, not a replacement for
+A class review summary is an implemented assignment-level derived export for
+review management and instructional planning. It is not a replacement for
 reading student work or consulting the underlying records.
 
-Suggested path:
+Canonical path:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/reports/class_summary.csv
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
 ```
 
-Required MVP columns:
+Stable columns:
 
 ```text
-assignment_id,class_id,student_id,requirements_status,overall_score,max_score,positive_tags,developing_tags,negative_tags
+class_id,assignment_id,student_id,row_status,review_state,submission_state,score_count,total_score,total_max_score,included_comment_count,selected_comment_count,tag_count,note_count,feedback_export_exists,submission_manifest_path,review_record_path,feedback_export_path,error
 ```
 
-Example row:
+Each immediate child directory under the assignment `submissions/` directory
+produces one row, sorted by `student_id`. `row_status` is one of `ready`,
+`missing_submission`, `invalid_submission`, `missing_review`, `invalid_review`,
+or `identity_mismatch`. Individual bad records remain visible as status rows.
+Ready rows contain counts and the arithmetic sums of teacher-entered `score`
+and `max_score` values. These totals are not percentages, grades, weighted
+scores, mastery results, or rubric levels.
 
-```csv
-assignment_id,class_id,student_id,requirements_status,overall_score,max_score,positive_tags,developing_tags,negative_tags
-villainy_final_essay_synthetic,english12_period3_synthetic,stu_0001,partially_met,13,20,4,5,1
-```
+The export reads only expected `submission.json` and `review.json` records and
+checks whether each `exports/feedback.md` path exists. It does not read
+feedback contents, evidence files, retained scans, standards profiles, or
+comment banks, and it does not mutate canonical records. Roster-aware missing
+student reporting and standards summaries remain future work.
 
 ## Synthetic Data Policy
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -559,7 +559,7 @@ contracts. Implementations must not split or mirror canonical review data
 across those files.
 
 `submissions/<student_id>/exports/feedback.md`,
-`reports/class_summary.csv`, and
+`assignments/<assignment_id>/exports/class_summary.csv`, and
 `reports/standards_summary.csv` are derived export artifacts. They may be
 generated from teacher-controlled review records, but they do
 not replace `review.json` and are not authoritative independent evidence.
@@ -578,6 +578,12 @@ Export does not mutate the review record, update timestamps, or advance
 `review_state` to `exported`. It writes only the derived feedback file and
 refuses to replace an existing file unless overwrite is explicitly requested.
 
+The class summary export similarly reads existing canonical records without
+mutating them. It reports missing, invalid, and identity-mismatched records as
+CSV status rows and includes only simple counts and arithmetic totals from
+teacher-entered review data. It does not inspect evidence or comment banks,
+calculate grades or mastery, or perform standards or roster reporting.
+
 ## Synthetic Example
 
 A complete fake record with a note, two tags, one criterion score, and one
@@ -591,7 +597,7 @@ This contract does not implement:
 * rubric-profile loading, validation, or criterion lookup;
 * overall, weighted, percentage, grade, or mastery score calculation;
 * standalone comment-bank lookup or reusable-comment management;
-* class-summary or standards-summary export;
+* standards-summary export or roster-aware missing-student reporting;
 * terminal-menu review workflows or review CLI commands beyond those listed;
 * editing or deletion of append-only review artifacts;
 * AI scoring, feedback, comments, suggestions, or automated grading;

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -60,7 +60,7 @@ Derived outputs are generated from teacher-reviewed records:
 
 * `feedback.md`
 * `reports/standards_summary.csv`
-* `reports/class_summary.csv`
+* `exports/class_summary.csv`
 
 `feedback.md` is a possible student-readable export. CSV reports are
 aggregations. These outputs are not independent evidence or substitutes for
@@ -204,6 +204,15 @@ Reports must be derived from teacher-confirmed artifacts rather than
 unconfirmed software judgments. They support instructional planning and
 clerical organization, but they do not replace reading student work or
 reviewing the underlying records.
+
+The implemented class review summary reads existing assignment submission and
+review records and emits one status row per discovered student directory.
+Ready rows include transparent totals of teacher-entered scores and maximums,
+but those sums are not grades, percentages, mastery judgments, or weighted
+results. Missing or invalid records remain visible as status rows. The export
+does not inspect evidence or source comment banks, use a roster, or mutate
+canonical records. Standards aggregation and roster-aware missing-student
+reporting remain separate future work.
 
 ## Relationship to Existing Documentation
 

--- a/quillan/class_summary_export.py
+++ b/quillan/class_summary_export.py
@@ -1,0 +1,397 @@
+"""Teacher-facing class review summary CSV export."""
+
+from __future__ import annotations
+
+import csv
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+
+CSV_COLUMNS: Final[tuple[str, ...]] = (
+    "class_id",
+    "assignment_id",
+    "student_id",
+    "row_status",
+    "review_state",
+    "submission_state",
+    "score_count",
+    "total_score",
+    "total_max_score",
+    "included_comment_count",
+    "selected_comment_count",
+    "tag_count",
+    "note_count",
+    "feedback_export_exists",
+    "submission_manifest_path",
+    "review_record_path",
+    "feedback_export_path",
+    "error",
+)
+
+
+class ClassSummaryExportError(Exception):
+    """Raised when a class review summary cannot be exported safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExportedClassSummary:
+    """Information about one generated assignment-level class summary."""
+
+    class_id: str
+    assignment_id: str
+    summary_path: Path
+    summary_relative_path: str
+    row_count: int
+    ready_count: int
+    missing_review_count: int
+    invalid_review_count: int
+    missing_submission_count: int
+    invalid_submission_count: int
+    identity_mismatch_count: int
+    created_at: str
+    overwrote_existing: bool
+
+
+def class_summary_export_path(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return the canonical assignment-level class summary CSV path."""
+    _validate_identifier(class_id, "class_id")
+    _validate_identifier(assignment_id, "assignment_id")
+    return (
+        Path(workspace_root)
+        / "classes"
+        / class_id
+        / "assignments"
+        / assignment_id
+        / "exports"
+        / "class_summary.csv"
+    )
+
+
+def export_class_review_summary(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    *,
+    overwrite: bool = False,
+    created_at: datetime | str | None = None,
+) -> ExportedClassSummary:
+    """Export one deterministic CSV row per discovered student directory."""
+    normalized_created_at = _normalize_timestamp(created_at)
+    try:
+        resolved_root = Path(workspace_root).resolve(strict=False)
+        output_path = class_summary_export_path(
+            resolved_root, class_id, assignment_id
+        )
+    except (OSError, RuntimeError, ClassSummaryExportError) as error:
+        raise ClassSummaryExportError(str(error)) from error
+
+    submissions_dir = output_path.parent.parent / "submissions"
+    if not submissions_dir.is_dir():
+        raise ClassSummaryExportError(
+            "Assignment submissions directory does not exist: "
+            f"{submissions_dir}"
+        )
+
+    overwrote_existing = output_path.exists()
+    if overwrote_existing and not overwrite:
+        raise ClassSummaryExportError(
+            f"Class summary export already exists: {output_path}. "
+            "Use --overwrite to replace it."
+        )
+
+    try:
+        student_dirs = sorted(
+            (path for path in submissions_dir.iterdir() if path.is_dir()),
+            key=lambda path: path.name,
+        )
+    except OSError as error:
+        raise ClassSummaryExportError(
+            f"Could not discover student submission directories: {error}"
+        ) from error
+
+    rows = [
+        _build_student_row(
+            resolved_root,
+            class_id,
+            assignment_id,
+            student_dir,
+        )
+        for student_dir in student_dirs
+    ]
+    _write_csv(output_path, rows, overwrite=overwrite)
+
+    counts = {
+        status: sum(row["row_status"] == status for row in rows)
+        for status in (
+            "ready",
+            "missing_review",
+            "invalid_review",
+            "missing_submission",
+            "invalid_submission",
+            "identity_mismatch",
+        )
+    }
+    return ExportedClassSummary(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        summary_path=output_path,
+        summary_relative_path=_relative_path(output_path, resolved_root),
+        row_count=len(rows),
+        ready_count=counts["ready"],
+        missing_review_count=counts["missing_review"],
+        invalid_review_count=counts["invalid_review"],
+        missing_submission_count=counts["missing_submission"],
+        invalid_submission_count=counts["invalid_submission"],
+        identity_mismatch_count=counts["identity_mismatch"],
+        created_at=normalized_created_at,
+        overwrote_existing=overwrote_existing,
+    )
+
+
+def _build_student_row(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_dir: Path,
+) -> dict[str, str]:
+    student_id = student_dir.name
+    manifest_path = student_dir / "submission.json"
+    review_path = student_dir / "review.json"
+    feedback_path = student_dir / "exports" / "feedback.md"
+    row = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+        "row_status": "",
+        "review_state": "",
+        "submission_state": "",
+        "score_count": "",
+        "total_score": "",
+        "total_max_score": "",
+        "included_comment_count": "",
+        "selected_comment_count": "",
+        "tag_count": "",
+        "note_count": "",
+        "feedback_export_exists": _csv_bool(feedback_path.is_file()),
+        "submission_manifest_path": _relative_path(
+            manifest_path, workspace_root
+        ),
+        "review_record_path": _relative_path(review_path, workspace_root),
+        "feedback_export_path": _relative_path(feedback_path, workspace_root),
+        "error": "",
+    }
+
+    if not manifest_path.is_file():
+        return _failed_row(
+            row,
+            "missing_submission",
+            f"Submission manifest is missing: {row['submission_manifest_path']}",
+        )
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        return _failed_row(
+            row, "invalid_submission", f"Invalid submission manifest: {error}"
+        )
+
+    row["submission_state"] = str(manifest["submission_state"])
+    mismatch = _identity_mismatch(
+        manifest, class_id, assignment_id, student_id, "Submission manifest"
+    )
+    if mismatch is not None:
+        return _failed_row(row, "identity_mismatch", mismatch)
+
+    if not review_path.is_file():
+        return _failed_row(
+            row,
+            "missing_review",
+            f"Review record is missing: {row['review_record_path']}",
+        )
+    try:
+        review = load_review_record(review_path)
+    except (OSError, ReviewRecordError) as error:
+        return _failed_row(
+            row, "invalid_review", f"Invalid review record: {error}"
+        )
+
+    mismatch = _identity_mismatch(
+        review, class_id, assignment_id, student_id, "Review record"
+    )
+    if mismatch is not None:
+        return _failed_row(row, "identity_mismatch", mismatch)
+
+    scores = review["scores"]
+    comments = review["comments"]
+    row.update(
+        {
+            "row_status": "ready",
+            "review_state": str(review["review_state"]),
+            "score_count": str(len(scores)),
+            "total_score": _format_number(
+                sum(score["score"] for score in scores)
+            ),
+            "total_max_score": _format_number(
+                sum(score["max_score"] for score in scores)
+            ),
+            "included_comment_count": str(
+                sum(comment["include_in_feedback"] for comment in comments)
+            ),
+            "selected_comment_count": str(len(comments)),
+            "tag_count": str(len(review["tags"])),
+            "note_count": str(len(review["notes"])),
+        }
+    )
+    return row
+
+
+def _failed_row(
+    row: dict[str, str], status: str, message: str
+) -> dict[str, str]:
+    row["row_status"] = status
+    row["error"] = " ".join(message.split())
+    return row
+
+
+def _identity_mismatch(
+    record: dict[str, Any],
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    record_name: str,
+) -> str | None:
+    expected_values = {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+    for field, expected in expected_values.items():
+        actual = record[field]
+        if actual != expected:
+            return (
+                f"{record_name} {field} is {actual!r}, expected {expected!r}."
+            )
+    return None
+
+
+def _write_csv(
+    path: Path, rows: list[dict[str, str]], *, overwrite: bool
+) -> None:
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise ClassSummaryExportError(
+            f"Could not create class summary export directory {parent}: {error}"
+        ) from error
+    if not parent.is_dir():
+        raise ClassSummaryExportError(
+            f"Class summary export parent is not a directory: {parent}"
+        )
+
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=parent,
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            writer = csv.DictWriter(
+                temporary_file,
+                fieldnames=CSV_COLUMNS,
+                lineterminator="\n",
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        if overwrite:
+            os.replace(temporary_path, path)
+        else:
+            os.link(temporary_path, path)
+            temporary_path.unlink()
+        temporary_path = None
+    except FileExistsError as error:
+        raise ClassSummaryExportError(
+            f"Class summary export already exists: {path}. "
+            "Use --overwrite to replace it."
+        ) from error
+    except (OSError, csv.Error) as error:
+        raise ClassSummaryExportError(
+            f"Could not write class summary export {path}: {error}"
+        ) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ClassSummaryExportError(
+                "created_at datetime must be timezone-aware."
+            )
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise ClassSummaryExportError(
+            "created_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ClassSummaryExportError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ClassSummaryExportError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identifier(value: str, field: str) -> None:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise ClassSummaryExportError(str(error)) from error
+
+
+def _relative_path(path: Path, workspace_root: Path) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ClassSummaryExportError(
+            f"Could not resolve workspace-relative export path: {error}"
+        ) from error
+
+
+def _csv_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _format_number(value: int | float) -> str:
+    return format(value, "g")

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -23,6 +23,11 @@ from quillan.assignment_submission_assembly import (
     assemble_assignment_submissions,
 )
 from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.class_summary_export import (
+    ClassSummaryExportError,
+    ExportedClassSummary,
+    export_class_review_summary,
+)
 from quillan.evidence_filing import (
     EvidenceFilingError,
     RoutedEvidenceFile,
@@ -197,6 +202,13 @@ def main(argv: list[str] | None = None) -> int:
             args.class_id,
             args.assignment_id,
             args.student_id,
+            overwrite=args.overwrite,
+        )
+
+    if args.command == "export-class-summary":
+        return _handle_export_class_summary(
+            args.class_id,
+            args.assignment_id,
             overwrite=args.overwrite,
         )
 
@@ -536,6 +548,29 @@ def _build_parser() -> argparse.ArgumentParser:
         "--overwrite",
         action="store_true",
         help="Replace an existing exports/feedback.md file.",
+    )
+
+    export_class_summary_parser = subparsers.add_parser(
+        "export-class-summary",
+        help="Export a class-level review summary CSV for one assignment.",
+        description=(
+            "Generate a teacher-facing CSV summary from existing submission "
+            "and review records for one class assignment. The export reports "
+            "review availability, review state, score totals, selected feedback "
+            "counts, tag counts, and note counts. It does not mutate canonical "
+            "records or evidence."
+        ),
+    )
+    export_class_summary_parser.add_argument(
+        "class_id", help="Class identifier."
+    )
+    export_class_summary_parser.add_argument(
+        "assignment_id", help="Assignment identifier."
+    )
+    export_class_summary_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing exports/class_summary.csv file.",
     )
 
     workspace_parser = subparsers.add_parser(
@@ -1034,6 +1069,45 @@ def _print_exported_feedback(exported: ExportedFeedback) -> None:
     print(f"Scores: {exported.score_count}")
     print(f"Overwrote existing: {_format_bool(exported.overwrote_existing)}")
     print(f"Feedback file: {exported.feedback_relative_path}")
+
+
+def _handle_export_class_summary(
+    class_id: str,
+    assignment_id: str,
+    *,
+    overwrite: bool,
+) -> int:
+    """Export one teacher-facing assignment class summary CSV."""
+    try:
+        workspace_root = resolve_workspace_root()
+        exported = export_class_review_summary(
+            workspace_root,
+            class_id,
+            assignment_id,
+            overwrite=overwrite,
+        )
+    except (WorkspaceRootError, ClassSummaryExportError) as error:
+        print(f"Error: could not export class review summary: {error}")
+        return 1
+
+    _print_exported_class_summary(exported)
+    return 0
+
+
+def _print_exported_class_summary(exported: ExportedClassSummary) -> None:
+    """Print a concise teacher-facing class summary export result."""
+    print("Exported class review summary:")
+    print(f"Class: {exported.class_id}")
+    print(f"Assignment: {exported.assignment_id}")
+    print(f"Rows: {exported.row_count}")
+    print(f"Ready: {exported.ready_count}")
+    print(f"Missing review: {exported.missing_review_count}")
+    print(f"Invalid review: {exported.invalid_review_count}")
+    print(f"Missing submission: {exported.missing_submission_count}")
+    print(f"Invalid submission: {exported.invalid_submission_count}")
+    print(f"Identity mismatch: {exported.identity_mismatch_count}")
+    print(f"Overwrote existing: {_format_bool(exported.overwrote_existing)}")
+    print(f"Summary file: {exported.summary_relative_path}")
 
 
 def _print_assignment_submission_status(

--- a/tests/test_class_summary_export.py
+++ b/tests/test_class_summary_export.py
@@ -1,0 +1,318 @@
+"""Tests for teacher-facing class review summary CSV export."""
+
+from __future__ import annotations
+
+import copy
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.class_summary_export import (
+    CSV_COLUMNS,
+    ClassSummaryExportError,
+    ExportedClassSummary,
+    class_summary_export_path,
+    export_class_review_summary,
+)
+from tests.test_review_tags import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    _manifest,
+    _review,
+)
+
+TIMESTAMP = "2026-06-23T12:30:00+00:00"
+
+
+def _student_dir(workspace: Path, student_id: str) -> Path:
+    return (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / student_id
+    )
+
+
+def _write_json(path: Path, value: Any) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def _records(student_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    manifest = copy.deepcopy(_manifest())
+    manifest["student_id"] = student_id
+    review = copy.deepcopy(_review("ready_for_export"))
+    review["student_id"] = student_id
+    review["submission_manifest_path"] = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"{student_id}/submission.json"
+    )
+    return manifest, review
+
+
+def _write_records(
+    workspace: Path, student_id: str
+) -> tuple[Path, Path, dict[str, Any]]:
+    manifest, review = _records(student_id)
+    student_dir = _student_dir(workspace, student_id)
+    manifest_path = _write_json(student_dir / "submission.json", manifest)
+    review_path = _write_json(student_dir / "review.json", review)
+    return manifest_path, review_path, review
+
+
+def _read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as file:
+        return list(csv.DictReader(file))
+
+
+def test_exports_sorted_ready_rows_with_stable_schema_and_totals(
+    tmp_path: Path,
+) -> None:
+    second_manifest, second_review_path, second_review = _write_records(
+        tmp_path, "00200"
+    )
+    first_manifest, first_review_path, first_review = _write_records(
+        tmp_path, "00100"
+    )
+    first_review["scores"].append(
+        {
+            "score_id": "score_0002",
+            "criterion_id": "organization",
+            "label": "Organization",
+            "score": 3.5,
+            "max_score": 5,
+            "updated_at": first_review["updated_at"],
+            "module_details": {},
+        }
+    )
+    first_review["comments"].append(
+        {
+            "comment_record_id": "comment_0002",
+            "label": "Excluded",
+            "text": "Not for feedback.",
+            "source": "custom",
+            "include_in_feedback": False,
+            "created_at": first_review["created_at"],
+            "module_details": {},
+        }
+    )
+    _write_json(first_review_path, first_review)
+    feedback_path = _student_dir(tmp_path, "00100") / "exports" / "feedback.md"
+    feedback_path.parent.mkdir()
+    feedback_path.write_text("existing feedback", encoding="utf-8")
+    evidence_path = tmp_path / "never-read-evidence.pdf"
+    comment_bank_path = tmp_path / "comment_banks" / "never-read.json"
+    evidence_path.write_bytes(b"evidence")
+    comment_bank_path.parent.mkdir()
+    comment_bank_path.write_text("comment bank", encoding="utf-8")
+    originals = {
+        first_manifest: first_manifest.read_bytes(),
+        first_review_path: first_review_path.read_bytes(),
+        second_manifest: second_manifest.read_bytes(),
+        second_review_path: second_review_path.read_bytes(),
+        evidence_path: evidence_path.read_bytes(),
+        comment_bank_path: comment_bank_path.read_bytes(),
+    }
+
+    result = export_class_review_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+
+    expected_path = class_summary_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    assert result == ExportedClassSummary(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        summary_path=expected_path,
+        summary_relative_path=(
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
+            "class_summary.csv"
+        ),
+        row_count=2,
+        ready_count=2,
+        missing_review_count=0,
+        invalid_review_count=0,
+        missing_submission_count=0,
+        invalid_submission_count=0,
+        identity_mismatch_count=0,
+        created_at=TIMESTAMP,
+        overwrote_existing=False,
+    )
+    with expected_path.open("r", encoding="utf-8", newline="") as file:
+        reader = csv.DictReader(file)
+        assert tuple(reader.fieldnames or ()) == CSV_COLUMNS
+        rows = list(reader)
+    assert [row["student_id"] for row in rows] == ["00100", "00200"]
+    first = rows[0]
+    assert first["row_status"] == "ready"
+    assert first["review_state"] == "ready_for_export"
+    assert first["submission_state"] == "unreviewed"
+    assert first["score_count"] == "2"
+    assert first["total_score"] == "6.5"
+    assert first["total_max_score"] == "9"
+    assert first["included_comment_count"] == "1"
+    assert first["selected_comment_count"] == "2"
+    assert first["tag_count"] == "1"
+    assert first["note_count"] == "1"
+    assert first["feedback_export_exists"] == "true"
+    assert first["submission_manifest_path"].endswith(
+        "/submissions/00100/submission.json"
+    )
+    assert first["review_record_path"].endswith(
+        "/submissions/00100/review.json"
+    )
+    assert first["feedback_export_path"].endswith(
+        "/submissions/00100/exports/feedback.md"
+    )
+    assert first["error"] == ""
+    assert rows[1]["feedback_export_exists"] == "false"
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+def test_status_rows_cover_missing_invalid_and_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    _student_dir(tmp_path, "00100").mkdir(parents=True)
+    _write_json(
+        _student_dir(tmp_path, "00200") / "submission.json", {"invalid": True}
+    )
+    manifest, _ = _records("00300")
+    _write_json(_student_dir(tmp_path, "00300") / "submission.json", manifest)
+    manifest, _ = _records("00400")
+    _write_json(_student_dir(tmp_path, "00400") / "submission.json", manifest)
+    (_student_dir(tmp_path, "00400") / "review.json").write_text(
+        "{", encoding="utf-8"
+    )
+    manifest, review = _records("other_student")
+    _write_json(_student_dir(tmp_path, "00500") / "submission.json", manifest)
+    _write_json(_student_dir(tmp_path, "00500") / "review.json", review)
+
+    result = export_class_review_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+    rows = _read_rows(result.summary_path)
+
+    assert [row["row_status"] for row in rows] == [
+        "missing_submission",
+        "invalid_submission",
+        "missing_review",
+        "invalid_review",
+        "identity_mismatch",
+    ]
+    assert all(row["error"] for row in rows)
+    assert rows[0]["submission_state"] == ""
+    assert rows[2]["submission_state"] == "unreviewed"
+    assert all(row["review_state"] == "" for row in rows)
+    assert all(row["score_count"] == "" for row in rows)
+    assert result.missing_submission_count == 1
+    assert result.invalid_submission_count == 1
+    assert result.missing_review_count == 1
+    assert result.invalid_review_count == 1
+    assert result.identity_mismatch_count == 1
+
+
+def test_empty_submissions_directory_writes_header_only(tmp_path: Path) -> None:
+    submissions = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+    )
+    submissions.mkdir(parents=True)
+
+    result = export_class_review_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+
+    assert result.row_count == 0
+    assert _read_rows(result.summary_path) == []
+    assert result.summary_path.read_text(encoding="utf-8").splitlines() == [
+        ",".join(CSV_COLUMNS)
+    ]
+
+
+def test_missing_submissions_directory_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ClassSummaryExportError, match="does not exist"):
+        export_class_review_summary(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+        )
+
+
+def test_overwrite_policy_replaces_only_derived_csv(tmp_path: Path) -> None:
+    manifest_path, review_path, _ = _write_records(tmp_path, "00100")
+    originals = {
+        manifest_path: manifest_path.read_bytes(),
+        review_path: review_path.read_bytes(),
+    }
+    first = export_class_review_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+    first.summary_path.write_text("manual edit", encoding="utf-8")
+
+    with pytest.raises(ClassSummaryExportError, match="--overwrite"):
+        export_class_review_summary(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+        )
+    assert first.summary_path.read_text(encoding="utf-8") == "manual edit"
+
+    second = export_class_review_summary(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        overwrite=True,
+        created_at=TIMESTAMP,
+    )
+    assert second.overwrote_existing is True
+    assert _read_rows(second.summary_path)[0]["row_status"] == "ready"
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "not-a-time",
+        "2026-06-23T12:30:00",
+        datetime(2026, 6, 23, 12, 30),
+        123,
+    ],
+)
+def test_invalid_timestamp_is_rejected(
+    tmp_path: Path, timestamp: object
+) -> None:
+    with pytest.raises(ClassSummaryExportError, match="timezone-aware"):
+        export_class_review_summary(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            created_at=timestamp,  # type: ignore[arg-type]
+        )
+
+
+def test_aware_datetime_is_normalized(tmp_path: Path) -> None:
+    submissions = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+    )
+    submissions.mkdir(parents=True)
+    timestamp = datetime(2026, 6, 23, 12, 30, tzinfo=timezone.utc)
+    result = export_class_review_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=timestamp
+    )
+    assert result.created_at == timestamp.isoformat()

--- a/tests/test_cli_class_summary_export.py
+++ b/tests/test_cli_class_summary_export.py
@@ -1,0 +1,99 @@
+"""CLI tests for teacher-facing class review summary export."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.class_summary_export import class_summary_export_path
+from quillan.cli import main
+from tests.test_class_summary_export import _student_dir, _write_records
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID
+
+
+def test_cli_exports_ready_and_non_ready_rows_and_prints_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest_path, review_path, _ = _write_records(tmp_path, "00100")
+    _student_dir(tmp_path, "00200").mkdir(parents=True)
+    originals = {
+        manifest_path: manifest_path.read_bytes(),
+        review_path: review_path.read_bytes(),
+    }
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(["export-class-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    assert "Exported class review summary:" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert "Rows: 2" in output
+    assert "Ready: 1" in output
+    assert "Missing review: 0" in output
+    assert "Invalid review: 0" in output
+    assert "Missing submission: 1" in output
+    assert "Invalid submission: 0" in output
+    assert "Identity mismatch: 0" in output
+    assert "Overwrote existing: no" in output
+    relative = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
+        "class_summary.csv"
+    )
+    assert f"Summary file: {relative}" in output
+    summary_path = class_summary_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    with summary_path.open("r", encoding="utf-8", newline="") as file:
+        rows = list(csv.DictReader(file))
+    assert [row["row_status"] for row in rows] == [
+        "ready",
+        "missing_submission",
+    ]
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+def test_cli_missing_submissions_directory_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    assert main(["export-class-summary", CLASS_ID, ASSIGNMENT_ID]) == 1
+    assert "submissions directory does not exist" in capsys.readouterr().out
+
+
+def test_cli_overwrite_flag_controls_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest_path, review_path, _ = _write_records(tmp_path, "00100")
+    originals = {
+        manifest_path: manifest_path.read_bytes(),
+        review_path: review_path.read_bytes(),
+    }
+    output_path = class_summary_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    output_path.parent.mkdir(parents=True)
+    output_path.write_text("manual edit", encoding="utf-8")
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    command = ["export-class-summary", CLASS_ID, ASSIGNMENT_ID]
+
+    assert main(command) == 1
+    assert output_path.read_text(encoding="utf-8") == "manual edit"
+    assert main([*command, "--overwrite"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Use --overwrite" in output
+    assert "Overwrote existing: yes" in output
+    assert "row_status" in output_path.read_text(encoding="utf-8")
+    for path, original in originals.items():
+        assert path.read_bytes() == original


### PR DESCRIPTION
## Summary

Adds a teacher-facing class review summary CSV export for one Quillan assignment.

This PR adds:

`quillan export-class-summary <class_id> <assignment_id> [--overwrite]`

The command writes:

`classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv`

## Changes

* Added `quillan/class_summary_export.py`

  * `ClassSummaryExportError`
  * `ExportedClassSummary`
  * `CSV_COLUMNS`
  * `class_summary_export_path(...)`
  * `export_class_review_summary(...)`
  * deterministic student-directory discovery
  * stable CSV column order
  * ready and non-ready status rows
  * transparent score totals
  * selected/included comment counts
  * tag and note counts
  * feedback-export existence checks
  * atomic CSV writing
  * overwrite protection
  * timestamp validation

* Added CLI support:

  * `quillan export-class-summary <class_id> <assignment_id>`
  * optional `--overwrite`

* Added tests for:

  * sorted ready rows
  * stable CSV schema
  * score totals
  * selected and included comment counts
  * tag and note counts
  * feedback export existence
  * workspace-relative paths
  * missing submission rows
  * invalid submission rows
  * missing review rows
  * invalid review rows
  * identity mismatch rows
  * empty submissions directory
  * missing submissions directory
  * overwrite behavior
  * timestamp validation
  * CLI success behavior
  * CLI handled failure behavior
  * non-mutation of canonical records

* Updated README, CLI contract, data contracts, review model, and changelog.

## CSV Row Statuses

The export includes one row per discovered student submission directory.

Supported row statuses:

* `ready`
* `missing_submission`
* `invalid_submission`
* `missing_review`
* `invalid_review`
* `identity_mismatch`

Individual missing or invalid student records do not fail the whole export. They produce status rows with concise error messages.

## CSV Data

Ready rows include:

* review state
* submission state
* score count
* total score
* total max score
* included comment count
* selected comment count
* tag count
* note count
* feedback export existence
* workspace-relative submission/review/feedback paths

Score totals are simple arithmetic sums of teacher-entered `score` and `max_score` values. They are not grades, percentages, weighted scores, or mastery calculations.

## Output Path

The derived CSV is written to:

`classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv`

Existing exports are protected unless `--overwrite` is supplied.

## Non-Mutation Guarantees

This PR does not mutate:

* `submission.json`
* `review.json`
* feedback exports
* routed evidence files
* retained source scans
* source comment banks

The export does not read evidence files or comment banks.

## Non-Goals

This PR does not implement:

* standards summary CSV
* standards mastery reporting
* roster-aware missing-student reporting
* batch export across assignments
* email export
* PDF export
* dashboard UI
* menu workflow
* score weighting
* percentage grades
* letter grades
* mastery calculation
* automatic scoring
* automatic comment selection
* AI feedback
* AI grading
* evidence inspection
* mutation of canonical records
* migration tooling

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

849 tests passed.

Closes #101
