### PR TITLE
Add guided review entry menu actions

### DIFF
--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -12,16 +12,36 @@ from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.cli_app.output import (
+    print_added_review_comment,
+    print_added_review_note,
+    print_added_review_tag,
     print_assignment_submission_status,
     print_opened_submission_review,
+    print_updated_review_score,
+    print_updated_submission_review_state,
     workspace_relative_display,
 )
-from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.comment_banks import CommentBankError, load_comment_bank
+from quillan.review_comments import ReviewCommentError, add_review_comment
+from quillan.review_notes import ReviewNoteError, add_review_note
+from quillan.review_record import (
+    ALLOWED_LOCATION_TYPES,
+    ALLOWED_TAG_POLARITIES,
+    ReviewRecordError,
+    load_review_record,
+)
 from quillan.review_record_paths import review_record_path
+from quillan.review_scores import ReviewScoreError, set_review_score
+from quillan.review_tags import ReviewTagError, add_review_tag
 from quillan.storage import assignment_config_path
 from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
     open_student_submission_for_review,
+)
+from quillan.submission_manifest import ALLOWED_SUBMISSION_STATES
+from quillan.submission_review_state import (
+    SubmissionReviewStateError,
+    update_submission_review_state,
 )
 from quillan.submission_status import (
     AssignmentSubmissionStatus,
@@ -326,14 +346,19 @@ def _launch_selected_student_review(
         )
         print()
         print("1. Open submission evidence")
-        print("2. Refresh summary")
-        print("3. Back")
+        print("2. Add teacher note")
+        print("3. Add structured tag")
+        print("4. Select reusable comment")
+        print("5. Set criterion score")
+        print("6. Update submission review state")
+        print("7. Refresh summary")
+        print("8. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "3"}:
+        if choice in {"", "8"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -344,10 +369,506 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "2":
+            _menu_add_review_note(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "3":
+            _menu_add_review_tag(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "4":
+            _menu_add_review_comment(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "5":
+            _menu_set_review_score(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "6":
+            _menu_update_submission_review_state(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "7":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 3.")
+            print("Invalid selection. Please enter a number from 1 to 8.")
             input("Press Enter to continue...")
+
+
+def _menu_add_review_note(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    text = input("Teacher note text: ").strip()
+    if not text:
+        print("Add note canceled. Teacher note text is required.")
+        return
+
+    try:
+        added = add_review_note(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            text,
+        )
+    except (ReviewNoteError, OSError) as error:
+        print(f"Error: could not add teacher note: {error}")
+        return
+
+    print_added_review_note(added)
+
+
+def _menu_add_review_tag(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    label = input("Tag label: ").strip()
+    if not label:
+        print("Add tag canceled. Tag label is required.")
+        return
+
+    print(
+        f"Polarity options: {', '.join(sorted(ALLOWED_TAG_POLARITIES))}"
+    )
+    polarity = input("Tag polarity: ").strip()
+    if polarity not in ALLOWED_TAG_POLARITIES:
+        print(
+            "Add tag canceled. Invalid polarity. "
+            f"Allowed values: {', '.join(sorted(ALLOWED_TAG_POLARITIES))}."
+        )
+        return
+
+    standard_code = input(
+        "Standard code (leave blank if not applicable): "
+    ).strip() or None
+    comment_id = None
+    if standard_code is not None:
+        comment_id = input(
+            "Comment ID (leave blank if not applicable): "
+        ).strip() or None
+    severity = _parse_optional_positive_int(
+        input("Severity (leave blank if not applicable): ")
+    )
+    teacher_note = input(
+        "Teacher note (leave blank if not applicable): "
+    ).strip() or None
+    page_number = _parse_optional_positive_int(
+        input("Page number (leave blank if not applicable): ")
+    )
+    evidence_id = input(
+        "Evidence ID (leave blank if not applicable): "
+    ).strip() or None
+    location_type = input(
+        "Location type (leave blank if not applicable): "
+    ).strip() or None
+    location_value: str | int | None = None
+    if location_type:
+        if location_type not in ALLOWED_LOCATION_TYPES:
+            print(
+                "Add tag canceled. Invalid location type. "
+                f"Allowed values: {', '.join(sorted(ALLOWED_LOCATION_TYPES))}."
+            )
+            return
+        raw_location = input(
+            "Location value (leave blank if not applicable): "
+        ).strip()
+        if raw_location:
+            if location_type in {
+                "page",
+                "paragraph",
+                "sentence",
+                "line",
+            }:
+                try:
+                    location_value = int(raw_location)
+                except ValueError:
+                    print(
+                        "Add tag canceled. Location value must be a positive integer "
+                        f"for {location_type}."
+                    )
+                    return
+            else:
+                location_value = raw_location
+
+    try:
+        added = add_review_tag(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            label=label,
+            polarity=polarity,
+            standard_code=standard_code,
+            comment_id=comment_id,
+            severity=severity,
+            teacher_note=teacher_note,
+            page_number=page_number,
+            evidence_id=evidence_id,
+            location_type=location_type,
+            location_value=location_value,
+        )
+    except (ReviewTagError, OSError) as error:
+        print(f"Error: could not add structured tag: {error}")
+        return
+
+    print_added_review_tag(added)
+
+
+def _load_available_comment_banks(
+    workspace_root: Path,
+) -> tuple[dict[str, Any], ...]:
+    comment_banks_dir = (
+        Path(workspace_root) / "shared" / "comment_banks"
+    )
+    if not comment_banks_dir.is_dir():
+        return ()
+
+    banks: list[dict[str, Any]] = []
+    for bank_path in sorted(
+        comment_banks_dir.glob("*.json"), key=lambda path: path.name.casefold()
+    ):
+        try:
+            bank = load_comment_bank(bank_path)
+        except (OSError, CommentBankError):
+            continue
+        banks.append(bank)
+    return tuple(banks)
+
+
+def _prompt_comment_bank(
+    banks: tuple[dict[str, Any], ...],
+) -> dict[str, Any] | None:
+    print("Available comment banks:")
+    for index, bank in enumerate(banks, start=1):
+        title = bank.get("title")
+        label = bank["bank_id"]
+        if isinstance(title, str) and title.strip():
+            label += f": {title.strip()}"
+        print(f"{index}. {label}")
+    print("B. Back")
+    print()
+
+    while True:
+        selection = input("Select comment bank: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            print("Select comment canceled.")
+            return None
+        if selection.isdigit():
+            index = int(selection) - 1
+            if 0 <= index < len(banks):
+                return banks[index]
+        for bank in banks:
+            if bank["bank_id"] == selection:
+                return bank
+        print(
+            "Invalid comment bank selection. "
+            "Please choose a listed bank or Back."
+        )
+
+
+def _prompt_comment_from_bank(bank: dict[str, Any]) -> dict[str, Any] | None:
+    raw_comments = bank.get("comments")
+    if not isinstance(raw_comments, list):
+        return None
+    comments: list[dict[str, Any]] = [
+        comment
+        for comment in raw_comments
+        if isinstance(comment, dict) and comment.get("student_facing") is True
+    ]
+    if not comments:
+        print(
+            "Select comment canceled. "
+            "No student-facing comments available in this bank."
+        )
+        return None
+
+    print("Available comments:")
+    for index, comment in enumerate(comments, start=1):
+        preview = comment.get("short_text") or comment["text"].splitlines()[0]
+        preview = preview.strip()
+        if len(preview) > 80:
+            preview = preview[:77] + "..."
+        print(
+            f"{index}. {comment['comment_id']}: {comment['label']} — {preview}"
+        )
+    print("B. Back")
+    print()
+
+    while True:
+        selection = input("Select comment: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            print("Select comment canceled.")
+            return None
+        if selection.isdigit():
+            index = int(selection) - 1
+            if 0 <= index < len(comments):
+                return comments[index]
+        for comment in comments:
+            if comment["comment_id"] == selection:
+                return comment
+        print(
+            "Invalid comment selection. "
+            "Please choose a listed comment or Back."
+        )
+
+
+def _prompt_optional_standard_code(comment: dict[str, Any]) -> str | None:
+    standard_codes = [
+        code
+        for code in comment.get("standard_codes", [])
+        if isinstance(code, str) and code.strip()
+    ]
+    if len(standard_codes) <= 1:
+        return None
+
+    print("Standard code options:")
+    for index, code in enumerate(standard_codes, start=1):
+        print(f"{index}. {code}")
+    print("B. Back")
+    print()
+
+    selection = input(
+        "Select standard code or leave blank to use default: "
+    ).strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit():
+        index = int(selection) - 1
+        if 0 <= index < len(standard_codes):
+            return standard_codes[index]
+    if selection in standard_codes:
+        return selection
+
+    print(
+        "Select comment canceled. "
+        "Invalid standard code selection."
+    )
+    return None
+
+
+_CANCEL = object()
+
+
+def _prompt_optional_boolean(
+    prompt: str,
+) -> bool | None | object:
+    raw = input(prompt)
+    normalized = raw.strip().lower()
+    if normalized in {"", "none"}:
+        return None
+    if normalized in {"y", "yes", "true", "t"}:
+        return True
+    if normalized in {"n", "no", "false", "f"}:
+        return False
+    print(
+        "Select comment canceled. Invalid response. "
+        "Use y/n or leave blank to use default."
+    )
+    return _CANCEL
+
+
+def _menu_add_review_comment(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    banks = _load_available_comment_banks(workspace_root)
+    if not banks:
+        print("Select comment canceled. No valid shared comment banks found.")
+        return
+
+    bank = _prompt_comment_bank(banks)
+    if bank is None:
+        return
+
+    comment = _prompt_comment_from_bank(bank)
+    if comment is None:
+        return
+
+    standard_code = _prompt_optional_standard_code(comment)
+    include_in_feedback = _prompt_optional_boolean(
+        "Include in feedback? (y/n, leave blank to use default): "
+    )
+    if include_in_feedback is _CANCEL:
+        return
+
+    val_include: bool | None = (
+        include_in_feedback if isinstance(include_in_feedback, bool) else None
+    )
+
+    try:
+        added = add_review_comment(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            bank_id=bank["bank_id"],
+            comment_id=comment["comment_id"],
+            standard_code=standard_code,
+            include_in_feedback=val_include,
+        )
+    except (ReviewCommentError, OSError) as error:
+        print(f"Error: could not select review comment: {error}")
+        return
+
+    print_added_review_comment(added)
+
+
+def _menu_set_review_score(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    criterion_id = input("Criterion ID: ").strip()
+    if not criterion_id:
+        print("Set score canceled. criterion_id is required.")
+        return
+
+    label = input("Criterion label: ").strip()
+    if not label:
+        print("Set score canceled. label is required.")
+        return
+
+    score = _parse_required_number(input("Score: "))
+    if score is None:
+        print("Set score canceled. score is required and must be a number.")
+        return
+
+    max_score = _parse_required_number(input("Max score: "))
+    if max_score is None:
+        print("Set score canceled. max_score is required and must be a number.")
+        return
+
+    scale = input("Scale (leave blank if not applicable): ").strip() or None
+    teacher_note = input(
+        "Teacher note (leave blank if not applicable): "
+    ).strip() or None
+
+    try:
+        updated = set_review_score(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            criterion_id=criterion_id,
+            label=label,
+            score=score,
+            max_score=max_score,
+            scale=scale,
+            teacher_note=teacher_note,
+        )
+    except (ReviewScoreError, OSError) as error:
+        print(f"Error: could not set review score: {error}")
+        return
+
+    print_updated_review_score(updated)
+
+
+def _menu_update_submission_review_state(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    print("Submission review state options:")
+    for index, state_opt in enumerate(sorted(ALLOWED_SUBMISSION_STATES), start=1):
+        print(f"{index}. {state_opt}")
+    print()
+
+    selection = input("Select submission review state: ").strip()
+    if not selection:
+        print("Update review state canceled.")
+        return
+
+    selected_state: str | None = None
+    if selection.isdigit():
+        index = int(selection) - 1
+        selected_state = sorted(ALLOWED_SUBMISSION_STATES)[index] if 0 <= index < len(ALLOWED_SUBMISSION_STATES) else None
+    else:
+        selected_state = selection
+
+    if selected_state not in ALLOWED_SUBMISSION_STATES:
+        print(
+            "Update review state canceled. Invalid state selection. "
+            f"Allowed values: {', '.join(sorted(ALLOWED_SUBMISSION_STATES))}."
+        )
+        return
+
+    try:
+        updated = update_submission_review_state(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            selected_state,
+        )
+    except SubmissionReviewStateError as error:
+        print(f"Error: could not update submission review state: {error}")
+        return
+
+    print_updated_submission_review_state(updated)
+
+
+def _parse_optional_positive_int(value: str) -> int | None:
+    if not value.strip():
+        return None
+    try:
+        parsed = int(value.strip())
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _parse_required_number(value: str) -> int | float | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        if "." in text or "e" in text.lower():
+            parsed = float(text)
+        else:
+            parsed = int(text)
+    except ValueError:
+        return None
+    return parsed
+
+
+def _parse_optional_boolean(value: str) -> bool | None:
+    text = value.strip().lower()
+    if text in {"", "none"}:
+        return None
+    if text in {"y", "yes", "true", "t"}:
+        return True
+    if text in {"n", "no", "false", "f"}:
+        return False
+    return None
 
 
 def _print_review_summary(

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -1,0 +1,469 @@
+"""Tests for guided selected-student review menu entry actions."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.cli import main
+import quillan.review_menu as review_menu
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+SECOND_STUDENT_ID = "stu_0002"
+TIMESTAMP = "2026-06-22T12:00:00+00:00"
+BANK_ID = "general_writing_synthetic"
+EXAMPLE_BANK_PATH = (
+    Path(__file__).parents[1]
+    / "examples"
+    / "comment_banks"
+    / f"{BANK_ID}.json"
+)
+
+
+def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
+    response_iterator = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError(
+                "Menu requested more input than the test provided."
+            ) from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _write_workspace(root: Path) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": SECOND_STUDENT_ID,
+                "last_name": "Patel",
+                "first_name": "Mina",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment), encoding="utf-8"
+    )
+    evidence_path = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "scans" / "response_stu_0001_pg_001.pdf"
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_bytes(b"synthetic evidence")
+    _write_manifest(root)
+
+
+def _write_manifest(root: Path) -> Path:
+    manifest = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [
+                    {
+                        "evidence_id": "evidence_001",
+                        "routed_evidence_path": (
+                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+                            "response_stu_0001_pg_001.pdf"
+                        ),
+                        "evidence_role": "selected",
+                        "evidence_state": "active",
+                        "duplicate_number": None,
+                        "created_at": TIMESTAMP,
+                        "retained_source": None,
+                        "module_details": {},
+                    }
+                ],
+            }
+        ],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+    path = submission_manifest_path(
+        root,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    return write_submission_manifest(path, manifest)
+
+
+def _write_bank(root: Path) -> None:
+    bank_path = root / "shared" / "comment_banks" / f"{BANK_ID}.json"
+    bank_path.parent.mkdir(parents=True, exist_ok=True)
+    bank_path.write_text(EXAMPLE_BANK_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _write_review_record(root: Path, review: dict[str, Any]) -> Path:
+    path = review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    return write_review_record(path, review)
+
+
+def _enter_selected_student(student_choice: str = "1") -> list[str]:
+    return ["5", "1", "1", "1", student_choice]
+
+
+def _exit_selected_student_to_main() -> list[str]:
+    return ["8", "", "2", "8"]
+
+
+def _exit_after_selected_student_action_to_main() -> list[str]:
+    return ["", "8", "", "2", "8"]
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def test_review_menu_selected_student_shows_review_entry_actions(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, _enter_selected_student() + _exit_selected_student_to_main())
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Selected Student Review" in output
+    assert "1. Open submission evidence" in output
+    assert "2. Add teacher note" in output
+    assert "3. Add structured tag" in output
+    assert "4. Select reusable comment" in output
+    assert "5. Set criterion score" in output
+    assert "6. Update submission review state" in output
+    assert "Review record: not started" in output
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+
+
+def test_review_menu_blank_note_cancels_without_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["2", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_adds_structured_tag_to_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + [
+            "3",
+            "claim",
+            "positive",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert review["tags"][0]["label"] == "claim"
+    assert review["tags"][0]["polarity"] == "positive"
+    assert review["review_state"] == "in_progress"
+
+
+def test_review_menu_blank_tag_cancels_without_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["3", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_no_comment_banks_returns_safely(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["4"]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    assert "No valid shared comment banks found" in capsys.readouterr().out
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_selects_reusable_comment_by_number(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_bank(workspace)
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["4", "1", "1", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Selected review comment:" in output
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert review["comments"][0]["bank_id"] == BANK_ID
+    assert review["comments"][0]["comment_id"] == "focus_is_clear"
+    assert review["review_state"] == "in_progress"
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_sets_criterion_score(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["5", "evidence", "Evidence", "3", "4", "", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert review["scores"][0]["criterion_id"] == "evidence"
+    assert review["scores"][0]["score"] == 3
+    assert review["scores"][0]["max_score"] == 4
+    assert review["review_state"] == "in_progress"
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_blank_score_cancels_without_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["5", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_invalid_score_does_not_corrupt_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": "in_progress",
+        "notes": [],
+        "tags": [],
+        "scores": [
+            {
+                "score_id": "score_0001",
+                "criterion_id": "evidence",
+                "label": "Evidence",
+                "score": 3,
+                "max_score": 4,
+                "updated_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "comments": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+    path = _write_review_record(workspace, review)
+    before = path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["5", "evidence", "Evidence", "5", "4", "", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    assert path.read_bytes() == before
+    assert json.loads(path.read_text(encoding="utf-8"))["scores"][0]["score"] == 3
+
+
+def test_review_menu_invalid_state_does_not_corrupt_manifest(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["6", "not_a_state"]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    assert manifest_path.read_bytes() == manifest_before
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -220,7 +220,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "3", "", "2", "8"])
+    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "8", "", "2", "8"])
 
     assert main(["menu"]) == 0
 
@@ -263,7 +263,10 @@ def test_review_summary_includes_existing_review_record_counts(
     )
     review_path.write_text(json.dumps(_review_record()), encoding="utf-8")
     review_before = review_path.read_bytes()
-    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "3", "", "2", "8"])
+    _menu_input(
+        monkeypatch,
+        ["5", "1", "1", "1", "1", "8", "", "2", "8"],
+    )
 
     assert main(["menu"]) == 0
 
@@ -310,7 +313,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "", "3", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "1", "", "8", "", "2", "8"],
     )
 
     assert main(["menu"]) == 0
@@ -328,7 +331,7 @@ def test_review_menu_reports_missing_openable_evidence(
 ) -> None:
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "2", "1", "", "3", "", "2", "8"],
+        ["5", "1", "1", "1", "2", "1", "", "8", "", "2", "8"],
     )
 
     assert main(["menu"]) == 0
@@ -338,6 +341,83 @@ def test_review_menu_reports_missing_openable_evidence(
     assert "Submission: not assembled" in output
     assert "Error: could not open student submission" in output
     assert not list(workspace.rglob("review.json"))
+
+
+
+def test_review_menu_adds_teacher_note_to_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        [
+            "5",
+            "1",
+            "1",
+            "1",
+            "1",
+            "2",
+            "This is a test note.",
+            "",
+            "8",
+            "",
+            "2",
+            "8",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+
+    review_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "review.json"
+    )
+    assert review_path.exists()
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review["notes"][0]["text"] == "This is a test note."
+    assert review["review_state"] == "in_progress"
+
+
+def test_review_menu_updates_submission_review_state(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        [
+            "5",
+            "1",
+            "1",
+            "1",
+            "1",
+            "6",
+            "in_progress",
+            "",
+            "8",
+            "",
+            "2",
+            "8",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+
+    manifest_path = submission_manifest_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["submission_state"] == "in_progress"
 
 
 def test_review_menu_no_classes_and_invalid_selection_back_out_safely(


### PR DESCRIPTION
## Summary

* Added guided teacher review-entry actions to the `Review Student Work` menu.
* Extended the selected-student review view with actions for:

  * adding teacher notes;
  * adding structured tags;
  * selecting reusable comments;
  * setting criterion scores;
  * updating submission review state.
* Added guided reusable comment-bank selection so teachers can select banks and comments by number instead of memorizing IDs.
* Preserved existing review services and validation behavior.
* Added focused regression coverage for guided review-entry menu flows.
* Updated README, CLI contract docs, and changelog.

## Behavior

The selected-student review menu now supports:

```text
1. Open submission evidence
2. Add teacher note
3. Add structured tag
4. Select reusable comment
5. Set criterion score
6. Update submission review state
7. Refresh summary
8. Back
```

Each action runs from the already-selected class, assignment, and student context, so the teacher does not need to re-enter those identifiers.

## Reused Services

The menu delegates review mutations to the existing Quillan services:

* `add_review_note(...)`
* `add_review_tag(...)`
* `add_review_comment(...)`
* `set_review_score(...)`
* `update_submission_review_state(...)`

The menu does not write review JSON directly or create a parallel review-entry subsystem.

## Reusable Comment Selection

The reusable comment workflow now:

* loads valid shared comment banks from `shared/comment_banks/`;
* displays available banks by number;
* displays student-facing comments by number;
* preserves authored comment-bank order;
* supports default include-in-feedback behavior on blank input;
* cancels safely on invalid include-in-feedback input;
* uses existing `add_review_comment(...)` validation and snapshot behavior.

## Safety Boundaries

Viewing summaries and opening evidence remain non-mutating.

Canceled or invalid review-entry actions do not create or corrupt review records or submission manifests.

This PR does **not** add:

* export menu actions;
* automatic submission assembly;
* source-file archiving;
* source-file deletion or movement;
* OCR;
* handwriting recognition;
* PDF text extraction;
* AI scoring;
* AI feedback;
* automatic grading;
* standards work;
* pds-core changes;
* pds-scoreform changes.

## Tests

Added or updated coverage for:

* selected-student review-entry menu actions;
* blank note cancellation;
* structured tag creation;
* blank tag cancellation;
* missing comment-bank behavior;
* reusable comment selection by number;
* criterion score setting;
* blank score cancellation;
* invalid score non-corruption;
* submission review-state update;
* invalid state non-corruption;
* existing selected-student evidence opening and summary behavior.

## Validation

Passed:

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest --basetemp .\.pytest-tmp`: `978 passed`
* `.\.venv\Scripts\python.exe -m ruff check .`
* `.\.venv\Scripts\python.exe -m mypy .`
* `$env:PATH = "$PWD\.venv\Scripts;$env:PATH"; powershell -ExecutionPolicy Bypass -File .\run_tests.ps1`

Temporary trace files were deleted and are not part of this PR.

Closes #137.
