### PR TITLE
Add QR-aware single-image route intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added QR-aware single-image intake to `quillan route-scan` through
+  `--decode-qr`. The command decodes one supported local image, validates the
+  decoded Quillan `doc=response` PDS1 payload, routes through existing
+  route-planning and evidence-filing layers, preserves decode, payload,
+  routing, and filing failures under scan review metadata, and keeps
+  `--payload` mode supported. PDF, folder/batch intake, submission assembly,
+  and automatic review-record creation remain out of scope.
 - Added a decode-only `quillan decode-scan` diagnostic command that reads one
   supported local image, reports QR decode and Quillan response-page validation
   details, distinguishes decode and payload failures with exit codes, and does

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Quillan currently supports:
 - an internal routing failure preservation API that writes shared `pds-core`
   failure metadata under `scans/review/`, including retained-source provenance
   when available, without copying review artifacts;
-- a direct `route-scan` command for already-decoded payloads that orchestrates
-  the existing parser, route planner, evidence filer, and failure review
-  helpers;
+- a direct `route-scan` command for already-decoded payloads or one supported
+  QR-bearing image that orchestrates the existing parser, QR decoder, payload
+  validator, route planner, evidence filer, and failure review helpers;
 - read-only assignment submission status listing, workspace-safe local evidence
   opening, and student-aware selected-evidence opening; and
 - explicit, teacher-controlled lightweight submission review-state updates
@@ -181,6 +181,7 @@ The commands in this workflow are:
 
 ```powershell
 quillan route-scan <source-file> --payload "<PDS1 payload>"
+quillan route-scan <source-image> --decode-qr
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-evidence-path>
@@ -196,8 +197,8 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
 - `route-scan` retains one selected source scan and files routed evidence from
-  an already-decoded payload; it does not decode QR codes or assemble a
-  submission.
+  either an already-decoded payload or one supported QR-bearing image; it does
+  not convert PDFs, batch-ingest folders, or assemble a submission.
 - `assemble-submissions` creates missing manifests from routed filenames, or
   fully regenerates them with `--overwrite`; it does not inspect file contents
   or choose among ambiguous duplicate evidence.
@@ -563,16 +564,25 @@ Route one selected scan using an already-decoded Quillan PDS1 payload:
 quillan route-scan <source-file> --payload "PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page>|doc=response"
 ```
 
+Or route one supported local image by decoding its Quillan response-page QR
+payload:
+
+```powershell
+quillan route-scan <source-image> --decode-qr
+```
+
 Successful routing retains the selected source under
 `scans/source/YYYY-MM-DD/` and files response evidence under the assignment
-`scans/` directory. Payload, planning, and filing failures are preserved under
-`scans/review/` when possible. Exit code `0` means the input was routed or
-safely preserved for review; exit code `1` means it could not be handled
-safely.
+`scans/` directory. Decode, payload, planning, and filing failures are
+preserved under `scans/review/` when possible. Exit code `0` means the input
+was routed or safely preserved for review; exit code `1` means it could not be
+handled safely.
 
-This direct developer/teacher primitive requires already-decoded payload text.
-It does not extract QR codes, split PDFs, run OCR, score, tag, generate
-feedback, or create reports.
+This direct developer/teacher primitive is single-scan only. QR-aware intake
+supports `.png`, `.jpg`, `.jpeg`, `.tif`, and `.tiff` images. It does not
+convert PDFs, batch-ingest folders, split multi-page scans, run OCR, score,
+tag, generate feedback, assemble submissions, create review records, or create
+reports.
 
 Assemble all student manifests discoverable from routed filenames in an
 assignment's `scans/` directory:
@@ -609,6 +619,7 @@ quillan --help
 quillan validate-standards <standards-profile.json>
 quillan validate-assignment <assignment.json>
 quillan route-scan <source-file> --payload "<PDS1|...>"
