### PR TITLE
Add Quillan QR image decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ planning and do not by themselves represent releases.
 
 ## Unreleased
 
+### Added
+
+- Added an internal, local OpenCV QR image decoder for supported response-page
+  image files. It returns structured decode results without routing scans,
+  validating PDS1 payloads, writing diagnostics, or mutating workspaces.
+
 ### Changed
 
 - Validated the repository documentation against the completed v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ authors = [
     { name = "Stephen Severino" }
 ]
 dependencies = [
+    "numpy<2.5",
+    "opencv-python",
     "qrcode[pil]",
     "reportlab",
 ]

--- a/quillan/qr_decode.py
+++ b/quillan/qr_decode.py
@@ -1,0 +1,319 @@
+"""Internal QR text decoding for local Quillan response-page images."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, TypeAlias, cast
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+
+ImageArray: TypeAlias = NDArray[np.integer[Any] | np.floating[Any]]
+QrCandidate: TypeAlias = tuple[str, ImageArray]
+
+SUPPORTED_IMAGE_EXTENSIONS: Final = frozenset(
+    {".jpeg", ".jpg", ".png", ".tif", ".tiff"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QrImageDecodeResult:
+    """The decoded QR text or a structured local image-decoding failure."""
+
+    payload_text: str | None
+    failure_category: str | None = None
+    failure_message: str | None = None
+    successful_attempt: str | None = None
+
+
+def decode_qr_payload_from_image_path(path: str | Path) -> QrImageDecodeResult:
+    """Load a supported local image file and decode one QR payload."""
+    source_path = Path(path)
+    if not source_path.exists():
+        return _failure("source_missing", "Image source does not exist.")
+    if not source_path.is_file():
+        return _failure(
+            "source_unreadable",
+            "Image source is not a regular file.",
+        )
+    if source_path.suffix.lower() not in SUPPORTED_IMAGE_EXTENSIONS:
+        return _failure(
+            "source_type_unsupported",
+            "Image source type is not supported.",
+        )
+
+    try:
+        image = cv2.imread(str(source_path), cv2.IMREAD_COLOR)
+    except (cv2.error, OSError):
+        return _failure(
+            "source_unreadable",
+            "Image source could not be read.",
+        )
+
+    if image is None:
+        return _failure(
+            "source_unreadable",
+            "Image source could not be loaded as an image.",
+        )
+    return decode_qr_payload_from_image(image)
+
+
+def decode_qr_payload_from_image(image: object) -> QrImageDecodeResult:
+    """Decode one QR payload from an already-loaded OpenCV image."""
+    if not isinstance(image, np.ndarray) or image.size == 0:
+        return _failure(
+            "source_unreadable",
+            "Provided image is not a readable OpenCV image.",
+        )
+
+    try:
+        detector = cv2.QRCodeDetector()
+        candidates = _qr_candidate_images(cast(ImageArray, image))
+        detector_error_seen = False
+        for label, candidate in candidates:
+            try:
+                decoded = detector.detectAndDecode(candidate)
+            except cv2.error:
+                detector_error_seen = True
+                continue
+
+            if not isinstance(decoded, tuple) or not decoded:
+                detector_error_seen = True
+                continue
+            payload_text = decoded[0]
+            if not isinstance(payload_text, str):
+                detector_error_seen = True
+                continue
+            if payload_text:
+                return QrImageDecodeResult(
+                    payload_text=payload_text,
+                    successful_attempt=label,
+                )
+        if detector_error_seen:
+            return _failure(
+                "payload_unreadable",
+                "QR detection failed for one or more image candidates.",
+            )
+    except Exception:
+        return _failure(
+            "processing_error",
+            "Image processing failed during QR decoding.",
+        )
+
+    return _failure(
+        "payload_missing",
+        "No QR payload could be decoded from the image.",
+    )
+
+
+def _failure(category: str, message: str) -> QrImageDecodeResult:
+    return QrImageDecodeResult(
+        payload_text=None,
+        failure_category=category,
+        failure_message=message,
+    )
+
+
+def _qr_candidate_images(image: ImageArray) -> Iterator[QrCandidate]:
+    """Yield a deterministic, bounded sequence of QR decode candidates."""
+    yield from _basic_preprocess_attempts(image)
+
+    crops = list(_upper_right_crop_candidates(image))
+    for crop_index, (crop_label, crop) in enumerate(crops, start=1):
+        for label, candidate in _basic_preprocess_attempts(crop):
+            yield f"crop {crop_index} {crop_label} {label}", candidate
+
+    for scale in (1.5, 2.0, 3.0):
+        yield (
+            f"raw {scale:g}x upscale",
+            _resize(image, scale),
+        )
+
+    for crop_index, (crop_label, crop) in enumerate(crops, start=1):
+        if crop_label != "tight":
+            continue
+        for label, candidate in _tight_crop_attempts(crop):
+            yield f"crop {crop_index} {crop_label} {label}", candidate
+
+
+def _basic_preprocess_attempts(image: ImageArray) -> Iterator[QrCandidate]:
+    yield "raw", image
+
+    gray = _as_grayscale(image)
+    if image.ndim != 2:
+        yield "grayscale", gray
+
+    blurred = cast(
+        ImageArray,
+        cv2.GaussianBlur(gray, (3, 3), 0),
+    )
+    yield (
+        "otsu threshold",
+        cast(
+            ImageArray,
+            cv2.threshold(
+                blurred,
+                0,
+                255,
+                cv2.THRESH_BINARY | cv2.THRESH_OTSU,
+            )[1],
+        ),
+    )
+    yield (
+        "otsu inverted threshold",
+        cast(
+            ImageArray,
+            cv2.threshold(
+                blurred,
+                0,
+                255,
+                cv2.THRESH_BINARY_INV | cv2.THRESH_OTSU,
+            )[1],
+        ),
+    )
+    yield (
+        "adaptive threshold",
+        cast(
+            ImageArray,
+            cv2.adaptiveThreshold(
+                gray,
+                255,
+                cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+                cv2.THRESH_BINARY,
+                31,
+                5,
+            ),
+        ),
+    )
+    yield (
+        "binary threshold",
+        cast(
+            ImageArray,
+            cv2.threshold(gray, 160, 255, cv2.THRESH_BINARY)[1],
+        ),
+    )
+
+
+def _upper_right_crop_candidates(image: ImageArray) -> Iterator[QrCandidate]:
+    """Yield crops around Quillan's one-inch upper-right response-page QR."""
+    height, width = image.shape[:2]
+    bounds = (
+        ("broad", 0.62, 0.00, 1.00, 0.32),
+        ("header", 0.72, 0.00, 1.00, 0.24),
+        ("focused", 0.76, 0.01, 0.99, 0.20),
+        ("tight", 0.79, 0.02, 0.98, 0.18),
+    )
+
+    for label, left, top, right, bottom in bounds:
+        x1 = max(0, int(width * left))
+        y1 = max(0, int(height * top))
+        x2 = min(width, int(width * right))
+        y2 = min(height, int(height * bottom))
+        if x2 > x1 and y2 > y1:
+            yield label, image[y1:y2, x1:x2]
+
+
+def _tight_crop_attempts(crop: ImageArray) -> Iterator[QrCandidate]:
+    gray = _as_grayscale(crop)
+    normalized = cast(
+        ImageArray,
+        cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8)).apply(gray),
+    )
+    threshold = cast(
+        ImageArray,
+        cv2.threshold(
+            cv2.GaussianBlur(gray, (3, 3), 0),
+            0,
+            255,
+            cv2.THRESH_BINARY | cv2.THRESH_OTSU,
+        )[1],
+    )
+
+    prepared = (
+        ("raw", crop),
+        ("grayscale normalized", normalized),
+        ("otsu threshold", threshold),
+    )
+    for label, candidate in prepared:
+        padded = _pad_quiet_zone(candidate)
+        yield f"{label} padded", padded
+        for scale in (2.0, 3.0, 4.0, 5.0):
+            yield f"{label} padded {scale:g}x upscale", _resize(padded, scale)
+
+    padded_normalized = _pad_quiet_zone(normalized)
+    for angle in (-3, -2, -1, 1, 2, 3):
+        rotated = _rotate(padded_normalized, angle)
+        yield (
+            "grayscale normalized padded "
+            f"rotated {angle:+g} degrees 3x upscale",
+            _resize(rotated, 3.0),
+        )
+
+
+def _as_grayscale(image: ImageArray) -> ImageArray:
+    if image.ndim == 2:
+        return image
+    if image.ndim != 3:
+        raise ValueError("Unsupported image dimensions.")
+    channels = image.shape[2]
+    if channels == 3:
+        return cast(ImageArray, cv2.cvtColor(image, cv2.COLOR_BGR2GRAY))
+    if channels == 4:
+        return cast(ImageArray, cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY))
+    raise ValueError("Unsupported image channel count.")
+
+
+def _pad_quiet_zone(image: ImageArray) -> ImageArray:
+    border = max(4, int(round(max(image.shape[:2]) * 0.15)))
+    fill: int | tuple[int, int, int]
+    fill = 255 if image.ndim == 2 else (255, 255, 255)
+    return cast(
+        ImageArray,
+        cv2.copyMakeBorder(
+            image,
+            border,
+            border,
+            border,
+            border,
+            cv2.BORDER_CONSTANT,
+            value=fill,
+        ),
+    )
+
+
+def _resize(image: ImageArray, scale: float) -> ImageArray:
+    return cast(
+        ImageArray,
+        cv2.resize(
+            image,
+            None,
+            fx=scale,
+            fy=scale,
+            interpolation=cv2.INTER_CUBIC,
+        ),
+    )
+
+
+def _rotate(image: ImageArray, angle: float) -> ImageArray:
+    height, width = image.shape[:2]
+    matrix = cv2.getRotationMatrix2D(
+        (width / 2.0, height / 2.0),
+        angle,
+        1.0,
+    )
+    fill: int | tuple[int, int, int]
+    fill = 255 if image.ndim == 2 else (255, 255, 255)
+    return cast(
+        ImageArray,
+        cv2.warpAffine(
+            image,
+            matrix,
+            (width, height),
+            flags=cv2.INTER_CUBIC,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=fill,
+        ),
+    )

