### PR TITLE
Adopt shared standards selection validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added Quillan assignment validation support for the shared pds-core
+  standards library contract.
 - Added QR-aware PDF page intake to `quillan route-scan --decode-qr`. The
   command converts each PDF page to an image, decodes and validates each page
   independently, files routed page evidence as PNG files, preserves page-level

--- a/README.md
+++ b/README.md
@@ -515,10 +515,12 @@ quillan add-tag <class_id> <assignment_id> <student_id> --label "Evidence needs 
 Tags are stored in the `tags` array of the student's canonical `review.json`.
 Optional flags can reference a standard (`--standard`), profile comment
 (`--comment-id`), severity, teacher note, page, evidence ID, and controlled
-location. Standard and comment references use the assignment config and
-`shared/standards/<profile_id>.json`; standards in the profile are allowed
-even when they are not assignment focus standards. A missing review record is
-created only for a valid matching `submission.json`.
+location. Assignment `standards_profile_id` and `focus_standards` values are
+shared `pds-core` standards-library references: `focus_standards` stores
+durable `standard_id` values, not teacher-facing display codes. Quillan-owned
+comments, hotwords, feedback templates, and review scaffolding remain module
+data that can reference those shared IDs. A missing review record is created
+only for a valid matching `submission.json`.
 
 Tags remain teacher-entered review artifacts. Adding one does not mutate the
 submission manifest or evidence, calculate a score, establish standard
@@ -560,6 +562,12 @@ Validate an assignment configuration:
 ```powershell
 quillan validate-assignment <assignment.json>
 ```
+
+This command keeps structural assignment validation available without a
+workspace standards library. Workspace-aware validation can additionally check
+that `standards_profile_id` exists in the shared `pds-core` standards library
+and that each `focus_standards` entry is a shared `standard_id` in that
+profile. Quillan does not maintain an independent standards universe.
 
 Route one selected scan using an already-decoded Quillan PDS1 payload:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -109,7 +109,10 @@ quillan validate-assignment <path>
 ```
 
 Loads a UTF-8 JSON assignment configuration and applies Quillan's current
-assignment validation rules.
+structural assignment validation rules. Cross-file validation against the
+shared `pds-core` workspace standards library is available through Quillan's
+assignment standards-selection helper, but this CLI command does not currently
+load the workspace standards library.
 
 On success, it writes this form to standard output:
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -49,21 +49,23 @@ Quillan data should be:
 * compatible with shared Paper Data Suite data structures;
 * auditable by a teacher.
 
-## Standards Profile
+## Legacy Quillan Standards Profile
 
-A standards profile is a teacher- or department-defined collection of
-instructional targets and reusable review language. Profiles can be reused
-across assignments to make teacher review, evidence organization, and
-reporting more consistent.
+Shared standards definitions and reusable standards profiles are owned by
+`pds-core` and stored in the workspace standards library. Quillan's older
+standards-profile shape is transitional module data for reusable review
+language such as comments, hotwords, feedback templates, and severity defaults
+that may reference shared `standard_id` values.
 
-A profile describes the review vocabulary available to a teacher. It does not
-discover standards, inspect writing automatically, determine whether a
-standard was met, generate authoritative feedback, or calculate a score.
+This legacy profile describes Quillan review vocabulary available to a
+teacher. It does not discover standards, inspect writing automatically,
+determine whether a standard was met, generate authoritative feedback, or
+calculate a score.
 
-Suggested Paper Data Suite path:
+Shared standards library path:
 
 ```text
-shared/standards/<profile_id>.json
+<PDS workspace root>/standards/library.json
 ```
 
 Standalone Quillan MVP path:
@@ -242,11 +244,11 @@ Example:
   "title": "Villainy Final Essay",
   "class_ids": ["english12_period3_synthetic"],
   "writing_type": "literary argument essay",
-  "standards_profile_id": "english_12_njsls_synthetic",
+  "standards_profile_id": "english12_2023_njsls",
   "tagging_mode": "focus",
   "focus_standards": [
-    "W.AW.11-12.1",
-    "W.WP.11-12.4"
+    "nj_ela_2023_rl_cr_11_12_1",
+    "nj_ela_2023_w_aw_11_12_1"
   ],
   "basic_requirements": {
     "paragraphs_min": 4,
@@ -261,6 +263,13 @@ Example:
   "rubric_id": "argument_essay_4pt_synthetic"
 }
 ```
