### PR TITLE
Add post-intake assembly guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added post-intake submission assembly next-step guidance based on routed scan
+  intake results.
 - Added folder-based QR scan intake to `quillan route-scan <folder> --decode-qr`.
   The command processes supported image/PDF scan files directly inside the
   folder in deterministic order, skips unsupported files with an aggregate

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Quillan currently supports:
   QR-bearing image, one QR-bearing PDF processed page by page, or a
   non-recursive folder of supported QR-bearing scan files. It orchestrates the
   existing parser, QR decoder, payload validator, route planner, evidence
-  filer, and failure review helpers;
+  filer, failure review helpers, and post-intake `assemble-submissions`
+  next-step guidance derived from the current intake summary;
 - read-only assignment submission status listing, workspace-safe local evidence
   opening, and student-aware selected-evidence opening; and
 - explicit, teacher-controlled lightweight submission review-state updates
@@ -155,24 +156,26 @@ The supported teacher/developer sequence is:
 3. `route-scan` retains the source scan and files routed assignment evidence.
 4. If routing cannot safely complete, Quillan preserves failure metadata under
    `scans/review/` rather than silently discarding the failure.
-5. `assemble-submissions` creates missing student submission manifests from
+5. QR-aware `route-scan` reports which class/assignment pairs have newly
+   routed evidence and prints explicit `assemble-submissions` next steps.
+6. `assemble-submissions` creates missing student submission manifests from
    routed evidence.
-6. `list-submissions` reports assignment status without writing files.
-7. `open-submission` opens the selected evidence for a specific student.
-8. The teacher reads and evaluates the evidence in the local system viewer.
-9. `add-note` appends a teacher-entered observation to the student's canonical
+7. `list-submissions` reports assignment status without writing files.
+8. `open-submission` opens the selected evidence for a specific student.
+9. The teacher reads and evaluates the evidence in the local system viewer.
+10. `add-note` appends a teacher-entered observation to the student's canonical
    `review.json`.
-10. `add-tag` appends a teacher-entered structured observation to that review
+11. `add-tag` appends a teacher-entered structured observation to that review
     record.
-11. `add-comment` selects student-facing teacher-authored language from a
+12. `add-comment` selects student-facing teacher-authored language from a
     shared comment bank into that review record as a stable snapshot.
-12. `set-score` sets or updates one explicitly teacher-entered criterion score.
-13. `export-feedback` writes selected comments and criterion scores to a
+13. `set-score` sets or updates one explicitly teacher-entered criterion score.
+14. `export-feedback` writes selected comments and criterion scores to a
     student-facing Markdown file.
-14. `export-class-summary` writes an assignment-level teacher review CSV.
-15. `export-standards-summary` writes an assignment-level standards-linked
+15. `export-class-summary` writes an assignment-level teacher review CSV.
+16. `export-standards-summary` writes an assignment-level standards-linked
     tag and selected-comment CSV.
-16. `set-review-state` records lightweight submission-manifest progress when
+17. `set-review-state` records lightweight submission-manifest progress when
     the teacher chooses.
 
 Opening evidence and updating review state are separate teacher-controlled
@@ -203,7 +206,11 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   QR-bearing PDF, or a non-recursive folder of supported QR-bearing scan files.
   PDF intake processes pages independently, files page evidence as PNG files,
   and preserves handled failures under `scans/review/`; it does not archive
-  source files, run OCR, use the menu, or assemble a submission.
+  source files, run OCR, use the menu, or assemble a submission. After
+  QR-aware intake, the command prints explicit `assemble-submissions` commands
+  for class/assignment pairs with newly routed pages in the current intake
+  summary. Preserved failures should still be reviewed before treating the
+  batch as complete.
 - `assemble-submissions` creates missing manifests from routed filenames, or
   fully regenerates them with `--overwrite`; it does not inspect file contents
   or choose among ambiguous duplicate evidence.
@@ -609,6 +616,15 @@ PDF conversion uses `pdf2image` and requires Poppler installed on the user's
 machine. The command does not move, delete, or archive source files, run OCR,
 score, tag, generate feedback, assemble submissions, create review records,
 create reports, or expose menu scan intake.
