### PR TITLE
Add review student work menu skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 *$py.class
 .Python
 .pytest_cache/
+.pytest-tmp/
 .mypy_cache/
 .ruff_cache/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ planning and do not by themselves represent releases.
 
 ### Added
 
+- Added a teacher-facing Review Student Work menu skeleton for selecting class,
+  assignment, and student/submission context before guided review entry.
 - Added a teacher-facing menu workflow for QR-aware scan intake from image,
   PDF, or folder sources.
 - Added post-intake submission assembly next-step guidance based on routed scan

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Quillan is part of the broader Paper Data Suite concept, alongside ScoreForm.
 Quillan is an early pre-1.0 foundation. The v0.7.0 milestone provides a
 teacher-controlled review and export foundation through direct CLI commands
 and Python APIs. The teacher-facing terminal menu currently covers assignment
-management, roster management, printable response pages, workspace settings,
-help, and exit; it does not yet guide the review and export workflow.
+management, roster management, printable response pages, QR-aware scan intake,
+a read-only Review Student Work navigation skeleton, workspace settings,
+help, and exit; guided review entry and export remain direct CLI/API workflows
+or future menu work.
 
 Quillan currently supports:
 
@@ -118,8 +120,8 @@ particular, Quillan does not currently provide:
 - automatic grading;
 - automatic mastery calculation, review-state decisions, or evidence
   selection among duplicates;
-- guided teacher-facing submission review, notes, tags, comment selection,
-  scoring, feedback export, or summary export workflows;
+- guided teacher-facing review entry, notes, tags, comment selection, scoring,
+  feedback export, or summary export workflows;
 - complete teacher-facing assignment editing workflows; or
 - a dedicated printable-response command.
 
@@ -438,10 +440,15 @@ routed. It does not expose payload mode, move or archive original source
 files, assemble submissions automatically, run OCR, score work, or perform AI
 feedback.
 
-The menu does not currently select submissions for review, add notes or tags,
-select comment-bank comments, enter scores, or export feedback or summaries.
-Those operations are direct CLI/API workflows or future teacher-facing
-usability work.
+The Review Student Work menu is a navigation/context-selection skeleton. It
+lets a teacher select a class, assignment, and student/submission; view the
+current submission status and a brief review summary; and open selected
+submission evidence through the same safe local-opening behavior as
+`open-submission`. It is read-only except for launching the local file viewer:
+it does not create or mutate `review.json` or `submission.json`, automatically
+assemble submissions, run OCR, score work, add notes or tags, select
+comment-bank comments, enter scores, export feedback, export summaries, or use
+AI.
 
 Show direct CLI help:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -12,8 +12,8 @@ development. It records:
   CLI.
 
 The CLI includes a developer-oriented, scriptable command layer and an initial
-teacher-facing menu with shared-roster management. It is not a complete
-teacher-facing application.
+teacher-facing menu with shared-roster management, scan intake, and read-only
+review navigation. It is not a complete teacher-facing application.
 This contract describes implemented behavior separately from future design. A
 command or workflow documented elsewhere as planned is not part of the current
 CLI until it is implemented, tested, and added here.
@@ -211,9 +211,10 @@ The menu provides:
 2. Roster Management
 3. Printable Response Pages
 4. Scan Intake / Route Paper Responses
-5. Workspace Settings
-6. Help
-7. Exit
+5. Review Student Work
+6. Workspace Settings
+7. Help
+8. Exit
 ```
 
 Roster Management provides:
@@ -303,6 +304,38 @@ The workflow does not automatically assemble submissions, move or archive the
 teacher's original source files, create `submission.json` or `review.json`,
 run OCR, score, tag, generate feedback, or perform AI work.
 
+Review Student Work provides a read-only guided navigation skeleton:
+
+```text
+1. Select class and assignment
+2. Back
+```
+
+The workflow lists available classes from the active workspace, lists
+assignments for the selected class, prints the current assignment submission
+status through the existing status formatting path, and lets the teacher pick a
+student/submission by number. Roster students remain visible even when they do
+not yet have an assembled submission. The selected-student view shows a brief
+current review summary with class, assignment, student, manifest/evidence
+status, review state, and existing `review.json` counts when a valid review
+record is already present.
+
+The selected-student view offers:
+
+```text
+1. Open submission evidence
+2. Refresh summary
+3. Back
+```
+
+Opening submission evidence delegates to the same existing safe selected
+evidence-opening path as `quillan open-submission <class_id> <assignment_id>
+<student_id>`. Missing manifests or missing selected evidence are reported
+clearly. The workflow does not automatically assemble submissions, create or
+mutate `submission.json` or `review.json`, update review state, add notes,
+tags, comments, or scores, export feedback or summaries, run OCR, parse
+evidence contents, score work, or perform AI work.
+
 Workspace Settings provides:
 
 ```text
