### PR TITLE
Add folder-based QR scan intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added folder-based QR scan intake to `quillan route-scan <folder> --decode-qr`.
+  The command processes supported image/PDF scan files directly inside the
+  folder in deterministic order, skips unsupported files with an aggregate
+  count, preserves recoverable failures for review, and reports one structured
+  intake summary across all processed sources.
 - Added structured QR scan-intake summaries for image and PDF routing,
   including routed, preserved, failed, and review-required counts.
 - Added Quillan assignment validation support for the shared pds-core
@@ -25,8 +30,8 @@ planning and do not by themselves represent releases.
   decoded Quillan `doc=response` PDS1 payload, routes through existing
   route-planning and evidence-filing layers, preserves decode, payload,
   routing, and filing failures under scan review metadata, and keeps
-  `--payload` mode supported. PDF, folder/batch intake, submission assembly,
-  and automatic review-record creation remain out of scope.
+  `--payload` mode supported. Submission assembly and automatic review-record
+  creation remain out of scope.
 - Added a decode-only `quillan decode-scan` diagnostic command that reads one
   supported local image, reports QR decode and Quillan response-page validation
   details, distinguishes decode and payload failures with exit codes, and does

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Quillan currently supports:
   failure metadata under `scans/review/`, including retained-source provenance
   when available, without copying review artifacts;
 - a direct `route-scan` command for already-decoded payloads, one supported
-  QR-bearing image, or a QR-bearing PDF processed page by page. It
-  orchestrates the existing parser, QR decoder, payload validator, route
-  planner, evidence filer, and failure review helpers;
+  QR-bearing image, one QR-bearing PDF processed page by page, or a
+  non-recursive folder of supported QR-bearing scan files. It orchestrates the
+  existing parser, QR decoder, payload validator, route planner, evidence
+  filer, and failure review helpers;
 - read-only assignment submission status listing, workspace-safe local evidence
   opening, and student-aware selected-evidence opening; and
 - explicit, teacher-controlled lightweight submission review-state updates
@@ -104,11 +105,11 @@ The data contracts and design documents describe additional teacher-review
 and paper-ingest workflows that are not yet implemented end to end. In
 particular, Quillan does not currently provide:
 
-- end-to-end production scan intake and routing beyond one already-selected
-  source file;
+- end-to-end production inbox draining, source archiving, or cleanup after
+  scan intake;
 - OCR or handwriting interpretation;
 - automatic conversion of scans into reviewed submissions;
-- batch-ingesting raw scan folders;
+- recursive raw scan folder intake;
 - merging newly routed evidence into existing teacher review state;
 - complete requirements-checking workflows;
 - AI tagging, AI scoring, or AI feedback;
@@ -197,11 +198,12 @@ quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
-- `route-scan` retains one selected source scan and files routed evidence from
-  either an already-decoded payload, one supported QR-bearing image, or one
-  QR-bearing PDF. PDF intake processes pages independently, files page evidence
-  as PNG files, and preserves handled failures under `scans/review/`; it does
-  not batch-ingest folders, run OCR, use the menu, or assemble a submission.
+- `route-scan` retains selected source scans and files routed evidence from
+  either an already-decoded payload, one supported QR-bearing image, one
+  QR-bearing PDF, or a non-recursive folder of supported QR-bearing scan files.
+  PDF intake processes pages independently, files page evidence as PNG files,
+  and preserves handled failures under `scans/review/`; it does not archive
+  source files, run OCR, use the menu, or assemble a submission.
 - `assemble-submissions` creates missing manifests from routed filenames, or
   fully regenerates them with `--overwrite`; it does not inspect file contents
   or choose among ambiguous duplicate evidence.
@@ -575,12 +577,13 @@ Route one selected scan using an already-decoded Quillan PDS1 payload:
 quillan route-scan <source-file> --payload "PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page>|doc=response"
 ```
 
-Or route one supported local image or PDF by decoding Quillan response-page QR
-payloads:
+Or route one supported local image, PDF, or non-recursive folder by decoding
+Quillan response-page QR payloads:
 
 ```powershell
 quillan route-scan <source-image> --decode-qr
 quillan route-scan <source-pdf> --decode-qr