+
+After QR-aware intake, `route-scan` derives class/assignment assembly targets
+from the current structured intake summary and prints safe next-step commands,
+such as `quillan assemble-submissions <class_id> <assignment_id>`, for newly
+routed evidence. It does not rescan assignment `scans/` directories and does
+not include preserved or failed pages as assembly targets. If review is
+required, the message warns that preserved failures should be reviewed before
+the batch is treated as complete. Submission assembly remains the explicit step
+that creates or refreshes manifests.
 
 Assemble all student manifests discoverable from routed filenames in an
 assignment's `scans/` directory:

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -420,6 +420,17 @@ when later files continued after a preserved failure. Preserved failures require
 review before intake is treated as complete. Exit `1` means an unexpected
 failure occurred or a failure could not be preserved safely.
 
+After QR-aware intake, the command derives assembly targets from routed
+`ScanIntakePageResult` entries in the current `ScanIntakeSummary`. Routed pages
+with both `class_id` and `assignment_id` are grouped by class/assignment and
+reported in deterministic order as explicit `quillan assemble-submissions
+<class_id> <assignment_id>` next-step commands. Preserved, failed, skipped, and
+malformed routed pages without complete class/assignment identity do not create
+assembly targets. The command does not scan assignment `scans/` directories to
+find targets, so the guidance only reflects evidence routed by the current
+intake run. When review is required, the next-step message warns that preserved
+failures should be reviewed before the batch is treated as complete.
+
 The command does not move, delete, or archive source files after folder intake.
 It does not expose menu scan intake, assemble submissions, create review
 records, run OCR, or identify a student from raw scan content without a valid

--- a/quillan/cli_app/handlers/routing.py
+++ b/quillan/cli_app/handlers/routing.py
@@ -22,6 +22,10 @@ from quillan.evidence_filing import (
     RoutedEvidenceFile,
     file_routed_response_evidence,
 )
