### PR TITLE
Add QR-aware PDF page intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added QR-aware PDF page intake to `quillan route-scan --decode-qr`. The
+  command converts each PDF page to an image, decodes and validates each page
+  independently, files routed page evidence as PNG files, preserves page-level
+  and conversion-level failures under `scans/review/`, and continues after
+  handled per-page failures. This adds the `pdf2image` runtime dependency;
+  Poppler must be installed separately by the user.
 - Added QR-aware single-image intake to `quillan route-scan` through
   `--decode-qr`. The command decodes one supported local image, validates the
   decoded Quillan `doc=response` PDS1 payload, routes through existing

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ Quillan currently supports:
 - an internal routing failure preservation API that writes shared `pds-core`
   failure metadata under `scans/review/`, including retained-source provenance
   when available, without copying review artifacts;
-- a direct `route-scan` command for already-decoded payloads or one supported
-  QR-bearing image that orchestrates the existing parser, QR decoder, payload
-  validator, route planner, evidence filer, and failure review helpers;
+- a direct `route-scan` command for already-decoded payloads, one supported
+  QR-bearing image, or a QR-bearing PDF processed page by page. It
+  orchestrates the existing parser, QR decoder, payload validator, route
+  planner, evidence filer, and failure review helpers;
 - read-only assignment submission status listing, workspace-safe local evidence
   opening, and student-aware selected-evidence opening; and
 - explicit, teacher-controlled lightweight submission review-state updates
@@ -103,12 +104,11 @@ The data contracts and design documents describe additional teacher-review
 and paper-ingest workflows that are not yet implemented end to end. In
 particular, Quillan does not currently provide:
 
-- end-to-end production scan intake and routing (the direct command requires
-  an already-selected source file and caller-supplied decoded payload);
-- QR extraction from scanned PDFs or images;
+- end-to-end production scan intake and routing beyond one already-selected
+  source file;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
-- splitting multi-page scanned PDFs or batch-ingesting raw scan folders;
+- batch-ingesting raw scan folders;
 - merging newly routed evidence into existing teacher review state;
 - complete requirements-checking workflows;
 - AI tagging, AI scoring, or AI feedback;
@@ -128,8 +128,8 @@ route planner, successful filing helper, and failure preservation helper follow
 the shared `pds-core` active scan contract: canonical retained sources belong
 in `scans/source/YYYY-MM-DD/`, canonical routing review records belong in
 `scans/review/`, and assignment-level `scans/` contains routed evidence rather
-than canonical source retention. QR extraction, PDF splitting, OCR, and
-review-state updates remain outside the direct routing and assembly commands.
+than canonical source retention. OCR and review-state updates remain outside
+the direct routing and assembly commands.
 
 ## Reviewable Evidence Workflow
 
@@ -182,6 +182,7 @@ The commands in this workflow are:
 ```powershell
 quillan route-scan <source-file> --payload "<PDS1 payload>"
 quillan route-scan <source-image> --decode-qr
+quillan route-scan <source-pdf> --decode-qr
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-evidence-path>
@@ -197,8 +198,10 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
 - `route-scan` retains one selected source scan and files routed evidence from
-  either an already-decoded payload or one supported QR-bearing image; it does
-  not convert PDFs, batch-ingest folders, or assemble a submission.
+  either an already-decoded payload, one supported QR-bearing image, or one
+  QR-bearing PDF. PDF intake processes pages independently, files page evidence
+  as PNG files, and preserves handled failures under `scans/review/`; it does
+  not batch-ingest folders, run OCR, use the menu, or assemble a submission.
 - `assemble-submissions` creates missing manifests from routed filenames, or
   fully regenerates them with `--overwrite`; it does not inspect file contents
   or choose among ambiguous duplicate evidence.
@@ -564,25 +567,29 @@ Route one selected scan using an already-decoded Quillan PDS1 payload:
 quillan route-scan <source-file> --payload "PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page>|doc=response"
 ```
 
-Or route one supported local image by decoding its Quillan response-page QR
-payload:
+Or route one supported local image or PDF by decoding Quillan response-page QR
+payloads:
 
 ```powershell
 quillan route-scan <source-image> --decode-qr
+quillan route-scan <source-pdf> --decode-qr
 ```
 
 Successful routing retains the selected source under
 `scans/source/YYYY-MM-DD/` and files response evidence under the assignment
-`scans/` directory. Decode, payload, planning, and filing failures are
-preserved under `scans/review/` when possible. Exit code `0` means the input
-was routed or safely preserved for review; exit code `1` means it could not be
-handled safely.
+`scans/` directory. PDF intake converts pages independently and files routed
+page evidence as PNG files, preserving the physical `source_page_number`
+separately from the decoded `payload_page_number`. Decode, payload, planning,
+filing, and PDF conversion failures are preserved under `scans/review/` when
+possible. Exit code `0` means the input was routed or safely preserved for
+review; exit code `1` means it could not be handled safely.
 
 This direct developer/teacher primitive is single-scan only. QR-aware intake
-supports `.png`, `.jpg`, `.jpeg`, `.tif`, and `.tiff` images. It does not
-convert PDFs, batch-ingest folders, split multi-page scans, run OCR, score,
-tag, generate feedback, assemble submissions, create review records, or create
-reports.
+supports `.png`, `.jpg`, `.jpeg`, `.tif`, and `.tiff` images plus `.pdf`
+files. PDF conversion uses `pdf2image` and requires Poppler installed on the
+user's machine. The command does not batch-ingest folders, run OCR, score, tag,
+generate feedback, assemble submissions, create review records, create reports,
+or expose menu scan intake.
 
 Assemble all student manifests discoverable from routed filenames in an
 assignment's `scans/` directory:
@@ -620,6 +627,7 @@ quillan validate-standards <standards-profile.json>
 quillan validate-assignment <assignment.json>
 quillan route-scan <source-file> --payload "<PDS1|...>"
 quillan route-scan <source-image> --decode-qr
+quillan route-scan <source-pdf> --decode-qr
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-path>

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -50,6 +50,7 @@ quillan validate-standards <path>
 quillan validate-assignment <path>
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
 quillan route-scan <source-image> --decode-qr
+quillan route-scan <source-pdf> --decode-qr
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-evidence-path>
@@ -382,23 +383,27 @@ handled-failure behavior in their command sections and help output.
 ```powershell
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
 quillan route-scan <source-image> --decode-qr
+quillan route-scan <source-pdf> --decode-qr
 ```
 
 This command routes one selected source file using exactly one payload source:
 caller-supplied canonical PDS1 text through `--payload`, or one decoded QR
-payload from a supported local image through `--decode-qr`. Supported QR image
-extensions are `.png`, `.jpg`, `.jpeg`, `.tif`, and `.tiff`.
+payload from a supported local image or each page of a PDF through
+`--decode-qr`. Supported QR image extensions are `.png`, `.jpg`, `.jpeg`,
+`.tif`, and `.tiff`; PDF intake supports `.pdf` and uses `pdf2image`, which
+requires Poppler installed on the user's machine.
 
 On success it retains the source under `scans/source/YYYY-MM-DD/` and files
-routed evidence under the target assignment's `scans/` directory. Decode,
-payload, planning, or filing failures are preserved under `scans/review/` when
-they can be handled safely.
+routed evidence under the target assignment's `scans/` directory. PDF pages
+route independently and successful PDF page evidence is filed as PNG files;
+`source_page_number` records the physical PDF page separately from the decoded
+`payload_page_number`. Decode, payload, planning, filing, or PDF conversion
+failures are preserved under `scans/review/` when they can be handled safely.
 
-The command does not convert PDFs, split multi-page PDFs, batch-ingest a
-folder, assemble submissions, create review records, run OCR, or identify a
-student from raw scan content without a valid payload. Exit `0` means the file
-was routed or safely preserved for review; exit `1` means it could not be
-handled safely.
+The command does not batch-ingest a folder, expose menu scan intake, assemble
+submissions, create review records, run OCR, or identify a student from raw
+scan content without a valid payload. Exit `0` means the file was routed or
+safely preserved for review; exit `1` means it could not be handled safely.
 
 ## Submission Assembly and Status
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 dependencies = [
     "numpy<2.5",
     "opencv-python",
+    "pdf2image",
     "qrcode[pil]",
     "reportlab",
 ]

--- a/quillan/cli_app/handlers/routing.py
+++ b/quillan/cli_app/handlers/routing.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import argparse
-from datetime import datetime, timezone
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import cast
 
+import cv2
 from pds_core.pds1 import Pds1PayloadError, parse_pds1_payload
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -22,8 +26,16 @@ from quillan.payload_validation import (
     ResponsePayloadValidationFailure,
     decoded_payload_to_response_page,
 )
