### PR TITLE
feat: add standards summary export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added `quillan export-standards-summary` and a focused read-only API for
+  writing assignment-level `exports/standards_summary.csv`. Rows are sorted by
+  `standard_code` and aggregate standards-linked tag polarity, selected
+  comment feedback inclusion, and distinct-student counts while retaining
+  assignment-level missing, invalid, and identity-mismatch counts. The export
+  excludes scores and notes, does not load standards profiles, read evidence
+  or comment banks, infer mastery or grades, use a roster, or mutate canonical
+  records.
 - Added `quillan export-class-summary` and a focused read-only API for writing
   assignment-level `exports/class_summary.csv`. The deterministic CSV includes
   one row per discovered student directory, status rows for missing, invalid,

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ The supported teacher/developer sequence is:
 13. `export-feedback` writes selected comments and criterion scores to a
     student-facing Markdown file.
 14. `export-class-summary` writes an assignment-level teacher review CSV.
-15. `set-review-state` records lightweight submission-manifest progress when
+15. `export-standards-summary` writes an assignment-level standards-linked
+    tag and selected-comment CSV.
+16. `set-review-state` records lightweight submission-manifest progress when
     the teacher chooses.
 
 Opening evidence and updating review state are separate teacher-controlled
@@ -162,6 +164,7 @@ quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --c
 quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan export-class-summary <class_id> <assignment_id> [--overwrite]
+quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
@@ -212,6 +215,14 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   score totals, selected comments, tags, notes, and feedback-file existence.
   The totals are transparent arithmetic, not grades. The export does not read
   evidence or comment banks and does not mutate canonical records.
+- `export-standards-summary` reads valid matching `submission.json` and
+  `review.json` records and writes
+  `assignments/<assignment_id>/exports/standards_summary.csv`. It creates one
+  sorted row per `standard_code` referenced by a structured tag or selected
+  comment, including tag polarity, feedback-inclusion, and distinct-student
+  counts. It does not include scores or notes, load standards profiles, infer
+  mastery or grades, read evidence or comment banks, use a roster, or mutate
+  canonical records. Existing output requires `--overwrite`.
 - `set-review-state` updates only the manifest's `submission_state` and
   `updated_at`; it does not inspect evidence or make a review decision.
 
@@ -222,7 +233,7 @@ teacher explicitly requests it.
 Quillan does not perform OCR, handwriting recognition, PDF text
 extraction, AI scoring, AI feedback, AI suggestions, automatic grading,
 automatic review-state updates, automatic evidence selection among duplicates,
-rubric scoring, automatic feedback generation, standards reporting, or
+rubric scoring, automatic feedback generation, standards mastery reporting, or
 roster-aware missing-student reporting. Quick
 notes and structured tags are teacher-entered
 records; they do not score or generate feedback by themselves.
@@ -575,6 +586,7 @@ quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity
 quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan export-class-summary <class_id> <assignment_id> [--overwrite]
+quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan workspace show
 quillan menu

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -50,6 +50,7 @@ quillan validate-standards <path>
 quillan validate-assignment <path>
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan export-class-summary <class_id> <assignment_id> [--overwrite]
+quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
 quillan workspace show
 quillan workspace set <path>
 quillan workspace validate
@@ -440,6 +441,30 @@ The export is read-only with respect to canonical records. It does not read
 evidence files or comment banks, use a roster, infer missing students,
 calculate percentages, grades, mastery, or weighted results, or generate a
 standards summary. Existing CSV files require `--overwrite`.
+
+## Standards Summary Export
+
+```powershell
+quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
+```
+
+This command discovers immediate student directories under the assignment
+`submissions/` directory and writes the derived
+`assignments/<assignment_id>/exports/standards_summary.csv`. It validates each
+available `submission.json` and `review.json`, counts missing, invalid, and
+identity-mismatched records without aborting the assignment export, and emits
+one row per referenced standard sorted by `standard_code`.
+
+Rows aggregate standards-linked structured tags by polarity and selected
+comments by feedback inclusion, plus distinct student counts. Artifacts
+without `standard_code` are ignored. If no valid linked artifacts exist, the
+command writes a header-only CSV. Success returns `0`; handled workspace,
+validation, missing-directory, and overwrite failures return `1`.
+
+The export does not include notes or scores, map criteria to standards, load a
+standards profile, inspect student writing or evidence, read comment banks,
+use AI, calculate grades or mastery, use a roster, or mutate canonical
+records. Existing CSV files require `--overwrite`.
 
 ## Output and Error Handling
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -697,28 +697,33 @@ requires explicit overwrite approval.
 
 ## Standards Summary Report
 
-A standards summary aggregates teacher-reviewed tag data by standard. It is a
-derived report rather than independent evidence and should remain traceable to
-its underlying review records.
+The standards summary is an implemented assignment-level derived export from
+valid matching `submission.json` and `review.json` records. It remains
+traceable to teacher-entered review artifacts and is not independent evidence.
 
