### PR TITLE
Validate Quillan response payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a decoded QR payload validation layer that converts canonical Quillan
+  `doc=response` PDS1 text into `DecodedResponsePage` values, returns structured
+  payload failures for missing, unsupported, malformed, wrong-module, and wrong
+  document-type payloads, and leaves raw QR decoding and routing unchanged.
 - Added an internal, local OpenCV QR image decoder for supported response-page
   image files. It returns structured decode results without routing scans,
   validating PDS1 payloads, writing diagnostics, or mutating workspaces.

--- a/quillan/payload_validation.py
+++ b/quillan/payload_validation.py
@@ -1,0 +1,175 @@
+"""Validate decoded QR payload text as Quillan response-page identity data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pds_core.identifiers import IdentifierValidationError
+from pds_core.pds1 import Pds1PayloadError, parse_pds1_payload
+from pds_core.qr_payload import QrPayloadValidationError
+from pds_core.scan_failure_metadata import is_routing_failure_category
+
+from quillan.route_planning import DecodedResponsePage
+
+
+@dataclass(frozen=True, slots=True)
+class ResponsePayloadValidationFailure:
+    """Structured failure from decoded response-page payload validation."""
+
+    failure_category: str
+    failure_message: str
+    raw_payload: str | None
+    module: str | None = None
+    document_type: str | None = None
+    class_id: str | None = None
+    assignment_id: str | None = None
+    student_id: str | None = None
+    page_number: int | None = None
+    module_details: dict[str, object] = field(default_factory=dict)
+
+
+def decoded_payload_to_response_page(
+    payload_text: str | None,
+) -> DecodedResponsePage | ResponsePayloadValidationFailure:
+    """Validate decoded QR text as a Quillan response-page payload."""
+    if payload_text is None or payload_text.strip() == "":
+        return _failure(
+            "payload_missing",
+            "Decoded QR payload text is missing.",
+            raw_payload=payload_text,
+        )
+
+    if not payload_text.startswith("PDS1"):
+        return _failure(
+            "payload_schema_unsupported",
+            "Decoded QR payload is not a PDS1 payload.",
+            raw_payload=payload_text,
+            reason="payload_schema_unsupported",
+            expected_schema="PDS1",
+        )
+
+    try:
+        payload = parse_pds1_payload(payload_text)
+    except Pds1PayloadError as error:
+        return _failure(
+            _parse_failure_category(error),
+            f"Decoded QR payload is not valid PDS1: {error}",
+            raw_payload=payload_text,
+            reason="payload_parse_failed",
+            parse_error=str(error),
+        )
+
+    document_type = payload.metadata.get("doc")
+    page_number = payload.page
+
+    if payload.module != "quillan":
+        return _failure(
+            "module_unsupported",
+            "Decoded PDS1 payload is not for the Quillan module.",
+            raw_payload=payload_text,
+            module=payload.module,
+            document_type=document_type,
+            class_id=payload.class_id,
+            assignment_id=payload.assignment_id,
+            student_id=payload.student_id,
+            page_number=page_number,
+            reason="module_unsupported",
+            expected_module="quillan",
+            actual_module=payload.module,
+        )
+
+    if document_type is None:
+        return _failure(
+            "payload_invalid",
+            "Decoded Quillan payload is missing doc=response metadata.",
+            raw_payload=payload_text,
+            module=payload.module,
+            document_type=document_type,
+            class_id=payload.class_id,
+            assignment_id=payload.assignment_id,
+            student_id=payload.student_id,
+            page_number=page_number,
+            reason="document_type_missing",
+            field="doc",
+            expected_document_type="response",
+        )
+
+    if document_type != "response":
+        return _failure(
+            "payload_invalid",
+            "Decoded Quillan payload is not a response page.",
+            raw_payload=payload_text,
+            module=payload.module,
+            document_type=document_type,
+            class_id=payload.class_id,
+            assignment_id=payload.assignment_id,
+            student_id=payload.student_id,
+            page_number=page_number,
+            reason="document_type_invalid",
+            field="doc",
+            expected_document_type="response",
+            actual_document_type=document_type,
+        )
+
+    if isinstance(page_number, bool) or not isinstance(page_number, int) or page_number < 1:
+        return _failure(
+            "payload_invalid",
+            "Decoded Quillan response page has an invalid page number.",
+            raw_payload=payload_text,
+            module=payload.module,
+            document_type=document_type,
+            class_id=payload.class_id,
+            assignment_id=payload.assignment_id,
+            student_id=payload.student_id,
+            page_number=page_number,
+            reason="page_number_invalid",
+            field="page",
+        )
+
+    return DecodedResponsePage(
+        module="quillan",
+        document_type="response",
+        class_id=payload.class_id,
+        assignment_id=payload.assignment_id,
+        student_id=payload.student_id,
+        page_number=page_number,
+        raw_payload=payload_text,
+    )
+
+
+def _parse_failure_category(error: Pds1PayloadError) -> str:
+    cause = error.__cause__
+    if isinstance(cause, QrPayloadValidationError) and isinstance(
+        cause.__cause__,
+        IdentifierValidationError,
+    ):
+        return "identifier_invalid"
+    return "payload_invalid"
+
+
+def _failure(
+    category: str,
+    message: str,
+    *,
+    raw_payload: str | None,
+    module: str | None = None,
+    document_type: str | None = None,
+    class_id: str | None = None,
+    assignment_id: str | None = None,
+    student_id: str | None = None,
+    page_number: int | None = None,
+    **module_details: object,
+) -> ResponsePayloadValidationFailure:
+    if not is_routing_failure_category(category):
+        raise ValueError(f"Unsupported routing failure category: {category}")
+    return ResponsePayloadValidationFailure(
+        failure_category=category,
+        failure_message=message,
+        raw_payload=raw_payload,
+        module=module,
+        document_type=document_type,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        page_number=page_number,
+        module_details=dict(module_details),
+    )

--- a/tests/test_response_payload_validation.py
+++ b/tests/test_response_payload_validation.py
@@ -1,0 +1,172 @@
+"""Tests for decoded Quillan response-payload validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quillan.payload_validation import (
+    ResponsePayloadValidationFailure,
+    decoded_payload_to_response_page,
+)
+from quillan.payloads import build_response_payload
+from quillan.route_planning import DecodedResponsePage
+
+
+def test_valid_quillan_response_payload_converts_to_decoded_response_page() -> None:
+    payload = build_response_payload(
+        class_id="english12_p4",
+        assignment_id="personal_narrative",
+        student_id="stu_0001",
+        page=2,
+    )
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, DecodedResponsePage)
+    assert result.module == "quillan"
+    assert result.document_type == "response"
+    assert result.class_id == "english12_p4"
+    assert result.assignment_id == "personal_narrative"
+    assert result.student_id == "stu_0001"
+    assert result.page_number == 2
+    assert result.raw_payload == payload
+
+
+def test_none_payload_gives_payload_missing() -> None:
+    result = decoded_payload_to_response_page(None)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_missing"
+    assert result.raw_payload is None
+
+
+def test_empty_payload_gives_payload_missing() -> None:
+    result = decoded_payload_to_response_page("")
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_missing"
+
+
+def test_whitespace_only_payload_gives_payload_missing() -> None:
+    result = decoded_payload_to_response_page("  \n\t  ")
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_missing"
+
+
+def test_non_pds1_text_gives_payload_schema_unsupported() -> None:
+    payload = "not a pds payload"
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_schema_unsupported"
+    assert result.raw_payload == payload
+
+
+def test_legacy_schema_gives_payload_schema_unsupported() -> None:
+    payload = "OMR1|class=english12|aid=essay|sid=stu_0001|page=1"
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_schema_unsupported"
+
+
+def test_malformed_pds1_gives_payload_invalid() -> None:
+    payload = "PDS1|module=quillan"
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_invalid"
+    assert result.failure_message
+    assert result.raw_payload == payload
+
+
+def test_wrong_module_gives_module_unsupported_with_identity_fields() -> None:
+    payload = "PDS1|module=scoreform|class=english12|aid=essay|sid=stu_0001|page=1"
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "module_unsupported"
+    assert result.module == "scoreform"
+    assert result.class_id == "english12"
+    assert result.assignment_id == "essay"
+    assert result.student_id == "stu_0001"
+    assert result.page_number == 1
+    assert result.module_details["expected_module"] == "quillan"
+
+
+def test_missing_doc_metadata_gives_payload_invalid() -> None:
+    payload = "PDS1|module=quillan|class=english12|aid=essay|sid=stu_0001|page=1"
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_invalid"
+    assert result.module == "quillan"
+    assert result.document_type is None
+    assert result.module_details["reason"] == "document_type_missing"
+
+
+def test_wrong_doc_metadata_gives_payload_invalid() -> None:
+    payload = (
+        "PDS1|module=quillan|class=english12|aid=essay|sid=stu_0001|"
+        "page=1|doc=cover"
+    )
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_invalid"
+    assert result.document_type == "cover"
+    assert result.module_details["reason"] == "document_type_invalid"
+
+
+def test_invalid_page_fails_cleanly() -> None:
+    payload = (
+        "PDS1|module=quillan|class=english12|aid=essay|sid=stu_0001|"
+        "page=nope|doc=response"
+    )
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category == "payload_invalid"
+    assert result.failure_message
+
+
+def test_invalid_identifier_fails_cleanly() -> None:
+    payload = (
+        "PDS1|module=quillan|class=english 12|aid=essay|sid=stu_0001|"
+        "page=1|doc=response"
+    )
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, ResponsePayloadValidationFailure)
+    assert result.failure_category in {"identifier_invalid", "payload_invalid"}
+    assert result.failure_message
+
+
+def test_validation_does_not_route_or_mutate_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    before = set(tmp_path.rglob("*"))
+    payload = build_response_payload(
+        class_id="english12_p4",
+        assignment_id="personal_narrative",
+        student_id="stu_0001",
+        page=1,
+    )
+
+    result = decoded_payload_to_response_page(payload)
+
+    assert isinstance(result, DecodedResponsePage)
+    assert set(tmp_path.rglob("*")) == before