+from quillan.intake_assembly import (
+    IntakeAssemblyTarget,
+    assembly_targets_from_intake_summary,
+)
 from quillan.payload_validation import (
     ResponsePayloadValidationFailure,
     decoded_payload_to_response_page,
@@ -130,6 +134,7 @@ def _route_source_file_qr(
     summary = ScanIntakeSummary((source_result,))
     print()
     print(format_scan_intake_summary(summary))
+    _print_submission_assembly_next_steps(summary)
     return 1 if summary.has_failures else 0
 
 
@@ -175,7 +180,45 @@ def _route_source_folder_qr(
         skipped_unsupported_count=skipped_unsupported_count,
     )
     print(format_scan_intake_summary(summary))
+    _print_submission_assembly_next_steps(summary)
     return 1 if summary.has_failures else 0
+
+
+def _print_submission_assembly_next_steps(summary: ScanIntakeSummary) -> None:
+    targets = assembly_targets_from_intake_summary(summary)
+    if not targets:
+        return
+
+    print()
+    if summary.requires_review:
+        print("Review required before intake is complete.")
+        print(
+            "You may assemble submissions for routed evidence now, but "
+            "preserved failures should be reviewed before treating the batch "
+            "as complete."
+        )
+        print()
+    print("Next step:" if len(targets) == 1 else "Next steps:")
+    print("Run submission assembly for newly routed evidence:")
+    if len(targets) == 1:
+        target = targets[0]
+        line = _format_assembly_command(target)
+        if target.routed_page_count != 1:
+            line = f"{line}  ({target.routed_page_count} routed pages)"
+        print(line)
+        return
+    for target in targets:
+        print(
+            f"- {_format_assembly_command(target)}  "
+            f"({target.routed_page_count} routed pages)"
+        )
+
+
+def _format_assembly_command(target: IntakeAssemblyTarget) -> str:
+    return (
+        "quillan assemble-submissions "
+        f"{target.class_id} {target.assignment_id}"
+    )
 
 
 def _intake_source_file_qr(

--- a/quillan/intake_assembly.py
+++ b/quillan/intake_assembly.py
@@ -1,0 +1,41 @@
+"""Derive submission assembly guidance from scan-intake results."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+from quillan.scan_intake_summary import ScanIntakeSummary
+
+
+@dataclass(frozen=True, slots=True)
+class IntakeAssemblyTarget:
+    """One class assignment with newly routed evidence."""
+
+    class_id: str
+    assignment_id: str
+    routed_page_count: int
+
+
+def assembly_targets_from_intake_summary(
+    summary: ScanIntakeSummary,
+) -> tuple[IntakeAssemblyTarget, ...]:
+    """Return deterministic assembly targets from routed intake pages."""
+    counts: Counter[tuple[str, str]] = Counter()
+    for source in summary.source_results:
+        for page in source.page_results:
+            if (
+                page.status == "routed"
+                and page.class_id is not None
+                and page.assignment_id is not None
+            ):
+                counts[(page.class_id, page.assignment_id)] += 1
+
+    return tuple(
+        IntakeAssemblyTarget(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            routed_page_count=counts[(class_id, assignment_id)],
+        )
+        for class_id, assignment_id in sorted(counts)
+    )

--- a/tests/test_cli_route_scan_folder.py
+++ b/tests/test_cli_route_scan_folder.py
@@ -24,6 +24,7 @@ from quillan.routing_review import RoutingReviewError
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
+SECOND_ASSIGNMENT_ID = "memoir_01_synthetic"
 STUDENT_ID = "stu_0001"
 SECOND_STUDENT_ID = "stu_0002"
 UNKNOWN_STUDENT_ID = "stu_9999"
@@ -38,8 +39,8 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def _write_workspace(root: Path) -> None:
     class_dir = root / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
-    assignment_dir.mkdir(parents=True)
+    assignments_dir = class_dir / "assignments"
+    assignments_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
         "w",
@@ -76,31 +77,35 @@ def _write_workspace(root: Path) -> None:
             }
         )
 
-    assignment = {
-        "assignment_id": ASSIGNMENT_ID,
-        "title": "Synthetic Essay",
-        "class_ids": [CLASS_ID],
-        "writing_type": "argument",
-        "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["W.1"],
-        "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
-    }
-    (assignment_dir / "assignment.json").write_text(
-        json.dumps(assignment),
-        encoding="utf-8",
-    )
+    for assignment_id in (ASSIGNMENT_ID, SECOND_ASSIGNMENT_ID):
+        assignment_dir = assignments_dir / assignment_id
+        assignment_dir.mkdir()
+        assignment = {
+            "assignment_id": assignment_id,
+            "title": "Synthetic Essay",
+            "class_ids": [CLASS_ID],
+            "writing_type": "argument",
+            "standards_profile_id": "synthetic_profile",
+            "tagging_mode": "focus",
+            "focus_standards": ["W.1"],
+            "basic_requirements": {"paragraphs_min": 1},
+            "rubric_id": "synthetic_rubric",
+        }
+        (assignment_dir / "assignment.json").write_text(
+            json.dumps(assignment),
+            encoding="utf-8",
+        )
 
 
 def _valid_payload(
     *,
+    assignment_id: str = ASSIGNMENT_ID,
     student_id: str = STUDENT_ID,
     page: int = 2,
 ) -> str:
     return build_response_payload(
         class_id=CLASS_ID,
-        assignment_id=ASSIGNMENT_ID,
+        assignment_id=assignment_id,
         student_id=student_id,
         page=page,
     )
@@ -184,6 +189,37 @@ def test_route_scan_decode_qr_folder_routes_supported_images_in_order(
     assert "Pages attempted: 2" in output
     assert "Routed: 2" in output
     assert "Skipped unsupported files: 0" in output
+    assert (
+        f"quillan assemble-submissions {CLASS_ID} {ASSIGNMENT_ID}  "
+        "(2 routed pages)"
+    ) in output
+
+
+def test_route_scan_decode_qr_folder_prints_sorted_assembly_targets(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+    _write_qr_image(
+        folder / "memoir.png",
+        _valid_payload(assignment_id=SECOND_ASSIGNMENT_ID),
+    )
+    _write_qr_image(folder / "essay.png", _valid_payload())
+
+    assert main(["route-scan", str(folder), "--decode-qr"]) == 0
+
+    output = capsys.readouterr().out
+    first_command = f"- quillan assemble-submissions {CLASS_ID} {ASSIGNMENT_ID}"
+    second_command = (
+        f"- quillan assemble-submissions {CLASS_ID} {SECOND_ASSIGNMENT_ID}"
+    )
+    assert "Next steps:" in output
+    assert first_command in output
+    assert second_command in output
+    assert output.index(first_command) < output.index(second_command)
+    assert not list(workspace.rglob("submission.json"))
 
 
 def test_route_scan_decode_qr_folder_processes_supported_pdfs(
@@ -281,6 +317,12 @@ def test_route_scan_decode_qr_folder_preserved_failure_continues(
     assert "Preserved for review: 1" in output
     assert "Review required: yes" in output
     assert "- payload_missing: 1" in output
+    assert (
+        "You may assemble submissions for routed evidence now, but "
+        "preserved failures should be reviewed before treating the batch "
+        "as complete."
+    ) in output
+    assert f"quillan assemble-submissions {CLASS_ID} {ASSIGNMENT_ID}" in output
 
 
 def test_route_scan_decode_qr_folder_pdf_conversion_failure_continues(

--- a/tests/test_cli_route_scan_pdf.py
+++ b/tests/test_cli_route_scan_pdf.py
@@ -198,6 +198,10 @@ def test_route_scan_decode_qr_pdf_routes_each_valid_page(
     assert "Sources processed: 1" in output
     assert "Pages attempted: 2" in output
     assert "Routed: 2" in output
+    assert (
+        f"quillan assemble-submissions {CLASS_ID} {ASSIGNMENT_ID}  "
+        "(2 routed pages)"
+    ) in output
     assert not list(workspace.rglob("submission.json"))
     assert not list(workspace.rglob("review.json"))
 
@@ -391,6 +395,12 @@ def test_route_scan_decode_qr_pdf_later_pages_process_after_failures(
     assert "Pages attempted: 3" in output
     assert "Routed: 1" in output
     assert "Preserved for review: 2" in output
+    assert (
+        "You may assemble submissions for routed evidence now, but "
+        "preserved failures should be reviewed before treating the batch "
+        "as complete."
+    ) in output
+    assert f"quillan assemble-submissions {CLASS_ID} {ASSIGNMENT_ID}" in output
 
 
 def test_route_scan_payload_mode_does_not_process_pdf_pages(

--- a/tests/test_cli_route_scan_qr.py
+++ b/tests/test_cli_route_scan_qr.py
@@ -174,6 +174,12 @@ def test_route_scan_decode_qr_successfully_routes_single_image(
     assert "Preserved for review: 0" in output
     assert "Failed: 0" in output
     assert "Review required: no" in output
+    assert "Next step:" in output
+    assert "Run submission assembly for newly routed evidence:" in output
+    assert (
+        f"quillan assemble-submissions {CLASS_ID} {ASSIGNMENT_ID}"
+        in output
+    )
     assert not (workspace / "scans" / "review").exists()
     assert not list(workspace.rglob("submission.json"))
     assert not list(workspace.rglob("review.json"))
@@ -261,6 +267,7 @@ def test_route_scan_decode_qr_blank_image_preserves_decode_failure(
     assert "Preserved for review: 1" in output
     assert "Review required: yes" in output
     assert "- payload_missing: 1" in output
+    assert "assemble-submissions" not in output
 
 
 def test_route_scan_decode_qr_unsupported_source_type_preserves_failure(

--- a/tests/test_intake_assembly.py
+++ b/tests/test_intake_assembly.py
@@ -1,0 +1,124 @@
+"""Tests for deriving submission assembly targets from scan intake."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from quillan.intake_assembly import (
+    IntakeAssemblyTarget,
+    assembly_targets_from_intake_summary,
+)
+from quillan.scan_intake_summary import (
+    ScanIntakePageResult,
+    ScanIntakeSourceResult,
+    ScanIntakeSummary,
+)
+
+
+def _page(
+    status: Literal["routed", "preserved", "failed"],
+    *,
+    class_id: str | None = "english12",
+    assignment_id: str | None = "final_exam",
+) -> ScanIntakePageResult:
+    return ScanIntakePageResult(
+        source_filename="scan.pdf",
+        source_page_number=1,
+        payload_page_number=1,
+        status=status,
+        class_id=class_id,
+        assignment_id=assignment_id,
+    )
+
+
+def _source(*pages: ScanIntakePageResult) -> ScanIntakeSourceResult:
+    return ScanIntakeSourceResult(
+        source_filename="scan.pdf",
+        source_path=Path("scan.pdf"),
+        source_type="pdf",
+        status="completed",
+        pages_attempted=len(pages),
+        routed_count=sum(1 for page in pages if page.status == "routed"),
+        preserved_count=sum(1 for page in pages if page.status == "preserved"),
+        failed_count=sum(1 for page in pages if page.status == "failed"),
+        page_results=pages,
+    )
+
+
+def test_empty_intake_summary_returns_no_assembly_targets() -> None:
+    assert assembly_targets_from_intake_summary(ScanIntakeSummary(())) == ()
+
+
+def test_one_routed_page_returns_one_target() -> None:
+    summary = ScanIntakeSummary((_source(_page("routed")),))
+
+    assert assembly_targets_from_intake_summary(summary) == (
+        IntakeAssemblyTarget("english12", "final_exam", 1),
+    )
+
+
+def test_multiple_routed_pages_for_same_assignment_are_counted() -> None:
+    summary = ScanIntakeSummary(
+        (_source(_page("routed"), _page("routed")),)
+    )
+
+    assert assembly_targets_from_intake_summary(summary) == (
+        IntakeAssemblyTarget("english12", "final_exam", 2),
+    )
+
+
+def test_multiple_targets_are_sorted_deterministically() -> None:
+    summary = ScanIntakeSummary(
+        (
+            _source(
+                _page(
+                    "routed",
+                    class_id="english12",
+                    assignment_id="memoir_unit",
+                ),
+                _page(
+                    "routed",
+                    class_id="english12",
+                    assignment_id="final_exam",
+                ),
+                _page(
+                    "routed",
+                    class_id="biology",
+                    assignment_id="lab_01",
+                ),
+            ),
+        )
+    )
+
+    assert assembly_targets_from_intake_summary(summary) == (
+        IntakeAssemblyTarget("biology", "lab_01", 1),
+        IntakeAssemblyTarget("english12", "final_exam", 1),
+        IntakeAssemblyTarget("english12", "memoir_unit", 1),
+    )
+
+
+def test_preserved_and_failed_pages_do_not_create_targets() -> None:
+    summary = ScanIntakeSummary(
+        (
+            _source(
+                _page("preserved"),
+                _page("failed"),
+            ),
+        )
+    )
+
+    assert assembly_targets_from_intake_summary(summary) == ()
+
+
+def test_routed_page_missing_class_or_assignment_is_ignored() -> None:
+    summary = ScanIntakeSummary(
+        (
+            _source(
+                _page("routed", class_id=None),
+                _page("routed", assignment_id=None),
+            ),
+        )
+    )
+
+    assert assembly_targets_from_intake_summary(summary) == ()


### PR DESCRIPTION
## Summary

* Added post-intake submission assembly guidance based on routed scan intake results.
* Added `quillan/intake_assembly.py` with `IntakeAssemblyTarget` and `assembly_targets_from_intake_summary(...)`.
* Updated `route-scan --decode-qr` to print explicit `assemble-submissions` next-step commands after the existing intake summary.
* Added review-required caution text when routed evidence exists alongside preserved failures.
* Added focused tests for helper behavior and CLI output across image, PDF, folder, multi-assignment, no-routed-pages, and preserved-failure paths.
* Updated README, CLI contract docs, and changelog.

## Behavior

After QR-aware scan intake, Quillan now derives assembly targets from routed pages in the current `ScanIntakeSummary`.

Targets are grouped by:

```text
(class_id, assignment_id)
```

Each target includes a routed-page count.

The CLI prints next-step commands such as:

```powershell
quillan assemble-submissions <class_id> <assignment_id>
```

For multi-page or grouped targets, the output includes the number of routed pages.

## Scope Boundary

Submission assembly remains explicit and teacher-controlled.

This PR does **not** automatically run `assemble-submissions`.

The route-scan command only prints next-step guidance based on evidence routed during the current intake run.

## Target Rules

Assembly targets are created only from routed page results that include both:

* `class_id`
* `assignment_id`

The following do **not** create assembly targets:

* preserved pages;
* failed pages;
* skipped unsupported files;
* routed pages missing complete class/assignment identity.

Targets are sorted deterministically.

## Review-Required Caution

If the intake summary requires review but also has routed pages, Quillan now warns that submissions may be assembled for routed evidence, but preserved failures should be reviewed before treating the batch as complete.

## Non-Goals

This PR does **not** add:

* automatic submission assembly;
* teacher-facing scan intake menu;
* review workflow menu;
* new manifest format;
* submission status redesign;
* evidence route redesign;
* source-file archiving;
* source-file deletion or movement;
* inbox draining;
* recursive folder intake;
* OCR;
* handwriting recognition;
* PDF text extraction;
* AI scoring;
* AI feedback;
* automatic grading;
* standards work;
* pds-core changes;
* pds-scoreform changes.

## Validation

Passed:

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest --basetemp .\.pytest-tmp`: `953 passed`
* `.\.venv\Scripts\python.exe -m ruff check .`
* `.\.venv\Scripts\python.exe -m mypy .`
* `$env:PATH = "$PWD\.venv\Scripts;$env:PATH"; .\run_tests.ps1`

Note: bare `.\run_tests.ps1` initially picked up a non-venv Python missing `pypdf`; rerunning with the project venv first on `PATH` passed cleanly.

Closes #134.