+quillan route-scan <source-folder> --decode-qr
 ```
 
 Successful routing retains the selected source under
@@ -590,18 +593,22 @@ page evidence as PNG files, preserving the physical `source_page_number`
 separately from the decoded `payload_page_number`. Decode, payload, planning,
 filing, and PDF conversion failures are preserved under `scans/review/` when
 possible. QR-aware image and PDF intake prints a structured summary with
-source, page, routed, preserved, failed, and review-required counts. Partial
-success is explicit: exit code `0` can mean every page routed or that expected
-failures were safely preserved for review. Preserved failures require review
-before intake is treated as complete. Exit code `1` means an unexpected or
-unpreserved failure occurred.
+source, page, routed, preserved, failed, skipped unsupported, and
+review-required counts. Folder intake produces one aggregate summary across all
+processed sources and continues after recoverable failures that can be
+preserved for review. Partial success is explicit: exit code `0` can mean every
+page routed or that expected failures were safely preserved for review.
+Preserved failures require review before intake is treated as complete. Exit
+code `1` means an unexpected or unpreserved failure occurred.
 
-This direct developer/teacher primitive is single-scan only. QR-aware intake
-supports `.png`, `.jpg`, `.jpeg`, `.tif`, and `.tiff` images plus `.pdf`
-files. PDF conversion uses `pdf2image` and requires Poppler installed on the
-user's machine. The command does not batch-ingest folders, run OCR, score, tag,
-generate feedback, assemble submissions, create review records, create reports,
-or expose menu scan intake.
+Folder intake is QR-aware only; `--payload` requires a source file and rejects
+folders. It processes only direct child files in deterministic filename order,
+does not recurse, and skips unsupported files while reporting their count.
+QR-aware intake supports `.jpeg`, `.jpg`, `.pdf`, `.png`, `.tif`, and `.tiff`.
+PDF conversion uses `pdf2image` and requires Poppler installed on the user's
+machine. The command does not move, delete, or archive source files, run OCR,
+score, tag, generate feedback, assemble submissions, create review records,
+create reports, or expose menu scan intake.
 
 Assemble all student manifests discoverable from routed filenames in an
 assignment's `scans/` directory:

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -381,20 +381,29 @@ workspace layouts. The active layout is documented in
 Commands that write files document their destination, overwrite policy, and
 handled-failure behavior in their command sections and help output.
 
-## Single-Scan Routing
+## Scan Routing
 
 ```powershell
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
 quillan route-scan <source-image> --decode-qr
 quillan route-scan <source-pdf> --decode-qr