@@ -325,12 +358,11 @@ delete files, and `PDS_WORKSPACE_ROOT` still takes precedence.
 The workspace submenu does not include school-year settings. The overall menu
 remains a guided shell rather than a complete teacher-facing application.
 
-The menu does not currently guide teachers through submission selection,
-evidence opening, review-state changes, notes, tags, comment-bank selection,
-criterion scoring, feedback export, class or standards summary export, or
-submission assembly. The implemented review, export, and assembly operations
-are available through the direct commands documented below and through focused
-Python APIs.
+The menu does not currently guide teachers through review-state changes, notes,
+tags, comment-bank selection, criterion scoring, feedback export, class or
+standards summary export, or submission assembly. Those implemented review,
+export, and assembly operations are available through the direct commands
+documented below and through focused Python APIs.
 
 Menu help describes Quillan as a local-first, teacher-controlled
 writing-evidence tool; keeps teacher judgment primary; states that Quillan is

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -117,6 +117,13 @@ def launch_scan_intake_workflow() -> None:
     pause_for_user()
 
 
+def launch_review_student_work_menu() -> None:
+    """Launch the teacher-facing review navigation workflow."""
+    from quillan.review_menu import launch_review_student_work_menu as launch
+
+    launch()
+
+
 def launch_workspace_menu(
     workspace_show: WorkspaceShowHandler,
     workspace_set: WorkspaceSetHandler,
@@ -191,9 +198,10 @@ def launch_menu(
             print("2. Roster Management")
             print("3. Printable Response Pages")
             print("4. Scan Intake / Route Paper Responses")
-            print("5. Workspace Settings")
-            print("6. Help")
-            print("7. Exit")
+            print("5. Review Student Work")
+            print("6. Workspace Settings")
+            print("7. Help")
+            print("8. Exit")
             print()
 
             choice = input("Select an option: ").strip()
@@ -208,22 +216,24 @@ def launch_menu(
             elif choice == "4":
                 launch_scan_intake_workflow()
             elif choice == "5":
+                launch_review_student_work_menu()
+            elif choice == "6":
                 launch_workspace_menu(
                     workspace_show,
                     workspace_set,
                     workspace_validate,
                     workspace_reset,
                 )
-            elif choice == "6":
+            elif choice == "7":
                 clear_screen()
                 print_menu_help()
                 print()
                 pause_for_user()
-            elif choice == "7":
+            elif choice == "8":
                 print("Goodbye.")
                 return 0
             else:
-                print("Invalid selection. Please enter a number from 1 to 7.")
+                print("Invalid selection. Please enter a number from 1 to 8.")
                 print()
                 pause_for_user()
     except KeyboardInterrupt:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -1,0 +1,459 @@
+"""Teacher-facing review navigation menu skeleton."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pds_core.classes import list_class_folders, load_class_roster
+from pds_core.rosters import RosterError
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.cli_app.output import (
+    print_assignment_submission_status,
+    print_opened_submission_review,
+    workspace_relative_display,
+)
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.review_record_paths import review_record_path
+from quillan.storage import assignment_config_path
+from quillan.submission_review_opening import (
+    SubmissionReviewOpeningError,
+    open_student_submission_for_review,
+)
+from quillan.submission_status import (
+    AssignmentSubmissionStatus,
+    StudentSubmissionStatus,
+    list_assignment_submission_status,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AssignmentChoice:
+    """One assignment available for teacher review navigation."""
+
+    assignment_id: str
+    title: str | None
+
+
+def launch_review_student_work_menu() -> int:
+    """Launch the read-only teacher review navigation workflow."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Review Student Work")
+            print("1. Select class and assignment")
+            print("2. Back")
+            print()
+            choice = input("Select an option: ").strip()
+            print()
+
+            if choice in {"", "2"}:
+                return 0
+            if choice != "1":
+                print("Invalid selection. Please enter a number from 1 to 2.")
+                print()
+                pause_for_user()
+                continue
+
+            clear_screen()
+            _run_review_selection_workflow()
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting review menu.")
+        return 0
+
+
+def _run_review_selection_workflow() -> int:
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Review Student Work")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+
+    class_id = _prompt_class_id(workspace_root)
+    if class_id is None:
+        return 0
+
+    assignment = _prompt_assignment(workspace_root, class_id)
+    if assignment is None:
+        return 0
+
+    status = _load_submission_status(
+        workspace_root,
+        class_id,
+        assignment.assignment_id,
+    )
+    if status is None:
+        return 1
+
+    print()
+    print_assignment_submission_status(status, workspace_root)
+    print()
+
+    student_id = _prompt_student_id(workspace_root, class_id, status)
+    if student_id is None:
+        return 0
+
+    return _launch_selected_student_review(
+        workspace_root,
+        class_id,
+        assignment.assignment_id,
+        student_id,
+    )
+
+
+def _workspace_root() -> Path | None:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return None
+
+
+def _prompt_class_id(workspace_root: Path) -> str | None:
+    folders = list_class_folders(workspace_root, require_roster=True)
+    if not folders:
+        print("No classes found in the current workspace.")
+        return None
+
+    print("Available classes:")
+    for index, folder in enumerate(folders, start=1):
+        print(f"{index}. {folder.class_id}")
+    print("B. Back")
+    print()
+
+    while True:
+        selection = input("Select class: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            print("Review selection canceled.")
+            return None
+        if selection.isdigit() and 1 <= int(selection) <= len(folders):
+            return folders[int(selection) - 1].class_id
+        for folder in folders:
+            if folder.class_id == selection:
+                return folder.class_id
+        print("Invalid class selection. Please choose a listed class or Back.")
+
+
+def _prompt_assignment(
+    workspace_root: Path,
+    class_id: str,
+) -> AssignmentChoice | None:
+    assignments = _available_assignments(workspace_root, class_id)
+    if not assignments:
+        print(f"No assignments found for class {class_id}.")
+        return None
+
+    print()
+    print(f"Assignments for {class_id}:")
+    for index, assignment in enumerate(assignments, start=1):
+        label = assignment.assignment_id
+        if assignment.title:
+            label += f" - {assignment.title}"
+        print(f"{index}. {label}")
+    print("B. Back")
+    print()
+
+    while True:
+        selection = input("Select assignment: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            print("Assignment selection canceled.")
+            return None
+        if selection.isdigit() and 1 <= int(selection) <= len(assignments):
+            return assignments[int(selection) - 1]
+        for assignment in assignments:
+            if assignment.assignment_id == selection:
+                return assignment
+        print(
+            "Invalid assignment selection. "
+            "Please choose a listed assignment or Back."
+        )
+
+
+def _available_assignments(
+    workspace_root: Path,
+    class_id: str,
+) -> tuple[AssignmentChoice, ...]:
+    assignments_dir = workspace_root / "classes" / class_id / "assignments"
+    if not assignments_dir.is_dir():
+        return ()
+
+    choices: list[AssignmentChoice] = []
+    for assignment_dir in sorted(
+        (path for path in assignments_dir.iterdir() if path.is_dir()),
+        key=lambda path: path.name.casefold(),
+    ):
+        config_path = assignment_config_path(
+            workspace_root,
+            class_id,
+            assignment_dir.name,
+        )
+        if not config_path.is_file():
+            continue
+        title = _load_assignment_title(config_path)
+        choices.append(
+            AssignmentChoice(
+                assignment_id=assignment_dir.name,
+                title=title,
+            )
+        )
+    return tuple(choices)
+
+
+def _load_assignment_title(config_path: Path) -> str | None:
+    try:
+        assignment = load_assignment_config(config_path)
+    except (AssignmentConfigError, OSError):
+        return None
+    title = assignment.get("title")
+    return title if isinstance(title, str) and title.strip() else None
+
+
+def _load_submission_status(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> AssignmentSubmissionStatus | None:
+    try:
+        return list_assignment_submission_status(
+            workspace_root,
+            class_id,
+            assignment_id,
+        )
+    except Exception as error:
+        print(f"Error: could not list submission status: {error}")
+        return None
+
+
+def _prompt_student_id(
+    workspace_root: Path,
+    class_id: str,
+    status: AssignmentSubmissionStatus,
+) -> str | None:
+    student_ids = _student_choices(workspace_root, class_id, status)
+    if not student_ids:
+        print("No students or submissions found for this class assignment.")
+        return None
+
+    status_by_student = {
+        student_status.student_id: student_status
+        for student_status in status.student_statuses
+    }
+    print("Select student/submission:")
+    for index, student_id in enumerate(student_ids, start=1):
+        print(
+            f"{index}. {student_id}: "
+            f"{_student_status_label(status_by_student.get(student_id))}"
+        )
+    print("B. Back")
+    print()
+
+    while True:
+        selection = input("Select student/submission: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            print("Student selection canceled.")
+            return None
+        if selection.isdigit() and 1 <= int(selection) <= len(student_ids):
+            return student_ids[int(selection) - 1]
+        if selection in student_ids:
+            return selection
+        print(
+            "Invalid student selection. "
+            "Please choose a listed student/submission or Back."
+        )
+
+
+def _student_choices(
+    workspace_root: Path,
+    class_id: str,
+    status: AssignmentSubmissionStatus,
+) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    try:
+        roster = load_class_roster(workspace_root, class_id)
+    except RosterError:
+        roster = None
+    if roster is not None:
+        for student in roster.students:
+            ordered.append(student.student_id)
+            seen.add(student.student_id)
+
+    for student_status in status.student_statuses:
+        if student_status.student_id not in seen:
+            ordered.append(student_status.student_id)
+            seen.add(student_status.student_id)
+
+    return tuple(ordered)
+
+
+def _student_status_label(status: StudentSubmissionStatus | None) -> str:
+    if status is None:
+        return "no manifest; no routed evidence"
+    if status.manifest_path is None:
+        return "routed evidence exists; no manifest"
+    evidence_count = sum(page.evidence_count for page in status.pages)
+    return (
+        f"{status.submission_state}; manifest exists; "
+        f"evidence files={evidence_count}"
+    )
+
+
+def _launch_selected_student_review(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> int:
+    from quillan.menu import clear_screen, print_menu_header
+
+    while True:
+        clear_screen()
+        print_menu_header("Selected Student Review")
+        _print_review_summary(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        print()
+        print("1. Open submission evidence")
+        print("2. Refresh summary")
+        print("3. Back")
+        print()
+
+        choice = input("Select an option: ").strip()
+        print()
+
+        if choice in {"", "3"}:
+            return 0
+        if choice == "1":
+            _open_submission_evidence(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "2":
+            continue
+        else:
+            print("Invalid selection. Please enter a number from 1 to 3.")
+            input("Press Enter to continue...")
+
+
+def _print_review_summary(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    print("Current review summary")
+    print()
+    print(f"Class: {class_id}")
+    print(f"Assignment: {assignment_id}")
+    print(f"Student: {student_id}")
+
+    status = _load_submission_status(workspace_root, class_id, assignment_id)
+    student_status = None
+    if status is not None:
+        student_status = next(
+            (
+                candidate
+                for candidate in status.student_statuses
+                if candidate.student_id == student_id
+            ),
+            None,
+        )
+    if student_status is None:
+        print("Submission: not assembled")
+        print("Evidence files: 0")
+        print("Review state: not_started")
+    elif student_status.manifest_path is None:
+        print("Submission: not assembled")
+        print("Evidence files: routed but not assembled")
+        print("Review state: not_started")
+    else:
+        print("Submission: assembled")
+        print(
+            "Submission manifest: "
+            f"{workspace_relative_display(student_status.manifest_path, workspace_root)}"
+        )
+        print(
+            "Evidence files: "
+            f"{sum(page.evidence_count for page in student_status.pages)}"
+        )
+        print(f"Review state: {student_status.submission_state}")
+
+    _print_review_record_summary(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+    )
+
+
+def _print_review_record_summary(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    path = review_record_path(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+    )
+    if not path.exists():
+        print("Review record: not started")
+        print("Review record file: missing")
+        return
+
+    try:
+        record = load_review_record(path)
+    except ReviewRecordError as error:
+        print("Review record: invalid")
+        print(f"Review record error: {error}")
+        return
+
+    print("Review record: exists")
+    print(f"Review record file: {workspace_relative_display(path, workspace_root)}")
+    print(f"Review record state: {record['review_state']}")
+    print(f"Notes: {_count_record_items(record, 'notes')}")
+    print(f"Tags: {_count_record_items(record, 'tags')}")
+    print(f"Comments: {_count_record_items(record, 'comments')}")
+    print(f"Scores: {_count_record_items(record, 'scores')}")
+
+
+def _count_record_items(record: dict[str, Any], field: str) -> int:
+    value = record.get(field)
+    return len(value) if isinstance(value, list) else 0
+
+
+def _open_submission_evidence(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    try:
+        opened = open_student_submission_for_review(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except SubmissionReviewOpeningError as error:
+        print(f"Error: could not open student submission: {error}")
+        return
+
+    print_opened_submission_review(opened)

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -17,7 +17,7 @@ function Invoke-Check {
     }
 }
 
-Invoke-Check "Running pytest..." { python -m pytest }
+Invoke-Check "Running pytest..." { python -m pytest --basetemp .\.pytest-tmp }
 Invoke-Check "Running Ruff..." { python -m ruff check . }
 Invoke-Check "Running mypy..." { python -m mypy . }
 Invoke-Check "Checking diff whitespace..." { git diff --check }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_cli_without_command_displays_menu_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["7"])
+    _menu_input(monkeypatch, ["8"])
 
     assert main([]) == 0
 
@@ -72,6 +72,7 @@ def test_cli_without_command_displays_menu_options_and_exits(
     assert "Roster Management" in output
     assert "Printable Response Pages" in output
     assert "Scan Intake / Route Paper Responses" in output
+    assert "Review Student Work" in output
     assert "Workspace Settings" in output
     assert "Help" in output
     assert "Exit" in output
@@ -395,7 +396,7 @@ def test_menu_dispatch_displays_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["7"])
+    _menu_input(monkeypatch, ["8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -405,6 +406,7 @@ def test_menu_dispatch_displays_options_and_exits(
     assert "Roster Management" in output
     assert "Printable Response Pages" in output
     assert "Scan Intake / Route Paper Responses" in output
+    assert "Review Student Work" in output
     assert "Workspace Settings" in output
     assert "Help" in output
     assert "Exit" in output
@@ -415,7 +417,7 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["6", "", "7"])
+    _menu_input(monkeypatch, ["7", "", "8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -433,7 +435,7 @@ def test_main_menu_opens_printable_response_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["3", "2", "7"])
+    _menu_input(monkeypatch, ["3", "2", "8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -447,7 +449,7 @@ def test_main_menu_opens_assignment_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["1", "3", "7"])
+    _menu_input(monkeypatch, ["1", "3", "8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -462,7 +464,7 @@ def test_main_menu_opens_roster_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "5", "7"])
+    _menu_input(monkeypatch, ["2", "5", "8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -488,7 +490,7 @@ def test_workspace_menu_reuses_workspace_show_handler(
         return 0
 
     monkeypatch.setattr(cli_workspace, "show_workspace", handle_workspace_show)
-    _menu_input(monkeypatch, ["5", "1", "", "5", "7"])
+    _menu_input(monkeypatch, ["6", "1", "", "5", "8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -519,7 +521,7 @@ def test_workspace_menu_sets_workspace_folder(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["5", "2", str(workspace_root), "", "5", "7"])
+    _menu_input(monkeypatch, ["6", "2", str(workspace_root), "", "5", "8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -543,7 +545,7 @@ def test_workspace_menu_blank_set_cancels_without_change(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["5", "2", "  ", "", "5", "7"])
+    _menu_input(monkeypatch, ["6", "2", "  ", "", "5", "8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -570,7 +572,7 @@ def test_workspace_menu_validates_current_workspace(
         "validate_workspace",
         handle_workspace_validate,
     )
-    _menu_input(monkeypatch, ["5", "3", "", "5", "7"])
+    _menu_input(monkeypatch, ["6", "3", "", "5", "8"])
 
     assert main(["menu"]) == 0
     assert calls == 1
@@ -597,7 +599,7 @@ def test_workspace_menu_resets_saved_preference(
         "reset_workspace",
         handle_workspace_reset,
     )
-    _menu_input(monkeypatch, ["5", "4", "", "5", "7"])
+    _menu_input(monkeypatch, ["6", "4", "", "5", "8"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -1,0 +1,356 @@
+"""Tests for the teacher-facing Review Student Work menu skeleton."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.cli import main
+import quillan.review_menu as review_menu
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+from quillan.submission_review_opening import OpenedSubmissionReview
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+SECOND_STUDENT_ID = "stu_0002"
+TIMESTAMP = "2026-06-22T12:00:00+00:00"
+EVIDENCE_RELATIVE_PATH = (
+    f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+    "response_stu_0001_pg_001.pdf"
+)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _menu_input(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[str],
+) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError(
+                "Menu requested more input than the test provided."
+            ) from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _write_workspace(root: Path) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": SECOND_STUDENT_ID,
+                "last_name": "Patel",
+                "first_name": "Mina",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment),
+        encoding="utf-8",
+    )
+    evidence_path = root / EVIDENCE_RELATIVE_PATH
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_bytes(b"synthetic evidence")
+    _write_manifest(root)
+
+
+def _write_manifest(root: Path) -> Path:
+    manifest = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [
+                    {
+                        "evidence_id": "evidence_001",
+                        "routed_evidence_path": EVIDENCE_RELATIVE_PATH,
+                        "evidence_role": "selected",
+                        "evidence_state": "active",
+                        "duplicate_number": None,
+                        "created_at": TIMESTAMP,
+                        "retained_source": None,
+                        "module_details": {},
+                    }
+                ],
+            }
+        ],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+    path = submission_manifest_path(
+        root,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    return write_submission_manifest(path, manifest)
+
+
+def _review_record() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": "in_progress",
+        "notes": [
+            {
+                "note_id": "note_0001",
+                "text": "Teacher observation.",
+                "created_at": TIMESTAMP,
+                "updated_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "tags": [],
+        "scores": [],
+        "comments": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def test_main_menu_shows_and_opens_review_student_work(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["5", "2", "8"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "5. Review Student Work" in output
+    assert "Review Student Work" in output
+    assert "1. Select class and assignment" in output
+    assert "Goodbye." in output
+
+
+def test_review_workflow_selects_context_and_shows_read_only_summary(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    manifest_before = manifest_path.read_bytes()
+    files_before = sorted(
+        path.relative_to(workspace)
+        for path in workspace.rglob("*")
+        if path.is_file()
+    )
+    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "3", "", "2", "8"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert f"1. {CLASS_ID}" in output
+    assert f"1. {ASSIGNMENT_ID} - Synthetic Essay" in output
+    assert f"Submission status for assignment {ASSIGNMENT_ID}" in output
+    assert f"1. {STUDENT_ID}: unreviewed; manifest exists; evidence files=1" in output
+    assert f"2. {SECOND_STUDENT_ID}: no manifest; no routed evidence" in output
+    assert "Selected Student Review" in output
+    assert "Current review summary" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Submission: assembled" in output
+    assert "Evidence files: 1" in output
+    assert "Review record: not started" in output
+    assert manifest_path.read_bytes() == manifest_before
+    assert files_before == sorted(
+        path.relative_to(workspace)
+        for path in workspace.rglob("*")
+        if path.is_file()
+    )
+
+
+def test_review_summary_includes_existing_review_record_counts(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "review.json"
+    )
+    review_path.write_text(json.dumps(_review_record()), encoding="utf-8")
+    review_before = review_path.read_bytes()
+    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "3", "", "2", "8"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Review record: exists" in output
+    assert "Review record state: in_progress" in output
+    assert "Notes: 1" in output
+    assert "Tags: 0" in output
+    assert review_path.read_bytes() == review_before
+
+
+def test_review_menu_open_submission_uses_existing_safe_opening(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[Path, str, str, str]] = []
+
+    def open_submission(
+        workspace_root: str | Path,
+        class_id: str,
+        assignment_id: str,
+        student_id: str,
+    ) -> OpenedSubmissionReview:
+        calls.append((Path(workspace_root), class_id, assignment_id, student_id))
+        return OpenedSubmissionReview(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            manifest_path=workspace / "submission.json",
+            manifest_relative_path="classes/class/submissions/submission.json",
+            page_number=1,
+            evidence_id="evidence_001",
+            evidence_path=workspace / "evidence.pdf",
+            evidence_relative_path="classes/class/scans/evidence.pdf",
+            submission_state="unreviewed",
+            page_state="present",
+        )
+
+    monkeypatch.setattr(
+        review_menu,
+        "open_student_submission_for_review",
+        open_submission,
+    )
+    _menu_input(
+        monkeypatch,
+        ["5", "1", "1", "1", "1", "1", "", "3", "", "2", "8"],
+    )
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert calls == [(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)]
+    assert "Opened submission evidence for review:" in output
+    assert "Path: classes/class/scans/evidence.pdf" in output
+
+
+def test_review_menu_reports_missing_openable_evidence(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        ["5", "1", "1", "1", "2", "1", "", "3", "", "2", "8"],
+    )
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert f"Student: {SECOND_STUDENT_ID}" in output
+    assert "Submission: not assembled" in output
+    assert "Error: could not open student submission" in output
+    assert not list(workspace.rglob("review.json"))
+
+
+def test_review_menu_no_classes_and_invalid_selection_back_out_safely(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
+    _menu_input(monkeypatch, ["5", "9", "", "1", "", "2", "8"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Invalid selection. Please enter a number from 1 to 2." in output
+    assert "No classes found in the current workspace." in output
+    assert "Goodbye." in output

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -170,7 +170,7 @@ def test_main_menu_exposes_scan_intake_option(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["7"])
+    _menu_input(monkeypatch, ["8"])
 
     assert main(["menu"]) == 0
 
@@ -182,7 +182,7 @@ def test_menu_scan_intake_empty_input_cancels(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["4", "  ", "", "7"])
+    _menu_input(monkeypatch, ["4", "  ", "", "8"])
 
     assert main(["menu"]) == 0
 
@@ -198,7 +198,7 @@ def test_menu_scan_intake_invalid_path_does_not_create_review_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     missing_source = workspace / "missing-scan.pdf"
-    _menu_input(monkeypatch, ["4", str(missing_source), "", "7"])
+    _menu_input(monkeypatch, ["4", str(missing_source), "", "8"])
 
     assert main(["menu"]) == 0
 
@@ -216,7 +216,7 @@ def test_menu_scan_intake_with_quoted_qr_image_routes_and_prints_next_step(
     source = tmp_path / "synthetic response.png"
     _write_qr_image(source, _valid_payload())
     original_bytes = source.read_bytes()
-    _menu_input(monkeypatch, ["4", f'  "{source}"  ', "", "7"])
+    _menu_input(monkeypatch, ["4", f'  "{source}"  ', "", "8"])
 
     assert main(["menu"]) == 0
 
@@ -250,7 +250,7 @@ def test_menu_scan_intake_pdf_uses_existing_qr_page_intake(
             _make_qr_image(_valid_payload(student_id=SECOND_STUDENT_ID, page=2)),
         ),
     )
-    _menu_input(monkeypatch, ["4", str(source), "", "7"])
+    _menu_input(monkeypatch, ["4", str(source), "", "8"])
 
     assert main(["menu"]) == 0
 
@@ -281,7 +281,7 @@ def test_menu_scan_intake_mixed_pdf_prints_review_warning(
             _blank_image(),
         ),
     )
-    _menu_input(monkeypatch, ["4", str(source), "", "7"])
+    _menu_input(monkeypatch, ["4", str(source), "", "8"])
 
     assert main(["menu"]) == 0
 
@@ -307,7 +307,7 @@ def test_menu_scan_intake_folder_processes_supported_files_and_skips_unsupported
     folder.mkdir()
     _write_qr_image(folder / "response.png", _valid_payload())
     (folder / "notes.txt").write_text("ignore me", encoding="utf-8")
-    _menu_input(monkeypatch, ["4", str(folder), "", "7"])
+    _menu_input(monkeypatch, ["4", str(folder), "", "8"])
 
     assert main(["menu"]) == 0
 


### PR DESCRIPTION
## Summary

* Added a teacher-facing `Review Student Work` menu skeleton.
* Added `quillan/review_menu.py` for read-only class → assignment → student/submission navigation.
* Wired the new main menu option into `quillan/menu.py`.
* Added submission status display inside the guided review workflow.
* Added a selected-student review summary view.
* Added safe evidence-opening delegation through the existing submission-opening path.
* Added refresh/back behavior for the selected-student view.
* Updated existing menu numbering tests.
* Added focused review-menu tests.
* Updated README, CLI contract docs, changelog, `.gitignore`, and `run_tests.ps1`.

## Behavior

The main menu now includes:

```text id="3hbm5r"
Review Student Work
```

The workflow lets a teacher:

* select a class;
* select an assignment;
* view current submission status;
* select a student/submission;
* view a brief current review summary;
* open submission evidence through the existing safe opening behavior;
* refresh the summary;
* back out safely.

## Review Summary

The selected-student view shows read-only context, including:

* class ID;
* assignment ID;
* student ID;
* submission status;
* manifest status/path when available;
* evidence count/status;
* review state;
* whether a review record exists;
* note/tag/comment/score counts when a valid `review.json` already exists.

## Safety Boundary

This PR is read-only except for launching the local evidence viewer through the existing safe opening path.

It does **not** create or mutate:

* `submission.json`;
* `review.json`;
* routed evidence;
* assignment config;
* roster data.

## Non-Goals

This PR does **not** add:

* teacher note entry;
* tag entry;
* comment-bank selection;
* score entry;
* review-state editing;
* feedback export;
* class summary export;
* standards summary export;
* automatic submission assembly;
* guided submission assembly;
* scan intake changes;
* source-file archiving;
* source-file deletion or movement;
* inbox draining;
* recursive folder intake;
* OCR;
* handwriting recognition;
* PDF text extraction;
* AI scoring;
* AI feedback;
* automatic grading;
* standards work;
* pds-core changes;
* pds-scoreform changes.

Guided review-entry actions remain future work.

## Test Wrapper Note

`run_tests.ps1` now runs pytest with:

```powershell id="nfvfev"
python -m pytest --basetemp .\.pytest-tmp
```

This matches the documented local validation command and avoids Windows temp permission failures. `.pytest-tmp/` is ignored.

## Validation

Passed:

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest --basetemp .\.pytest-tmp`: `966 passed`
* `.\.venv\Scripts\python.exe -m ruff check .`
* `.\.venv\Scripts\python.exe -m mypy .`
* `$env:PATH = "$PWD\.venv\Scripts;$env:PATH"; powershell -ExecutionPolicy Bypass -File .\run_tests.ps1`

`git diff --check` reports only Git CRLF normalization warnings, with no whitespace errors.

Closes #136.