+from quillan.pdf_pages import (
+    PdfPageConversionError,
+    PdfPageConversionFailure,
+    PdfPageImage,
+    iter_pdf_page_images,
+)
 from quillan.qr_decode import (
+    ImageArray,
     QrImageDecodeResult,
+    decode_qr_payload_from_image,
     decode_qr_payload_from_image_path,
 )
 from quillan.route_planning import (
@@ -42,6 +54,13 @@ from quillan.routing_review import (
 )
 
 
+@dataclass(frozen=True, slots=True)
+class _PageRouteOutcome:
+    page_number: int
+    status: str
+    category: str | None = None
+
+
 def handle_route_scan(args: argparse.Namespace) -> int:
     """Route one source scan from caller-supplied payload text or image QR."""
     source_file: Path = args.source_file
@@ -56,6 +75,14 @@ def handle_route_scan(args: argparse.Namespace) -> int:
         return 1
 
     if args.decode_qr:
+        if not _validate_source_file(source_file):
+            return 1
+        if source_file.suffix.lower() == ".pdf":
+            return _route_source_pdf_qr(
+                workspace_root,
+                source_file=source_file,
+                created_at=intake_timestamp,
+            )
         decoded_result = _decoded_page_from_source_qr(
             workspace_root,
             source_file=source_file,
@@ -153,12 +180,58 @@ def _decoded_page_from_source_qr(
     return validation_result
 
 
+def _decoded_page_from_qr_image(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    image: object,
+    source_page_number: int,
+    created_at: datetime,
+) -> DecodedResponsePage | int:
+    """Decode and validate a Quillan response-page QR from one loaded image."""
+    try:
+        decode_result = decode_qr_payload_from_image(image)
+    except Exception as error:
+        decode_result = QrImageDecodeResult(
+            payload_text=None,
+            failure_category="processing_error",
+            failure_message=f"Unexpected QR decode failure: {error}",
+        )
+
+    if decode_result.payload_text is None:
+        return _preserve_decode_failure(
+            workspace_root,
+            source_file=source_file,
+            decode_result=decode_result,
+            created_at=created_at,
+            source_page_number=source_page_number,
+        )
+
+    validation_result = decoded_payload_to_response_page(
+        decode_result.payload_text
+    )
+    if isinstance(validation_result, ResponsePayloadValidationFailure):
+        return _preserve_payload_validation_failure(
+            workspace_root,
+            source_file=source_file,
+            failure=validation_result,
+            created_at=created_at,
+            source_page_number=source_page_number,
+        )
+
+    return validation_result
+
+
 def _route_decoded_page(
     workspace_root: Path,
     *,
     source_file: Path,
     decoded_page: DecodedResponsePage,
     created_at: datetime,
+    routed_source_file_path: Path | None = None,
+    routed_extension: str | None = None,
+    source_page_number: int | None = None,
+    print_success: bool = True,
 ) -> int:
     """Plan and file one already-decoded Quillan response page."""
     try:
@@ -171,6 +244,7 @@ def _route_decoded_page(
                 workspace_root,
                 route_failure=route_result,
                 source_filename=source_file.name,
+                source_page_number=source_page_number,
                 created_at=created_at,
             )
             print_route_failure_review(route_result, review_record)
@@ -182,6 +256,8 @@ def _route_decoded_page(
                 route_plan=route_result,
                 source_file_path=source_file,
                 intake_timestamp=created_at,
+                routed_source_file_path=routed_source_file_path,
+                routed_extension=routed_extension,
             )
         except EvidenceFilingError as error:
             review_record = preserve_evidence_filing_error_for_review(
@@ -189,6 +265,7 @@ def _route_decoded_page(
                 error=error,
                 route_plan=route_result,
                 source_filename=source_file.name,
+                source_page_number=source_page_number,
                 created_at=created_at,
             )
             print_evidence_filing_review(error, review_record)
@@ -200,8 +277,201 @@ def _route_decoded_page(
         print(f"Error: unexpected route-scan failure: {error}")
         return 1
 
-    print_routed_evidence(filed_evidence)
+    if print_success:
+        print_routed_evidence(filed_evidence)
     return 0
+
+
+def _route_source_pdf_qr(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    created_at: datetime,
+) -> int:
+    """Convert and route each page of a QR-bearing PDF scan independently."""
+    print(f"Processing PDF: {source_file}")
+    try:
+        pages = list(iter_pdf_page_images(source_file))
+    except PdfPageConversionError as error:
+        return _preserve_pdf_conversion_failure(
+            workspace_root,
+            source_file=source_file,
+            failure=error.failure,
+            created_at=created_at,
+        )
+    except Exception as error:
+        failure = PdfPageConversionFailure(
+            failure_category="processing_error",
+            failure_message=f"Unexpected PDF conversion failure: {error}",
+            module_details={"failure_origin": "pdf_conversion"},
+        )
+        return _preserve_pdf_conversion_failure(
+            workspace_root,
+            source_file=source_file,
+            failure=failure,
+            created_at=created_at,
+        )
+
+    if not pages:
+        failure = PdfPageConversionFailure(
+            failure_category="source_unreadable",
+            failure_message="PDF did not contain any pages to process.",
+            module_details={
+                "failure_origin": "pdf_conversion",
+                "reason": "zero_pages",
+            },
+        )
+        return _preserve_pdf_conversion_failure(
+            workspace_root,
+            source_file=source_file,
+            failure=failure,
+            created_at=created_at,
+        )
+
+    print(f"Pages: {len(pages)}")
+    print()
+    outcomes: list[_PageRouteOutcome] = []
+    with tempfile.TemporaryDirectory(prefix="quillan-pdf-pages-") as temp_dir:
+        temp_root = Path(temp_dir)
+        for page in pages:
+            outcome = _route_pdf_page_qr(
+                workspace_root,
+                source_file=source_file,
+                page=page,
+                created_at=created_at
+                + timedelta(microseconds=page.page_number - 1),
+                temp_root=temp_root,
+            )
+            outcomes.append(outcome)
+            if outcome.status == "routed":
+                print(f"Page {outcome.page_number}: routed")
+            else:
+                print(
+                    f"Page {outcome.page_number}: preserved for review"
+                    f" - {outcome.category}"
+                )
+
+    routed = sum(1 for outcome in outcomes if outcome.status == "routed")
+    preserved = sum(1 for outcome in outcomes if outcome.status == "preserved")
+    failed = sum(1 for outcome in outcomes if outcome.status == "failed")
+    print()
+    print("Summary:")
+    print(f"Pages processed: {len(outcomes)}")
+    print(f"Routed: {routed}")
+    print(f"Preserved for review: {preserved}")
+    print(f"Failed: {failed}")
+    return 1 if failed else 0
+
+
+def _route_pdf_page_qr(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    page: PdfPageImage,
+    created_at: datetime,
+    temp_root: Path,
+) -> _PageRouteOutcome:
+    decoded_result = _decoded_page_from_qr_image(
+        workspace_root,
+        source_file=source_file,
+        image=page.image,
+        source_page_number=page.page_number,
+        created_at=created_at,
+    )
+    if isinstance(decoded_result, int):
+        return _PageRouteOutcome(
+            page_number=page.page_number,
+            status="preserved" if decoded_result == 0 else "failed",
+            category=_latest_review_category(workspace_root),
+        )
+
+    page_image_path = temp_root / f"page_{page.page_number:03d}.png"
+    try:
+        written = cv2.imwrite(str(page_image_path), cast(ImageArray, page.image))
+    except cv2.error as error:
+        print(f"Error: could not prepare PDF page image for routing: {error}")
+        return _PageRouteOutcome(page.page_number, "failed", "processing_error")
+    if not written:
+        print("Error: could not prepare PDF page image for routing.")
+        return _PageRouteOutcome(page.page_number, "failed", "processing_error")
+
+    return _route_pdf_decoded_page(
+        workspace_root,
+        source_file=source_file,
+        decoded_page=decoded_result,
+        created_at=created_at,
+        routed_source_file_path=page_image_path,
+        source_page_number=page.page_number,
+    )
+
+
+def _route_pdf_decoded_page(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    decoded_page: DecodedResponsePage,
+    created_at: datetime,
+    routed_source_file_path: Path,
+    source_page_number: int,
+) -> _PageRouteOutcome:
+    """Plan and file one decoded PDF page, returning a page summary outcome."""
+    try:
+        route_result = plan_decoded_response_page_route(
+            workspace_root,
+            decoded_page,
+        )
+        if isinstance(route_result, RouteFailure):
+            review_record = preserve_route_failure_for_review(
+                workspace_root,
+                route_failure=route_result,
+                source_filename=source_file.name,
+                source_page_number=source_page_number,
+                created_at=created_at,
+            )
+            return _PageRouteOutcome(
+                source_page_number,
+                "preserved",
+                review_record.failure_category,
+            )
+
+        try:
+            # The existing filing layer retains the original source for each
+            # page route. The routed artifact itself is the extracted page PNG,
+            # so assignment evidence is never the whole multi-page PDF.
+            file_routed_response_evidence(
+                workspace_root,
+                route_plan=route_result,
+                source_file_path=source_file,
+                intake_timestamp=created_at,
+                routed_source_file_path=routed_source_file_path,
+                routed_extension=".png",
+            )
+        except EvidenceFilingError as error:
+            review_record = preserve_evidence_filing_error_for_review(
+                workspace_root,
+                error=error,
+                route_plan=route_result,
+                source_filename=source_file.name,
+                source_page_number=source_page_number,
+                created_at=created_at,
+            )
+            return _PageRouteOutcome(
+                source_page_number,
+                "preserved",
+                review_record.failure_category,
+            )
+    except RoutingReviewError as error:
+        print(f"Error: could not preserve scan routing failure for review: {error}")
+        return _PageRouteOutcome(
+            source_page_number,
+            "failed",
+            "review_preservation_failed",
+        )
+    except Exception as error:
+        print(f"Error: unexpected route-scan failure: {error}")
+        return _PageRouteOutcome(source_page_number, "failed", "processing_error")
+
+    return _PageRouteOutcome(source_page_number, "routed")
 
 
 def _validate_source_file(source_file: Path) -> bool:
@@ -270,6 +540,7 @@ def _preserve_decode_failure(
     source_file: Path,
     decode_result: QrImageDecodeResult,
     created_at: datetime,
+    source_page_number: int | None = None,
 ) -> int:
     """Preserve source/QR decode failure context for teacher review."""
     try:
@@ -277,6 +548,7 @@ def _preserve_decode_failure(
             workspace_root,
             decode_result=decode_result,
             source_filename=source_file.name,
+            source_page_number=source_page_number,
             created_at=created_at,
         )
     except RoutingReviewError as review_error:
@@ -306,6 +578,7 @@ def _preserve_payload_validation_failure(
     source_file: Path,
     failure: ResponsePayloadValidationFailure,
     created_at: datetime,
+    source_page_number: int | None = None,
 ) -> int:
     """Preserve decoded-payload validation failure context for review."""
     try:
@@ -313,6 +586,7 @@ def _preserve_payload_validation_failure(
             workspace_root,
             source_filename=source_file.name,
             failure=failure,
+            source_page_number=source_page_number,
             created_at=created_at,
         )
     except RoutingReviewError as review_error:
@@ -346,3 +620,72 @@ def _print_preserved_intake_failure(
     print(f"Reason: {reason}")
     print(f"Category: {category}")
     print(f"Review record: {review_record.failure_metadata_relative_path}")
+
+
+def _preserve_pdf_conversion_failure(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    failure: PdfPageConversionFailure,
+    created_at: datetime,
+) -> int:
+    """Preserve a whole-PDF conversion failure as one review record."""
+    try:
+        review_record = preserve_routing_failure_for_review(
+            workspace_root,
+            failure_category=failure.failure_category,
+            failure_message=failure.failure_message,
+            source_filename=source_file.name,
+            module=None,
+            source_page_number=failure.source_page_number,
+            detected_payload=None,
+            payload_page_number=None,
+            class_id=None,
+            assignment_id=None,
+            student_id=None,
+            module_details={
+                "failure_origin": "pdf_conversion",
+                **failure.module_details,
+            },
+            created_at=created_at,
+        )
+    except RoutingReviewError as review_error:
+        print(
+            "Error: PDF conversion failure could not be preserved for review: "
+            f"{review_error}"
+        )
+        return 1
+    except Exception as unexpected_error:
+        print(
+            "Error: unexpected failure while preserving PDF conversion failure: "
+            f"{unexpected_error}"
+        )
+        return 1
+
+    print("PDF could not be converted; preserved for review.")
+    print(f"Category: {review_record.failure_category}")
+    print(f"Review record: {review_record.failure_metadata_relative_path}")
+    return 0
+
+
+def _latest_review_category(workspace_root: Path) -> str | None:
+    review_dir = workspace_root / "scans" / "review"
+    try:
+        records = sorted(
+            review_dir.glob("*.json"),
+            key=lambda path: path.stat().st_mtime_ns,
+        )
+    except OSError:
+        return None
+    if not records:
+        return None
+    try:
+        import json
+
+        loaded = json.loads(records[-1].read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    category = loaded.get("failure_category")
+    return category if isinstance(category, str) else None

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -76,10 +76,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     route_scan_parser = subparsers.add_parser(
         "route-scan",
-        help="Route one Quillan response scan from payload text or image QR.",
+        help="Route one Quillan response scan from payload text or QR.",
         description=(
             "Route one scan file using either an already-decoded Quillan PDS1 "
-            "payload or a QR payload decoded from a supported local image. "
+            "payload or QR payloads decoded from a supported local image or "
+            "PDF. PDF files are processed page by page. "
             "Exit 0 means the file was routed or safely preserved for review; "
             "exit 1 means the input could not be handled safely."
         ),
@@ -99,7 +100,10 @@ def build_parser() -> argparse.ArgumentParser:
     payload_group.add_argument(
         "--decode-qr",
         action="store_true",
-        help="Decode the Quillan response-page QR payload from the source image.",
+        help=(
+            "Decode Quillan response-page QR payloads from a source image or "
+            "PDF."
+        ),
     )
     route_scan_parser.set_defaults(handler=handle_route_scan)
 

--- a/quillan/pdf_pages.py
+++ b/quillan/pdf_pages.py
@@ -1,0 +1,128 @@
+"""PDF page conversion for QR-aware scan intake."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+
+DEFAULT_PDF_DPI = 200
+
+
+@dataclass(frozen=True, slots=True)
+class PdfPageImage:
+    """One converted PDF page as an OpenCV-compatible BGR image."""
+
+    page_number: int
+    image: object
+
+
+@dataclass(frozen=True, slots=True)
+class PdfPageConversionFailure:
+    """Structured PDF conversion failure for routing-review preservation."""
+
+    failure_category: str
+    failure_message: str
+    source_page_number: int | None = None
+    module_details: dict[str, object] = field(default_factory=dict)
+
+
+def iter_pdf_page_images(
+    path: str | Path,
+    *,
+    dpi: int = DEFAULT_PDF_DPI,
+) -> Iterator[PdfPageImage]:
+    """Yield converted PDF pages as OpenCV BGR images.
+
+    The pdf2image package delegates rendering to Poppler. Callers should catch
+    ``PdfPageConversionError`` and preserve it through routing review metadata.
+    """
+    pdf_path = Path(path)
+    try:
+        from pdf2image import convert_from_path  # type: ignore[import-not-found]
+        from pdf2image.exceptions import (  # type: ignore[import-not-found]
+            PDFInfoNotInstalledError,
+            PDFPageCountError,
+            PDFPopplerTimeoutError,
+            PDFSyntaxError,
+        )
+    except ImportError as error:
+        raise PdfPageConversionError(
+            PdfPageConversionFailure(
+                failure_category="processing_error",
+                failure_message=(
+                    "PDF conversion support is unavailable; install pdf2image."
+                ),
+                module_details={"failure_origin": "pdf_conversion"},
+            )
+        ) from error
+
+    try:
+        pages = convert_from_path(pdf_path, dpi=dpi)
+    except PDFInfoNotInstalledError as error:
+        raise PdfPageConversionError(
+            PdfPageConversionFailure(
+                failure_category="source_unreadable",
+                failure_message=(
+                    "PDF could not be converted because Poppler is not installed "
+                    "or is not on PATH."
+                ),
+                module_details={
+                    "failure_origin": "pdf_conversion",
+                    "reason": "poppler_missing",
+                },
+            )
+        ) from error
+    except (PDFPageCountError, PDFPopplerTimeoutError, PDFSyntaxError, OSError) as error:
+        raise PdfPageConversionError(
+            PdfPageConversionFailure(
+                failure_category="source_unreadable",
+                failure_message=f"PDF could not be converted: {error}",
+                module_details={"failure_origin": "pdf_conversion"},
+            )
+        ) from error
+    except Exception as error:
+        raise PdfPageConversionError(
+            PdfPageConversionFailure(
+                failure_category="processing_error",
+                failure_message=f"Unexpected PDF conversion failure: {error}",
+                module_details={"failure_origin": "pdf_conversion"},
+            )
+        ) from error
+
+    if not pages:
+        raise PdfPageConversionError(
+            PdfPageConversionFailure(
+                failure_category="source_unreadable",
+                failure_message="PDF did not contain any pages to process.",
+                module_details={
+                    "failure_origin": "pdf_conversion",
+                    "reason": "zero_pages",
+                },
+            )
+        )
+
+    for page_number, page in enumerate(pages, start=1):
+        yield PdfPageImage(
+            page_number=page_number,
+            image=_pil_page_to_bgr_image(page),
+        )
+
+
+class PdfPageConversionError(RuntimeError):
+    """Raised when a PDF cannot be converted into page images."""
+
+    def __init__(self, failure: PdfPageConversionFailure) -> None:
+        super().__init__(failure.failure_message)
+        self.failure = failure
+
+
+def _pil_page_to_bgr_image(page: Any) -> NDArray[np.uint8]:
+    rgb_page = page.convert("RGB")
+    rgb_array = cast(NDArray[np.uint8], np.asarray(rgb_page))
+    return cast(NDArray[np.uint8], cv2.cvtColor(rgb_array, cv2.COLOR_RGB2BGR))

--- a/quillan/routing_review.py
+++ b/quillan/routing_review.py
@@ -199,6 +199,7 @@ def preserve_decode_failure_for_review(
     *,
     decode_result: QrImageDecodeResult,
     source_filename: str,
+    source_page_number: int | None = None,
     created_at: datetime | None = None,
 ) -> RoutingReviewRecord:
     """Preserve source/QR decode failure context without invented identity."""
@@ -215,6 +216,7 @@ def preserve_decode_failure_for_review(
         module=None,
         detected_payload=None,
         payload_page_number=None,
+        source_page_number=source_page_number,
         class_id=None,
         assignment_id=None,
         student_id=None,
@@ -231,6 +233,7 @@ def preserve_payload_validation_failure_for_review(
     *,
     failure: ResponsePayloadValidationFailure,
     source_filename: str,
+    source_page_number: int | None = None,
     created_at: datetime | None = None,
 ) -> RoutingReviewRecord:
     """Preserve decoded-payload validation failure context for review."""
@@ -251,6 +254,7 @@ def preserve_payload_validation_failure_for_review(
         source_filename=source_filename,
         module=failure.module,
         detected_payload=failure.raw_payload,
+        source_page_number=source_page_number,
         payload_page_number=failure.page_number,
         class_id=failure.class_id,
         assignment_id=failure.assignment_id,
@@ -268,6 +272,7 @@ def preserve_evidence_filing_error_for_review(
     source_filename: str,
     retained_source: RetainedSourceScan | None = None,
     review_copy_path: str | Path | None = None,
+    source_page_number: int | None = None,
     module_details: dict[str, object] | None = None,
     created_at: datetime | None = None,
 ) -> RoutingReviewRecord:
@@ -299,6 +304,7 @@ def preserve_evidence_filing_error_for_review(
             else retained_source.retained_source_path
         ),
         review_copy_path=review_copy_path,
+        source_page_number=source_page_number,
         payload_page_number=route_plan.page_number,
         class_id=route_plan.class_id,
         assignment_id=route_plan.assignment_id,

--- a/tests/test_cli_route_scan_pdf.py
+++ b/tests/test_cli_route_scan_pdf.py
@@ -1,0 +1,429 @@
+"""Focused tests for QR-aware PDF page scan routing."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+from pds_core.scan_failure_metadata import validate_routing_failure_metadata
+import pytest
+import qrcode
+from qrcode.image.pil import PilImage
+
+from quillan.cli import main
+import quillan.cli_app.handlers.routing as cli_routing
+from quillan.evidence_filing import EvidenceFilingError
+from quillan.evidence_filing import file_routed_response_evidence
+from quillan.payloads import build_response_payload
+from quillan.pdf_pages import PdfPageConversionError, PdfPageConversionFailure
+from quillan.pdf_pages import PdfPageImage
+from quillan.route_planning import RoutePlan
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+SECOND_STUDENT_ID = "stu_0002"
+UNKNOWN_ASSIGNMENT_ID = "essay_unknown_synthetic"
+UNKNOWN_STUDENT_ID = "stu_9999"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr(cli_routing, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _write_workspace(root: Path) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": SECOND_STUDENT_ID,
+                "last_name": "Patel",
+                "first_name": "Mina",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment),
+        encoding="utf-8",
+    )
+
+
+def _source_pdf(tmp_path: Path) -> Path:
+    source = tmp_path / "responses.pdf"
+    source.write_bytes(b"%PDF-1.4\nsynthetic response scan\n%%EOF\n")
+    return source
+
+
+def _valid_payload(
+    *,
+    assignment_id: str = ASSIGNMENT_ID,
+    student_id: str = STUDENT_ID,
+    page: int = 2,
+) -> str:
+    return build_response_payload(
+        class_id=CLASS_ID,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        page=page,
+    )
+
+
+def _make_qr_image(payload: str, *, box_size: int = 8) -> NDArray[np.uint8]:
+    qr = qrcode.QRCode[PilImage](
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=box_size,
+        border=4,
+        image_factory=PilImage,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    rgb_image = image.get_image().convert("RGB")
+    return cast(
+        NDArray[np.uint8],
+        cv2.cvtColor(np.asarray(rgb_image), cv2.COLOR_RGB2BGR),
+    )
+
+
+def _blank_image() -> NDArray[np.uint8]:
+    return np.full((550, 425, 3), 255, dtype=np.uint8)
+
+
+def _pdf_pages(*images: object) -> list[PdfPageImage]:
+    return [
+        PdfPageImage(page_number=page_number, image=image)
+        for page_number, image in enumerate(images, start=1)
+    ]
+
+
+def _review_metadata_records(workspace: Path) -> list[dict[str, object]]:
+    records = sorted((workspace / "scans" / "review").glob("*.json"))
+    loaded_records: list[dict[str, object]] = []
+    for record in records:
+        loaded = json.loads(record.read_text(encoding="utf-8"))
+        assert isinstance(loaded, dict)
+        validate_routing_failure_metadata(loaded)
+        loaded_records.append(loaded)
+    return loaded_records
+
+
+def _routed_pngs(workspace: Path) -> list[Path]:
+    return sorted(
+        (
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "scans"
+        ).glob("response_*.png")
+    )
+
+
+def test_route_scan_decode_qr_pdf_routes_each_valid_page(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = _source_pdf(tmp_path)
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(
+            _make_qr_image(_valid_payload(student_id=STUDENT_ID, page=1)),
+            _make_qr_image(_valid_payload(student_id=SECOND_STUDENT_ID, page=2)),
+        ),
+    )
+
+    result = main(["route-scan", str(source), "--decode-qr"])
+
+    output = capsys.readouterr().out
+    routed = _routed_pngs(workspace)
+    assert result == 0
+    assert len(routed) == 2
+    assert {path.suffix for path in routed} == {".png"}
+    assert not list(workspace.rglob("response_*.pdf"))
+    assert not _review_metadata_records(workspace)
+    assert "Pages processed: 2" in output
+    assert "Routed: 2" in output
+    assert not list(workspace.rglob("submission.json"))
+    assert not list(workspace.rglob("review.json"))
+
+
+def test_route_scan_decode_qr_pdf_preserves_blank_page_and_continues(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = _source_pdf(tmp_path)
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(
+            _make_qr_image(_valid_payload()),
+            _blank_image(),
+        ),
+    )
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata_records(workspace)
+    assert len(_routed_pngs(workspace)) == 1
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "payload_missing"
+    assert metadata[0]["source_page_number"] == 2
+    assert metadata[0]["detected_payload"] is None
+    assert metadata[0]["student_id"] is None
+    assert "Preserved for review: 1" in output
+
+
+def test_route_scan_decode_qr_pdf_preserves_payload_validation_failure(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source_pdf(tmp_path)
+    bad_payload = "not a pds payload"
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(
+            _make_qr_image(_valid_payload()),
+            _make_qr_image(bad_payload),
+        ),
+    )
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata_records(workspace)
+    assert len(_routed_pngs(workspace)) == 1
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "payload_schema_unsupported"
+    assert metadata[0]["detected_payload"] == bad_payload
+    assert metadata[0]["source_page_number"] == 2
+
+
+def test_route_scan_decode_qr_pdf_preserves_route_planning_failure(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source_pdf(tmp_path)
+    unknown_student_payload = _valid_payload(student_id=UNKNOWN_STUDENT_ID)
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(
+            _make_qr_image(_valid_payload()),
+            _make_qr_image(unknown_student_payload),
+        ),
+    )
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata_records(workspace)
+    assert len(_routed_pngs(workspace)) == 1
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "student_unknown"
+    assert metadata[0]["detected_payload"] == unknown_student_payload
+    assert metadata[0]["student_id"] == UNKNOWN_STUDENT_ID
+    assert metadata[0]["payload_page_number"] == 2
+    assert metadata[0]["source_page_number"] == 2
+
+
+def test_route_scan_decode_qr_pdf_conversion_failure_is_preserved_once(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source_pdf(tmp_path)
+
+    def fail_conversion(_source: Path) -> list[PdfPageImage]:
+        raise PdfPageConversionError(
+            PdfPageConversionFailure(
+                failure_category="source_unreadable",
+                failure_message="Synthetic conversion failure.",
+                module_details={"failure_origin": "pdf_conversion"},
+            )
+        )
+
+    monkeypatch.setattr(cli_routing, "iter_pdf_page_images", fail_conversion)
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata_records(workspace)
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "source_unreadable"
+    assert metadata[0]["source_page_number"] is None
+    assert metadata[0]["module_details"] == {"failure_origin": "pdf_conversion"}
+    assert not _routed_pngs(workspace)
+
+
+def test_route_scan_decode_qr_pdf_zero_pages_is_preserved(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source_pdf(tmp_path)
+    monkeypatch.setattr(cli_routing, "iter_pdf_page_images", lambda _source: [])
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata_records(workspace)
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "source_unreadable"
+    assert not _routed_pngs(workspace)
+
+
+def test_route_scan_decode_qr_pdf_evidence_failure_is_preserved(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source_pdf(tmp_path)
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(
+            _make_qr_image(_valid_payload()),
+            _make_qr_image(_valid_payload(student_id=SECOND_STUDENT_ID, page=3)),
+        ),
+    )
+    def fail_first_page(workspace_root: str | Path, **kwargs: Any) -> object:
+        route_plan = cast(RoutePlan, kwargs["route_plan"])
+        if route_plan.student_id == STUDENT_ID:
+            raise EvidenceFilingError("Synthetic disk write failure.")
+        return file_routed_response_evidence(workspace_root, **kwargs)
+
+    monkeypatch.setattr(cli_routing, "file_routed_response_evidence", fail_first_page)
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata_records(workspace)
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "evidence_write_failed"
+    assert metadata[0]["source_page_number"] == 1
+    assert metadata[0]["student_id"] == STUDENT_ID
+    assert len(_routed_pngs(workspace)) == 1
+
+
+def test_route_scan_decode_qr_pdf_later_pages_process_after_failures(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = _source_pdf(tmp_path)
+    non_pds_payload = "not a pds payload"
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(
+            _blank_image(),
+            _make_qr_image(_valid_payload()),
+            _make_qr_image(non_pds_payload),
+        ),
+    )
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata_records(workspace)
+    categories = [record["failure_category"] for record in metadata]
+    assert len(_routed_pngs(workspace)) == 1
+    assert categories == ["payload_missing", "payload_schema_unsupported"]
+    assert [record["source_page_number"] for record in metadata] == [1, 3]
+    assert "Pages processed: 3" in output
+    assert "Routed: 1" in output
+    assert "Preserved for review: 2" in output
+
+
+def test_route_scan_payload_mode_does_not_process_pdf_pages(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source_pdf(tmp_path)
+
+    def fail_pdf_conversion(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("payload mode should not convert PDF pages")
+
+    monkeypatch.setattr(cli_routing, "iter_pdf_page_images", fail_pdf_conversion)
+
+    assert main(["route-scan", str(source), "--payload", _valid_payload()]) == 0
+    assert list(workspace.rglob("response_*.pdf"))
+    assert not list(workspace.rglob("response_*.png"))
+
+
+def test_route_scan_decode_qr_pdf_unknown_assignment_preserves_identity(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source_pdf(tmp_path)
+    payload = _valid_payload(assignment_id=UNKNOWN_ASSIGNMENT_ID)
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(_make_qr_image(payload)),
+    )
+
+    assert main(["route-scan", str(source), "--decode-qr"]) == 0
+
+    metadata = _review_metadata_records(workspace)
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "assignment_unknown"
+    assert metadata[0]["assignment_id"] == UNKNOWN_ASSIGNMENT_ID
+    assert metadata[0]["source_page_number"] == 1

--- a/tests/test_cli_route_scan_qr.py
+++ b/tests/test_cli_route_scan_qr.py
@@ -254,8 +254,8 @@ def test_route_scan_decode_qr_unsupported_source_type_preserves_failure(
     workspace: Path,
     tmp_path: Path,
 ) -> None:
-    source = tmp_path / "scan.pdf"
-    source.write_bytes(b"%PDF-1.4\nsynthetic\n%%EOF\n")
+    source = tmp_path / "scan.gif"
+    source.write_bytes(b"synthetic")
 
     assert main(["route-scan", str(source), "--decode-qr"]) == 0
 
@@ -267,7 +267,7 @@ def test_route_scan_decode_qr_unsupported_source_type_preserves_failure(
     module_details = metadata["module_details"]
     assert isinstance(module_details, dict)
     assert module_details["failure_origin"] == "qr_decode"
-    assert not list(workspace.rglob("response_*.pdf"))
+    assert not list(workspace.rglob("response_*.gif"))
 
 
 def test_route_scan_decode_qr_non_pds_payload_preserves_validation_failure(
@@ -453,15 +453,20 @@ def test_route_scan_decode_qr_evidence_filing_failure_is_preserved(
     assert "could not be filed; preserved for review" in output
 
 
-def test_route_scan_decode_qr_pdf_remains_unsupported(
+def test_route_scan_decode_qr_pdf_conversion_failure_is_preserved(
     workspace: Path,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source = tmp_path / "synthetic-response.pdf"
     source.write_bytes(b"%PDF-1.4\nsynthetic response scan\n%%EOF\n")
+    monkeypatch.setattr(cli_routing, "iter_pdf_page_images", lambda _source: [])
 
     assert main(["route-scan", str(source), "--decode-qr"]) == 0
 
     metadata = _review_metadata(workspace)
-    assert metadata["failure_category"] == "source_type_unsupported"
+    assert metadata["failure_category"] == "source_unreadable"
+    module_details = metadata["module_details"]
+    assert isinstance(module_details, dict)
+    assert module_details["failure_origin"] == "pdf_conversion"
     assert not list(workspace.rglob("response_*.pdf"))


### PR DESCRIPTION
## Summary

* Added QR-aware PDF page intake for `route-scan --decode-qr`.
* Added `quillan/pdf_pages.py` with bounded `pdf2image`-backed PDF page conversion.
* Added `pdf2image` as a runtime dependency.
* Extended `route-scan --decode-qr` so:

  * supported image files continue to process as single images;
  * `.pdf` files process page by page.
* Each PDF page is independently:

  * converted to an image;
  * QR-decoded;
  * payload-validated;
  * route-planned;
  * filed as routed evidence or preserved as a routing-review failure.
* Routed PDF page evidence is written as page-specific PNG evidence, not as the full multi-page PDF.
* Page-level decode, validation, route-planning, and evidence-filing failures preserve `source_page_number`.
* Conversion-level and zero-page PDF failures preserve one review metadata record.
* Processing continues after handled page-level failures.
* Updated README, CLI contract, parser help, and changelog.
* Added focused synthetic PDF intake tests.

## CLI Behavior

`route-scan --decode-qr` now supports both image files and PDF files:

```powershell
quillan route-scan <source_image> --decode-qr
```

```powershell
quillan route-scan <source_pdf> --decode-qr
```

PDF files are processed page by page.

Existing payload mode remains unchanged:

```powershell
quillan route-scan <source_file> --payload "<already-decoded PDS1 payload>"
```

## PDF Evidence Behavior

For PDF intake, routed assignment evidence is stored as PNG page evidence.

The routed evidence is not the original multi-page PDF. This keeps the assignment evidence page-specific and prevents one routed page from ambiguously pointing to an entire scan packet.

`source_page_number` tracks the physical PDF page number.

`payload_page_number` tracks the page number decoded from the QR payload.

These are preserved distinctly.

## Failure Preservation

PDF intake preserves handled failures through existing routing-review metadata:

* conversion-level PDF failures preserve one review record;
* zero-page PDFs preserve one review record;
* page-level QR decode failures preserve page-level review metadata;
* page-level payload validation failures preserve detected payload and source page;
* page-level route-planning failures preserve parsed identity, detected payload, and source page;
* page-level evidence-filing failures preserve route identity and source page.

Handled page-level failures do not stop later pages from processing.

## Scope Notes

This PR does **not** add:

* folder/batch intake;
* batch summaries across multiple source files;
* menu scan intake;
* automatic submission assembly;
* automatic review record creation;
* `decode-scan` PDF routing;
* OCR;
* handwriting recognition;
* AI feedback;
* AI scoring;
* automatic grading;
* automatic mastery behavior;
* changes to `pds-core`;
* changes to `pds-scoreform`.

`decode-scan` remains diagnostic-only.

## Validation

* `.\.venv\Scripts\python.exe -m pytest --basetemp .\.pytest-tmp` passed: `922 passed`.
* `.\.venv\Scripts\python.exe -m ruff check .` passed.
* `.\.venv\Scripts\python.exe -m mypy .` passed.
* `git diff --check` passed, with only Git CRLF warnings.
* `.\run_tests.ps1` was blocked by PowerShell execution policy.
* The bypassed wrapper reached the script but failed on the known local bare-`python` launcher issue, so the requested venv equivalents above were used.

Closes #131.