--- a/tests/test_qr_decode.py
+++ b/tests/test_qr_decode.py
@@ -1,0 +1,231 @@
+"""Tests for Quillan's internal QR image-decoding layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+import pytest
+import qrcode
+from qrcode.image.pil import PilImage
+
+from quillan.payloads import build_response_payload
+from quillan.qr_decode import (
+    ImageArray,
+    decode_qr_payload_from_image,
+    decode_qr_payload_from_image_path,
+)
+
+
+def _make_qr_image(payload: str, *, box_size: int = 8) -> NDArray[np.uint8]:
+    qr = qrcode.QRCode[PilImage](
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=box_size,
+        border=4,
+        image_factory=PilImage,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    rgb_image = image.get_image().convert("RGB")
+    return cast(
+        NDArray[np.uint8],
+        cv2.cvtColor(np.asarray(rgb_image), cv2.COLOR_RGB2BGR),
+    )
+
+
+def _response_payload() -> str:
+    return build_response_payload(
+        class_id="english12_p4_synthetic",
+        assignment_id="literary_argument_synthetic",
+        student_id="stu_0001",
+        page=1,
+    )
+
+
+def test_synthetic_quillan_qr_image_decodes_successfully() -> None:
+    payload = _response_payload()
+
+    result = decode_qr_payload_from_image(_make_qr_image(payload))
+
+    assert result.payload_text == payload
+    assert result.failure_category is None
+    assert result.failure_message is None
+    assert result.successful_attempt
+
+
+def test_synthetic_qr_image_path_decodes_successfully(tmp_path: Path) -> None:
+    payload = _response_payload()
+    source = tmp_path / "synthetic-response.png"
+    assert cv2.imwrite(str(source), _make_qr_image(payload))
+
+    result = decode_qr_payload_from_image_path(source)
+
+    assert result.payload_text == payload
+    assert result.failure_category is None
+    assert result.successful_attempt
+
+
+def test_path_loaded_rgba_png_decodes_successfully(tmp_path: Path) -> None:
+    payload = _response_payload()
+    source = tmp_path / "synthetic-response-rgba.png"
+    bgra_image = cv2.cvtColor(_make_qr_image(payload), cv2.COLOR_BGR2BGRA)
+    bgra_image[:, :, 3] = 180
+    assert cv2.imwrite(str(source), bgra_image)
+
+    result = decode_qr_payload_from_image_path(source)
+
+    assert result.payload_text == payload
+    assert result.failure_category is None
+    assert result.successful_attempt
+
+
+def test_synthetic_full_response_page_decodes_successfully() -> None:
+    payload = _response_payload()
+    page = np.full((2200, 1700, 3), 255, dtype=np.uint8)
+    qr_image = cv2.resize(
+        _make_qr_image(payload),
+        (200, 200),
+        interpolation=cv2.INTER_NEAREST,
+    )
+    page[100:300, 1400:1600] = qr_image
+
+    result = decode_qr_payload_from_image(page)
+
+    assert result.payload_text == payload
+    assert result.failure_category is None
+    assert result.successful_attempt
+
+
+def test_upper_right_crop_attempt_has_a_diagnostic_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = "synthetic crop fallback"
+    expected_crop_shape = (320, 304)
+
+    class CropOnlyDetector:
+        def detectAndDecode(
+            self,
+            image: ImageArray,
+        ) -> tuple[str, None, None]:
+            decoded = payload if image.shape[:2] == expected_crop_shape else ""
+            return decoded, None, None
+
+    monkeypatch.setattr(cv2, "QRCodeDetector", CropOnlyDetector)
+    page = np.full((1000, 800, 3), 255, dtype=np.uint8)
+
+    result = decode_qr_payload_from_image(page)
+
+    assert result.payload_text == payload
+    assert result.successful_attempt == "crop 1 broad raw"
+
+
+def test_candidate_level_opencv_error_does_not_prevent_later_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = "synthetic later candidate"
+
+    class LaterSuccessDetector:
+        calls = 0
+
+        def detectAndDecode(
+            self,
+            image: ImageArray,
+        ) -> tuple[str, None, None]:
+            type(self).calls += 1
+            if type(self).calls == 1:
+                raise cv2.error("synthetic candidate failure")
+            decoded = payload if type(self).calls == 2 else ""
+            return decoded, None, None
+
+    monkeypatch.setattr(cv2, "QRCodeDetector", LaterSuccessDetector)
+
+    result = decode_qr_payload_from_image(
+        np.full((100, 100, 3), 255, dtype=np.uint8)
+    )
+
+    assert result.payload_text == payload
+    assert result.failure_category is None
+    assert result.successful_attempt == "grayscale"
+
+
+def test_candidate_level_opencv_errors_without_success_report_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class AlwaysFailingDetector:
+        def detectAndDecode(
+            self,
+            image: ImageArray,
+        ) -> tuple[str, None, None]:
+            raise cv2.error("synthetic candidate failure")
+
+    monkeypatch.setattr(cv2, "QRCodeDetector", AlwaysFailingDetector)
+
+    result = decode_qr_payload_from_image(
+        np.full((100, 100, 3), 255, dtype=np.uint8)
+    )
+
+    assert result.payload_text is None
+    assert result.failure_category == "payload_unreadable"
+    assert result.failure_message
+
+
+def test_missing_file_gives_structured_failure(tmp_path: Path) -> None:
+    result = decode_qr_payload_from_image_path(tmp_path / "missing.png")
+
+    assert result.payload_text is None
+    assert result.failure_category == "source_missing"
+    assert result.failure_message
+    assert result.successful_attempt is None
+
+
+def test_unsupported_extension_gives_structured_failure(tmp_path: Path) -> None:
+    source = tmp_path / "scan.pdf"
+    source.write_bytes(b"%PDF-synthetic")
+
+    result = decode_qr_payload_from_image_path(source)
+
+    assert result.payload_text is None
+    assert result.failure_category == "source_type_unsupported"
+
+
+def test_invalid_image_content_gives_structured_failure(tmp_path: Path) -> None:
+    source = tmp_path / "scan.png"
+    source.write_text("not an image", encoding="utf-8")
+
+    result = decode_qr_payload_from_image_path(source)
+
+    assert result.payload_text is None
+    assert result.failure_category == "source_unreadable"
+    assert result.failure_message
+
+
+def test_blank_image_reports_missing_payload_without_workspace_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    before = set(tmp_path.rglob("*"))
+
+    result = decode_qr_payload_from_image(
+        np.full((550, 425, 3), 255, dtype=np.uint8)
+    )
+
+    assert result.payload_text is None
+    assert result.failure_category == "payload_missing"
+    assert result.failure_message
+    assert set(tmp_path.rglob("*")) == before
+
+
+def test_decoder_returns_arbitrary_nonempty_qr_text_without_validation() -> None:
+    payload = "synthetic text that is intentionally not a PDS1 payload"
+
+    result = decode_qr_payload_from_image(_make_qr_image(payload))
+
+    assert result.payload_text == payload
+    assert result.failure_category is None
+    assert result.successful_attempt


### PR DESCRIPTION
## Summary

* Added Quillan’s internal QR image-decoding layer for local response-page images.
* Added `opencv-python` and `numpy<2.5` runtime dependencies for local OpenCV-based QR recognition.
* Implemented bounded QR decode attempts using raw images, grayscale conversion, thresholding, upper-right response-page crops, padding, scaling, and small rotation fallback.
* Added structured decode success/failure results through `QrImageDecodeResult`.
* Added path-based image loading with supported image-extension checks.
* Hardened path-based image loading to use `cv2.IMREAD_COLOR`.
* Hardened candidate-level OpenCV error handling so one bad candidate does not abort the whole decode sequence.
* Added synthetic tests for successful QR decoding, full-page upper-right decoding, RGBA path-loaded PNGs, arbitrary raw QR text, structured failures, candidate-level OpenCV errors, and no workspace mutation.
* Added a changelog entry.

## Scope Notes

This is intentionally decode-only.

This PR does **not** add:

* PDS1 payload validation;
* conversion to `DecodedResponsePage`;
* route planning integration;
* retained-source filing;
* routed-evidence filing;
* routing failure metadata writing;
* CLI commands;
* menu workflows;
* PDF intake;
* folder/batch intake;
* OCR;
* handwriting recognition;
* AI scoring;
* AI feedback;
* automatic grading;
* automatic mastery behavior;
* workspace writes.

PDS1/Quillan response-page validation remains for #127.

PDF intake remains for a later issue.

## Validation

* `git diff --check` passed, with existing LF→CRLF warnings for `CHANGELOG.md` and `pyproject.toml`.
* `python -m pytest` equivalent via venv passed: `874 passed`.
* `python -m ruff check .` passed.
* `python -m mypy .` passed.
* `.\run_tests.ps1` was blocked by local PowerShell execution policy, then passed with one-off `-ExecutionPolicy Bypass`: `874 passed`, Ruff passed, mypy passed, diff check passed.

## Notes

Temporary `.pytest-tmp-*-followup` directories were generated during validation and removed manually before commit.

Closes #126.