+
+Assignment configs store shared `pds-core` standards references. The
+`standards_profile_id` should identify a profile in the workspace standards
+library, and `focus_standards` should contain shared `standard_id` values
+rather than teacher-facing display codes. Quillan-specific comments, hotwords,
+feedback templates, review tags, and writing-review scaffolding remain
+module-owned; Quillan does not maintain an independent standards universe.
 
 ## Submission Manifest
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -511,11 +511,10 @@ quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity
 
 It appends one teacher-entered tag to `tags`, using sequential IDs such as
 `tag_0001`. Optional references to pages and evidence IDs are validated
-against the adjacent submission manifest. Optional standard and comment
-references are validated through the assignment config and the canonical
-`shared/standards/<profile_id>.json` profile. Standards present in the profile
-are accepted even when they are outside `focus_standards`; reusable comment
-labels and polarities must match their stored profile values.
+against the adjacent submission manifest. Optional standard references use
+shared `pds-core` `standard_id` values from the workspace standards library.
+Reusable comment references remain Quillan-owned module data; their labels and
+polarities must match the stored Quillan comment/profile values.
 
 The command follows the same creation, timestamp, state-transition, complete
 record validation, safe-write, preservation, and non-mutation policies as

--- a/quillan/assignments.py
+++ b/quillan/assignments.py
@@ -7,6 +7,11 @@ from pathlib import Path
 from typing import Any, cast
 
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.standards import (
+    StandardsLibrary,
+    StandardsValidationError,
+    validate_profile_standard_selection,
+)
 
 ALLOWED_TAGGING_MODES = {"focus", "focus_plus_past", "benchmark", "custom"}
 
@@ -69,6 +74,35 @@ def validate_assignment_config(assignment: dict[str, Any]) -> None:
     _validate_focus_standards(assignment["focus_standards"])
     _validate_basic_requirements(assignment["basic_requirements"])
     _validate_non_empty_string(assignment["rubric_id"], "rubric_id")
+
+
+def validate_assignment_standards_selection(
+    assignment: dict[str, Any],
+    standards_library: StandardsLibrary,
+) -> tuple[str, ...]:
+    """Validate assignment standards against a shared pds-core library.
+
+    The returned values are normalized shared ``standard_id`` references.
+    Structural assignment validation remains available separately through
+    ``validate_assignment_config`` for callers that do not have a workspace
+    standards library loaded.
+    """
+    validate_assignment_config(assignment)
+
+    profile_id = cast(str, assignment["standards_profile_id"])
+    focus_standards = cast(list[str], assignment["focus_standards"])
+
+    try:
+        return validate_profile_standard_selection(
+            standards_library,
+            profile_id=profile_id,
+            selected_standard_ids=focus_standards,
+        )
+    except StandardsValidationError as error:
+        raise AssignmentConfigError(
+            "Invalid assignment standards selection for "
+            f"standards_profile_id {profile_id!r} and focus_standards: {error}"
+        ) from error
 
 
 def _validate_class_ids(class_ids: Any) -> None:

--- a/quillan/standards.py
+++ b/quillan/standards.py
@@ -1,4 +1,11 @@
-"""Standards profile loading and validation for Quillan."""
+"""Legacy Quillan standards-profile loading and validation.
+
+Shared standards definitions and reusable standards profiles are owned by
+``pds-core``. This module remains for transitional Quillan-specific profile
+data such as comment-bank scaffolding, hotwords, feedback templates, and
+severity defaults that are not part of the shared ``StandardDefinition``
+contract.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_assignment_standards_selection.py
+++ b/tests/test_assignment_standards_selection.py
@@ -1,0 +1,170 @@
+"""Tests for assignment standards selection against pds-core libraries."""
+
+from __future__ import annotations
+
+import pytest
+
+from pds_core.standards import StandardDefinition, StandardsLibrary, StandardsProfile
+
+from quillan.assignments import (
+    AssignmentConfigError,
+    validate_assignment_config,
+    validate_assignment_standards_selection,
+)
+
+
+def _valid_assignment_config() -> dict[str, object]:
+    return {
+        "assignment_id": "villainy_final_essay_synthetic",
+        "title": "Villainy Final Essay",
+        "class_ids": ["english12_period3_synthetic"],
+        "writing_type": "literary argument essay",
+        "standards_profile_id": "english12_2023_njsls",
+        "tagging_mode": "focus",
+        "focus_standards": [
+            "nj_ela_2023_rl_cr_11_12_1",
+            "nj_ela_2023_w_aw_11_12_1",
+        ],
+        "basic_requirements": {
+            "paragraphs_min": 4,
+            "paragraphs_max": 6,
+            "word_count_min": 500,
+            "required_elements": ["thesis", "textual evidence"],
+        },
+        "rubric_id": "argument_essay_4pt_synthetic",
+    }
+
+
+def _standards_library() -> StandardsLibrary:
+    standards = (
+        StandardDefinition(
+            standard_id="nj_ela_2023_rl_cr_11_12_1",
+            code="RL.CR.11-12.1",
+            source="NJSLS-ELA 2023",
+            short_name="Close Reading Evidence",
+            description="Cite strong and thorough textual evidence.",
+        ),
+        StandardDefinition(
+            standard_id="nj_ela_2023_w_aw_11_12_1",
+            code="W.AW.11-12.1",
+            source="NJSLS-ELA 2023",
+            short_name="Argument Writing",
+            description="Write arguments supported by evidence.",
+        ),
+        StandardDefinition(
+            standard_id="nj_ela_2023_l_vi_11_12_4",
+            code="L.VI.11-12.4",
+            source="NJSLS-ELA 2023",
+            short_name="Vocabulary in Context",
+            description="Determine or clarify meaning of unknown words.",
+        ),
+    )
+    profiles = (
+        StandardsProfile(
+            profile_id="english12_2023_njsls",
+            standards=(
+                "nj_ela_2023_rl_cr_11_12_1",
+                "nj_ela_2023_w_aw_11_12_1",
+            ),
+        ),
+        StandardsProfile(
+            profile_id="english12_2023_language",
+            standards=("nj_ela_2023_l_vi_11_12_4",),
+        ),
+    )
+    return StandardsLibrary(standards=standards, profiles=profiles)
+
+
+def test_assignment_standards_selection_accepts_valid_profile_and_focus() -> None:
+    assert validate_assignment_standards_selection(
+        _valid_assignment_config(),
+        _standards_library(),
+    ) == (
+        "nj_ela_2023_rl_cr_11_12_1",
+        "nj_ela_2023_w_aw_11_12_1",
+    )
+
+
+def test_assignment_standards_selection_returns_normalized_focus_ids() -> None:
+    assignment = _valid_assignment_config()
+    assignment["standards_profile_id"] = " english12_2023_njsls "
+    assignment["focus_standards"] = [" nj_ela_2023_rl_cr_11_12_1 "]
+
+    assert validate_assignment_standards_selection(
+        assignment,
+        _standards_library(),
+    ) == ("nj_ela_2023_rl_cr_11_12_1",)
+
+
+def test_assignment_standards_selection_rejects_missing_profile_id() -> None:
+    assignment = _valid_assignment_config()
+    del assignment["standards_profile_id"]
+
+    with pytest.raises(AssignmentConfigError, match="standards_profile_id"):
+        validate_assignment_standards_selection(assignment, _standards_library())
+
+
+def test_assignment_standards_selection_rejects_unknown_profile_id() -> None:
+    assignment = _valid_assignment_config()
+    assignment["standards_profile_id"] = "missing_profile"
+
+    with pytest.raises(
+        AssignmentConfigError,
+        match="standards_profile_id.*missing_profile",
+    ):
+        validate_assignment_standards_selection(assignment, _standards_library())
+
+
+def test_assignment_standards_selection_rejects_unknown_focus_standard() -> None:
+    assignment = _valid_assignment_config()
+    assignment["focus_standards"] = ["nj_ela_2023_missing"]
+
+    with pytest.raises(
+        AssignmentConfigError,
+        match="focus_standards.*nj_ela_2023_missing",
+    ):
+        validate_assignment_standards_selection(assignment, _standards_library())
+
+
+def test_assignment_standards_selection_rejects_standard_outside_profile() -> None:
+    assignment = _valid_assignment_config()
+    assignment["focus_standards"] = ["nj_ela_2023_l_vi_11_12_4"]
+
+    with pytest.raises(
+        AssignmentConfigError,
+        match="focus_standards.*nj_ela_2023_l_vi_11_12_4",
+    ):
+        validate_assignment_standards_selection(assignment, _standards_library())
+
+
+def test_assignment_standards_selection_rejects_duplicate_focus_standards() -> None:
+    assignment = _valid_assignment_config()
+    assignment["focus_standards"] = [
+        "nj_ela_2023_rl_cr_11_12_1",
+        " nj_ela_2023_rl_cr_11_12_1 ",
+    ]
+
+    with pytest.raises(AssignmentConfigError, match="duplicate standard IDs"):
+        validate_assignment_standards_selection(assignment, _standards_library())
+
+
+def test_assignment_standards_selection_accepts_empty_focus_standards() -> None:
+    assignment = _valid_assignment_config()
+    assignment["focus_standards"] = []
+
+    assert validate_assignment_standards_selection(
+        assignment,
+        _standards_library(),
+    ) == ()
+
+
+def test_structural_assignment_validation_accepts_valid_config_without_library() -> None:
+    validate_assignment_config(_valid_assignment_config())
+
+
+def test_structural_assignment_validation_rejects_malformed_config_without_library() -> None:
+    assignment = _valid_assignment_config()
+    assignment["focus_standards"] = "nj_ela_2023_rl_cr_11_12_1"
+
+    with pytest.raises(AssignmentConfigError, match="focus_standards.*list"):
+        validate_assignment_config(assignment)


### PR DESCRIPTION
## Summary

* Added `validate_assignment_standards_selection(...)` for validating Quillan assignment standards selections against the shared `pds-core` `StandardsLibrary`.
* Delegated profile and selected-standard validation to `pds_core.standards.validate_profile_standard_selection(...)`.
* Kept `validate_assignment_config(...)` structural-only.
* Added focused synthetic tests for valid selections and failure cases.
* Marked Quillan’s legacy standards profile/comment scaffolding as transitional and Quillan-owned.
* Updated README, docs, and changelog to describe shared `standard_id` usage and pds-core standards-library ownership.

## Shared Standards Validation

Quillan assignment configs now have a narrow shared-library validation path:

* `standards_profile_id` is validated against the shared pds-core standards library.
* `focus_standards` are validated as shared `standard_id`s.
* selected standards must exist in the library;
* selected standards must belong to the selected profile;
* duplicate selected standards are rejected;
* normalized selected IDs are returned.

Structural assignment validation remains separate and does not require a standards library.

## Module Boundary

This PR keeps Quillan-specific review/comment behavior out of pds-core.

Quillan-owned behavior remains Quillan-owned, including:

* comments;
* hotwords;
* feedback templates;
* severity defaults;
* review/comment scaffolding.

Those behaviors should reference shared `standard_id`s rather than define an independent standards universe.

## Non-Goals

This PR does **not** add:

* pds-core changes;
* pds-scoreform changes;
* full review-tag migration;
* full comment-bank migration;
* teacher-facing standards editing UI;
* standards import/export commands;
* Codex-assisted standards ingestion;
* bundled official standards libraries;
* AI-generated feedback;
* grading or mastery logic;
* scan intake changes;
* review-menu workflow changes.

## Validation

* `git diff --check` passed.
* `.\run_tests.ps1` passed:

  * `932 passed`
  * Ruff passed
  * mypy passed: `Success: no issues found in 100 source files`
  * diff whitespace check passed

Closes #148.