+quillan route-scan <source-image> --decode-qr
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-path>

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -49,6 +49,7 @@ quillan --help
 quillan validate-standards <path>
 quillan validate-assignment <path>
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
+quillan route-scan <source-image> --decode-qr
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-evidence-path>
@@ -376,22 +377,28 @@ workspace layouts. The active layout is documented in
 Commands that write files document their destination, overwrite policy, and
 handled-failure behavior in their command sections and help output.
 
-## Decoded-Payload Scan Routing
+## Single-Scan Routing
 
 ```powershell
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
+quillan route-scan <source-image> --decode-qr
 ```
 
-This command routes one selected source file using caller-supplied canonical
-PDS1 text. On success it retains the source under
-`scans/source/YYYY-MM-DD/` and files routed evidence under the target
-assignment's `scans/` directory. Payload, planning, or filing failures are
-preserved under `scans/review/` when they can be handled safely.
+This command routes one selected source file using exactly one payload source:
+caller-supplied canonical PDS1 text through `--payload`, or one decoded QR
+payload from a supported local image through `--decode-qr`. Supported QR image
+extensions are `.png`, `.jpg`, `.jpeg`, `.tif`, and `.tiff`.
 
-The command does not inspect PDFs or images for QR codes, decode QR codes,
-split multi-page PDFs, batch-ingest a folder, run OCR, or identify a student
-from raw scan content. Exit `0` means the file was routed or safely preserved
-for review; exit `1` means it could not be handled safely.
+On success it retains the source under `scans/source/YYYY-MM-DD/` and files
+routed evidence under the target assignment's `scans/` directory. Decode,
+payload, planning, or filing failures are preserved under `scans/review/` when
+they can be handled safely.
+
+The command does not convert PDFs, split multi-page PDFs, batch-ingest a
+folder, assemble submissions, create review records, run OCR, or identify a
+student from raw scan content without a valid payload. Exit `0` means the file
+was routed or safely preserved for review; exit `1` means it could not be
+handled safely.
 
 ## Submission Assembly and Status
 

--- a/quillan/cli_app/handlers/routing.py
+++ b/quillan/cli_app/handlers/routing.py
@@ -18,12 +18,21 @@ from quillan.evidence_filing import (
     EvidenceFilingError,
     file_routed_response_evidence,
 )
+from quillan.payload_validation import (
+    ResponsePayloadValidationFailure,
+    decoded_payload_to_response_page,
+)
+from quillan.qr_decode import (
+    QrImageDecodeResult,
+    decode_qr_payload_from_image_path,
+)
 from quillan.route_planning import (
     DecodedResponsePage,
     RouteFailure,
     plan_decoded_response_page_route,
 )
 from quillan.routing_review import (
+    RoutingReviewRecord,
     RoutingReviewError,
     preserve_evidence_filing_error_for_review,
     preserve_route_failure_for_review,
@@ -32,9 +41,8 @@ from quillan.routing_review import (
 
 
 def handle_route_scan(args: argparse.Namespace) -> int:
-    """Route one source scan from caller-supplied decoded PDS1 text."""
+    """Route one source scan from caller-supplied payload text or image QR."""
     source_file: Path = args.source_file
-    payload_text: str = args.payload
     intake_timestamp = datetime.now(timezone.utc)
     try:
         workspace_root = resolve_workspace_root()
@@ -45,9 +53,40 @@ def handle_route_scan(args: argparse.Namespace) -> int:
         print(f"Error: unexpected workspace resolution failure: {error}")
         return 1
 
-    if not _validate_source_file(source_file):
-        return 1
+    if args.decode_qr:
+        decoded_result = _decoded_page_from_source_qr(
+            workspace_root,
+            source_file=source_file,
+            created_at=intake_timestamp,
+        )
+    else:
+        if not _validate_source_file(source_file):
+            return 1
+        decoded_result = _decoded_page_from_payload_text(
+            workspace_root,
+            source_file=source_file,
+            payload_text=args.payload,
+            created_at=intake_timestamp,
+        )
 
+    if isinstance(decoded_result, int):
+        return decoded_result
+    return _route_decoded_page(
+        workspace_root,
+        source_file=source_file,
+        decoded_page=decoded_result,
+        created_at=intake_timestamp,
+    )
+
+
+def _decoded_page_from_payload_text(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    payload_text: str,
+    created_at: datetime,
+) -> DecodedResponsePage | int:
+    """Convert caller-supplied PDS1 text into a decoded response page."""
     try:
         payload = parse_pds1_payload(payload_text)
     except Pds1PayloadError as error:
@@ -56,7 +95,7 @@ def handle_route_scan(args: argparse.Namespace) -> int:
             source_file=source_file,
             payload_text=payload_text,
             error=error,
-            created_at=intake_timestamp,
+            created_at=created_at,
         )
     except Exception as error:
         print(f"Error: unexpected PDS1 payload parsing failure: {error}")
@@ -71,7 +110,55 @@ def handle_route_scan(args: argparse.Namespace) -> int:
         page_number=payload.page,
         raw_payload=payload_text,
     )
