### PR TITLE
docs: validate v0.7.0 milestone documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ planning and do not by themselves represent releases.
 
 ### Changed
 
+- Validated the repository documentation against the completed v0.7.0
+  milestone implementation. The docs now distinguish direct CLI/API review
+  and export support from the current teacher-facing menu, use the canonical
+  `review.json` and export paths consistently, and keep QR recognition,
+  production scan intake, OCR, AI, automatic grading, and guided menu review
+  workflows identified as future work. This is milestone documentation
+  validation, not a published v0.7.0 package release.
 - Split the CLI implementation into smaller internal parser, argument,
   output, and command-handler modules. Public command behavior and the
   `quillan.cli:main` console-script entrypoint remain unchanged.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Quillan is part of the broader Paper Data Suite concept, alongside ScoreForm.
 
 ## Current Status
 
-Quillan is an early pre-1.0 foundation. It provides direct CLI commands and
-an initial teacher-facing terminal menu skeleton, but it is not yet a complete
-teacher-facing application.
+Quillan is an early pre-1.0 foundation. The v0.7.0 milestone provides a
+teacher-controlled review and export foundation through direct CLI commands
+and Python APIs. The teacher-facing terminal menu currently covers assignment
+management, roster management, printable response pages, workspace settings,
+help, and exit; it does not yet guide the review and export workflow.
 
 Quillan currently supports:
 
@@ -70,6 +72,23 @@ Printable response generation is exposed through the teacher-facing menu and
 the Python API in `quillan.printable_response`. It is not exposed as a
 dedicated direct CLI command.
 
+Current classroom-data workflows are local-first: they read and write the
+teacher-selected Paper Data Suite workspace and do not upload student work,
+review records, comment banks, or exports to a hosted service. Canonical v0.7
+records and exports live at:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+shared/comment_banks/<bank_id>.json
+```
+
+Opening evidence delegates only to the local system viewer. Exports are
+derived files and never replace the canonical manifest or review record.
+
 ## Core Principle
 
 Quillan is not an AI essay grader.
@@ -89,11 +108,18 @@ particular, Quillan does not currently provide:
 - QR extraction from scanned PDFs or images;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
+- splitting multi-page scanned PDFs or batch-ingesting raw scan folders;
 - merging newly routed evidence into existing teacher review state;
 - complete requirements-checking workflows;
 - AI tagging, AI scoring, or AI feedback;
+- AI suggestions or PDF text extraction;
 - automatic grading;
-- complete teacher-facing assignment editing or review workflows; or
+- automatic mastery calculation, review-state decisions, or evidence
+  selection among duplicates;
+- guided teacher-facing submission review, notes, tags, comment selection,
+  scoring, feedback export, or summary export workflows;
+- teacher-facing scan intake or QR recognition;
+- complete teacher-facing assignment editing workflows; or
 - a dedicated printable-response command.
 
 The intended scan-routing rules and failure behavior are documented in
@@ -390,6 +416,10 @@ validation through Roster Management, and combined class-packet generation
 through Printable Response Pages. Workspace Settings can show, set,
 validate/create, and reset the shared Paper Data Suite workspace root. Help
 summarizes Quillan's teacher-controlled purpose and safe-data expectations.
+The menu does not currently select submissions for review, add notes or tags,
+select comment-bank comments, enter scores, export feedback or summaries,
+ingest scans, or recognize QR codes. Those operations are direct CLI/API
+workflows or future teacher-facing usability work.
 
 Show direct CLI help:
 
@@ -585,12 +615,16 @@ quillan open-evidence <workspace-relative-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
+quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
 quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan workspace show
+quillan workspace set <path>
+quillan workspace validate
+quillan workspace reset
 quillan menu
 ```
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -48,6 +48,16 @@ quillan
 quillan --help
 quillan validate-standards <path>
 quillan validate-assignment <path>
+quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
+quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
+quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+quillan open-evidence <workspace-relative-evidence-path>
+quillan open-submission <class_id> <assignment_id> <student_id>
+quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+quillan add-note <class_id> <assignment_id> <student_id> --text "..."
+quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity <polarity>
+quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
+quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
@@ -71,8 +81,7 @@ quillan menu
 ```
 
 Bare `quillan` and the explicit `menu` command launch the same interactive
-menu skeleton. Direct validation and workspace-status commands remain
-non-interactive.
+menu skeleton. The other commands remain direct and non-interactive.
 
 ### `validate-standards`
 
@@ -288,6 +297,13 @@ delete files, and `PDS_WORKSPACE_ROOT` still takes precedence.
 The workspace submenu does not include school-year settings. The overall menu
 remains a guided shell rather than a complete teacher-facing application.
 
+The menu does not currently guide teachers through submission selection,
+evidence opening, review-state changes, notes, tags, comment-bank selection,
+criterion scoring, feedback export, class or standards summary export, scan
+intake, or QR recognition. The implemented review and export operations are
+available through the direct commands documented below and through focused
+Python APIs.
+
 Menu help describes Quillan as a local-first, teacher-controlled
 writing-evidence tool; keeps teacher judgment primary; states that Quillan is
 not automated grading software; identifies currently unsupported AI, OCR,
@@ -302,11 +318,12 @@ A future menu may guide teachers through additional multi-step work after
 those workflows are actually implemented. It should orchestrate reusable
 application functions rather than becoming the only route to core operations.
 
-CLI parsing, presentation, and command handlers live in the internal
-`quillan.cli_app` package. `quillan/cli.py` remains the public compatibility
-facade and console-script entrypoint. Validation, storage, workspace
-resolution, and other domain behavior belong in their relevant modules or in
-shared `pds-core` services.
+CLI parser construction lives in `quillan/cli_app/parser.py`; argument
+conversion, output helpers, top-level dispatch, and command handlers live
+under `quillan/cli_app`. `quillan/cli.py` remains the public compatibility
+facade and `quillan.cli:main` console-script entrypoint. Validation, storage,
+workspace resolution, and other domain behavior belong in their relevant
+modules or in shared `pds-core` services.
 
 ## Help and Discoverability
 
@@ -356,9 +373,77 @@ Commands that operate on managed Paper Data Suite records should use shared
 workspace layouts. The active layout is documented in
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
 
-A future command that writes files must document its destination, overwrite
-policy, and partial-failure behavior before that behavior is treated as
-stable.
+Commands that write files document their destination, overwrite policy, and
+handled-failure behavior in their command sections and help output.
+
+## Decoded-Payload Scan Routing
+
+```powershell
+quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
+```
+
+This command routes one selected source file using caller-supplied canonical
+PDS1 text. On success it retains the source under
+`scans/source/YYYY-MM-DD/` and files routed evidence under the target
+assignment's `scans/` directory. Payload, planning, or filing failures are
+preserved under `scans/review/` when they can be handled safely.
+
+The command does not inspect PDFs or images for QR codes, decode QR codes,
+split multi-page PDFs, batch-ingest a folder, run OCR, or identify a student
+from raw scan content. Exit `0` means the file was routed or safely preserved
+for review; exit `1` means it could not be handled safely.
+
+## Submission Assembly and Status
+
+```powershell
+quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
+quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+```
+
+`assemble-submissions` discovers already-routed PDF and image evidence by the
+assignment filename convention and creates canonical student
+`submission.json` manifests. Existing manifests are skipped unless
+`--overwrite` requests full regeneration. Assembly does not inspect evidence
+contents, recover provenance absent from filenames, or choose among ambiguous
+duplicate evidence.
+
+`list-submissions` is read-only. It reports manifest and page states,
+present-but-unselected evidence, students needing assembly, unassembled routed
+files, and skipped filenames without creating or modifying records.
+
+## Evidence and Submission Opening
+
+```powershell
+quillan open-evidence <workspace-relative-evidence-path>
+quillan open-submission <class_id> <assignment_id> <student_id>
+```
+
+`open-evidence` opens one existing file that resolves inside the active
+workspace. `open-submission` validates one canonical manifest and opens its
+single selected evidence item. Both commands are read-only and do not inspect
+content, select evidence, or update review state.
+
+## Submission Review State
+
+```powershell
+quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+```
+
+The allowed states are `unreviewed`, `in_progress`, `needs_rescan`, and
+`reviewed`. This command updates only `submission_state` and `updated_at` in
+the validated manifest. It does not open or inspect evidence or make an
+automatic review decision.
+
+## Quick Teacher Notes
+
+```powershell
+quillan add-note <class_id> <assignment_id> <student_id> --text "..."
+```
+
+This direct command appends one teacher-entered note to canonical
+`review.json`, creating the record only when the adjacent `submission.json`
+exists, validates, and matches the requested identity. It preserves the
+manifest, evidence, and unrelated review content.
 
 ## Structured Review Tags
 
@@ -377,6 +462,20 @@ returns `0` and reports the class, assignment, student, tag ID, polarity,
 review state, and workspace-relative review-record path. The command never
 mutates the submission manifest, routed evidence, or retained source scans,
 and it does not score, analyze, or generate feedback.
+
+## Reusable Comment Selection
+
+```powershell
+quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
+```
+
+This direct command validates a shared comment bank and appends one
+teacher-selected student-facing comment to canonical `review.json`. Optional
+`--standard`, `--include-in-feedback`, and `--exclude-from-feedback` flags
+refine the snapshot. The command copies label and text and preserves
+`bank_id + comment_id` provenance, so later bank edits do not change the
+review. It does not export feedback or mutate the source bank, manifest, or
+evidence.
 
 ## Criterion Scores
 
@@ -552,12 +651,14 @@ explicitly outside the current end-to-end foundation:
 
 * printable response generation as a dedicated command;
 * submission validation as a dedicated command;
-* workspace creation or selection;
-* production scan routing or QR extraction;
+* guided teacher-facing review and export workflows;
+* raw-scan QR recognition, PDF splitting, folder batch intake, or automatic
+  production scan routing;
 * OCR or handwriting interpretation;
 * complete requirements-checking workflows;
 * AI grading, scoring, tagging, or feedback; and
-* complete terminal-menu submission review and reporting workflows.
+* automatic grading, mastery calculation, review-state decisions, or
+  duplicate-evidence selection.
 
 Their presence in design documents or Python modules does not add them to the
 CLI contract.

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -236,8 +236,8 @@ Comment field rules are:
   It is a stable source identifier and should not be renamed once selected
   into review records.
 * `label` and `text` must be non-empty strings. `label` is concise,
-  teacher-facing selection text; `text` is the full reusable language that a
-  future workflow may snapshot into a review.
+  teacher-facing selection text; `text` is the full reusable language that
+  the direct selection workflow can snapshot into a review.
 * `short_text`, `subcategory`, `teacher_note`, `follow_up_prompt`, and
   `revision_action`, when present, must be non-empty strings.
 * `category_id` must reference a category in the same bank.
@@ -253,8 +253,8 @@ Comment field rules are:
 * `severity_default`, when present, must be a non-negative integer. It is a
   triage and organization default, not a score.
 * `include_in_feedback_default` must be a boolean. It is the initial
-  preference for a future selection workflow, not an instruction to export
-  the source comment automatically.
+  preference used by the direct selection workflow, not an instruction to
+  export the source comment automatically.
 * `student_facing` must be a boolean. `false` marks language or guidance that
   is not appropriate to copy directly into student-facing feedback.
 * `tags` and `hotwords`, when present, must be arrays of non-empty strings
@@ -364,9 +364,9 @@ mutated. No feedback export is performed.
 Schema version `1` and the first runtime workflow do not implement:
 
 * comment bank editing, menus, search, or UI;
-* mutation of `review.json`, `submission.json`, or evidence files;
+* mutation of comment-bank source files, `submission.json`, or evidence files;
 * assignment-local merge or override behavior;
-* feedback, email, LMS, or PDF export;
+* guided feedback export from a comment-bank menu, email, LMS, or PDF export;
 * reports or standard-mastery conclusions;
 * automatic suggestions, standard detection, scoring, or grading;
 * AI feedback or AI comment generation;

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -7,14 +7,14 @@ shared comment banks, assignments, submissions, teacher review, requirements
 checks, feedback exports, and reports.
 
 Standards profiles, assignment configurations, the legacy text-oriented
-submission metadata shape, and the reviewable-evidence submission manifest
-have implemented Python validation support. New-manifest writing and assembly
-from caller-provided evidence metadata are implemented; evidence discovery,
-merging, and state-changing review workflows are not. The writing-response
-payload contract is implemented and used by printable PDF generation.
-Requirements, teacher-review records, feedback exports, and reporting records
-remain contracts for teacher-controlled workflows that are not yet
-implemented end to end.
+submission metadata shape, comment banks, review records, and the
+reviewable-evidence submission manifest have implemented Python validation
+support. Routed-evidence discovery and manifest assembly, explicit
+teacher-controlled review updates, reusable-comment selection, and student,
+class, and standards exports are implemented through direct CLI commands and
+Python APIs. The writing-response payload contract is implemented and used by
+printable PDF generation. Requirements checking and guided teacher-facing
+review remain future work.
 
 For the expected workspace layout and file lifecycle of these records, see
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
@@ -507,10 +507,12 @@ PDS1|module=quillan|class=english12_p4|aid=personal_narrative|sid=1001|page=1|do
 This contract identifies response documents only. The implemented printable
 generator embeds the payload in a QR code on each response page and writes the
 batch PDF to the assignment-local `templates/` directory. Student display
-names are printed for handling but are not included in the payload. QR
-extraction from later scans, scan routing, and OCR remain unimplemented. The
-printable page structure, identity fields, writing area, and output location
-are defined in
+names are printed for handling but are not included in the payload. A direct
+`route-scan` command can retain and route a selected source file when the
+caller supplies an already-decoded canonical PDS1 payload. QR extraction from
+raw scans, PDF splitting, batch scan intake, automatic raw-scan routing, and
+OCR remain unimplemented. The printable page structure, identity fields,
+writing area, and output location are defined in
 [`printable_response_template.md`](printable_response_template.md).
 
 ## Requirements Check

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -26,8 +26,21 @@ Quillan currently has:
 * student submission manifest assembly and read-only status listing;
 * local evidence opening and student submission opening;
 * teacher-controlled lightweight review-state updates;
+* canonical `review.json` records with direct teacher-entered notes, structured
+  tags, reusable comment-bank selection, and criterion scores;
+* student feedback, class review summary, and standards summary exports;
+* a refactored direct CLI implementation under `quillan/cli_app`, with
+  `quillan/cli.py` retained as the compatibility facade;
+* a teacher-facing menu for assignment management, roster management,
+  printable response pages, workspace settings, help, and exit;
 * automated tests for standards validation and CLI behavior;
 * configured development checks using `pytest`, `ruff`, and `mypy`.
+
+The v0.7 review and export foundation is primarily a direct CLI/API workflow.
+The menu does not yet guide submission review, notes, tags, reusable comments,
+scores, exports, scan intake, or QR recognition. Raw-scan QR decoding, PDF
+splitting, batch intake, OCR, AI judgment, automatic grading, automatic
+mastery calculation, and automatic evidence selection remain unimplemented.
 
 ## MVP Scope
 
@@ -103,7 +116,12 @@ Examples and tests should use:
 * synthetic scores;
 * synthetic teacher comments.
 
-## Initial Architecture
+## Original Architecture Sketch
+
+The list below records the initial planning decomposition. The current source
+tree uses focused modules such as `review_record.py`, `review_notes.py`,
+`review_tags.py`, `review_comments.py`, `review_scores.py`,
+`feedback_export.py`, the summary exporters, and `quillan/cli_app`.
 
 Package modules:
 
@@ -277,65 +295,74 @@ Planned responsibility:
 
 ### `tagging.py`
 
-Planned responsibility:
+Implemented responsibility is now split across `review_tags.py`,
+`review_notes.py`, `review_comments.py`, and the canonical
+`review_record.py` model:
 
-* support standard/comment selection;
-* store structured tag records;
-* validate tag locations;
-* support teacher notes.
+* direct teacher-controlled standard/comment selection;
+* structured tags and validated locations;
+* reusable comment-bank snapshots; and
+* teacher-entered notes.
 
 ### `scoring.py`
 
-Planned responsibility:
+Implemented criterion-score responsibility now lives in `review_scores.py`:
 
-* summarize tags;
-* support rubric score entry;
-* store final teacher scores;
-* eventually suggest score bands without making final decisions.
+* record or update teacher-entered criterion scores in `review.json`;
+* preserve unrelated review data; and
+* avoid inferred scores, overall grades, mastery calculations, or automatic
+  score suggestions.
 
 ### `feedback.py`
 
-Planned responsibility:
+Implemented feedback responsibility now lives in `feedback_export.py`:
 
-* generate student-readable feedback from tags, scores, and teacher notes;
-* export feedback as Markdown.
+* export student-readable Markdown from selected comments and
+  teacher-entered criterion scores; and
+* keep private notes, tags, score notes, and provenance out of the export.
 
 ### `reports.py`
 
-Planned responsibility:
+Implemented reporting responsibility is split across
+`class_summary_export.py` and `standards_summary_export.py`:
 
-* aggregate class-level results;
-* summarize standards performance;
-* summarize rubric performance;
-* export CSV reports.
+* export assignment-level class review status and transparent score totals;
+* aggregate standards-linked tags and selected comments; and
+* avoid grades, mastery conclusions, evidence inspection, or roster inference.
 
 ### `storage.py`
 
-Planned responsibility:
+Current storage responsibility is distributed across focused path and writer
+modules and shared `pds-core` services:
 
-* centralize paths and file writing;
-* support local project-root configuration;
-* eventually integrate with Paper Data Suite shared storage.
+* resolve and manage the shared Paper Data Suite workspace;
+* compute canonical submission, review, comment-bank, and export paths; and
+* use safe local writes with explicit overwrite policies.
 
 ### `validation.py`
 
-Planned responsibility:
+Validation remains colocated with the relevant contracts and focused modules:
 
-* hold shared validation helpers once multiple modules need them.
+* standards, assignments, manifests, reviews, and comment banks validate
+  before use; and
+* shared cross-module primitives come from `pds-core` where applicable.
 
 ### `cli.py`
 
 Responsible for:
 
-* teacher-facing terminal commands;
-* direct CLI workflows;
-* the initial menu shell and future menu workflows.
+* retaining the public `quillan.cli:main` compatibility entrypoint.
 
 Current status:
 
-* implemented `validate-standards`;
-* implemented the initial bare `quillan` / `quillan menu` skeleton;
-* covered by tests.
+* parser construction, argument conversion, output, dispatch, and handlers
+  live under `quillan/cli_app`;
+* direct commands cover validation, decoded-payload routing, submission
+  assembly/status/opening, explicit review updates, and all v0.7 exports;
+* bare `quillan` and `quillan menu` launch the current teacher-facing menu;
+* guided teacher-facing review/export and raw-scan intake remain future work;
+  and
+* the command surface is covered by focused tests.
 
 ## Development Sequence
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -548,6 +548,27 @@ rubric-profile loading and criterion lookup remain future work. Quillan does
 not infer criterion scores or calculate an overall, weighted, percentage,
 grade, or mastery score.
 
+## Reusable Comment Selection
+
+The direct reusable-comment command is:
+
+```powershell
+quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
+```
+
+It validates the shared bank at `shared/comment_banks/<bank_id>.json`, selects
+one student-facing teacher-authored comment, and appends a stable snapshot to
+`review.json.comments`. The snapshot preserves `bank_id + comment_id`
+provenance and copies the source label and text so later bank edits do not
+change an existing review. The teacher may choose a valid source standard and
+may override the bank's feedback-inclusion default.
+
+Selection requires a valid matching adjacent `submission.json`, creates a
+missing review record using the same state and preservation rules as notes and
+tags, and does not mutate the source bank, submission manifest, evidence, or
+retained scans. It does not export feedback, select comments automatically,
+analyze writing, score work, or infer mastery.
+
 ## Derived Artifacts and Historical Names
 
 `review.json` is the canonical active v0.7 teacher-review record for notes,
@@ -604,7 +625,8 @@ This contract does not implement:
 
 * rubric-profile loading, validation, or criterion lookup;
 * overall, weighted, percentage, grade, or mastery score calculation;
-* assignment-driven comment-bank activation or reusable-comment management;
+* assignment-driven comment-bank activation, bank editing, or guided
+  reusable-comment management;
 * roster-aware missing-student reporting;
 * terminal-menu review workflows or review CLI commands beyond those listed;
 * editing or deletion of append-only review artifacts;

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -59,11 +59,12 @@ in `review.json`.
 
 Derived outputs are generated from teacher-reviewed records:
 
-* `exports/feedback.md`
-* `exports/class_summary.csv`
-* `exports/standards_summary.csv`
+* `submissions/<student_id>/exports/feedback.md`
+* `assignments/<assignment_id>/exports/class_summary.csv`
+* `assignments/<assignment_id>/exports/standards_summary.csv`
 
-`exports/feedback.md` is a student-readable export. CSV reports are
+The student-level `exports/feedback.md` is a student-readable export. The
+assignment-level CSV reports are
 aggregations. These outputs are not independent evidence or substitutes for
 `review.json`; they should remain traceable to the teacher-confirmed records
 from which they were derived.

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -59,7 +59,8 @@ The expected current and reserved layout is:
               submission.txt
               requirements.json
               review.json
-              feedback.md
+              exports/
+                feedback.md
           exports/
             standards_summary.csv
             class_summary.csv
@@ -124,26 +125,28 @@ defined in
 ### Workspace `scans/source/YYYY-MM-DD/`
 
 The shared canonical store for active retained source scans, date-bucketed by
-the PDS intake date in UTC. A future scan workflow must copy every readable
-selected source here before Quillan-specific parsing or routing, leave the
-teacher's original selected file untouched, avoid silent overwrites, and
-preserve provenance from routed evidence back to this retained source.
+the PDS intake date in UTC. The direct `route-scan` workflow copies its
+selected readable source here before Quillan-specific routing, leaves the
+teacher's original selected file untouched, avoids silent overwrites, and
+preserves provenance from routed evidence back to this retained source.
 
 ### Workspace `scans/review/`
 
 The shared workspace-level location for canonical routing failure records and
-optional problem artifacts. Future Quillan failures must use the shared
-`pds-core` metadata shape and failure categories, with Quillan-specific details
-under `module_details`. Quillan does not currently create or process this
-directory.
+optional problem artifacts. The direct `route-scan` workflow uses the shared
+`pds-core` metadata shape and failure categories, with Quillan-specific
+details under `module_details`, when a routing input can be safely preserved
+for teacher review.
 
 ### Assignment `scans/`
 
-A reserved assignment-local directory for routed scan evidence. It is not the
-canonical retained source location. The future validation, naming, collision,
-provenance, and failure-review behavior is defined in
-[`scan_routing_design.md`](scan_routing_design.md). Its presence does not imply
-that Quillan currently routes scans, performs OCR, or files captured pages.
+The assignment-local directory for routed scan evidence. It is not the
+canonical retained source location. The direct `route-scan` workflow files a
+selected source here only when the caller supplies an already-decoded
+canonical PDS1 payload. The validation, naming, collision, provenance, and
+failure-review behavior is defined in
+[`scan_routing_design.md`](scan_routing_design.md). Quillan does not inspect
+raw scans for QR codes, split PDFs, batch-ingest folders, or perform OCR.
 
 ### `submissions/<student_id>/submission.json`
 
@@ -156,8 +159,11 @@ comments, or feedback exports.
 
 Loading, validation, canonical path computation, safe writing, and
 new-manifest assembly from caller-provided evidence metadata are implemented
-in modules distinct from the legacy text-oriented loader. Scan-folder
-discovery, merging, and state-changing review workflows are not implemented.
+in modules distinct from the legacy text-oriented loader. The direct
+`assemble-submissions` command discovers already-routed evidence by filename
+and creates missing manifests; it does not merge into existing manifests or
+choose among ambiguous duplicates. `set-review-state` provides an explicit,
+metadata-only teacher-controlled state update.
 
 ### `submissions/<student_id>/submission.txt`
 
@@ -182,17 +188,19 @@ comments, and an explicit `review_state`. It references the adjacent
 `review_state` is independent of `submission_state`; neither state
 automatically determines the other. The complete record contract is defined
 in [`review_record_contract.md`](review_record_contract.md). Loading, writing,
-review commands, and exports are not implemented by this document.
+direct review commands, and derived exports are implemented by the runtime;
+guided teacher-facing menu review is not.
 
 Earlier separate `tags.json` and `scores.json` designs are historical and are
 not alternate active v0.7 paths.
 
-### `submissions/<student_id>/feedback.md`
+### `submissions/<student_id>/exports/feedback.md`
 
-A reserved future student-readable export derived from teacher-controlled
-review data. It should remain traceable to `review.json` and must not be
-treated as an independent review record or a replacement for teacher
-judgment. Feedback export is not implemented by this document.
+The implemented student-readable Markdown export derived from a valid matching
+`submission.json` and `review.json`. It remains traceable to `review.json` and
+must not be treated as an independent review record or a replacement for
+teacher judgment. Existing output is protected unless overwrite is explicitly
+requested.
 
 ### `exports/`
 
@@ -255,7 +263,7 @@ container for notes, tags, criterion scores, and selected comments.
 
 Derived outputs are generated from teacher-reviewed records:
 
-* `feedback.md`
+* `submissions/<student_id>/exports/feedback.md`
 * `exports/standards_summary.csv`
 * `exports/class_summary.csv`
 
@@ -291,9 +299,11 @@ required structure, identity fields, PDS1 payload use, writing area, and
 implemented `templates/printable_response_pages.pdf` output for printable
 writing-response pages.
 
-[`scan_routing_design.md`](scan_routing_design.md) defines how a future router
-should validate decoded response payloads and create Quillan routed evidence
-under the shared `pds-core` active scan contract. Canonical retained sources
-belong in `scans/source/YYYY-MM-DD/`, canonical failure records belong in
-`scans/review/`, and assignment-level `scans/` contains routed evidence.
+[`scan_routing_design.md`](scan_routing_design.md) defines how decoded response
+payloads are validated and how Quillan routed evidence fits the shared
+`pds-core` active scan contract. The direct `route-scan` command implements the
+caller-supplied decoded-payload slice. Canonical retained sources belong in
+`scans/source/YYYY-MM-DD/`, canonical failure records belong in
+`scans/review/`, and assignment-level `scans/` contains routed evidence. QR
+recognition, PDF splitting, batch raw-scan intake, and OCR remain future work.
 


### PR DESCRIPTION
## Summary

Validates and updates Quillan’s v0.7.0 milestone documentation.

This documentation pass aligns the repository with the completed v0.7.0 teacher-controlled review/export foundation and clearly distinguishes implemented direct CLI/API workflows from future teacher-facing menu and scan-intake work.

## Docs Updated

Updated documentation across nine files, including:

* `README.md`
* `CHANGELOG.md`
* `docs/cli_contract.md`
* `docs/data_contracts.md`
* `docs/review_record_contract.md`
* `docs/teacher_review_model.md`
* `docs/comment_bank_contract.md`
* `docs/workspace_lifecycle.md`
* `docs/development_plan.md`

## Key Corrections

* Documented the full direct CLI/API review and export workflow.
* Clarified that the teacher-facing menu currently supports assignment, roster, printable-response, workspace, and help workflows, but not guided review/export workflows.
* Corrected canonical review, feedback, and summary paths.
* Distinguished decoded-payload routing from unimplemented QR recognition and raw-scan intake.
* Preserved OCR, AI, automatic grading, automatic review-state, and mastery-reporting boundaries.
* Marked standalone `tags.json` and `scores.json` as historical rather than active v0.7 artifacts.
* Reflected the CLI refactor into `quillan/cli_app`.
* Added the v0.7.0 milestone documentation-validation changelog entry.

## Current v0.7.0 State Documented

The documentation now reflects that Quillan supports the v0.7 review/export workflow through direct CLI commands and application APIs, including:

* submission assembly from already-routed evidence;
* submission status listing;
* opening selected submissions/evidence;
* teacher-entered notes;
* structured teacher tags;
* reusable comment-bank selection;
* teacher-entered criterion scores;
* student-facing feedback export;
* class review summary export;
* standards summary export.

## Future Work Clarified

The documentation now clearly states that the following remain future work:

* guided teacher-facing review menu workflow;
* QR recognition from scanned pages;
* raw-scan/batch scan intake;
* PDF splitting;
* OCR;
* handwriting recognition;
* AI tagging;
* AI scoring;
* AI feedback;
* automatic grading;
* automatic mastery calculation.

## Non-Behavioral Change

This PR is documentation-only.

It does not introduce:

* runtime behavior changes;
* new commands;
* new menu workflows;
* data-contract changes;
* storage-layout changes;
* migration behavior;
* scan-intake behavior;
* review/export behavior changes.

## Validation

Passed:

* `git diff --check`
* `python -m pytest`
* `python -m ruff check .`
* `python -m mypy .`
* `.\run_tests.ps1`

862 tests passed.

mypy checked 90 source files.

Closes #120 
