### PR TITLE
Add decode-only scan diagnostic command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a decode-only `quillan decode-scan` diagnostic command that reads one
+  supported local image, reports QR decode and Quillan response-page validation
+  details, distinguishes decode and payload failures with exit codes, and does
+  not route, preserve, or write workspace data.
 - Added a decoded QR payload validation layer that converts canonical Quillan
   `doc=response` PDS1 text into `DecodedResponsePage` values, returns structured
   payload failures for missing, unsupported, malformed, wrong-module, and wrong

--- a/quillan/cli_app/handlers/decoding.py
+++ b/quillan/cli_app/handlers/decoding.py
@@ -1,0 +1,95 @@
+"""Decode-only scan diagnostic command handler."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from quillan.payload_validation import (
+    ResponsePayloadValidationFailure,
+    decoded_payload_to_response_page,
+)
+from quillan.qr_decode import decode_qr_payload_from_image_path
+from quillan.route_planning import DecodedResponsePage
+
+
+def handle_decode_scan(args: argparse.Namespace) -> int:
+    """Decode and validate one scan image without routing or writing data."""
+    source_file: Path = args.source_file
+    hide_payload: bool = args.hide_payload
+
+    print("Quillan scan decode diagnostic")
+    print()
+    print(f"Source: {source_file}")
+
+    try:
+        decode_result = decode_qr_payload_from_image_path(source_file)
+    except Exception as error:
+        print("QR decode: failed")
+        print("Category: processing_error")
+        print(f"Reason: Unexpected QR image decoding failure: {error}")
+        return 1
+
+    if decode_result.payload_text is None:
+        print("QR decode: failed")
+        print(f"Category: {decode_result.failure_category}")
+        print(f"Reason: {decode_result.failure_message}")
+        return 2
+
+    print("QR decode: success")
+    print(f"Decode attempt: {decode_result.successful_attempt}")
+    _print_payload(decode_result.payload_text, hide_payload=hide_payload)
+    print()
+
+    try:
+        validation_result = decoded_payload_to_response_page(
+            decode_result.payload_text
+        )
+    except Exception as error:
+        print("Payload validation: failed")
+        print("Category: payload_invalid")
+        print(f"Reason: Unexpected payload validation failure: {error}")
+        return 1
+
+    if isinstance(validation_result, ResponsePayloadValidationFailure):
+        _print_validation_failure(validation_result)
+        return 3
+
+    _print_response_page(validation_result)
+    return 0
+
+
+def _print_payload(payload_text: str, *, hide_payload: bool) -> None:
+    if hide_payload:
+        print("Payload: hidden")
+        return
+    print(f"Payload: {payload_text}")
+
+
+def _print_response_page(page: DecodedResponsePage) -> None:
+    print("Payload validation: success")
+    print(f"Module: {page.module}")
+    print(f"Document type: {page.document_type}")
+    print(f"Class ID: {page.class_id}")
+    print(f"Assignment ID: {page.assignment_id}")
+    print(f"Student ID: {page.student_id}")
+    print(f"Page number: {page.page_number}")
+
+
+def _print_validation_failure(
+    failure: ResponsePayloadValidationFailure,
+) -> None:
+    print("Payload validation: failed")
+    print(f"Category: {failure.failure_category}")
+    print(f"Reason: {failure.failure_message}")
+    _print_optional_field("Module", failure.module)
+    _print_optional_field("Document type", failure.document_type)
+    _print_optional_field("Class ID", failure.class_id)
+    _print_optional_field("Assignment ID", failure.assignment_id)
+    _print_optional_field("Student ID", failure.student_id)
+    _print_optional_field("Page number", failure.page_number)
+
+
+def _print_optional_field(label: str, value: object | None) -> None:
+    if value is not None:
+        print(f"{label}: {value}")

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -17,6 +17,7 @@ from quillan.cli_app.handlers.exports import (
     handle_export_feedback,
     handle_export_standards_summary,
 )
+from quillan.cli_app.handlers.decoding import handle_decode_scan
 from quillan.cli_app.handlers.review import (
     handle_add_comment,
     handle_add_note,
@@ -93,6 +94,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Already-decoded canonical PDS1 payload text.",
     )
     route_scan_parser.set_defaults(handler=handle_route_scan)
+
+    decode_scan_parser = subparsers.add_parser(
+        "decode-scan",
+        help="Decode a Quillan response-page QR payload without routing.",
+        description=(
+            "Decode one supported local image file, report the raw QR payload "
+            "and Quillan response-page identity, and exit without routing, "
+            "copying, preserving, assembling, or writing workspace data."
+        ),
+    )
+    decode_scan_parser.add_argument(
+        "source_file",
+        type=Path,
+        help="Path to a supported local image scan file.",
+    )
+    decode_scan_parser.add_argument(
+        "--hide-payload",
+        action="store_true",
+        help="Suppress raw QR payload text in diagnostic output.",
+    )
+    decode_scan_parser.set_defaults(handler=handle_decode_scan)
 
     assemble_parser = subparsers.add_parser(
         "assemble-submissions",

--- a/tests/test_cli_decode_scan.py
+++ b/tests/test_cli_decode_scan.py
@@ -1,0 +1,206 @@
+"""Focused tests for the decode-only scan diagnostic CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+import pytest
+import qrcode
+from qrcode.image.pil import PilImage
+
+from quillan.cli import main
+from quillan.payloads import build_response_payload
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+
+
+def _make_qr_image(payload: str, *, box_size: int = 8) -> NDArray[np.uint8]:
+    qr = qrcode.QRCode[PilImage](
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=box_size,
+        border=4,
+        image_factory=PilImage,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    rgb_image = image.get_image().convert("RGB")
+    return cast(
+        NDArray[np.uint8],
+        cv2.cvtColor(np.asarray(rgb_image), cv2.COLOR_RGB2BGR),
+    )
+
+
+def _write_qr_image(path: Path, payload: str) -> None:
+    assert cv2.imwrite(str(path), _make_qr_image(payload))
+
+
+def _valid_payload() -> str:
+    return build_response_payload(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        page=2,
+    )
+
+
+def test_decode_scan_valid_quillan_response_image_prints_identity(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = _valid_payload()
+    source = tmp_path / "synthetic-response.png"
+    _write_qr_image(source, payload)
+
+    result = main(["decode-scan", str(source)])
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert "Quillan scan decode diagnostic" in output
+    assert f"Source: {source}" in output
+    assert "QR decode: success" in output
+    assert "Decode attempt:" in output
+    assert f"Payload: {payload}" in output
+    assert "Payload validation: success" in output
+    assert "Module: quillan" in output
+    assert "Document type: response" in output
+    assert f"Class ID: {CLASS_ID}" in output
+    assert f"Assignment ID: {ASSIGNMENT_ID}" in output
+    assert f"Student ID: {STUDENT_ID}" in output
+    assert "Page number: 2" in output
+
+
+def test_decode_scan_hide_payload_suppresses_raw_payload(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = _valid_payload()
+    source = tmp_path / "synthetic-response.png"
+    _write_qr_image(source, payload)
+
+    result = main(["decode-scan", str(source), "--hide-payload"])
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert payload not in output
+    assert "Payload: hidden" in output
+    assert "Payload validation: success" in output
+    assert f"Class ID: {CLASS_ID}" in output
+    assert f"Student ID: {STUDENT_ID}" in output
+
+
+def test_decode_scan_blank_image_exits_two_and_reports_decode_failure(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "blank.png"
+    blank = np.full((550, 425, 3), 255, dtype=np.uint8)
+    assert cv2.imwrite(str(source), blank)
+
+    result = main(["decode-scan", str(source)])
+
+    output = capsys.readouterr().out
+    assert result == 2
+    assert "QR decode: failed" in output
+    assert "Category: payload_missing" in output
+
+
+def test_decode_scan_unsupported_source_type_exits_two(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "scan.pdf"
+    source.write_bytes(b"%PDF-1.4\nsynthetic\n%%EOF\n")
+
+    result = main(["decode-scan", str(source)])
+
+    output = capsys.readouterr().out
+    assert result == 2
+    assert "QR decode: failed" in output
+    assert "Category: source_type_unsupported" in output
+
+
+def test_decode_scan_non_pds1_qr_exits_three(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = "not a pds payload"
+    source = tmp_path / "non-pds.png"
+    _write_qr_image(source, payload)
+
+    result = main(["decode-scan", str(source)])
+
+    output = capsys.readouterr().out
+    assert result == 3
+    assert "QR decode: success" in output
+    assert f"Payload: {payload}" in output
+    assert "Payload validation: failed" in output
+    assert "Category: payload_schema_unsupported" in output
+
+
+def test_decode_scan_wrong_module_exits_three_and_reports_identity(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = (
+        "PDS1|module=scoreform|class=english12|aid=quiz1|"
+        "sid=stu_0001|page=1"
+    )
+    source = tmp_path / "scoreform.png"
+    _write_qr_image(source, payload)
+
+    result = main(["decode-scan", str(source)])
+
+    output = capsys.readouterr().out
+    assert result == 3
+    assert "Payload validation: failed" in output
+    assert "Category: module_unsupported" in output
+    assert "Module: scoreform" in output
+    assert "Class ID: english12" in output
+    assert "Assignment ID: quiz1" in output
+    assert "Student ID: stu_0001" in output
+    assert "Page number: 1" in output
+
+
+def test_decode_scan_does_not_resolve_or_mutate_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    payload = _valid_payload()
+    source = tmp_path / "synthetic-response.png"
+    _write_qr_image(source, payload)
+    before_paths = {path.relative_to(tmp_path) for path in tmp_path.rglob("*")}
+
+    assert main(["decode-scan", str(source)]) == 0
+    after_success = {path.relative_to(tmp_path) for path in tmp_path.rglob("*")}
+
+    assert main(["decode-scan", str(tmp_path / "missing.png")]) == 2
+    after_failure = {path.relative_to(tmp_path) for path in tmp_path.rglob("*")}
+
+    assert after_success == before_paths
+    assert after_failure == before_paths
+    assert not (tmp_path / "scans").exists()
+    assert not (tmp_path / "classes").exists()
+    assert not list(tmp_path.rglob("*.json"))
+    assert not list(tmp_path.rglob("response_*.png"))
+
+
+def test_decode_scan_help_documents_decode_only_behavior(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["decode-scan", "--help"])
+
+    output = capsys.readouterr().out
+    assert error.value.code == 0
+    assert "decode-scan" in output
+    assert "without routing" in output
+    assert "--hide-payload" in output


### PR DESCRIPTION
## Summary

* Added a top-level `decode-scan` CLI command for decode-only scan diagnostics.
* Wired `quillan decode-scan <source_file>` into the CLI parser.
* Added `quillan/cli_app/handlers/decoding.py` to keep diagnostic command handling separate from routing.
* The command calls the existing QR image decoder from #126.
* The command validates decoded payloads through the response-page validation layer from #127.
* Added human-readable diagnostic output for:

  * successful QR decode and Quillan response-page validation;
  * QR decode failure;
  * payload validation failure.
* Added `--hide-payload` to suppress raw QR payload text while still showing response-page identity fields.
* Added exit code behavior:

  * `0` for successful QR decode and Quillan response-page validation;
  * `1` for unexpected handler/system errors;
  * `2` for QR/image decode failures;
  * `3` for payload validation failures.
* Added focused CLI tests for success, hidden payload output, blank-image decode failure, unsupported source type, non-PDS1 payloads, wrong-module payloads, no workspace mutation, and help text.
* Updated the changelog.

## Scope Notes

This PR is intentionally diagnostic-only.

It does **not** add:

* route planning;
* workspace resolution;
* source scan retention;
* routed evidence filing;
* routing failure metadata writing;
* preservation of failures under `scans/review`;
* batch intake;
* folder intake;
* PDF intake;
* menu integration;
* submission assembly;
* evidence opening;
* review record changes;
* export workflows;
* OCR;
* handwriting recognition;
* AI feedback;
* AI scoring;
* automatic grading;
* automatic mastery behavior.

Existing `route-scan` behavior is unchanged.

## Validation

* `.\.venv\Scripts\python.exe -m pytest --basetemp .pytest-tmp` passed: `895 passed`.
* `.\.venv\Scripts\python.exe -m ruff check .` passed.
* `.\.venv\Scripts\python.exe -m mypy .` passed.
* `git diff --check` passed.
* `powershell -ExecutionPolicy Bypass -File .\run_tests.ps1` passed with the venv on `PATH` and local pytest basetemp.

Closes #128.
