### PR TITLE
Harden routing failure metadata preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ planning and do not by themselves represent releases.
 
 ### Changed
 
+- Hardened QR-aware `route-scan` failure preservation so decode, payload
+  validation, payload parse, route-planning, and evidence-filing failures use
+  consistent routing-review metadata, stable `failure_origin` details, shared
+  failure categories, schema validation coverage, and no invented identity
+  fields before payload identity is available.
 - Validated the repository documentation against the completed v0.7.0
   milestone implementation. The docs now distinguish direct CLI/API review
   and export support from the current teacher-facing menu, use the canonical

--- a/quillan/cli_app/handlers/routing.py
+++ b/quillan/cli_app/handlers/routing.py
@@ -34,7 +34,9 @@ from quillan.route_planning import (
 from quillan.routing_review import (
     RoutingReviewRecord,
     RoutingReviewError,
+    preserve_decode_failure_for_review,
     preserve_evidence_filing_error_for_review,
+    preserve_payload_validation_failure_for_review,
     preserve_route_failure_for_review,
     preserve_routing_failure_for_review,
 )
@@ -234,7 +236,7 @@ def _preserve_payload_parse_failure(
             failure_category="payload_invalid",
             failure_message=str(error),
             source_filename=source_file.name,
-            module="quillan",
+            module=None,
             detected_payload=payload_text,
             module_details={
                 "failure_origin": "payload_parse",
@@ -270,20 +272,11 @@ def _preserve_decode_failure(
     created_at: datetime,
 ) -> int:
     """Preserve source/QR decode failure context for teacher review."""
-    category = decode_result.failure_category or "processing_error"
-    message = decode_result.failure_message or "QR decoding failed."
     try:
-        review_record = preserve_routing_failure_for_review(
+        review_record = preserve_decode_failure_for_review(
             workspace_root,
-            failure_category=category,
-            failure_message=message,
+            decode_result=decode_result,
             source_filename=source_file.name,
-            module=None,
-            detected_payload=None,
-            module_details={
-                "failure_origin": "qr_decode",
-                "decode_attempt": decode_result.successful_attempt,
-            },
             created_at=created_at,
         )
     except RoutingReviewError as review_error:
@@ -300,8 +293,8 @@ def _preserve_decode_failure(
         return 1
 
     _print_preserved_intake_failure(
-        reason=message,
-        category=category,
+        reason=review_record.failure_message,
+        category=review_record.failure_category,
         review_record=review_record,
     )
     return 0
@@ -315,23 +308,11 @@ def _preserve_payload_validation_failure(
     created_at: datetime,
 ) -> int:
     """Preserve decoded-payload validation failure context for review."""
-    module_details: dict[str, object] = {
-        "failure_origin": "payload_validation",
-    }
-    module_details.update(failure.module_details)
     try:
-        review_record = preserve_routing_failure_for_review(
+        review_record = preserve_payload_validation_failure_for_review(
             workspace_root,
-            failure_category=failure.failure_category,
-            failure_message=failure.failure_message,
             source_filename=source_file.name,
-            module=failure.module,
-            detected_payload=failure.raw_payload,
-            payload_page_number=failure.page_number,
-            class_id=failure.class_id,
-            assignment_id=failure.assignment_id,
-            student_id=failure.student_id,
-            module_details=module_details,
+            failure=failure,
             created_at=created_at,
         )
     except RoutingReviewError as review_error:

--- a/quillan/routing_review.py
+++ b/quillan/routing_review.py
@@ -20,6 +20,8 @@ from quillan.evidence_filing import (
     EvidenceFilingError,
     RetainedSourceScan,
 )
+from quillan.payload_validation import ResponsePayloadValidationFailure
+from quillan.qr_decode import QrImageDecodeResult
 from quillan.route_planning import RouteFailure, RoutePlan
 
 _FAILURE_ID_DIGEST_LENGTH = 12
@@ -160,6 +162,9 @@ def preserve_route_failure_for_review(
     if not isinstance(route_failure, RouteFailure):
         raise RoutingReviewError("route_failure must be a RouteFailure.")
 
+    module_details: dict[str, object] = {"failure_origin": "route_planning"}
+    module_details.update(route_failure.module_details)
+
     return preserve_routing_failure_for_review(
         workspace_root,
         failure_category=route_failure.failure_category,
@@ -184,7 +189,73 @@ def preserve_route_failure_for_review(
         class_id=route_failure.class_id,
         assignment_id=route_failure.assignment_id,
         student_id=route_failure.student_id,
-        module_details=route_failure.module_details,
+        module_details=module_details,
+        created_at=created_at,
+    )
+
+
+def preserve_decode_failure_for_review(
+    workspace_root: str | Path,
+    *,
+    decode_result: QrImageDecodeResult,
+    source_filename: str,
+    created_at: datetime | None = None,
+) -> RoutingReviewRecord:
+    """Preserve source/QR decode failure context without invented identity."""
+    if not isinstance(decode_result, QrImageDecodeResult):
+        raise RoutingReviewError("decode_result must be a QrImageDecodeResult.")
+
+    category = decode_result.failure_category or "processing_error"
+    message = decode_result.failure_message or "QR decoding failed."
+    return preserve_routing_failure_for_review(
+        workspace_root,
+        failure_category=category,
+        failure_message=message,
+        source_filename=source_filename,
+        module=None,
+        detected_payload=None,
+        payload_page_number=None,
+        class_id=None,
+        assignment_id=None,
+        student_id=None,
+        module_details={
+            "failure_origin": "qr_decode",
+            "decode_attempt": decode_result.successful_attempt,
+        },
+        created_at=created_at,
+    )
+
+
+def preserve_payload_validation_failure_for_review(
+    workspace_root: str | Path,
+    *,
+    failure: ResponsePayloadValidationFailure,
+    source_filename: str,
+    created_at: datetime | None = None,
+) -> RoutingReviewRecord:
+    """Preserve decoded-payload validation failure context for review."""
+    if not isinstance(failure, ResponsePayloadValidationFailure):
+        raise RoutingReviewError(
+            "failure must be a ResponsePayloadValidationFailure."
+        )
+
+    module_details: dict[str, object] = {
+        "failure_origin": "payload_validation",
+    }
+    module_details.update(failure.module_details)
+
+    return preserve_routing_failure_for_review(
+        workspace_root,
+        failure_category=failure.failure_category,
+        failure_message=failure.failure_message,
+        source_filename=source_filename,
+        module=failure.module,
+        detected_payload=failure.raw_payload,
+        payload_page_number=failure.page_number,
+        class_id=failure.class_id,
+        assignment_id=failure.assignment_id,
+        student_id=failure.student_id,
+        module_details=module_details,
         created_at=created_at,
     )
 

--- a/tests/test_cli_route_scan.py
+++ b/tests/test_cli_route_scan.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 import pytest
+from pds_core.scan_failure_metadata import validate_routing_failure_metadata
 
 from quillan.cli import main
 import quillan.cli_app.handlers.routing as cli_routing
@@ -85,6 +86,7 @@ def _review_metadata(workspace: Path) -> dict[str, object]:
     assert len(records) == 1
     loaded = json.loads(records[0].read_text(encoding="utf-8"))
     assert isinstance(loaded, dict)
+    validate_routing_failure_metadata(loaded)
     return loaded
 
 
@@ -162,6 +164,10 @@ def test_route_scan_preserves_route_planning_failure(
     assert result == 0
     assert metadata["failure_category"] == "class_unknown"
     assert metadata["detected_payload"] == payload
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "route_planning"
+    assert module_details["reason"] == "class_unknown"
     assert not list(workspace.rglob("response_*.pdf"))
     assert not list(workspace.rglob("submissions"))
     assert "preserved for review" in output
@@ -184,6 +190,8 @@ def test_route_scan_preserves_payload_parse_failure(
     assert result == 0
     assert metadata["failure_category"] == "payload_invalid"
     assert metadata["detected_payload"] == malformed_payload
+    assert metadata["module"] is None
+    assert metadata["payload_page_number"] is None
     assert metadata["class_id"] is None
     assert metadata["assignment_id"] is None
     assert metadata["student_id"] is None
@@ -280,9 +288,14 @@ def test_route_scan_preserves_evidence_filing_error(
     metadata = _review_metadata(workspace)
     assert result == 0
     assert metadata["failure_category"] == "evidence_write_failed"
+    assert metadata["module"] == "quillan"
     assert metadata["class_id"] == CLASS_ID
     assert metadata["assignment_id"] == ASSIGNMENT_ID
     assert metadata["student_id"] == STUDENT_ID
+    assert metadata["payload_page_number"] == 2
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "evidence_filing"
     assert "could not be filed; preserved for review" in output
 
 

--- a/tests/test_cli_route_scan_qr.py
+++ b/tests/test_cli_route_scan_qr.py
@@ -13,6 +13,7 @@ from numpy.typing import NDArray
 import pytest
 import qrcode
 from qrcode.image.pil import PilImage
+from pds_core.scan_failure_metadata import validate_routing_failure_metadata
 
 from quillan.cli import main
 import quillan.cli_app.handlers.routing as cli_routing
@@ -125,7 +126,16 @@ def _review_metadata(workspace: Path) -> dict[str, object]:
     assert len(records) == 1
     loaded = json.loads(records[0].read_text(encoding="utf-8"))
     assert isinstance(loaded, dict)
+    validate_routing_failure_metadata(loaded)
     return loaded
+
+
+def _assert_no_identity(metadata: dict[str, object]) -> None:
+    assert metadata["module"] is None
+    assert metadata["payload_page_number"] is None
+    assert metadata["class_id"] is None
+    assert metadata["assignment_id"] is None
+    assert metadata["student_id"] is None
 
 
 def test_route_scan_decode_qr_successfully_routes_single_image(
@@ -227,8 +237,10 @@ def test_route_scan_decode_qr_blank_image_preserves_decode_failure(
     metadata = _review_metadata(workspace)
     assert result == 0
     assert metadata["failure_category"] == "payload_missing"
+    assert metadata["failure_message"]
+    assert metadata["source_filename"] == source.name
     assert metadata["detected_payload"] is None
-    assert metadata["module"] is None
+    _assert_no_identity(metadata)
     assert metadata["module_details"] == {
         "failure_origin": "qr_decode",
         "decode_attempt": None,
@@ -249,6 +261,12 @@ def test_route_scan_decode_qr_unsupported_source_type_preserves_failure(
 
     metadata = _review_metadata(workspace)
     assert metadata["failure_category"] == "source_type_unsupported"
+    assert metadata["source_filename"] == source.name
+    assert metadata["detected_payload"] is None
+    _assert_no_identity(metadata)
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "qr_decode"
     assert not list(workspace.rglob("response_*.pdf"))
 
 
@@ -267,6 +285,7 @@ def test_route_scan_decode_qr_non_pds_payload_preserves_validation_failure(
     assert isinstance(module_details, dict)
     assert metadata["failure_category"] == "payload_schema_unsupported"
     assert metadata["detected_payload"] == payload
+    _assert_no_identity(metadata)
     assert module_details["failure_origin"] == "payload_validation"
     assert not list(workspace.rglob("response_*.png"))
 
@@ -288,6 +307,68 @@ def test_route_scan_decode_qr_wrong_module_preserves_validation_failure(
     assert metadata["failure_category"] == "module_unsupported"
     assert metadata["detected_payload"] == payload
     assert metadata["module"] == "scoreform"
+    assert metadata["class_id"] == "english12"
+    assert metadata["assignment_id"] == "quiz1"
+    assert metadata["student_id"] == STUDENT_ID
+    assert metadata["payload_page_number"] == 1
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "payload_validation"
+    assert module_details["expected_module"] == "quillan"
+    assert not list(workspace.rglob("response_*.png"))
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason", "actual_document_type"),
+    [
+        (
+            build_response_payload(
+                class_id=CLASS_ID,
+                assignment_id=ASSIGNMENT_ID,
+                student_id=STUDENT_ID,
+                page=2,
+            ).replace("|doc=response", ""),
+            "document_type_missing",
+            None,
+        ),
+        (
+            build_response_payload(
+                class_id=CLASS_ID,
+                assignment_id=ASSIGNMENT_ID,
+                student_id=STUDENT_ID,
+                page=2,
+            ).replace("doc=response", "doc=cover"),
+            "document_type_invalid",
+            "cover",
+        ),
+    ],
+)
+def test_route_scan_decode_qr_document_type_validation_preserves_identity(
+    workspace: Path,
+    tmp_path: Path,
+    payload: str,
+    reason: str,
+    actual_document_type: str | None,
+) -> None:
+    source = tmp_path / f"{reason}.png"
+    _write_qr_image(source, payload)
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata(workspace)
+    assert metadata["failure_category"] == "payload_invalid"
+    assert metadata["detected_payload"] == payload
+    assert metadata["module"] == "quillan"
+    assert metadata["class_id"] == CLASS_ID
+    assert metadata["assignment_id"] == ASSIGNMENT_ID
+    assert metadata["student_id"] == STUDENT_ID
+    assert metadata["payload_page_number"] == 2
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "payload_validation"
+    assert module_details["reason"] == reason
+    if actual_document_type is not None:
+        assert module_details["actual_document_type"] == actual_document_type
     assert not list(workspace.rglob("response_*.png"))
 
 
@@ -304,7 +385,13 @@ def test_route_scan_decode_qr_unknown_student_preserves_route_failure(
     metadata = _review_metadata(workspace)
     assert metadata["failure_category"] == "student_unknown"
     assert metadata["detected_payload"] == payload
+    assert metadata["class_id"] == CLASS_ID
+    assert metadata["assignment_id"] == ASSIGNMENT_ID
     assert metadata["student_id"] == UNKNOWN_STUDENT_ID
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "route_planning"
+    assert module_details["reason"] == "student_unknown"
     assert not list(workspace.rglob("response_*.png"))
 
 
@@ -321,7 +408,13 @@ def test_route_scan_decode_qr_unknown_assignment_preserves_route_failure(
     metadata = _review_metadata(workspace)
     assert metadata["failure_category"] == "assignment_unknown"
     assert metadata["detected_payload"] == payload
+    assert metadata["class_id"] == CLASS_ID
     assert metadata["assignment_id"] == UNKNOWN_ASSIGNMENT_ID
+    assert metadata["student_id"] == STUDENT_ID
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "route_planning"
+    assert module_details["reason"] == "assignment_unknown"
     assert not list(workspace.rglob("response_*.png"))
 
 
@@ -352,6 +445,11 @@ def test_route_scan_decode_qr_evidence_filing_failure_is_preserved(
     assert metadata["class_id"] == CLASS_ID
     assert metadata["assignment_id"] == ASSIGNMENT_ID
     assert metadata["student_id"] == STUDENT_ID
+    assert metadata["payload_page_number"] == 2
+    assert metadata["module"] == "quillan"
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "evidence_filing"
     assert "could not be filed; preserved for review" in output
 
 

--- a/tests/test_routing_review.py
+++ b/tests/test_routing_review.py
@@ -9,12 +9,20 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-from pds_core.scan_failure_metadata import ROUTING_FAILURE_CATEGORIES
+from pds_core.scan_failure_metadata import (
+    ROUTING_FAILURE_CATEGORIES,
+    validate_routing_failure_metadata,
+)
 
 from quillan.evidence_filing import (
     EvidenceFilingError,
     RetainedSourceScan,
 )
+from quillan.payload_validation import (
+    ResponsePayloadValidationFailure,
+    decoded_payload_to_response_page,
+)
+from quillan.qr_decode import QrImageDecodeResult
 from quillan.route_planning import (
     DecodedResponsePage,
     RouteFailure,
@@ -23,7 +31,9 @@ from quillan.route_planning import (
 )
 from quillan.routing_review import (
     RoutingReviewError,
+    preserve_decode_failure_for_review,
     preserve_evidence_filing_error_for_review,
+    preserve_payload_validation_failure_for_review,
     preserve_route_failure_for_review,
     preserve_routing_failure_for_review,
 )
@@ -40,10 +50,12 @@ RAW_PAYLOAD = (
 
 
 def _read_metadata(path: Path) -> dict[str, object]:
-    return cast(
+    metadata = cast(
         dict[str, object],
         json.loads(path.read_text(encoding="utf-8")),
     )
+    validate_routing_failure_metadata(metadata)
+    return metadata
 
 
 def _route_failure(workspace: Path) -> RouteFailure:
@@ -155,6 +167,37 @@ def test_shared_writer_refuses_failure_id_collision(tmp_path: Path) -> None:
         )
 
 
+def test_failure_metadata_filenames_are_unique_for_distinct_failures(
+    tmp_path: Path,
+) -> None:
+    first = preserve_routing_failure_for_review(
+        tmp_path,
+        failure_category="payload_invalid",
+        failure_message="Invalid.",
+        source_filename="scan.pdf",
+        detected_payload="first",
+        created_at=CREATED_AT,
+    )
+    second = preserve_routing_failure_for_review(
+        tmp_path,
+        failure_category="payload_invalid",
+        failure_message="Invalid.",
+        source_filename="scan.pdf",
+        detected_payload="second",
+        created_at=CREATED_AT,
+    )
+
+    assert first.failure_metadata_path != second.failure_metadata_path
+    records = sorted((tmp_path / "scans" / "review").glob("*.json"))
+    assert records == sorted(
+        [first.failure_metadata_path, second.failure_metadata_path]
+    )
+    for record in records:
+        validate_routing_failure_metadata(
+            json.loads(record.read_text(encoding="utf-8"))
+        )
+
+
 def test_preserves_route_failure_fields_without_replanning(
     tmp_path: Path,
 ) -> None:
@@ -176,7 +219,72 @@ def test_preserves_route_failure_fields_without_replanning(
     assert metadata["student_id"] == STUDENT_ID
     assert metadata["detected_payload"] == RAW_PAYLOAD
     assert metadata["payload_page_number"] == 2
-    assert metadata["module_details"] == failure.module_details
+    expected_details: dict[str, object] = {
+        "failure_origin": "route_planning",
+    }
+    expected_details.update(failure.module_details)
+    assert metadata["module_details"] == expected_details
+
+
+def test_decode_failure_adapter_preserves_null_identity(
+    tmp_path: Path,
+) -> None:
+    record = preserve_decode_failure_for_review(
+        tmp_path,
+        decode_result=QrImageDecodeResult(
+            payload_text=None,
+            failure_category="payload_missing",
+            failure_message="No QR payload could be decoded.",
+        ),
+        source_filename="blank.png",
+        created_at=CREATED_AT,
+    )
+
+    metadata = _read_metadata(record.failure_metadata_path)
+    assert metadata["failure_category"] == "payload_missing"
+    assert metadata["failure_message"] == "No QR payload could be decoded."
+    assert metadata["source_filename"] == "blank.png"
+    assert metadata["module"] is None
+    assert metadata["detected_payload"] is None
+    assert metadata["payload_page_number"] is None
+    assert metadata["class_id"] is None
+    assert metadata["assignment_id"] is None
+    assert metadata["student_id"] is None
+    assert metadata["module_details"] == {
+        "failure_origin": "qr_decode",
+        "decode_attempt": None,
+    }
+
+
+def test_payload_validation_failure_adapter_preserves_parsed_identity(
+    tmp_path: Path,
+) -> None:
+    payload = RAW_PAYLOAD.replace("doc=response", "doc=cover")
+    failure = decoded_payload_to_response_page(payload)
+    assert isinstance(failure, ResponsePayloadValidationFailure)
+
+    record = preserve_payload_validation_failure_for_review(
+        tmp_path,
+        failure=failure,
+        source_filename="wrong-doc.png",
+        created_at=CREATED_AT,
+    )
+
+    metadata = _read_metadata(record.failure_metadata_path)
+    assert metadata["failure_category"] == "payload_invalid"
+    assert metadata["module"] == "quillan"
+    assert metadata["detected_payload"] == payload
+    assert metadata["class_id"] == CLASS_ID
+    assert metadata["assignment_id"] == ASSIGNMENT_ID
+    assert metadata["student_id"] == STUDENT_ID
+    assert metadata["payload_page_number"] == 2
+    assert metadata["module_details"] == {
+        "failure_origin": "payload_validation",
+        "reason": "document_type_invalid",
+        "field": "doc",
+        "expected_document_type": "response",
+        "actual_document_type": "cover",
+    }
 
 
 def test_route_failure_adapter_accepts_retained_source_provenance(


### PR DESCRIPTION
## Summary

* Hardened Quillan scan-routing failure preservation through the existing routing-review metadata path.
* Moved QR decode failure preservation into `quillan.routing_review`.
* Moved decoded-payload validation failure preservation into `quillan.routing_review`.
* Kept `quillan.cli_app.handlers.routing` focused on CLI orchestration.
* Standardized `module_details.failure_origin` across preserved failure paths:

  * `qr_decode`
  * `payload_validation`
  * `payload_parse`
  * `route_planning`
  * `evidence_filing`
* Updated malformed legacy `route-scan --payload` parse failures to preserve `module=None`, avoiding invented identity before valid payload parsing.
* Added shared `pds-core` routing failure metadata validation on review metadata test readback.
* Expanded exact metadata assertions for:

  * QR decode failures;
  * unsupported source failures;
  * non-PDS payload validation failures;
  * wrong-module validation failures;
  * missing/wrong document-type validation failures;
  * route-planning failures;
  * evidence-filing failures;
  * malformed `--payload` parse failures;
  * preservation-write failures.
* Updated the changelog.

## Scope Notes

This PR is metadata-preservation hardening only.

It does **not** add:

* new QR decoding behavior;
* new payload validation rules beyond preservation support;
* PDF intake;
* folder/batch intake;
* batch summaries;
* menu integration;
* submission assembly;
* automatic review record creation;
* feedback export changes;
* OCR;
* handwriting recognition;
* AI feedback;
* AI scoring;
* automatic grading;
* automatic mastery behavior;
* new shared failure categories;
* changes to `pds-core`;
* changes to `pds-scoreform`.

## Failure Metadata Contract

Handled scan-intake failures continue to preserve review metadata under `scans/review`.

The hardened contract ensures:

* only shared routing failure categories are used;
* detected payloads are preserved when available;
* parsed identity fields are preserved when safely available;
* identity fields are not invented when unavailable;
* failure origin is consistently recorded in `module_details`;
* metadata validates against the shared `pds-core` schema;
* handled preserved failures return exit `0`;
* preservation failures return exit `1`.

## Validation

* `.\.venv\Scripts\python.exe -m pytest --basetemp .\.pytest-tmp` passed: `912 passed`.
* `.\.venv\Scripts\python.exe -m ruff check .` passed.
* `.\.venv\Scripts\python.exe -m mypy .` passed.
* `git diff --check` passed.
* `powershell -ExecutionPolicy Bypass -File .\run_tests.ps1` failed on the known bare-`python` launcher issue: `Program 'python.exe' failed to run: A specified logon session does not exist`.

Closes #130.