+    return decoded_page
 
+
+def _decoded_page_from_source_qr(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    created_at: datetime,
+) -> DecodedResponsePage | int:
+    """Decode and validate a Quillan response-page QR from one image."""
+    try:
+        decode_result = decode_qr_payload_from_image_path(source_file)
+    except Exception as error:
+        decode_result = QrImageDecodeResult(
+            payload_text=None,
+            failure_category="processing_error",
+            failure_message=f"Unexpected QR decode failure: {error}",
+        )
+
+    if decode_result.payload_text is None:
+        return _preserve_decode_failure(
+            workspace_root,
+            source_file=source_file,
+            decode_result=decode_result,
+            created_at=created_at,
+        )
+
+    validation_result = decoded_payload_to_response_page(
+        decode_result.payload_text
+    )
+    if isinstance(validation_result, ResponsePayloadValidationFailure):
+        return _preserve_payload_validation_failure(
+            workspace_root,
+            source_file=source_file,
+            failure=validation_result,
+            created_at=created_at,
+        )
+
+    return validation_result
+
+
+def _route_decoded_page(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    decoded_page: DecodedResponsePage,
+    created_at: datetime,
+) -> int:
+    """Plan and file one already-decoded Quillan response page."""
     try:
         route_result = plan_decoded_response_page_route(
             workspace_root,
@@ -82,7 +169,7 @@ def handle_route_scan(args: argparse.Namespace) -> int:
                 workspace_root,
                 route_failure=route_result,
                 source_filename=source_file.name,
-                created_at=intake_timestamp,
+                created_at=created_at,
             )
             print_route_failure_review(route_result, review_record)
             return 0
@@ -92,7 +179,7 @@ def handle_route_scan(args: argparse.Namespace) -> int:
                 workspace_root,
                 route_plan=route_result,
                 source_file_path=source_file,
-                intake_timestamp=intake_timestamp,
+                intake_timestamp=created_at,
             )
         except EvidenceFilingError as error:
             review_record = preserve_evidence_filing_error_for_review(
@@ -100,7 +187,7 @@ def handle_route_scan(args: argparse.Namespace) -> int:
                 error=error,
                 route_plan=route_result,
                 source_filename=source_file.name,
-                created_at=intake_timestamp,
+                created_at=created_at,
             )
             print_evidence_filing_review(error, review_record)
             return 0