### PR DESCRIPTION
## Summary

* Added `quillan/payload_validation.py` with a focused decoded-payload validation layer.
* Added `ResponsePayloadValidationFailure` for structured validation failures.
* Added `decoded_payload_to_response_page(...)` to convert valid Quillan response-page payloads into `DecodedResponsePage`.
* Used `pds_core.pds1.parse_pds1_payload(...)` as the source of truth for PDS1 parsing.
* Required valid response-page payloads to use:

  * `module=quillan`
  * `doc=response`
  * valid class, assignment, student, and page identity fields.
* Added structured failure handling for:

  * missing payloads;
  * unsupported schemas;
  * malformed PDS1 payloads;
  * wrong modules;
  * missing `doc` metadata;
  * wrong document type;
  * invalid page values;
  * reliable identifier-invalid cases.
* Added focused synthetic tests for valid conversion, failure classification, identity-field preservation, and no workspace mutation.
* Updated the changelog.

## Scope Notes

This PR intentionally adds validation/conversion only.

It does **not** add:

* QR image-decoder behavior changes;
* route planning changes;
* class directory checks;
* roster checks;
* assignment config checks;
* student lookup;
* retained-source filing;
* routed-evidence filing;
* routing failure metadata writing;
* CLI commands;
* menu workflows;
* PDF intake;
* folder/batch intake;
* submission assembly;
* review records;
* export workflows;
* OCR;
* handwriting recognition;
* AI feedback;
* AI scoring;
* automatic grading;
* automatic mastery behavior.

Raw QR image decoding remains raw: arbitrary non-PDS1 QR text can still be decoded by the #126 decoder. This PR adds the separate validation layer that later intake/routing work can call.

## Validation

* `git diff --check` passed.
* `.venv\Scripts\python.exe -m ruff check .` passed.
* `.venv\Scripts\python.exe -m mypy .` passed.
* `.venv\Scripts\python.exe -m pytest --basetemp .pytest-basetemp-issue-127-full` passed: `887 passed`.
* `.\run_tests.ps1` was blocked by local PowerShell execution policy.
* `powershell -ExecutionPolicy Bypass -File .\run_tests.ps1` started, but could not complete because the system `python.exe` launcher cannot run in this session.
* The equivalent venv-based pytest, Ruff, mypy, and diff checks listed above passed.

Closes #127.