-Suggested path:
-
-```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/reports/standards_summary.csv
-```
-
-Required MVP columns:
+Canonical path:
 
 ```text
-assignment_id,class_id,standard_code,positive_tags,developing_tags,negative_tags,most_common_positive,most_common_developing,most_common_negative
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
 ```
 
-Example row:
+Stable columns:
 
-```csv
-assignment_id,class_id,standard_code,positive_tags,developing_tags,negative_tags,most_common_positive,most_common_developing,most_common_negative
-villainy_final_essay_synthetic,english12_period3_synthetic,W.AW.11-12.1,12,18,6,clear_claim,evidence_needs_explanation,unsupported_claim
+```text
+class_id,assignment_id,standard_code,student_count,tag_student_count,comment_student_count,tag_count,positive_tag_count,developing_tag_count,negative_tag_count,neutral_tag_count,selected_comment_count,included_comment_count,excluded_comment_count,review_count,missing_review_count,invalid_review_count,missing_submission_count,invalid_submission_count,identity_mismatch_count,source
 ```
+
+Each row represents one `standard_code` referenced by a tag or selected
+comment in a valid matching review, sorted by code. Tag counts use the four
+validated polarities. Comment counts distinguish included and excluded
+selected comments. Student counts are distinct per standard and source type.
+Assignment-level record-status counts repeat on each row; a report with no
+standards-linked artifacts contains only the header.
+
+The export ignores tags and comments without `standard_code`, scores, and
+notes. It does not load standards profiles, map criteria to standards, infer
+mastery, calculate grades, inspect evidence, read comment banks, use a roster,
+or mutate canonical records.
 
 ## Class Summary Report
 
@@ -750,7 +755,7 @@ The export reads only expected `submission.json` and `review.json` records and
 checks whether each `exports/feedback.md` path exists. It does not read
 feedback contents, evidence files, retained scans, standards profiles, or
 comment banks, and it does not mutate canonical records. Roster-aware missing
-student reporting and standards summaries remain future work.
+student reporting remains future work.
 
 ## Synthetic Data Policy
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -560,7 +560,8 @@ across those files.
 
 `submissions/<student_id>/exports/feedback.md`,
 `assignments/<assignment_id>/exports/class_summary.csv`, and
-`reports/standards_summary.csv` are derived export artifacts. They may be
+`assignments/<assignment_id>/exports/standards_summary.csv` are derived export
+artifacts. They may be
 generated from teacher-controlled review records, but they do
 not replace `review.json` and are not authoritative independent evidence.
 `requirements.json` remains a separate reserved structural-check record
@@ -583,6 +584,13 @@ mutating them. It reports missing, invalid, and identity-mismatched records as
 CSV status rows and includes only simple counts and arithmetic totals from
 teacher-entered review data. It does not inspect evidence or comment banks,
 calculate grades or mastery, or perform standards or roster reporting.
+
+The standards summary export validates the same per-student canonical records
+and aggregates only tags and selected comments that contain `standard_code`.
+It reports tag polarity, comment feedback inclusion, distinct-student counts,
+and assignment-level missing/invalid counts. It excludes scores and notes and
+does not load standards profiles, inspect evidence, read comment banks, infer
+mastery, calculate grades, use a roster, or mutate canonical records.
 
 ## Synthetic Example
 

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -59,8 +59,8 @@ in `review.json`.
 Derived outputs are generated from teacher-reviewed records:
 
 * `feedback.md`
-* `reports/standards_summary.csv`
 * `exports/class_summary.csv`
+* `exports/standards_summary.csv`
 
 `feedback.md` is a possible student-readable export. CSV reports are
 aggregations. These outputs are not independent evidence or substitutes for
@@ -86,6 +86,14 @@ they do not establish a tag without teacher confirmation.
 
 Tags can support review consistency and reporting, but they do not
 mechanically determine scores.
+
+The assignment-level `exports/standards_summary.csv` report groups only
+standards-linked tags and selected comments from valid matching review
+records. It reports tag polarity, feedback inclusion, and distinct-student
+counts without reading evidence or source comment banks. It does not include
+scores or notes, load standards profiles, infer mastery, calculate grades, or
+mutate canonical records. Student discovery is directory-based; roster-aware
+missing-student reporting remains future work.
 
 ## Evidence Philosophy
 

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -60,7 +60,7 @@ The expected current and reserved layout is:
               requirements.json
               review.json
               feedback.md
-          reports/
+          exports/
             standards_summary.csv
             class_summary.csv
           debug/
@@ -194,13 +194,12 @@ review data. It should remain traceable to `review.json` and must not be
 treated as an independent review record or a replacement for teacher
 judgment. Feedback export is not implemented by this document.
 
-### `reports/`
+### `exports/`
 
-The assignment-local location for future reports derived from
-teacher-reviewed records. Expected MVP report names are
-`standards_summary.csv` and `class_summary.csv`. Reports summarize records;
-they do not replace the underlying source evidence or teacher-review
-artifacts. Report generation is not implemented by this document.
+The assignment-local location for derived teacher-facing reports. Implemented
+report names are `standards_summary.csv` and `class_summary.csv`. Reports
+summarize records; they do not replace the underlying source evidence or
+teacher-review artifacts.
 
 ### `debug/`
 
@@ -257,8 +256,8 @@ container for notes, tags, criterion scores, and selected comments.
 Derived outputs are generated from teacher-reviewed records:
 
 * `feedback.md`
-* `reports/standards_summary.csv`
-* `reports/class_summary.csv`
+* `exports/standards_summary.csv`
+* `exports/class_summary.csv`
 
 Exports and reports should be reproducible from the applicable reviewed
 records and should not become the sole copy of submission evidence or teacher

--- a/quillan/cli.py
+++ b/quillan/cli.py
@@ -73,6 +73,11 @@ from quillan.review_tags import (
     add_review_tag,
 )
 from quillan.standards import StandardsProfileError, load_standards_profile
+from quillan.standards_summary_export import (
+    ExportedStandardsSummary,
+    StandardsSummaryExportError,
+    export_standards_summary,
+)
 from quillan.submission_status import (
     AssignmentSubmissionStatus,
     list_assignment_submission_status,
@@ -207,6 +212,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "export-class-summary":
         return _handle_export_class_summary(
+            args.class_id,
+            args.assignment_id,
+            overwrite=args.overwrite,
+        )
+
+    if args.command == "export-standards-summary":
+        return _handle_export_standards_summary(
             args.class_id,
             args.assignment_id,
             overwrite=args.overwrite,
@@ -571,6 +583,28 @@ def _build_parser() -> argparse.ArgumentParser:
         "--overwrite",
         action="store_true",
         help="Replace an existing exports/class_summary.csv file.",
+    )
+
+    export_standards_summary_parser = subparsers.add_parser(
+        "export-standards-summary",
+        help="Export a standards-focused review summary CSV for one assignment.",
+        description=(
+            "Generate a teacher-facing CSV summary of standards-linked review "
+            "tags and selected comments across one class assignment. The "
+            "export reads existing review records and does not mutate "
+            "canonical records, evidence, or source comment banks."
+        ),
+    )
+    export_standards_summary_parser.add_argument(
+        "class_id", help="Class identifier."
+    )
+    export_standards_summary_parser.add_argument(
+        "assignment_id", help="Assignment identifier."
+    )
+    export_standards_summary_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing exports/standards_summary.csv file.",
     )
 
     workspace_parser = subparsers.add_parser(
@@ -1101,6 +1135,48 @@ def _print_exported_class_summary(exported: ExportedClassSummary) -> None:
     print(f"Assignment: {exported.assignment_id}")
     print(f"Rows: {exported.row_count}")
     print(f"Ready: {exported.ready_count}")
+    print(f"Missing review: {exported.missing_review_count}")
+    print(f"Invalid review: {exported.invalid_review_count}")
+    print(f"Missing submission: {exported.missing_submission_count}")
+    print(f"Invalid submission: {exported.invalid_submission_count}")
+    print(f"Identity mismatch: {exported.identity_mismatch_count}")
+    print(f"Overwrote existing: {_format_bool(exported.overwrote_existing)}")
+    print(f"Summary file: {exported.summary_relative_path}")
+
+
+def _handle_export_standards_summary(
+    class_id: str,
+    assignment_id: str,
+    *,
+    overwrite: bool,
+) -> int:
+    """Export one teacher-facing assignment standards summary CSV."""
+    try:
+        workspace_root = resolve_workspace_root()
+        exported = export_standards_summary(
+            workspace_root,
+            class_id,
+            assignment_id,
+            overwrite=overwrite,
+        )
+    except (WorkspaceRootError, StandardsSummaryExportError) as error:
+        print(f"Error: could not export standards summary: {error}")
+        return 1
+
+    _print_exported_standards_summary(exported)
+    return 0
+
+
+def _print_exported_standards_summary(
+    exported: ExportedStandardsSummary,
+) -> None:
+    """Print a concise teacher-facing standards summary export result."""
+    print("Exported standards summary:")
+    print(f"Class: {exported.class_id}")
+    print(f"Assignment: {exported.assignment_id}")
+    print(f"Rows: {exported.row_count}")
+    print(f"Standards: {exported.standard_count}")
+    print(f"Valid reviews: {exported.review_count}")
     print(f"Missing review: {exported.missing_review_count}")
     print(f"Invalid review: {exported.invalid_review_count}")
     print(f"Missing submission: {exported.missing_submission_count}")

--- a/quillan/standards_summary_export.py
+++ b/quillan/standards_summary_export.py
@@ -1,0 +1,407 @@
+"""Teacher-facing standards-linked review summary CSV export."""
+
+from __future__ import annotations
+
+import csv
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+
+CSV_COLUMNS: Final[tuple[str, ...]] = (
+    "class_id",
+    "assignment_id",
+    "standard_code",
+    "student_count",
+    "tag_student_count",
+    "comment_student_count",
+    "tag_count",
+    "positive_tag_count",
+    "developing_tag_count",
+    "negative_tag_count",
+    "neutral_tag_count",
+    "selected_comment_count",
+    "included_comment_count",
+    "excluded_comment_count",
+    "review_count",
+    "missing_review_count",
+    "invalid_review_count",
+    "missing_submission_count",
+    "invalid_submission_count",
+    "identity_mismatch_count",
+    "source",
+)
+
+
+class StandardsSummaryExportError(Exception):
+    """Raised when a standards summary cannot be exported safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExportedStandardsSummary:
+    """Information about one generated assignment standards summary."""
+
+    class_id: str
+    assignment_id: str
+    summary_path: Path
+    summary_relative_path: str
+    row_count: int
+    standard_count: int
+    student_count: int
+    review_count: int
+    missing_review_count: int
+    invalid_review_count: int
+    missing_submission_count: int
+    invalid_submission_count: int
+    identity_mismatch_count: int
+    created_at: str
+    overwrote_existing: bool
+
+
+@dataclass(slots=True)
+class _StandardCounts:
+    """Mutable aggregation state for one standard code."""
+
+    tag_students: set[str] = field(default_factory=set)
+    comment_students: set[str] = field(default_factory=set)
+    tag_count: int = 0
+    positive_tag_count: int = 0
+    developing_tag_count: int = 0
+    negative_tag_count: int = 0
+    neutral_tag_count: int = 0
+    selected_comment_count: int = 0
+    included_comment_count: int = 0
+    excluded_comment_count: int = 0
+
+
+def standards_summary_export_path(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> Path:
+    """Return the canonical assignment-level standards summary CSV path."""
+    _validate_identifier(class_id, "class_id")
+    _validate_identifier(assignment_id, "assignment_id")
+    return (
+        Path(workspace_root)
+        / "classes"
+        / class_id
+        / "assignments"
+        / assignment_id
+        / "exports"
+        / "standards_summary.csv"
+    )
+
+
+def export_standards_summary(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    *,
+    overwrite: bool = False,
+    created_at: datetime | str | None = None,
+) -> ExportedStandardsSummary:
+    """Export standards-linked tag and selected-comment aggregates."""
+    normalized_created_at = _normalize_timestamp(created_at)
+    try:
+        resolved_root = Path(workspace_root).resolve(strict=False)
+        output_path = standards_summary_export_path(
+            resolved_root, class_id, assignment_id
+        )
+    except (OSError, RuntimeError, StandardsSummaryExportError) as error:
+        raise StandardsSummaryExportError(str(error)) from error
+
+    submissions_dir = output_path.parent.parent / "submissions"
+    if not submissions_dir.is_dir():
+        raise StandardsSummaryExportError(
+            "Assignment submissions directory does not exist: "
+            f"{submissions_dir}"
+        )
+
+    overwrote_existing = output_path.exists()
+    if overwrote_existing and not overwrite:
+        raise StandardsSummaryExportError(
+            f"Standards summary export already exists: {output_path}. "
+            "Use --overwrite to replace it."
+        )
+
+    try:
+        student_dirs = sorted(
+            (path for path in submissions_dir.iterdir() if path.is_dir()),
+            key=lambda path: path.name,
+        )
+    except OSError as error:
+        raise StandardsSummaryExportError(
+            f"Could not discover student submission directories: {error}"
+        ) from error
+
+    aggregates: dict[str, _StandardCounts] = {}
+    status_counts = {
+        "review": 0,
+        "missing_review": 0,
+        "invalid_review": 0,
+        "missing_submission": 0,
+        "invalid_submission": 0,
+        "identity_mismatch": 0,
+    }
+    for student_dir in student_dirs:
+        _inspect_student(
+            class_id,
+            assignment_id,
+            student_dir,
+            aggregates,
+            status_counts,
+        )
+
+    rows = [
+        _build_row(
+            class_id,
+            assignment_id,
+            standard_code,
+            aggregates[standard_code],
+            status_counts,
+        )
+        for standard_code in sorted(aggregates)
+    ]
+    _write_csv(output_path, rows, overwrite=overwrite)
+
+    return ExportedStandardsSummary(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        summary_path=output_path,
+        summary_relative_path=_relative_path(output_path, resolved_root),
+        row_count=len(rows),
+        standard_count=len(aggregates),
+        student_count=len(student_dirs),
+        review_count=status_counts["review"],
+        missing_review_count=status_counts["missing_review"],
+        invalid_review_count=status_counts["invalid_review"],
+        missing_submission_count=status_counts["missing_submission"],
+        invalid_submission_count=status_counts["invalid_submission"],
+        identity_mismatch_count=status_counts["identity_mismatch"],
+        created_at=normalized_created_at,
+        overwrote_existing=overwrote_existing,
+    )
+
+
+def _inspect_student(
+    class_id: str,
+    assignment_id: str,
+    student_dir: Path,
+    aggregates: dict[str, _StandardCounts],
+    status_counts: dict[str, int],
+) -> None:
+    student_id = student_dir.name
+    manifest_path = student_dir / "submission.json"
+    review_path = student_dir / "review.json"
+
+    if not manifest_path.is_file():
+        status_counts["missing_submission"] += 1
+        return
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError):
+        status_counts["invalid_submission"] += 1
+        return
+    if _has_identity_mismatch(
+        manifest, class_id, assignment_id, student_id
+    ):
+        status_counts["identity_mismatch"] += 1
+        return
+
+    if not review_path.is_file():
+        status_counts["missing_review"] += 1
+        return
+    try:
+        review = load_review_record(review_path)
+    except (OSError, ReviewRecordError):
+        status_counts["invalid_review"] += 1
+        return
+    if _has_identity_mismatch(review, class_id, assignment_id, student_id):
+        status_counts["identity_mismatch"] += 1
+        return
+
+    status_counts["review"] += 1
+    for tag in review["tags"]:
+        standard_code = tag.get("standard_code")
+        if standard_code is None:
+            continue
+        counts = aggregates.setdefault(standard_code, _StandardCounts())
+        counts.tag_students.add(student_id)
+        counts.tag_count += 1
+        polarity_field = f"{tag['polarity']}_tag_count"
+        setattr(counts, polarity_field, getattr(counts, polarity_field) + 1)
+
+    for comment in review["comments"]:
+        standard_code = comment.get("standard_code")
+        if standard_code is None:
+            continue
+        counts = aggregates.setdefault(standard_code, _StandardCounts())
+        counts.comment_students.add(student_id)
+        counts.selected_comment_count += 1
+        if comment["include_in_feedback"]:
+            counts.included_comment_count += 1
+        else:
+            counts.excluded_comment_count += 1
+
+
+def _build_row(
+    class_id: str,
+    assignment_id: str,
+    standard_code: str,
+    counts: _StandardCounts,
+    status_counts: dict[str, int],
+) -> dict[str, str]:
+    return {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "standard_code": standard_code,
+        "student_count": str(
+            len(counts.tag_students | counts.comment_students)
+        ),
+        "tag_student_count": str(len(counts.tag_students)),
+        "comment_student_count": str(len(counts.comment_students)),
+        "tag_count": str(counts.tag_count),
+        "positive_tag_count": str(counts.positive_tag_count),
+        "developing_tag_count": str(counts.developing_tag_count),
+        "negative_tag_count": str(counts.negative_tag_count),
+        "neutral_tag_count": str(counts.neutral_tag_count),
+        "selected_comment_count": str(counts.selected_comment_count),
+        "included_comment_count": str(counts.included_comment_count),
+        "excluded_comment_count": str(counts.excluded_comment_count),
+        "review_count": str(status_counts["review"]),
+        "missing_review_count": str(status_counts["missing_review"]),
+        "invalid_review_count": str(status_counts["invalid_review"]),
+        "missing_submission_count": str(status_counts["missing_submission"]),
+        "invalid_submission_count": str(status_counts["invalid_submission"]),
+        "identity_mismatch_count": str(status_counts["identity_mismatch"]),
+        "source": "review_tags_and_comments",
+    }
+
+
+def _has_identity_mismatch(
+    record: dict[str, Any],
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> bool:
+    return any(
+        record[field] != expected
+        for field, expected in (
+            ("class_id", class_id),
+            ("assignment_id", assignment_id),
+            ("student_id", student_id),
+        )
+    )
+
+
+def _write_csv(
+    path: Path, rows: list[dict[str, str]], *, overwrite: bool
+) -> None:
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise StandardsSummaryExportError(
+            f"Could not create standards summary export directory {parent}: "
+            f"{error}"
+        ) from error
+    if not parent.is_dir():
+        raise StandardsSummaryExportError(
+            f"Standards summary export parent is not a directory: {parent}"
+        )
+
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=parent,
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            writer = csv.DictWriter(
+                temporary_file,
+                fieldnames=CSV_COLUMNS,
+                lineterminator="\n",
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        if overwrite:
+            os.replace(temporary_path, path)
+        else:
+            os.link(temporary_path, path)
+            temporary_path.unlink()
+        temporary_path = None
+    except FileExistsError as error:
+        raise StandardsSummaryExportError(
+            f"Standards summary export already exists: {path}. "
+            "Use --overwrite to replace it."
+        ) from error
+    except (OSError, csv.Error) as error:
+        raise StandardsSummaryExportError(
+            f"Could not write standards summary export {path}: {error}"
+        ) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise StandardsSummaryExportError(
+                "created_at datetime must be timezone-aware."
+            )
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise StandardsSummaryExportError(
+            "created_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise StandardsSummaryExportError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise StandardsSummaryExportError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identifier(value: str, field: str) -> None:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise StandardsSummaryExportError(str(error)) from error
+
+
+def _relative_path(path: Path, workspace_root: Path) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise StandardsSummaryExportError(
+            f"Could not resolve workspace-relative export path: {error}"
+        ) from error

--- a/tests/test_cli_standards_summary_export.py
+++ b/tests/test_cli_standards_summary_export.py
@@ -1,0 +1,106 @@
+"""CLI tests for teacher-facing standards summary CSV export."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+import quillan.cli
+from quillan.cli import main
+from quillan.standards_summary_export import standards_summary_export_path
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID
+from tests.test_standards_summary_export import _tag, _write_review
+
+
+def test_cli_exports_standards_rows_and_prints_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    paths = _write_review(
+        tmp_path,
+        "00100",
+        tags=[_tag("tag_1", "W.A", "positive")],
+        comments=[],
+    )
+    originals = {path: path.read_bytes() for path in paths}
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(["export-standards-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    assert "Exported standards summary:" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert "Rows: 1" in output
+    assert "Standards: 1" in output
+    assert "Valid reviews: 1" in output
+    assert "Missing review: 0" in output
+    assert "Invalid review: 0" in output
+    assert "Missing submission: 0" in output
+    assert "Invalid submission: 0" in output
+    assert "Identity mismatch: 0" in output
+    assert "Overwrote existing: no" in output
+    relative = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
+        "standards_summary.csv"
+    )
+    assert f"Summary file: {relative}" in output
+    with standards_summary_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    ).open("r", encoding="utf-8", newline="") as file:
+        assert list(csv.DictReader(file))[0]["standard_code"] == "W.A"
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+def test_cli_handles_missing_directory_and_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+    command = ["export-standards-summary", CLASS_ID, ASSIGNMENT_ID]
+    assert main(command) == 1
+    assert "submissions directory does not exist" in capsys.readouterr().out
+
+    _write_review(
+        tmp_path,
+        "00100",
+        tags=[_tag("tag_1", "W.A", "positive")],
+        comments=[],
+    )
+    output_path = standards_summary_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    output_path.parent.mkdir(parents=True)
+    output_path.write_text("manual edit", encoding="utf-8")
+
+    assert main(command) == 1
+    assert output_path.read_text(encoding="utf-8") == "manual edit"
+    assert main([*command, "--overwrite"]) == 0
+    output = capsys.readouterr().out
+    assert "Use --overwrite" in output
+    assert "Overwrote existing: yes" in output
+
+
+def test_cli_writes_header_only_when_no_standard_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review(
+        tmp_path,
+        "00100",
+        tags=[_tag("tag_1", None, "neutral")],
+        comments=[],
+    )
+    monkeypatch.setattr(quillan.cli, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(["export-standards-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
+
+    with standards_summary_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    ).open("r", encoding="utf-8", newline="") as file:
+        assert list(csv.DictReader(file)) == []

--- a/tests/test_standards_summary_export.py
+++ b/tests/test_standards_summary_export.py
@@ -1,0 +1,302 @@
+"""Tests for teacher-facing standards summary CSV export."""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.standards_summary_export import (
+    CSV_COLUMNS,
+    ExportedStandardsSummary,
+    StandardsSummaryExportError,
+    export_standards_summary,
+    standards_summary_export_path,
+)
+from tests.test_class_summary_export import _records, _student_dir, _write_json
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID
+
+TIMESTAMP = "2026-06-23T13:00:00+00:00"
+
+
+def _tag(
+    tag_id: str, standard_code: str | None, polarity: str
+) -> dict[str, Any]:
+    tag = {
+        "tag_id": tag_id,
+        "label": f"{polarity} tag",
+        "polarity": polarity,
+        "created_at": TIMESTAMP,
+        "module_details": {},
+    }
+    if standard_code is not None:
+        tag["standard_code"] = standard_code
+    return tag
+
+
+def _comment(
+    comment_id: str, standard_code: str | None, included: bool
+) -> dict[str, Any]:
+    comment = {
+        "comment_record_id": comment_id,
+        "label": "Selected comment",
+        "text": "Snapshotted teacher-selected language.",
+        "source": "custom",
+        "include_in_feedback": included,
+        "created_at": TIMESTAMP,
+        "module_details": {},
+    }
+    if standard_code is not None:
+        comment.update(
+            {
+                "source": "standards_profile",
+                "comment_id": f"source_{comment_id}",
+                "standard_code": standard_code,
+            }
+        )
+    return comment
+
+
+def _write_review(
+    workspace: Path,
+    student_id: str,
+    *,
+    tags: list[dict[str, Any]],
+    comments: list[dict[str, Any]],
+) -> tuple[Path, Path]:
+    manifest, review = _records(student_id)
+    review["tags"] = tags
+    review["comments"] = comments
+    student_dir = _student_dir(workspace, student_id)
+    return (
+        _write_json(student_dir / "submission.json", manifest),
+        _write_json(student_dir / "review.json", review),
+    )
+
+
+def _read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as file:
+        return list(csv.DictReader(file))
+
+
+def test_aggregates_standards_in_sorted_stable_rows_without_mutation(
+    tmp_path: Path,
+) -> None:
+    first_paths = _write_review(
+        tmp_path,
+        "00100",
+        tags=[
+            _tag("tag_1", "W.Z", "positive"),
+            _tag("tag_2", "W.A", "developing"),
+            _tag("tag_3", "W.A", "negative"),
+            _tag("tag_4", None, "neutral"),
+        ],
+        comments=[
+            _comment("comment_1", "W.A", True),
+            _comment("comment_2", "W.A", False),
+            _comment("comment_3", None, True),
+        ],
+    )
+    second_paths = _write_review(
+        tmp_path,
+        "00200",
+        tags=[
+            _tag("tag_1", "W.A", "neutral"),
+            _tag("tag_2", "W.A", "positive"),
+        ],
+        comments=[
+            _comment("comment_1", "W.A", True),
+            _comment("comment_2", "W.Z", False),
+        ],
+    )
+    evidence = tmp_path / "evidence.pdf"
+    evidence.write_bytes(b"never read")
+    bank = tmp_path / "comment_banks" / "bank.json"
+    bank.parent.mkdir()
+    bank.write_text("{not json", encoding="utf-8")
+    originals = {
+        path: path.read_bytes()
+        for path in (*first_paths, *second_paths, evidence, bank)
+    }
+
+    result = export_standards_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+
+    expected_path = standards_summary_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    assert result == ExportedStandardsSummary(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        summary_path=expected_path,
+        summary_relative_path=(
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
+            "standards_summary.csv"
+        ),
+        row_count=2,
+        standard_count=2,
+        student_count=2,
+        review_count=2,
+        missing_review_count=0,
+        invalid_review_count=0,
+        missing_submission_count=0,
+        invalid_submission_count=0,
+        identity_mismatch_count=0,
+        created_at=TIMESTAMP,
+        overwrote_existing=False,
+    )
+    with expected_path.open("r", encoding="utf-8", newline="") as file:
+        reader = csv.DictReader(file)
+        assert tuple(reader.fieldnames or ()) == CSV_COLUMNS
+        rows = list(reader)
+    assert [row["standard_code"] for row in rows] == ["W.A", "W.Z"]
+    first = rows[0]
+    assert first["student_count"] == "2"
+    assert first["tag_student_count"] == "2"
+    assert first["comment_student_count"] == "2"
+    assert first["tag_count"] == "4"
+    assert first["positive_tag_count"] == "1"
+    assert first["developing_tag_count"] == "1"
+    assert first["negative_tag_count"] == "1"
+    assert first["neutral_tag_count"] == "1"
+    assert first["selected_comment_count"] == "3"
+    assert first["included_comment_count"] == "2"
+    assert first["excluded_comment_count"] == "1"
+    assert first["review_count"] == "2"
+    assert first["source"] == "review_tags_and_comments"
+    assert rows[1]["student_count"] == "2"
+    assert rows[1]["tag_student_count"] == "1"
+    assert rows[1]["comment_student_count"] == "1"
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+def test_non_ready_counts_repeat_on_rows_and_do_not_abort(tmp_path: Path) -> None:
+    _write_review(
+        tmp_path,
+        "00100",
+        tags=[_tag("tag_1", "W.A", "positive")],
+        comments=[],
+    )
+    _student_dir(tmp_path, "00200").mkdir(parents=True)
+    manifest, _ = _records("00300")
+    _write_json(_student_dir(tmp_path, "00300") / "submission.json", manifest)
+    manifest, _ = _records("00400")
+    _write_json(_student_dir(tmp_path, "00400") / "submission.json", manifest)
+    (_student_dir(tmp_path, "00400") / "review.json").write_text(
+        "{", encoding="utf-8"
+    )
+    _write_json(
+        _student_dir(tmp_path, "00500") / "submission.json", {"invalid": True}
+    )
+    manifest, review = _records("other_student")
+    _write_json(_student_dir(tmp_path, "00600") / "submission.json", manifest)
+    _write_json(_student_dir(tmp_path, "00600") / "review.json", review)
+
+    result = export_standards_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+
+    assert result.review_count == 1
+    assert result.missing_submission_count == 1
+    assert result.missing_review_count == 1
+    assert result.invalid_review_count == 1
+    assert result.invalid_submission_count == 1
+    assert result.identity_mismatch_count == 1
+    row = _read_rows(result.summary_path)[0]
+    assert row["missing_submission_count"] == "1"
+    assert row["missing_review_count"] == "1"
+    assert row["invalid_review_count"] == "1"
+    assert row["invalid_submission_count"] == "1"
+    assert row["identity_mismatch_count"] == "1"
+
+
+def test_no_linked_artifacts_writes_header_only(tmp_path: Path) -> None:
+    _write_review(
+        tmp_path,
+        "00100",
+        tags=[_tag("tag_1", None, "neutral")],
+        comments=[_comment("comment_1", None, True)],
+    )
+
+    result = export_standards_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+
+    assert result.row_count == result.standard_count == 0
+    assert result.review_count == 1
+    assert _read_rows(result.summary_path) == []
+    assert result.summary_path.read_text(encoding="utf-8").splitlines() == [
+        ",".join(CSV_COLUMNS)
+    ]
+
+
+def test_no_valid_reviews_writes_header_only_with_counts(tmp_path: Path) -> None:
+    _student_dir(tmp_path, "00100").mkdir(parents=True)
+
+    result = export_standards_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+
+    assert result.row_count == result.review_count == 0
+    assert result.missing_submission_count == 1
+    assert _read_rows(result.summary_path) == []
+
+
+def test_missing_submissions_directory_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(StandardsSummaryExportError, match="does not exist"):
+        export_standards_summary(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+        )
+
+
+def test_overwrite_replaces_only_the_derived_csv(tmp_path: Path) -> None:
+    paths = _write_review(
+        tmp_path,
+        "00100",
+        tags=[_tag("tag_1", "W.A", "positive")],
+        comments=[],
+    )
+    originals = {path: path.read_bytes() for path in paths}
+    first = export_standards_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+    )
+    first.summary_path.write_text("manual edit", encoding="utf-8")
+
+    with pytest.raises(StandardsSummaryExportError, match="--overwrite"):
+        export_standards_summary(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
+        )
+    assert first.summary_path.read_text(encoding="utf-8") == "manual edit"
+
+    second = export_standards_summary(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        overwrite=True,
+        created_at=TIMESTAMP,
+    )
+    assert second.overwrote_existing is True
+    assert _read_rows(second.summary_path)[0]["standard_code"] == "W.A"
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    ["not-a-time", "2026-06-23T13:00:00", datetime(2026, 6, 23, 13), 123],
+)
+def test_invalid_timestamp_is_rejected(
+    tmp_path: Path, timestamp: object
+) -> None:
+    with pytest.raises(StandardsSummaryExportError, match="timezone-aware"):
+        export_standards_summary(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            created_at=timestamp,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Adds a teacher-facing standards summary CSV export for one Quillan assignment.

This PR adds:

`quillan export-standards-summary <class_id> <assignment_id> [--overwrite]`

The command writes:

`classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv`

## Changes

* Added `quillan/standards_summary_export.py`

  * `StandardsSummaryExportError`
  * `ExportedStandardsSummary`
  * `CSV_COLUMNS`
  * `standards_summary_export_path(...)`
  * `export_standards_summary(...)`
  * deterministic student-directory discovery
  * standards aggregation from review tags and selected comments
  * record-status counting
  * header-only empty export behavior
  * atomic CSV writing
  * overwrite protection
  * timestamp validation

* Added CLI support:

  * `quillan export-standards-summary <class_id> <assignment_id>`
  * optional `--overwrite`

* Added tests for:

  * standards row aggregation
  * deterministic row ordering
  * stable CSV schema
  * distinct student counts
  * tag student counts
  * comment student counts
  * tag polarity counts
  * selected comment counts
  * included/excluded comment counts
  * missing submission counts
  * invalid submission counts
  * missing review counts
  * invalid review counts
  * identity mismatch counts
  * header-only exports when no standards-linked artifacts exist
  * header-only exports when no valid reviews exist
  * missing submissions directory handling
  * overwrite behavior
  * timestamp validation
  * CLI success behavior
  * CLI handled failure behavior
  * non-mutation of canonical records and unrelated files

* Updated README, CLI/data/review/lifecycle documentation, and changelog.

## Aggregation Behavior

The export summarizes standards-linked artifacts from valid matching `review.json` records.

Sources:

* `review.json.tags[*].standard_code`
* `review.json.comments[*].standard_code`

The CSV includes one row per referenced standard.

Each row includes:

* distinct student count
* distinct tag student count
* distinct comment student count
* total tag count
* positive tag count
* developing tag count
* negative tag count
* neutral tag count
* selected comment count
* included comment count
* excluded comment count
* valid review count
* missing/invalid record counts
* source marker: `review_tags_and_comments`

## Record Status Policy

Missing or invalid student records do not fail the whole export.

The export counts:

* valid reviews
* missing submissions
* invalid submissions
* missing reviews
* invalid reviews
* identity mismatches

Only assignment-level failures, overwrite protection, invalid timestamp input, or path/write problems fail the export.

## Empty Export Behavior

If valid reviews exist but no standards-linked tags or comments exist, the export writes a header-only CSV.

If no valid reviews exist but the submissions directory exists, the export also writes a header-only CSV and reports the non-ready counts.

## Non-Mutation Guarantees

This PR does not mutate:

* `submission.json`
* `review.json`
* feedback exports
* class summary exports
* routed evidence files
* retained source scans
* source comment banks

The export does not read evidence files, comment banks, or standards profiles.

## Non-Goals

This PR does not implement:

* standards mastery reporting
* standards-profile loading
* standards-profile ordering
* criterion-to-standard mapping
* rubric-profile loading
* score-to-standard aggregation
* percentage grades
* letter grades
* mastery calculation
* roster-aware missing-student reporting
* batch export across all assignments
* feedback export changes
* class summary export changes
* email export
* PDF export
* dashboard UI
* menu workflow
* automatic scoring
* automatic comment selection
* AI feedback
* AI grading
* evidence inspection
* comment bank lookup
* mutation of canonical records
* migration tooling

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

862 tests passed.

Closes #116