@@ -173,3 +260,108 @@ def _preserve_payload_parse_failure(
     print("Category: payload_invalid")
     print(f"Review record: {review_record.failure_metadata_relative_path}")
     return 0
+
+
+def _preserve_decode_failure(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    decode_result: QrImageDecodeResult,
+    created_at: datetime,
+) -> int:
+    """Preserve source/QR decode failure context for teacher review."""
+    category = decode_result.failure_category or "processing_error"
+    message = decode_result.failure_message or "QR decoding failed."
+    try:
+        review_record = preserve_routing_failure_for_review(
+            workspace_root,
+            failure_category=category,
+            failure_message=message,
+            source_filename=source_file.name,
+            module=None,
+            detected_payload=None,
+            module_details={
+                "failure_origin": "qr_decode",
+                "decode_attempt": decode_result.successful_attempt,
+            },
+            created_at=created_at,
+        )
+    except RoutingReviewError as review_error:
+        print(
+            "Error: QR decode failure could not be preserved for review: "
+            f"{review_error}"
+        )
+        return 1
+    except Exception as unexpected_error:
+        print(
+            "Error: unexpected failure while preserving QR decode failure: "
+            f"{unexpected_error}"
+        )
+        return 1
+
+    _print_preserved_intake_failure(
+        reason=message,
+        category=category,
+        review_record=review_record,
+    )
+    return 0
+
+
+def _preserve_payload_validation_failure(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    failure: ResponsePayloadValidationFailure,
+    created_at: datetime,
+) -> int:
+    """Preserve decoded-payload validation failure context for review."""
+    module_details: dict[str, object] = {
+        "failure_origin": "payload_validation",
+    }
+    module_details.update(failure.module_details)
+    try:
+        review_record = preserve_routing_failure_for_review(
+            workspace_root,
+            failure_category=failure.failure_category,
+            failure_message=failure.failure_message,
+            source_filename=source_file.name,
+            module=failure.module,
+            detected_payload=failure.raw_payload,
+            payload_page_number=failure.page_number,
+            class_id=failure.class_id,
+            assignment_id=failure.assignment_id,
+            student_id=failure.student_id,
+            module_details=module_details,
+            created_at=created_at,
+        )
+    except RoutingReviewError as review_error:
+        print(
+            "Error: decoded payload failure could not be preserved for review: "
+            f"{review_error}"
+        )
+        return 1
+    except Exception as unexpected_error:
+        print(
+            "Error: unexpected failure while preserving decoded payload failure: "
+            f"{unexpected_error}"
+        )
+        return 1
+
+    _print_preserved_intake_failure(
+        reason=failure.failure_message,
+        category=failure.failure_category,
+        review_record=review_record,
+    )
+    return 0
+
+
+def _print_preserved_intake_failure(
+    *,
+    reason: str,
+    category: str,
+    review_record: RoutingReviewRecord,
+) -> None:
+    print("Quillan response page was not routed; preserved for review.")
+    print(f"Reason: {reason}")
+    print(f"Category: {category}")
+    print(f"Review record: {review_record.failure_metadata_relative_path}")

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -76,9 +76,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     route_scan_parser = subparsers.add_parser(
         "route-scan",
-        help="Route a scan using an already-decoded Quillan PDS1 payload.",
+        help="Route one Quillan response scan from payload text or image QR.",
         description=(
-            "Route a scan file using an already-decoded Quillan PDS1 payload. "
+            "Route one scan file using either an already-decoded Quillan PDS1 "
+            "payload or a QR payload decoded from a supported local image. "
             "Exit 0 means the file was routed or safely preserved for review; "
             "exit 1 means the input could not be handled safely."
         ),
@@ -88,10 +89,17 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Path to the selected source scan file.",
     )
-    route_scan_parser.add_argument(
+    payload_group = route_scan_parser.add_mutually_exclusive_group(
+        required=True
+    )
+    payload_group.add_argument(
         "--payload",
-        required=True,
         help="Already-decoded canonical PDS1 payload text.",
+    )
+    payload_group.add_argument(
+        "--decode-qr",
+        action="store_true",
+        help="Decode the Quillan response-page QR payload from the source image.",
     )
     route_scan_parser.set_defaults(handler=handle_route_scan)
 

--- a/tests/test_cli_route_scan_qr.py
+++ b/tests/test_cli_route_scan_qr.py
@@ -1,0 +1,369 @@
+"""Focused tests for QR-aware single-image scan routing."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import cast
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+import pytest
+import qrcode
+from qrcode.image.pil import PilImage
+
+from quillan.cli import main
+import quillan.cli_app.handlers.routing as cli_routing
+from quillan.evidence_filing import EvidenceFilingError
+from quillan.payloads import build_response_payload
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+UNKNOWN_ASSIGNMENT_ID = "essay_unknown_synthetic"
+UNKNOWN_STUDENT_ID = "stu_9999"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr(cli_routing, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _write_workspace(
+    root: Path,
+    *,
+    assignment_id: str = ASSIGNMENT_ID,
+) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / assignment_id
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": assignment_id,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment),
+        encoding="utf-8",
+    )
+
+
+def _make_qr_image(payload: str, *, box_size: int = 8) -> NDArray[np.uint8]:
+    qr = qrcode.QRCode[PilImage](
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=box_size,
+        border=4,
+        image_factory=PilImage,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    rgb_image = image.get_image().convert("RGB")
+    return cast(
+        NDArray[np.uint8],
+        cv2.cvtColor(np.asarray(rgb_image), cv2.COLOR_RGB2BGR),
+    )
+
+
+def _write_qr_image(path: Path, payload: str) -> None:
+    assert cv2.imwrite(str(path), _make_qr_image(payload))
+
+
+def _valid_payload(
+    *,
+    assignment_id: str = ASSIGNMENT_ID,
+    student_id: str = STUDENT_ID,
+) -> str:
+    return build_response_payload(
+        class_id=CLASS_ID,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        page=2,
+    )
+
+
+def _review_metadata(workspace: Path) -> dict[str, object]:
+    records = list((workspace / "scans" / "review").glob("*.json"))
+    assert len(records) == 1
+    loaded = json.loads(records[0].read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_route_scan_decode_qr_successfully_routes_single_image(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = _valid_payload()
+    source = tmp_path / "synthetic-response.png"
+    _write_qr_image(source, payload)
+    original_bytes = source.read_bytes()
+
+    result = main(["route-scan", str(source), "--decode-qr"])
+
+    output = capsys.readouterr().out
+    retained_files = list((workspace / "scans" / "source").rglob("*.png"))
+    routed_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_stu_0001_pg_002.png"
+    )
+    assert result == 0
+    assert len(retained_files) == 1
+    assert retained_files[0].read_bytes() == original_bytes
+    assert routed_path.read_bytes() == original_bytes
+    assert "Routed Quillan response page." in output
+    assert "Routed evidence: classes/" in output
+    assert not (workspace / "scans" / "review").exists()
+    assert not list(workspace.rglob("submission.json"))
+    assert not list(workspace.rglob("review.json"))
+
+
+def test_route_scan_payload_mode_still_works_without_qr_decoding(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "teacher-scan.png"
+    source.write_bytes(b"synthetic routed image bytes")
+
+    def fail_decode(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("payload mode should not decode QR images")
+
+    monkeypatch.setattr(cli_routing, "decode_qr_payload_from_image_path", fail_decode)
+
+    assert main(["route-scan", str(source), "--payload", _valid_payload()]) == 0
+    assert list(
+        (
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "scans"
+        ).glob("response_*.png")
+    )
+
+
+def test_route_scan_requires_payload_or_decode_qr(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "synthetic-response.png"
+    source.write_bytes(b"synthetic")
+
+    with pytest.raises(SystemExit) as error:
+        main(["route-scan", str(source)])
+
+    assert error.value.code == 2
+
+
+def test_route_scan_rejects_payload_and_decode_qr_together(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "synthetic-response.png"
+    source.write_bytes(b"synthetic")
+
+    with pytest.raises(SystemExit) as error:
+        main(["route-scan", str(source), "--payload", "PDS1", "--decode-qr"])
+
+    assert error.value.code == 2
+
+
+def test_route_scan_decode_qr_blank_image_preserves_decode_failure(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "blank.png"
+    blank = np.full((550, 425, 3), 255, dtype=np.uint8)
+    assert cv2.imwrite(str(source), blank)
+
+    result = main(["route-scan", str(source), "--decode-qr"])
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata(workspace)
+    assert result == 0
+    assert metadata["failure_category"] == "payload_missing"
+    assert metadata["detected_payload"] is None
+    assert metadata["module"] is None
+    assert metadata["module_details"] == {
+        "failure_origin": "qr_decode",
+        "decode_attempt": None,
+    }
+    assert not list(workspace.rglob("response_*.png"))
+    assert "preserved for review" in output
+    assert "Category: payload_missing" in output
+
+
+def test_route_scan_decode_qr_unsupported_source_type_preserves_failure(
+    workspace: Path,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "scan.pdf"
+    source.write_bytes(b"%PDF-1.4\nsynthetic\n%%EOF\n")
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata(workspace)
+    assert metadata["failure_category"] == "source_type_unsupported"
+    assert not list(workspace.rglob("response_*.pdf"))
+
+
+def test_route_scan_decode_qr_non_pds_payload_preserves_validation_failure(
+    workspace: Path,
+    tmp_path: Path,
+) -> None:
+    payload = "not a pds payload"
+    source = tmp_path / "non-pds.png"
+    _write_qr_image(source, payload)
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata(workspace)
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert metadata["failure_category"] == "payload_schema_unsupported"
+    assert metadata["detected_payload"] == payload
+    assert module_details["failure_origin"] == "payload_validation"
+    assert not list(workspace.rglob("response_*.png"))
+
+
+def test_route_scan_decode_qr_wrong_module_preserves_validation_failure(
+    workspace: Path,
+    tmp_path: Path,
+) -> None:
+    payload = (
+        "PDS1|module=scoreform|class=english12|aid=quiz1|"
+        "sid=stu_0001|page=1"
+    )
+    source = tmp_path / "scoreform.png"
+    _write_qr_image(source, payload)
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata(workspace)
+    assert metadata["failure_category"] == "module_unsupported"
+    assert metadata["detected_payload"] == payload
+    assert metadata["module"] == "scoreform"
+    assert not list(workspace.rglob("response_*.png"))
+
+
+def test_route_scan_decode_qr_unknown_student_preserves_route_failure(
+    workspace: Path,
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload(student_id=UNKNOWN_STUDENT_ID)
+    source = tmp_path / "unknown-student.png"
+    _write_qr_image(source, payload)
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata(workspace)
+    assert metadata["failure_category"] == "student_unknown"
+    assert metadata["detected_payload"] == payload
+    assert metadata["student_id"] == UNKNOWN_STUDENT_ID
+    assert not list(workspace.rglob("response_*.png"))
+
+
+def test_route_scan_decode_qr_unknown_assignment_preserves_route_failure(
+    workspace: Path,
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload(assignment_id=UNKNOWN_ASSIGNMENT_ID)
+    source = tmp_path / "unknown-assignment.png"
+    _write_qr_image(source, payload)
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata(workspace)
+    assert metadata["failure_category"] == "assignment_unknown"
+    assert metadata["detected_payload"] == payload
+    assert metadata["assignment_id"] == UNKNOWN_ASSIGNMENT_ID
+    assert not list(workspace.rglob("response_*.png"))
+
+
+def test_route_scan_decode_qr_evidence_filing_failure_is_preserved(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "synthetic-response.png"
+    _write_qr_image(source, _valid_payload())
+
+    def fail_filing(*_args: object, **_kwargs: object) -> None:
+        raise EvidenceFilingError("Synthetic disk write failure.")
+
+    monkeypatch.setattr(
+        cli_routing,
+        "file_routed_response_evidence",
+        fail_filing,
+    )
+
+    result = main(["route-scan", str(source), "--decode-qr"])
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata(workspace)
+    assert result == 0
+    assert metadata["failure_category"] == "evidence_write_failed"
+    assert metadata["class_id"] == CLASS_ID
+    assert metadata["assignment_id"] == ASSIGNMENT_ID
+    assert metadata["student_id"] == STUDENT_ID
+    assert "could not be filed; preserved for review" in output
+
+
+def test_route_scan_decode_qr_pdf_remains_unsupported(
+    workspace: Path,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "synthetic-response.pdf"
+    source.write_bytes(b"%PDF-1.4\nsynthetic response scan\n%%EOF\n")
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata(workspace)
+    assert metadata["failure_category"] == "source_type_unsupported"
+    assert not list(workspace.rglob("response_*.pdf"))


### PR DESCRIPTION
## Summary

* Added QR-aware single-image route intake to `route-scan`.
* Updated `route-scan` so callers must provide exactly one of:

  * `--payload "<already-decoded PDS1 payload>"`
  * `--decode-qr`
* Added QR mode that:

  * decodes one supported local image through the existing QR image decoder;
  * validates the decoded payload through the existing Quillan response-page validation layer;
  * converges with payload mode for route planning and evidence filing.
* Preserved existing `route-scan --payload` behavior.
* Added preservation of QR decode failures through routing-review metadata.
* Added preservation of decoded-payload validation failures through routing-review metadata.
* Continued preserving route-planning failures and evidence-filing failures through the existing review metadata path.
* Added focused QR route intake tests for:

  * successful QR-aware routing;
  * payload-mode regression;
  * parser exclusivity;
  * blank-image decode failure;
  * unsupported source type;
  * non-PDS1 payload validation failure;
  * wrong-module validation failure;
  * unknown student route failure;
  * unknown assignment route failure;
  * evidence-filing failure;
  * PDF unsupported behavior.
* Updated CLI documentation and changelog to document single-image QR-aware routing.

## CLI Shape

`route-scan` now supports:

```powershell
quillan route-scan <source_file> --payload "<already-decoded PDS1 payload>"
```

and:

```powershell
quillan route-scan <source_file> --decode-qr
```

The parser rejects calls that provide neither option or both options.

## Scope Notes

This PR adds single-image QR-aware routing only.

It does **not** add:

* PDF intake;
* folder/batch intake;
* batch summaries;
* menu scan intake;
* automatic submission assembly;
* automatic review record creation;
* feedback export changes;
* OCR;
* handwriting recognition;
* AI feedback;
* AI scoring;
* automatic grading;
* automatic mastery behavior;
* changes to `pds-core`;
* changes to `pds-scoreform`.

`decode-scan` remains diagnostic-only and non-mutating.

Successful QR-aware route intake files routed evidence and retained source scans through the existing evidence-filing layer, but it does not create `submission.json` or `review.json`.

## Failure Preservation

QR-aware mode preserves handled intake failures for review:

* QR/source decode failures preserve review metadata with the decoder failure category.
* Payload validation failures preserve review metadata with the validation failure category and detected payload when available.
* Route-planning failures continue to preserve review metadata through the existing route failure path.
* Evidence-filing failures continue to preserve review metadata through the existing evidence filing failure path.

Handled preservation outcomes return exit `0`, consistent with existing `route-scan` behavior.

Exit `1` remains reserved for failures that cannot be handled or preserved safely.

## Validation

* `.\.venv\Scripts\python.exe -m pytest --basetemp .\.pytest-tmp` passed: `907 passed`.
* `.\.venv\Scripts\python.exe -m ruff check .` passed.
* `.\.venv\Scripts\python.exe -m mypy .` passed.
* `git diff --check` passed, with only CRLF normalization warnings.
* `.\run_tests.ps1` was blocked by PowerShell execution policy.
* Bypassing policy reached the script, but its hard-coded bare `python` failed in this shell with “A specified logon session does not exist.”
* The equivalent venv-based validation commands above passed.

Closes #129.
