### PR TITLE
Add scan intake menu workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a teacher-facing menu workflow for QR-aware scan intake from image,
+  PDF, or folder sources.
 - Added post-intake submission assembly next-step guidance based on routed scan
   intake results.
 - Added folder-based QR scan intake to `quillan route-scan <folder> --decode-qr`.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ particular, Quillan does not currently provide:
   selection among duplicates;
 - guided teacher-facing submission review, notes, tags, comment selection,
   scoring, feedback export, or summary export workflows;
-- teacher-facing scan intake or QR recognition;
 - complete teacher-facing assignment editing workflows; or
 - a dedicated printable-response command.
 
@@ -206,7 +205,7 @@ quillan set-review-state <class_id> <assignment_id> <student_id> <state>
   QR-bearing PDF, or a non-recursive folder of supported QR-bearing scan files.
   PDF intake processes pages independently, files page evidence as PNG files,
   and preserves handled failures under `scans/review/`; it does not archive
-  source files, run OCR, use the menu, or assemble a submission. After
+  source files, run OCR, or assemble a submission. After
   QR-aware intake, the command prints explicit `assemble-submissions` commands
   for class/assignment pairs with newly routed pages in the current intake
   summary. Preserved failures should still be reviewed before treating the
@@ -409,9 +408,9 @@ canonical payload such as:
 PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page_number>|doc=response
 ```
 
-Generating this QR code is implemented. A caller can route a selected scan
-after separately decoding its payload, but Quillan does not extract QR codes,
-split PDFs, or perform OCR.
+Generating this QR code is implemented. Quillan can route selected scans by
+decoding QR payloads from supported image files, PDF pages, or direct files in
+a non-recursive folder. It does not perform OCR.
 
 ## Running Quillan
 
@@ -425,14 +424,24 @@ quillan
 
 The menu provides writing assignment config creation and validation through
 Assignment Management, class roster creation, viewing, staged editing, and
-validation through Roster Management, and combined class-packet generation
-through Printable Response Pages. Workspace Settings can show, set,
-validate/create, and reset the shared Paper Data Suite workspace root. Help
-summarizes Quillan's teacher-controlled purpose and safe-data expectations.
+validation through Roster Management, combined class-packet generation through
+Printable Response Pages, and guided QR scan intake through Scan Intake /
+Route Paper Responses. Workspace Settings can show, set, validate/create, and
+reset the shared Paper Data Suite workspace root. Help summarizes Quillan's
+teacher-controlled purpose and safe-data expectations.
+
+The scan-intake menu asks for an image, PDF, or non-recursive folder path and
+uses the same QR-aware behavior as `quillan route-scan <source> --decode-qr`.
+It prints the structured scan intake summary, preserves handled failures for
+review, and shows explicit `assemble-submissions` next steps when pages were
+routed. It does not expose payload mode, move or archive original source
+files, assemble submissions automatically, run OCR, score work, or perform AI
+feedback.
+
 The menu does not currently select submissions for review, add notes or tags,
-select comment-bank comments, enter scores, export feedback or summaries,
-ingest scans, or recognize QR codes. Those operations are direct CLI/API
-workflows or future teacher-facing usability work.
+select comment-bank comments, enter scores, or export feedback or summaries.
+Those operations are direct CLI/API workflows or future teacher-facing
+usability work.
 
 Show direct CLI help:
 
@@ -615,7 +624,8 @@ QR-aware intake supports `.jpeg`, `.jpg`, `.pdf`, `.png`, `.tif`, and `.tiff`.
 PDF conversion uses `pdf2image` and requires Poppler installed on the user's
 machine. The command does not move, delete, or archive source files, run OCR,
 score, tag, generate feedback, assemble submissions, create review records,
-create reports, or expose menu scan intake.
+or create reports. The Scan Intake / Route Paper Responses menu uses this same
+QR-aware route-scan behavior.
 
 After QR-aware intake, `route-scan` derives class/assignment assembly targets
 from the current structured intake summary and prints safe next-step commands,

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -210,9 +210,10 @@ The menu provides:
 1. Assignment Management
 2. Roster Management
 3. Printable Response Pages
-4. Workspace Settings
-5. Help
-6. Exit
+4. Scan Intake / Route Paper Responses
+5. Workspace Settings
+6. Help
+7. Exit
 ```
 
 Roster Management provides:
@@ -280,6 +281,28 @@ alter roster or assignment data. It does not add individual PDFs, scan
 routing, OCR, review, scoring, feedback, reports, AI, or a direct printable
 CLI command.
 
+Scan Intake / Route Paper Responses prompts for a local scan source path:
+
+```text
+Scan file or folder path (leave blank to cancel):
+```
+
+Blank input cancels without routing files. Nonblank input trims surrounding
+whitespace and removes one matching pair of surrounding quotes, so pasted
+Windows paths such as `"C:\Users\Teacher\Desktop\scan folder"` work as a
+single path. The source may be a supported image file, a PDF, or a
+non-recursive folder containing supported image/PDF scan files. The workflow
+uses the same QR-aware implementation path as
+`quillan route-scan <source> --decode-qr`; it does not expose payload mode.
+It prints the structured scan intake summary, including processed sources,
+attempted pages, routed, preserved, failed, skipped unsupported, review
+required, and failure-category counts. If routed evidence exists, it prints
+the same explicit `assemble-submissions` next-step guidance as the direct
+command. If review is required, the preserved-failure caution is printed.
+The workflow does not automatically assemble submissions, move or archive the
+teacher's original source files, create `submission.json` or `review.json`,
+run OCR, score, tag, generate feedback, or perform AI work.
+
 Workspace Settings provides:
 
 ```text
@@ -304,16 +327,17 @@ remains a guided shell rather than a complete teacher-facing application.
 
 The menu does not currently guide teachers through submission selection,
 evidence opening, review-state changes, notes, tags, comment-bank selection,
-criterion scoring, feedback export, class or standards summary export, scan
-intake, or QR recognition. The implemented review and export operations are
-available through the direct commands documented below and through focused
+criterion scoring, feedback export, class or standards summary export, or
+submission assembly. The implemented review, export, and assembly operations
+are available through the direct commands documented below and through focused
 Python APIs.
 
 Menu help describes Quillan as a local-first, teacher-controlled
 writing-evidence tool; keeps teacher judgment primary; states that Quillan is
-not automated grading software; identifies currently unsupported AI, OCR,
-scan-routing, and review workflows; and summarizes repository safe-data
-expectations and current direct commands.
+not automated grading software; identifies currently unsupported AI, OCR, and
+review workflows; notes that guided scan intake routes QR-coded response pages
+only; and summarizes repository safe-data expectations and current direct
+commands.
 
 The menu clears the screen only when both standard input and standard output
 are interactive terminals. A normal exit or `KeyboardInterrupt` returns status
@@ -432,7 +456,8 @@ intake run. When review is required, the next-step message warns that preserved
 failures should be reviewed before the batch is treated as complete.
 
 The command does not move, delete, or archive source files after folder intake.
-It does not expose menu scan intake, assemble submissions, create review
+The Scan Intake / Route Paper Responses menu invokes this same QR-aware intake
+path. QR-aware scan intake does not assemble submissions, create review
 records, run OCR, or identify a student from raw scan content without a valid
 payload.
 

--- a/quillan/cli_app/handlers/routing.py
+++ b/quillan/cli_app/handlers/routing.py
@@ -81,17 +81,9 @@ def handle_route_scan(args: argparse.Namespace) -> int:
         return 1
 
     if args.decode_qr:
-        if source_file.is_dir():
-            return _route_source_folder_qr(
-                workspace_root,
-                source_folder=source_file,
-                created_at=intake_timestamp,
-            )
-        if not _validate_source_file(source_file):
-            return 1
-        return _route_source_file_qr(
+        return run_qr_scan_intake(
+            source_file,
             workspace_root,
-            source_file=source_file,
             created_at=intake_timestamp,
         )
     else:
@@ -116,6 +108,45 @@ def handle_route_scan(args: argparse.Namespace) -> int:
         workspace_root,
         source_file=source_file,
         decoded_page=decoded_result,
+        created_at=intake_timestamp,
+    )
+
+
+def run_qr_scan_intake(
+    source_path: Path,
+    workspace_root: Path | None = None,
+    *,
+    created_at: datetime | None = None,
+) -> int:
+    """Run QR-aware scan intake for one image, PDF, or direct child folder."""
+    intake_timestamp = (
+        datetime.now(timezone.utc) if created_at is None else created_at
+    )
+    try:
+        resolved_workspace_root = (
+            resolve_workspace_root() if workspace_root is None else workspace_root
+        )
+    except WorkspaceRootError as error:
+        print(f"Error: could not resolve the PDS workspace: {error}")
+        return 1
+    except Exception as error:
+        print(f"Error: unexpected workspace resolution failure: {error}")
+        return 1
+
+    if not source_path.exists():
+        print(f"Error: scan source does not exist: {source_path}")
+        return 1
+    if source_path.is_dir():
+        return _route_source_folder_qr(
+            resolved_workspace_root,
+            source_folder=source_path,
+            created_at=intake_timestamp,
+        )
+    if not _validate_source_file(source_path):
+        return 1
+    return _route_source_file_qr(
+        resolved_workspace_root,
+        source_file=source_path,
         created_at=intake_timestamp,
     )
 

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 from collections.abc import Callable
+from pathlib import Path
 
 WorkspaceShowHandler = Callable[[], int]
 WorkspaceSetHandler = Callable[[str], int]
@@ -43,7 +44,8 @@ def print_menu_help() -> None:
     print("Teacher judgment remains primary; Quillan is not automated grading software.")
     print()
     print("Quillan does not currently implement AI tagging, AI scoring,")
-    print("AI feedback, OCR, scan routing, or full teacher-facing review workflows.")
+    print("AI feedback, OCR, or full teacher-facing review workflows.")
+    print("Guided scan intake routes QR-coded response pages only.")
     print()
     print("Use synthetic data only in repository examples and tests.")
     print("Do not commit or post real student data, rosters, scans, writing, grades,")
@@ -81,6 +83,38 @@ def launch_printable_response_menu() -> None:
     )
 
     launch()
+
+
+def _normalize_menu_path(raw_path: str) -> Path | None:
+    stripped = raw_path.strip()
+    if not stripped:
+        return None
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {
+        '"',
+        "'",
+    }:
+        stripped = stripped[1:-1].strip()
+    if not stripped:
+        return None
+    return Path(stripped)
+
+
+def launch_scan_intake_workflow() -> None:
+    """Prompt for a scan source and run QR-aware routing intake."""
+    from quillan.cli_app.handlers.routing import run_qr_scan_intake
+
+    clear_screen()
+    print_menu_header("Scan Intake / Route Paper Responses")
+    raw_source_path = input("Scan file or folder path (leave blank to cancel): ")
+    print()
+
+    source_path = _normalize_menu_path(raw_source_path)
+    if source_path is None:
+        print("Scan intake canceled. No scan files were routed.")
+    else:
+        run_qr_scan_intake(source_path)
+    print()
+    pause_for_user()
 
 
 def launch_workspace_menu(
@@ -156,9 +190,10 @@ def launch_menu(
             print("1. Assignment Management")
             print("2. Roster Management")
             print("3. Printable Response Pages")
-            print("4. Workspace Settings")
-            print("5. Help")
-            print("6. Exit")
+            print("4. Scan Intake / Route Paper Responses")
+            print("5. Workspace Settings")
+            print("6. Help")
+            print("7. Exit")
             print()
 
             choice = input("Select an option: ").strip()
@@ -171,22 +206,24 @@ def launch_menu(
             elif choice == "3":
                 launch_printable_response_menu()
             elif choice == "4":
+                launch_scan_intake_workflow()
+            elif choice == "5":
                 launch_workspace_menu(
                     workspace_show,
                     workspace_set,
                     workspace_validate,
                     workspace_reset,
                 )
-            elif choice == "5":
+            elif choice == "6":
                 clear_screen()
                 print_menu_help()
                 print()
                 pause_for_user()
-            elif choice == "6":
+            elif choice == "7":
                 print("Goodbye.")
                 return 0
             else:
-                print("Invalid selection. Please enter a number from 1 to 6.")
+                print("Invalid selection. Please enter a number from 1 to 7.")
                 print()
                 pause_for_user()
     except KeyboardInterrupt:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_cli_without_command_displays_menu_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["6"])
+    _menu_input(monkeypatch, ["7"])
 
     assert main([]) == 0
 
@@ -71,6 +71,7 @@ def test_cli_without_command_displays_menu_options_and_exits(
     assert "Assignment Management" in output
     assert "Roster Management" in output
     assert "Printable Response Pages" in output
+    assert "Scan Intake / Route Paper Responses" in output
     assert "Workspace Settings" in output
     assert "Help" in output
     assert "Exit" in output
@@ -394,7 +395,7 @@ def test_menu_dispatch_displays_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["6"])
+    _menu_input(monkeypatch, ["7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -403,6 +404,7 @@ def test_menu_dispatch_displays_options_and_exits(
     assert "Assignment Management" in output
     assert "Roster Management" in output
     assert "Printable Response Pages" in output
+    assert "Scan Intake / Route Paper Responses" in output
     assert "Workspace Settings" in output
     assert "Help" in output
     assert "Exit" in output
@@ -413,7 +415,7 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["5", "", "6"])
+    _menu_input(monkeypatch, ["6", "", "7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -431,7 +433,7 @@ def test_main_menu_opens_printable_response_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["3", "2", "6"])
+    _menu_input(monkeypatch, ["3", "2", "7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -445,7 +447,7 @@ def test_main_menu_opens_assignment_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["1", "3", "6"])
+    _menu_input(monkeypatch, ["1", "3", "7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -460,7 +462,7 @@ def test_main_menu_opens_roster_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "5", "6"])
+    _menu_input(monkeypatch, ["2", "5", "7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -486,7 +488,7 @@ def test_workspace_menu_reuses_workspace_show_handler(
         return 0
 
     monkeypatch.setattr(cli_workspace, "show_workspace", handle_workspace_show)
-    _menu_input(monkeypatch, ["4", "1", "", "5", "6"])
+    _menu_input(monkeypatch, ["5", "1", "", "5", "7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -517,7 +519,7 @@ def test_workspace_menu_sets_workspace_folder(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["4", "2", str(workspace_root), "", "5", "6"])
+    _menu_input(monkeypatch, ["5", "2", str(workspace_root), "", "5", "7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -541,7 +543,7 @@ def test_workspace_menu_blank_set_cancels_without_change(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["4", "2", "  ", "", "5", "6"])
+    _menu_input(monkeypatch, ["5", "2", "  ", "", "5", "7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -568,7 +570,7 @@ def test_workspace_menu_validates_current_workspace(
         "validate_workspace",
         handle_workspace_validate,
     )
-    _menu_input(monkeypatch, ["4", "3", "", "5", "6"])
+    _menu_input(monkeypatch, ["5", "3", "", "5", "7"])
 
     assert main(["menu"]) == 0
     assert calls == 1
@@ -595,7 +597,7 @@ def test_workspace_menu_resets_saved_preference(
         "reset_workspace",
         handle_workspace_reset,
     )
-    _menu_input(monkeypatch, ["4", "4", "", "5", "6"])
+    _menu_input(monkeypatch, ["5", "4", "", "5", "7"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -1,0 +1,318 @@
+"""Tests for the teacher-facing QR scan intake menu workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import csv
+import json
+from pathlib import Path
+from typing import cast
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+import pytest
+import qrcode
+from qrcode.image.pil import PilImage
+
+from quillan.cli import main
+import quillan.cli_app.handlers.routing as cli_routing
+from quillan.payloads import build_response_payload
+from quillan.pdf_pages import PdfPageImage
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+SECOND_STUDENT_ID = "stu_0002"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr(cli_routing, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _menu_input(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[str],
+) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError(
+                "Menu requested more input than the test provided."
+            ) from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _write_workspace(root: Path) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": SECOND_STUDENT_ID,
+                "last_name": "Patel",
+                "first_name": "Mina",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment),
+        encoding="utf-8",
+    )
+
+
+def _valid_payload(
+    *,
+    student_id: str = STUDENT_ID,
+    page: int = 2,
+) -> str:
+    return build_response_payload(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=student_id,
+        page=page,
+    )
+
+
+def _make_qr_image(payload: str, *, box_size: int = 8) -> NDArray[np.uint8]:
+    qr = qrcode.QRCode[PilImage](
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=box_size,
+        border=4,
+        image_factory=PilImage,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    rgb_image = image.get_image().convert("RGB")
+    return cast(
+        NDArray[np.uint8],
+        cv2.cvtColor(np.asarray(rgb_image), cv2.COLOR_RGB2BGR),
+    )
+
+
+def _write_qr_image(path: Path, payload: str) -> None:
+    assert cv2.imwrite(str(path), _make_qr_image(payload))
+
+
+def _blank_image() -> NDArray[np.uint8]:
+    return np.full((550, 425, 3), 255, dtype=np.uint8)
+
+
+def _pdf_pages(*images: object) -> list[PdfPageImage]:
+    return [
+        PdfPageImage(page_number=page_number, image=image)
+        for page_number, image in enumerate(images, start=1)
+    ]
+
+
+def _routed_pngs(workspace: Path) -> list[Path]:
+    return sorted(
+        (
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "scans"
+        ).glob("response_*.png")
+    )
+
+
+def test_main_menu_exposes_scan_intake_option(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["7"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "4. Scan Intake / Route Paper Responses" in output
+
+
+def test_menu_scan_intake_empty_input_cancels(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["4", "  ", "", "7"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Scan Intake / Route Paper Responses" in output
+    assert "Scan intake canceled. No scan files were routed." in output
+    assert "Goodbye." in output
+
+
+def test_menu_scan_intake_invalid_path_does_not_create_review_metadata(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing_source = workspace / "missing-scan.pdf"
+    _menu_input(monkeypatch, ["4", str(missing_source), "", "7"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert f"Error: scan source does not exist: {missing_source}" in output
+    assert not (workspace / "scans" / "review").exists()
+
+
+def test_menu_scan_intake_with_quoted_qr_image_routes_and_prints_next_step(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "synthetic response.png"
+    _write_qr_image(source, _valid_payload())
+    original_bytes = source.read_bytes()
+    _menu_input(monkeypatch, ["4", f'  "{source}"  ', "", "7"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert len(_routed_pngs(workspace)) == 1
+    assert source.read_bytes() == original_bytes
+    assert "Scan intake summary" in output
+    assert "Sources processed: 1" in output
+    assert "Pages attempted: 1" in output
+    assert "Routed: 1" in output
+    assert "Review required: no" in output
+    assert "Run submission assembly for newly routed evidence:" in output
+    assert f"quillan assemble-submissions {CLASS_ID} {ASSIGNMENT_ID}" in output
+    assert not list(workspace.rglob("submission.json"))
+    assert not list(workspace.rglob("review.json"))
+
+
+def test_menu_scan_intake_pdf_uses_existing_qr_page_intake(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "responses.pdf"
+    source.write_bytes(b"%PDF-1.4\nsynthetic response scan\n%%EOF\n")
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(
+            _make_qr_image(_valid_payload(student_id=STUDENT_ID, page=1)),
+            _make_qr_image(_valid_payload(student_id=SECOND_STUDENT_ID, page=2)),
+        ),
+    )
+    _menu_input(monkeypatch, ["4", str(source), "", "7"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert len(_routed_pngs(workspace)) == 2
+    assert "Processing PDF:" in output
+    assert "Pages attempted: 2" in output
+    assert "Routed: 2" in output
+    assert (
+        f"quillan assemble-submissions {CLASS_ID} {ASSIGNMENT_ID}  "
+        "(2 routed pages)"
+    ) in output
+
+
+def test_menu_scan_intake_mixed_pdf_prints_review_warning(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "mixed.pdf"
+    source.write_bytes(b"%PDF-1.4\nsynthetic response scan\n%%EOF\n")
+    monkeypatch.setattr(
+        cli_routing,
+        "iter_pdf_page_images",
+        lambda _source: _pdf_pages(
+            _make_qr_image(_valid_payload()),
+            _blank_image(),
+        ),
+    )
+    _menu_input(monkeypatch, ["4", str(source), "", "7"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert len(_routed_pngs(workspace)) == 1
+    assert "Routed: 1" in output
+    assert "Preserved for review: 1" in output
+    assert "Review required: yes" in output
+    assert "- payload_missing: 1" in output
+    assert (
+        "preserved failures should be reviewed before treating the batch "
+        "as complete."
+    ) in output
+
+
+def test_menu_scan_intake_folder_processes_supported_files_and_skips_unsupported(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    folder = tmp_path / "inbox"
+    folder.mkdir()
+    _write_qr_image(folder / "response.png", _valid_payload())
+    (folder / "notes.txt").write_text("ignore me", encoding="utf-8")
+    _menu_input(monkeypatch, ["4", str(folder), "", "7"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert len(_routed_pngs(workspace)) == 1
+    assert "Processing folder:" in output
+    assert "Sources processed: 1" in output
+    assert "Skipped unsupported files: 1" in output


### PR DESCRIPTION
## Summary

* Added a teacher-facing menu workflow for QR-aware scan intake.
* Added shared QR intake helper `run_qr_scan_intake(...)`.
* Kept direct `route-scan --decode-qr` on the same QR intake path.
* Added main menu option `Scan Intake / Route Paper Responses`.
* Added guided scan file/folder path prompt.
* Added whitespace and surrounding-quote normalization for pasted paths.
* Added blank-input cancel behavior.
* Added focused menu scan-intake tests.
* Updated existing menu-numbering tests.
* Updated README, CLI contract docs, and changelog.

## Behavior

The menu now includes:

```text id="9uxljz"
Scan Intake / Route Paper Responses
```

The workflow prompts for a local scan source path:

```text id="5n028x"
Scan file or folder path (leave blank to cancel):
```

Supported source paths include:

* QR-bearing image files;
* QR-bearing PDF files;
* non-recursive folders of supported QR-bearing scan files.

The menu workflow uses the same QR-aware intake behavior as:

```powershell id="1hj4ue"
quillan route-scan <source> --decode-qr
```

## Teacher-Facing Scope

The menu workflow:

* routes QR-coded response pages;
* prints the structured scan-intake summary;
* preserves handled failures for review;
* shows explicit `assemble-submissions` next-step guidance when pages are routed;
* warns when preserved failures require review.

It does **not** expose payload mode.

## Safety Boundaries

The scan-intake menu does **not**:

* move original source files;
* delete original source files;
* archive original source files;
* automatically assemble submissions;
* create `submission.json`;
* create `review.json`;
* run OCR;
* score work;
* tag work;
* generate feedback;
* perform AI work.

## Non-Goals

This PR does **not** add:

* automatic submission assembly;
* guided submission assembly menu;
* review student work menu;
* review note entry;
* review tag entry;
* review comment selection;
* review score entry;
* export menu workflows;
* source-file archiving;
* source-file deletion or movement;
* inbox draining;
* recursive folder intake;
* OCR;
* handwriting recognition;
* PDF text extraction;
* AI scoring;
* AI feedback;
* automatic grading;
* standards work;
* pds-core changes;
* pds-scoreform changes.

## Validation

Passed:

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest --basetemp .\.pytest-tmp`: `960 passed`
* `.\.venv\Scripts\python.exe -m ruff check .`
* `.\.venv\Scripts\python.exe -m mypy .`
* `$env:PATH = "$PWD\.venv\Scripts;$env:PATH"; .\run_tests.ps1`

The wrapper also passed all checks.

Closes #135.