+quillan route-scan <source-folder> --decode-qr
 ```
 
-This command routes one selected source file using exactly one payload source:
-caller-supplied canonical PDS1 text through `--payload`, or one decoded QR
-payload from a supported local image or each page of a PDF through
-`--decode-qr`. Supported QR image extensions are `.png`, `.jpg`, `.jpeg`,
-`.tif`, and `.tiff`; PDF intake supports `.pdf` and uses `pdf2image`, which
-requires Poppler installed on the user's machine.
+This command routes selected scan sources using exactly one payload source:
+caller-supplied canonical PDS1 text through `--payload`, or QR payloads
+decoded from a supported local image, each page of a PDF, or every supported
+scan file directly inside a folder through `--decode-qr`. Folder intake is
+QR-aware only; `--payload` requires a file and rejects folders. Supported scan
+extensions are `.jpeg`, `.jpg`, `.pdf`, `.png`, `.tif`, and `.tiff`. PDF intake
+uses `pdf2image`, which requires Poppler installed on the user's machine.
+
+Folder intake is non-recursive. It processes only direct child files in
+deterministic order by case-insensitive filename with a stable filename
+tie-breaker. Unsupported files such as `.txt`, `.csv`, `.DS_Store`, or
+`Thumbs.db` are skipped, counted in the structured summary, and are not
+failures. An empty folder, or a folder with no supported scan files, prints a
+clear error and exits `1`.
 
 On success it retains the source under `scans/source/YYYY-MM-DD/` and files
 routed evidence under the target assignment's `scans/` directory. PDF pages
@@ -403,15 +412,18 @@ route independently and successful PDF page evidence is filed as PNG files;
 `payload_page_number`. Decode, payload, planning, filing, or PDF conversion
 failures are preserved under `scans/review/` when they can be handled safely.
 QR-aware image and PDF intake prints a structured scan intake summary with
-source, page, routed, preserved, failed, and review-required counts. Partial
-success is explicit: exit `0` can mean all pages routed or that expected
-failures were safely preserved for review. Preserved failures require review
-before intake is treated as complete. Exit `1` means an unexpected failure
-occurred or a failure could not be preserved safely.
+source, page, routed, preserved, failed, skipped unsupported, and
+review-required counts. Folder intake produces one aggregate summary across all
+processed sources. Partial success is explicit: exit `0` can mean all pages
+routed or that expected failures were safely preserved for review, including
+when later files continued after a preserved failure. Preserved failures require
+review before intake is treated as complete. Exit `1` means an unexpected
+failure occurred or a failure could not be preserved safely.
 
-The command does not batch-ingest a folder, expose menu scan intake, assemble
-submissions, create review records, run OCR, or identify a student from raw
-scan content without a valid payload.
+The command does not move, delete, or archive source files after folder intake.
+It does not expose menu scan intake, assemble submissions, create review
+records, run OCR, or identify a student from raw scan content without a valid
+payload.
 
 ## Submission Assembly and Status
 
@@ -672,8 +684,8 @@ explicitly outside the current end-to-end foundation:
 * printable response generation as a dedicated command;
 * submission validation as a dedicated command;
 * guided teacher-facing review and export workflows;
-* raw-scan QR recognition, PDF splitting, folder batch intake, or automatic
-  production scan routing;
+* recursive scan folder intake, source-file archiving, inbox draining, or
+  automatic production scan routing;
 * OCR or handwriting interpretation;
 * complete requirements-checking workflows;
 * AI grading, scoring, tagging, or feedback; and

--- a/quillan/cli_app/handlers/routing.py
+++ b/quillan/cli_app/handlers/routing.py
@@ -35,6 +35,7 @@ from quillan.pdf_pages import (
 from quillan.qr_decode import (
     ImageArray,
     QrImageDecodeResult,
+    SUPPORTED_IMAGE_EXTENSIONS,
     decode_qr_payload_from_image,
     decode_qr_payload_from_image_path,
 )
@@ -59,9 +60,11 @@ from quillan.scan_intake_summary import (
     format_scan_intake_summary,
 )
 
+SUPPORTED_SCAN_EXTENSIONS = frozenset({*SUPPORTED_IMAGE_EXTENSIONS, ".pdf"})
+
 
 def handle_route_scan(args: argparse.Namespace) -> int:
-    """Route one source scan from caller-supplied payload text or image QR."""
+    """Route source scans from caller-supplied payload text or QR."""
     source_file: Path = args.source_file
     intake_timestamp = datetime.now(timezone.utc)
     try:
@@ -74,20 +77,26 @@ def handle_route_scan(args: argparse.Namespace) -> int:
         return 1
 
     if args.decode_qr:
-        if not _validate_source_file(source_file):
-            return 1
-        if source_file.suffix.lower() == ".pdf":
-            return _route_source_pdf_qr(
+        if source_file.is_dir():
+            return _route_source_folder_qr(
                 workspace_root,
-                source_file=source_file,
+                source_folder=source_file,
                 created_at=intake_timestamp,
             )
-        return _route_source_image_qr(
+        if not _validate_source_file(source_file):
+            return 1
+        return _route_source_file_qr(
             workspace_root,
             source_file=source_file,
             created_at=intake_timestamp,
         )
     else:
+        if source_file.is_dir():
+            print(
+                "Error: --payload route-scan mode requires a source file, "
+                "not a folder."
+            )
+            return 1
         if not _validate_source_file(source_file):
             return 1
         decoded_result = _decoded_page_from_payload_text(
@@ -104,6 +113,89 @@ def handle_route_scan(args: argparse.Namespace) -> int:
         source_file=source_file,
         decoded_page=decoded_result,
         created_at=intake_timestamp,
+    )
+
+
+def _route_source_file_qr(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    created_at: datetime,
+) -> int:
+    source_result = _intake_source_file_qr(
+        workspace_root,
+        source_file=source_file,
+        created_at=created_at,
+    )
+    summary = ScanIntakeSummary((source_result,))
+    print()
+    print(format_scan_intake_summary(summary))
+    return 1 if summary.has_failures else 0
+
+
+def _route_source_folder_qr(
+    workspace_root: Path,
+    *,
+    source_folder: Path,
+    created_at: datetime,
+) -> int:
+    if not _validate_source_folder(source_folder):
+        return 1
+
+    supported_files, skipped_unsupported_count = _discover_supported_scan_files(
+        source_folder
+    )
+    if not supported_files:
+        print(f"Error: no supported scan files found in folder: {source_folder}")
+        if skipped_unsupported_count:
+            print(f"Skipped unsupported files: {skipped_unsupported_count}")
+        return 1
+
+    print(f"Processing folder: {source_folder}")
+    print(f"Supported scan files: {len(supported_files)}")
+    if skipped_unsupported_count:
+        print(f"Skipped unsupported files: {skipped_unsupported_count}")
+    print()
+
+    source_results: list[ScanIntakeSourceResult] = []
+    for source_index, source_file in enumerate(supported_files):
+        print(f"Source {source_index + 1}: {source_file.name}")
+        source_results.append(
+            _intake_source_file_qr(
+                workspace_root,
+                source_file=source_file,
+                created_at=created_at + timedelta(seconds=source_index),
+                route_image_as_png=True,
+            )
+        )
+        print()
+
+    summary = ScanIntakeSummary(
+        tuple(source_results),
+        skipped_unsupported_count=skipped_unsupported_count,
+    )
+    print(format_scan_intake_summary(summary))
+    return 1 if summary.has_failures else 0
+
+
+def _intake_source_file_qr(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    created_at: datetime,
+    route_image_as_png: bool = False,
+) -> ScanIntakeSourceResult:
+    if source_file.suffix.lower() == ".pdf":
+        return _intake_source_pdf_qr(
+            workspace_root,
+            source_file=source_file,
+            created_at=created_at,
+        )
+    return _intake_source_image_qr(
+        workspace_root,
+        source_file=source_file,
+        created_at=created_at,
+        route_as_png=route_image_as_png,
     )
 
 
@@ -221,13 +313,14 @@ def _decoded_page_from_qr_image(
     return validation_result
 
 
-def _route_source_image_qr(
+def _intake_source_image_qr(
     workspace_root: Path,
     *,
     source_file: Path,
     created_at: datetime,
-) -> int:
-    """Decode and route one QR-bearing image, then print an intake summary."""
+    route_as_png: bool = False,
+) -> ScanIntakeSourceResult:
+    """Decode and route one QR-bearing image."""
     decoded_result = _decoded_page_from_source_qr(
         workspace_root,
         source_file=source_file,
@@ -236,24 +329,72 @@ def _route_source_image_qr(
     if isinstance(decoded_result, ScanIntakePageResult):
         page_result = decoded_result
     else:
-        page_result = _route_decoded_page_result(
+        if route_as_png and source_file.suffix.lower() != ".png":
+            page_result = _route_decoded_image_page_as_png_result(
+                workspace_root,
+                source_file=source_file,
+                decoded_page=decoded_result,
+                created_at=created_at,
+            )
+        else:
+            page_result = _route_decoded_page_result(
+                workspace_root,
+                source_file=source_file,
+                decoded_page=decoded_result,
+                created_at=created_at,
+            )
+    return _source_result_from_pages(
+        source_file=source_file,
+        source_type="image",
+        page_results=(page_result,),
+    )
+
+
+def _route_decoded_image_page_as_png_result(
+    workspace_root: Path,
+    *,
+    source_file: Path,
+    decoded_page: DecodedResponsePage,
+    created_at: datetime,
+) -> ScanIntakePageResult:
+    with tempfile.TemporaryDirectory(prefix="quillan-image-route-") as temp_dir:
+        routed_image_path = Path(temp_dir) / "source.png"
+        try:
+            image = cv2.imread(str(source_file), cv2.IMREAD_COLOR)
+            written = (
+                False
+                if image is None
+                else cv2.imwrite(str(routed_image_path), image)
+            )
+        except cv2.error as error:
+            print(f"Error: could not prepare source image for routing: {error}")
+            return _failed_page_result(
+                source_filename=source_file.name,
+                source_page_number=None,
+                payload_page_number=decoded_page.page_number,
+                failure_category="processing_error",
+                failure_message=str(error),
+                decoded_page=decoded_page,
+            )
+        if not written:
+            print("Error: could not prepare source image for routing.")
+            return _failed_page_result(
+                source_filename=source_file.name,
+                source_page_number=None,
+                payload_page_number=decoded_page.page_number,
+                failure_category="processing_error",
+                failure_message="Could not prepare source image for routing.",
+                decoded_page=decoded_page,
+            )
+
+        return _route_decoded_page_result(
             workspace_root,
             source_file=source_file,
-            decoded_page=decoded_result,
+            decoded_page=decoded_page,
             created_at=created_at,
+            routed_source_file_path=routed_image_path,
+            routed_extension=".png",
         )
-    summary = ScanIntakeSummary(
-        (
-            _source_result_from_pages(
-                source_file=source_file,
-                source_type="image",
-                page_results=(page_result,),
-            ),
-        )
-    )
-    print()
-    print(format_scan_intake_summary(summary))
-    return 1 if summary.has_failures else 0
 
 
 def _route_decoded_page(
@@ -377,18 +518,18 @@ def _route_decoded_page_result(
     )
 
 
-def _route_source_pdf_qr(
+def _intake_source_pdf_qr(
     workspace_root: Path,
     *,
     source_file: Path,
     created_at: datetime,
-) -> int:
+) -> ScanIntakeSourceResult:
     """Convert and route each page of a QR-bearing PDF scan independently."""
     print(f"Processing PDF: {source_file}")
     try:
         pages = list(iter_pdf_page_images(source_file))
     except PdfPageConversionError as error:
-        return _preserve_pdf_conversion_failure(
+        return _pdf_conversion_failure_source_result(
             workspace_root,
             source_file=source_file,
             failure=error.failure,
@@ -400,7 +541,7 @@ def _route_source_pdf_qr(
             failure_message=f"Unexpected PDF conversion failure: {error}",
             module_details={"failure_origin": "pdf_conversion"},
         )
-        return _preserve_pdf_conversion_failure(
+        return _pdf_conversion_failure_source_result(
             workspace_root,
             source_file=source_file,
             failure=failure,
@@ -416,7 +557,7 @@ def _route_source_pdf_qr(
                 "reason": "zero_pages",
             },
         )
-        return _preserve_pdf_conversion_failure(
+        return _pdf_conversion_failure_source_result(
             workspace_root,
             source_file=source_file,
             failure=failure,
@@ -447,18 +588,11 @@ def _route_source_pdf_qr(
                     f" - {page_result.failure_category}"
                 )
 
-    summary = ScanIntakeSummary(
-        (
-            _source_result_from_pages(
-                source_file=source_file,
-                source_type="pdf",
-                page_results=tuple(page_results),
-            ),
-        )
+    return _source_result_from_pages(
+        source_file=source_file,
+        source_type="pdf",
+        page_results=tuple(page_results),
     )
-    print()
-    print(format_scan_intake_summary(summary))
-    return 1 if summary.has_failures else 0
 
 
 def _route_pdf_page_qr(
@@ -621,6 +755,37 @@ def _validate_source_file(source_file: Path) -> bool:
         print(f"Error: source file is not readable: {error}")
         return False
     return True
+
+
+def _validate_source_folder(source_folder: Path) -> bool:
+    """Return whether the selected scan folder is an existing directory."""
+    try:
+        if not source_folder.is_dir():
+            print(
+                "Error: scan folder must be an existing directory: "
+                f"{source_folder}"
+            )
+            return False
+        list(source_folder.iterdir())
+    except OSError as error:
+        print(f"Error: scan folder is not readable: {error}")
+        return False
+    return True
+
+
+def _discover_supported_scan_files(source_folder: Path) -> tuple[list[Path], int]:
+    """Return direct child scan files in deterministic order and skip count."""
+    supported_files: list[Path] = []
+    skipped_unsupported_count = 0
+    for child in source_folder.iterdir():
+        if not child.is_file():
+            continue
+        if child.suffix.lower() in SUPPORTED_SCAN_EXTENSIONS:
+            supported_files.append(child)
+        else:
+            skipped_unsupported_count += 1
+    supported_files.sort(key=lambda path: (path.name.lower(), path.name))
+    return supported_files, skipped_unsupported_count
 
 
 def _preserve_payload_parse_failure(
@@ -798,13 +963,13 @@ def _print_preserved_intake_failure(
     print(f"Review record: {review_record.failure_metadata_relative_path}")
 
 
-def _preserve_pdf_conversion_failure(
+def _pdf_conversion_failure_source_result(
     workspace_root: Path,
     *,
     source_file: Path,
     failure: PdfPageConversionFailure,
     created_at: datetime,
-) -> int:
+) -> ScanIntakeSourceResult:
     """Preserve a whole-PDF conversion failure as one review record."""
     try:
         review_record = preserve_routing_failure_for_review(
@@ -830,78 +995,57 @@ def _preserve_pdf_conversion_failure(
             "Error: PDF conversion failure could not be preserved for review: "
             f"{review_error}"
         )
-        summary = ScanIntakeSummary(
-            (
-                ScanIntakeSourceResult(
-                    source_filename=source_file.name,
-                    source_path=source_file,
-                    source_type="pdf",
-                    status="failed",
-                    pages_attempted=0,
-                    routed_count=0,
-                    preserved_count=0,
-                    failed_count=1,
-                    page_results=(),
-                    source_failure_category="review_preservation_failed",
-                    source_failure_message=str(review_error),
-                ),
-            )
+        return ScanIntakeSourceResult(
+            source_filename=source_file.name,
+            source_path=source_file,
+            source_type="pdf",
+            status="failed",
+            pages_attempted=0,
+            routed_count=0,
+            preserved_count=0,
+            failed_count=1,
+            page_results=(),
+            source_failure_category="review_preservation_failed",
+            source_failure_message=str(review_error),
         )
-        print()
-        print(format_scan_intake_summary(summary))
-        return 1
     except Exception as unexpected_error:
         print(
             "Error: unexpected failure while preserving PDF conversion failure: "
             f"{unexpected_error}"
         )
-        summary = ScanIntakeSummary(
-            (
-                ScanIntakeSourceResult(
-                    source_filename=source_file.name,
-                    source_path=source_file,
-                    source_type="pdf",
-                    status="failed",
-                    pages_attempted=0,
-                    routed_count=0,
-                    preserved_count=0,
-                    failed_count=1,
-                    page_results=(),
-                    source_failure_category="processing_error",
-                    source_failure_message=str(unexpected_error),
-                ),
-            )
+        return ScanIntakeSourceResult(
+            source_filename=source_file.name,
+            source_path=source_file,
+            source_type="pdf",
+            status="failed",
+            pages_attempted=0,
+            routed_count=0,
+            preserved_count=0,
+            failed_count=1,
+            page_results=(),
+            source_failure_category="processing_error",
+            source_failure_message=str(unexpected_error),
         )
-        print()
-        print(format_scan_intake_summary(summary))
-        return 1
 
     print("PDF could not be converted; preserved for review.")
     print(f"Category: {review_record.failure_category}")
     print(f"Review record: {review_record.failure_metadata_relative_path}")
-    summary = ScanIntakeSummary(
-        (
-            ScanIntakeSourceResult(
-                source_filename=source_file.name,
-                source_path=source_file,
-                source_type="pdf",
-                status="preserved",
-                pages_attempted=0,
-                routed_count=0,
-                preserved_count=1,
-                failed_count=0,
-                page_results=(),
-                source_failure_category=review_record.failure_category,
-                source_failure_message=review_record.failure_message,
-                review_metadata_relative_path=(
-                    review_record.failure_metadata_relative_path
-                ),
-            ),
-        )
+    return ScanIntakeSourceResult(
+        source_filename=source_file.name,
+        source_path=source_file,
+        source_type="pdf",
+        status="preserved",
+        pages_attempted=0,
+        routed_count=0,
+        preserved_count=1,
+        failed_count=0,
+        page_results=(),
+        source_failure_category=review_record.failure_category,
+        source_failure_message=review_record.failure_message,
+        review_metadata_relative_path=(
+            review_record.failure_metadata_relative_path
+        ),
     )
-    print()
-    print(format_scan_intake_summary(summary))
-    return 0
 
 
 def _page_result_from_filed_evidence(

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -76,19 +76,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     route_scan_parser = subparsers.add_parser(
         "route-scan",
-        help="Route one Quillan response scan from payload text or QR.",
+        help="Route Quillan response scans from payload text or QR.",
         description=(
             "Route one scan file using either an already-decoded Quillan PDS1 "
             "payload or QR payloads decoded from a supported local image or "
-            "PDF. PDF files are processed page by page. "
-            "Exit 0 means the file was routed or safely preserved for review; "
-            "exit 1 means the input could not be handled safely."
+            "PDF. With --decode-qr, a folder path processes supported image "
+            "and PDF files directly inside that folder in deterministic order. "
+            "PDF files are processed page by page. Exit 0 means all attempted "
+            "scan sources were routed or safely preserved for review; exit 1 "
+            "means the input or an attempted source could not be handled safely."
         ),
     )
     route_scan_parser.add_argument(
         "source_file",
         type=Path,
-        help="Path to the selected source scan file.",
+        help="Path to the selected source scan file, or a folder with --decode-qr.",
     )
     payload_group = route_scan_parser.add_mutually_exclusive_group(
         required=True
@@ -102,7 +104,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Decode Quillan response-page QR payloads from a source image or "
-            "PDF."
+            "PDF, or from supported image/PDF files directly inside a folder."
         ),
     )
     route_scan_parser.set_defaults(handler=handle_route_scan)

--- a/quillan/scan_intake_summary.py
+++ b/quillan/scan_intake_summary.py
@@ -49,6 +49,7 @@ class ScanIntakeSummary:
     """Aggregate QR-aware scan intake outcomes."""
 
     source_results: tuple[ScanIntakeSourceResult, ...]
+    skipped_unsupported_count: int = 0
 
     @property
     def source_count(self) -> int:
@@ -108,6 +109,7 @@ def format_scan_intake_summary(summary: ScanIntakeSummary) -> str:
         f"Routed: {summary.routed_count}",
         f"Preserved for review: {summary.preserved_count}",
         f"Failed: {summary.failed_count}",
+        f"Skipped unsupported files: {summary.skipped_unsupported_count}",
         f"Review required: {'yes' if summary.requires_review else 'no'}",
     ]
     if summary.has_failures:

--- a/tests/test_cli_route_scan.py
+++ b/tests/test_cli_route_scan.py
@@ -233,8 +233,8 @@ def test_route_scan_directory_source_returns_one_without_review_record(
 
     output = capsys.readouterr().out
     assert result == 1
-    assert "source file" in output
-    assert "existing regular file" in output
+    assert "--payload route-scan mode requires a source file" in output
+    assert "not a folder" in output
     assert not (workspace / "scans" / "review").exists()
     assert not (workspace / "scans" / "source").exists()
     assert not list(workspace.rglob("response_*.pdf"))

--- a/tests/test_cli_route_scan_folder.py
+++ b/tests/test_cli_route_scan_folder.py
@@ -1,0 +1,352 @@
+"""Focused tests for folder-based QR scan intake."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import cast
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+from pds_core.scan_failure_metadata import validate_routing_failure_metadata
+import pytest
+import qrcode
+from qrcode.image.pil import PilImage
+
+from quillan.cli import main
+import quillan.cli_app.handlers.routing as cli_routing
+from quillan.payloads import build_response_payload
+from quillan.pdf_pages import PdfPageConversionError, PdfPageConversionFailure
+from quillan.pdf_pages import PdfPageImage
+from quillan.routing_review import RoutingReviewError
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+SECOND_STUDENT_ID = "stu_0002"
+UNKNOWN_STUDENT_ID = "stu_9999"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr(cli_routing, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _write_workspace(root: Path) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": SECOND_STUDENT_ID,
+                "last_name": "Patel",
+                "first_name": "Mina",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment),
+        encoding="utf-8",
+    )
+
+
+def _valid_payload(
+    *,
+    student_id: str = STUDENT_ID,
+    page: int = 2,
+) -> str:
+    return build_response_payload(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=student_id,
+        page=page,
+    )
+
+
+def _make_qr_image(payload: str, *, box_size: int = 8) -> NDArray[np.uint8]:
+    qr = qrcode.QRCode[PilImage](
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=box_size,
+        border=4,
+        image_factory=PilImage,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    rgb_image = image.get_image().convert("RGB")
+    return cast(
+        NDArray[np.uint8],
+        cv2.cvtColor(np.asarray(rgb_image), cv2.COLOR_RGB2BGR),
+    )
+
+
+def _write_qr_image(path: Path, payload: str) -> None:
+    assert cv2.imwrite(str(path), _make_qr_image(payload))
+
+
+def _blank_image(path: Path) -> None:
+    blank = np.full((550, 425, 3), 255, dtype=np.uint8)
+    assert cv2.imwrite(str(path), blank)
+
+
+def _pdf_pages(*images: object) -> list[PdfPageImage]:
+    return [
+        PdfPageImage(page_number=page_number, image=image)
+        for page_number, image in enumerate(images, start=1)
+    ]
+
+
+def _review_metadata_records(workspace: Path) -> list[dict[str, object]]:
+    records = sorted((workspace / "scans" / "review").glob("*.json"))
+    loaded_records: list[dict[str, object]] = []
+    for record in records:
+        loaded = json.loads(record.read_text(encoding="utf-8"))
+        assert isinstance(loaded, dict)
+        validate_routing_failure_metadata(loaded)
+        loaded_records.append(loaded)
+    return loaded_records
+
+
+def _routed_pngs(workspace: Path) -> list[Path]:
+    return sorted(
+        (
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "scans"
+        ).glob("response_*.png")
+    )
+
+
+def test_route_scan_decode_qr_folder_routes_supported_images_in_order(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+    _write_qr_image(folder / "b_scan.png", _valid_payload(student_id=SECOND_STUDENT_ID))
+    _write_qr_image(folder / "A_scan.png", _valid_payload(student_id=STUDENT_ID))
+
+    result = main(["route-scan", str(folder), "--decode-qr"])
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert len(_routed_pngs(workspace)) == 2
+    assert output.index("Source 1: A_scan.png") < output.index("Source 2: b_scan.png")
+    assert "Sources processed: 2" in output
+    assert "Pages attempted: 2" in output
+    assert "Routed: 2" in output
+    assert "Skipped unsupported files: 0" in output
+
+
+def test_route_scan_decode_qr_folder_processes_supported_pdfs(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+    source = folder / "responses.pdf"
+    source.write_bytes(b"%PDF-1.4\nsynthetic response scan\n%%EOF\n")
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(_make_qr_image(_valid_payload())),
+    )
+
+    assert main(["route-scan", str(folder), "--decode-qr"]) == 0
+
+    output = capsys.readouterr().out
+    assert len(_routed_pngs(workspace)) == 1
+    assert "Sources processed: 1" in output
+    assert "Pages attempted: 1" in output
+    assert "Routed: 1" in output
+
+
+def test_route_scan_decode_qr_folder_skips_unsupported_files(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+    _write_qr_image(folder / "response.jpg", _valid_payload())
+    (folder / "notes.txt").write_text("ignore me", encoding="utf-8")
+    (folder / "Thumbs.db").write_bytes(b"synthetic")
+
+    assert main(["route-scan", str(folder), "--decode-qr"]) == 0
+
+    output = capsys.readouterr().out
+    assert len(_routed_pngs(workspace)) == 1
+    assert "Skipped unsupported files: 2" in output
+
+
+def test_route_scan_decode_qr_folder_empty_returns_clear_error(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "empty"
+    folder.mkdir()
+
+    assert main(["route-scan", str(folder), "--decode-qr"]) == 1
+
+    output = capsys.readouterr().out
+    assert f"Error: no supported scan files found in folder: {folder}" in output
+    assert not _routed_pngs(workspace)
+
+
+def test_route_scan_payload_mode_rejects_folder(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+
+    assert main(["route-scan", str(folder), "--payload", _valid_payload()]) == 1
+
+    output = capsys.readouterr().out
+    assert "--payload route-scan mode requires a source file" in output
+    assert not _routed_pngs(workspace)
+
+
+def test_route_scan_decode_qr_folder_preserved_failure_continues(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+    _blank_image(folder / "blank.png")
+    _write_qr_image(folder / "valid.png", _valid_payload())
+
+    assert main(["route-scan", str(folder), "--decode-qr"]) == 0
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata_records(workspace)
+    assert len(_routed_pngs(workspace)) == 1
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "payload_missing"
+    assert "Sources processed: 2" in output
+    assert "Routed: 1" in output
+    assert "Preserved for review: 1" in output
+    assert "Review required: yes" in output
+    assert "- payload_missing: 1" in output
+
+
+def test_route_scan_decode_qr_folder_pdf_conversion_failure_continues(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+    bad_pdf = folder / "bad.pdf"
+    good_pdf = folder / "good.pdf"
+    bad_pdf.write_bytes(b"%PDF-1.4\nbad\n%%EOF\n")
+    good_pdf.write_bytes(b"%PDF-1.4\ngood\n%%EOF\n")
+
+    def convert(source: Path) -> list[PdfPageImage]:
+        if source.name == "bad.pdf":
+            raise PdfPageConversionError(
+                PdfPageConversionFailure(
+                    failure_category="source_unreadable",
+                    failure_message="Synthetic conversion failure.",
+                    module_details={"failure_origin": "pdf_conversion"},
+                )
+            )
+        return _pdf_pages(_make_qr_image(_valid_payload()))
+
+    monkeypatch.setattr(cli_routing, "iter_pdf_page_images", convert)
+
+    assert main(["route-scan", str(folder), "--decode-qr"]) == 0
+
+    output = capsys.readouterr().out
+    metadata = _review_metadata_records(workspace)
+    assert len(_routed_pngs(workspace)) == 1
+    assert len(metadata) == 1
+    assert metadata[0]["failure_category"] == "source_unreadable"
+    assert "Sources processed: 2" in output
+    assert "Routed: 1" in output
+    assert "Preserved for review: 1" in output
+    assert "- source_unreadable: 1" in output
+
+
+def test_route_scan_decode_qr_folder_unpreserved_failure_exits_one(
+    workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+    _blank_image(folder / "blank.png")
+    _write_qr_image(folder / "valid.png", _valid_payload())
+
+    def fail_preservation(*_args: object, **_kwargs: object) -> object:
+        raise RoutingReviewError("Synthetic preservation failure.")
+
+    monkeypatch.setattr(
+        cli_routing,
+        "preserve_decode_failure_for_review",
+        fail_preservation,
+    )
+
+    assert main(["route-scan", str(folder), "--decode-qr"]) == 1
+
+    output = capsys.readouterr().out
+    assert len(_routed_pngs(workspace)) == 1
+    assert "Sources processed: 2" in output
+    assert "Routed: 1" in output
+    assert "Failed: 1" in output
+    assert "- review_preservation_failed: 1" in output

--- a/tests/test_scan_intake_summary.py
+++ b/tests/test_scan_intake_summary.py
@@ -41,6 +41,7 @@ def test_empty_summary_counts_are_zero() -> None:
     assert summary.routed_count == 0
     assert summary.preserved_count == 0
     assert summary.failed_count == 0
+    assert summary.skipped_unsupported_count == 0
     assert not summary.requires_review
     assert not summary.has_failures
     assert summary.failure_categories == {}
@@ -125,6 +126,15 @@ def test_summary_formatter_includes_review_message_and_categories() -> None:
     assert "Scan intake summary" in output
     assert "Sources processed: 1" in output
     assert "Pages attempted: 1" in output
+    assert "Skipped unsupported files: 0" in output
     assert "Review required: yes" in output
     assert "Review required before intake is complete." in output
     assert "- payload_missing: 1" in output
+
+
+def test_summary_formatter_includes_skipped_unsupported_count() -> None:
+    output = format_scan_intake_summary(
+        ScanIntakeSummary((), skipped_unsupported_count=3)
+    )
+
+    assert "Skipped unsupported files: 3" in output


### PR DESCRIPTION
## Summary

* Added folder-based QR scan intake through `quillan route-scan <folder> --decode-qr`.
* Added non-recursive folder discovery for supported scan files.
* Added deterministic filename ordering.
* Added unsupported-file skip counting and summary output.
* Reused the shared single-source QR intake path through `_intake_source_file_qr(...)`.
* Rejected folder input for `--payload` mode with a clear error.
* Added folder-intake tests.
* Updated parser help, README, CLI contract docs, and changelog.

## Behavior

Folder-based QR intake now processes supported scan files directly inside a selected folder:

* `.jpeg`
* `.jpg`
* `.pdf`
* `.png`
* `.tif`
* `.tiff`

Folder intake is non-recursive. Unsupported files are skipped and counted, not treated as routing failures.

Example:

```powershell
quillan route-scan path\to\folder --decode-qr
```

`--payload` mode remains single-file only. Passing a folder with `--payload` now returns a clear error:

```text
--payload route-scan mode requires a source file, not a folder.
```

## Summary Output

Folder intake produces one aggregate `ScanIntakeSummary` across all processed sources, including:

* sources processed;
* pages attempted;
* routed count;
* preserved-for-review count;
* failed count;
* skipped unsupported file count;
* review-required status;
* failure categories.

Recoverable failures are preserved for review and do not stop later files from being processed.

## Routing Details

Folder intake reuses the existing image/PDF QR intake path rather than duplicating routing logic.

For non-PNG images in folder mode, the implementation routes through a temporary PNG artifact while retaining the original source file. This keeps `.jpg`, `.jpeg`, `.tif`, and `.tiff` supported while preserving routed PNG evidence behavior.

## Scope Boundary

This PR does **not** add:

* recursive folder traversal;
* inbox draining;
* source-file archiving;
* moving or deleting source files;
* submission assembly;
* teacher-facing menu integration;
* review workflow menus;
* export workflow changes;
* OCR;
* handwriting recognition;
* PDF text extraction;
* AI scoring;
* AI feedback;
* automatic grading;
* standards work;
* pds-core changes;
* pds-scoreform changes.

Submission assembly remains future work.

## Validation

`.\run_tests.ps1` passed with the project venv first on `PATH`:

* pytest: `946 passed`
* Ruff: `All checks passed!`
* mypy: `Success: no issues found in 103 source files`
* diff whitespace: `All checks passed`

Note: running `.\run_tests.ps1` without the venv on `PATH` picked up the wrong global Python environment and failed collection due to missing `pypdf`. The passing run used:

```powershell
$env:PATH = "$PWD\.venv\Scripts;$env:PATH"; .\run_tests.ps1
```

Closes #133.
