### PR TITLE
Add guided export menu actions

### DIFF
--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -11,15 +11,27 @@ from pds_core.rosters import RosterError
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.class_summary_export import (
+    ClassSummaryExportError,
+    export_class_review_summary,
+)
 from quillan.cli_app.output import (
     print_added_review_comment,
     print_added_review_note,
     print_added_review_tag,
     print_assignment_submission_status,
+    print_exported_class_summary,
+    print_exported_feedback,
+    print_exported_standards_summary,
     print_opened_submission_review,
     print_updated_review_score,
     print_updated_submission_review_state,
     workspace_relative_display,
+)
+from quillan.feedback_export import FeedbackExportError, export_student_feedback
+from quillan.standards_summary_export import (
+    StandardsSummaryExportError,
+    export_standards_summary,
 )
 from quillan.comment_banks import CommentBankError, load_comment_bank
 from quillan.review_comments import ReviewCommentError, add_review_comment
@@ -105,27 +117,10 @@ def _run_review_selection_workflow() -> int:
     if assignment is None:
         return 0
 
-    status = _load_submission_status(
+    return _launch_assignment_review_actions(
         workspace_root,
         class_id,
         assignment.assignment_id,
-    )
-    if status is None:
-        return 1
-
-    print()
-    print_assignment_submission_status(status, workspace_root)
-    print()
-
-    student_id = _prompt_student_id(workspace_root, class_id, status)
-    if student_id is None:
-        return 0
-
-    return _launch_selected_student_review(
-        workspace_root,
-        class_id,
-        assignment.assignment_id,
-        student_id,
     )
 
 
@@ -351,14 +346,15 @@ def _launch_selected_student_review(
         print("4. Select reusable comment")
         print("5. Set criterion score")
         print("6. Update submission review state")
-        print("7. Refresh summary")
-        print("8. Back")
+        print("7. Export student feedback")
+        print("8. Refresh summary")
+        print("9. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "8"}:
+        if choice in {"", "9"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -409,9 +405,17 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "7":
+            _menu_export_student_feedback(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "8":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 8.")
+            print("Invalid selection. Please enter a number from 1 to 9.")
             input("Press Enter to continue...")
 
 
@@ -978,3 +982,138 @@ def _open_submission_evidence(
         return
 
     print_opened_submission_review(opened)
+
+
+def _prompt_overwrite_export() -> bool | object:
+    response = input("Overwrite existing export if present? (y/N): ").strip().lower()
+    if response in {"", "n", "no"}:
+        return False
+    if response in {"y", "yes"}:
+        return True
+    print("Export canceled. Please enter y or n.")
+    return _CANCEL
+
+
+def _menu_export_student_feedback(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    overwrite = _prompt_overwrite_export()
+    if overwrite is _CANCEL:
+        return
+    assert isinstance(overwrite, bool)
+    try:
+        exported = export_student_feedback(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            overwrite=overwrite,
+        )
+    except (FeedbackExportError, OSError) as error:
+        print(f"Error: could not export student feedback: {error}")
+        return
+    print_exported_feedback(exported)
+
+
+def _menu_export_class_summary(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> None:
+    overwrite = _prompt_overwrite_export()
+    if overwrite is _CANCEL:
+        return
+    assert isinstance(overwrite, bool)
+    try:
+        exported = export_class_review_summary(
+            workspace_root,
+            class_id,
+            assignment_id,
+            overwrite=overwrite,
+        )
+    except (ClassSummaryExportError, OSError) as error:
+        print(f"Error: could not export class review summary: {error}")
+        return
+    print_exported_class_summary(exported)
+
+
+def _menu_export_standards_summary(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> None:
+    overwrite = _prompt_overwrite_export()
+    if overwrite is _CANCEL:
+        return
+    assert isinstance(overwrite, bool)
+    try:
+        exported = export_standards_summary(
+            workspace_root,
+            class_id,
+            assignment_id,
+            overwrite=overwrite,
+        )
+    except (StandardsSummaryExportError, OSError) as error:
+        print(f"Error: could not export standards summary: {error}")
+        return
+    print_exported_standards_summary(exported)
+
+
+def _launch_assignment_review_actions(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> int:
+    from quillan.menu import clear_screen, print_menu_header
+
+    while True:
+        clear_screen()
+        print_menu_header("Assignment Review Actions")
+
+        status = _load_submission_status(
+            workspace_root,
+            class_id,
+            assignment_id,
+        )
+        if status is None:
+            input("Press Enter to continue...")
+            return 1
+
+        print_assignment_submission_status(status, workspace_root)
+        print()
+
+        print("1. Select student/submission")
+        print("2. Export class review summary")
+        print("3. Export standards summary")
+        print("4. Refresh submission status")
+        print("5. Back")
+        print()
+
+        choice = input("Select an option: ").strip()
+        print()
+
+        if choice in {"", "5"}:
+            return 0
+        elif choice == "1":
+            student_id = _prompt_student_id(workspace_root, class_id, status)
+            if student_id is not None:
+                _launch_selected_student_review(
+                    workspace_root,
+                    class_id,
+                    assignment_id,
+                    student_id,
+                )
+        elif choice == "2":
+            _menu_export_class_summary(workspace_root, class_id, assignment_id)
+            input("Press Enter to continue...")
+        elif choice == "3":
+            _menu_export_standards_summary(workspace_root, class_id, assignment_id)
+            input("Press Enter to continue...")
+        elif choice == "4":
+            continue
+        else:
+            print("Invalid selection. Please enter a number from 1 to 5.")
+            input("Press Enter to continue...")

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -1,0 +1,722 @@
+"""Tests for guided export actions in the Review Student Work menu."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.cli import main
+import quillan.review_menu as review_menu
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+SECOND_STUDENT_ID = "stu_0002"
+TIMESTAMP = "2026-06-22T12:00:00+00:00"
+
+
+def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError(
+                "Menu requested more input than the test provided."
+            ) from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _enter_assignment_review_actions() -> list[str]:
+    return ["5", "1", "1", "1"]
+
+
+def _exit_assignment_review_actions_to_main() -> list[str]:
+    return ["5", "", "2", "8"]
+
+
+def _exit_after_assignment_action_to_main() -> list[str]:
+    return ["", "5", "", "2", "8"]
+
+
+def _enter_selected_student(student_choice: str = "1") -> list[str]:
+    return _enter_assignment_review_actions() + ["1", student_choice]
+
+
+def _exit_selected_student_to_main() -> list[str]:
+    return ["9"] + _exit_assignment_review_actions_to_main()
+
+
+def _exit_after_selected_student_action_to_main() -> list[str]:
+    return ["", "9"] + _exit_assignment_review_actions_to_main()
+
+
+def _write_workspace(root: Path) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+
+    with (class_dir / "roster.csv").open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": SECOND_STUDENT_ID,
+                "last_name": "Patel",
+                "first_name": "Mina",
+                "period": "3",
+            }
+        )
+
+    assignment = {
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic_profile",
+        "tagging_mode": "focus",
+        "focus_standards": ["W.1"],
+        "basic_requirements": {"paragraphs_min": 1},
+        "rubric_id": "synthetic_rubric",
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment), encoding="utf-8"
+    )
+
+    evidence_path = (
+        root
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_stu_0001_pg_001.pdf"
+    )
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_bytes(b"synthetic evidence")
+
+    _write_manifest(root)
+
+
+def _write_manifest(root: Path) -> Path:
+    manifest = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [
+                    {
+                        "evidence_id": "evidence_001",
+                        "routed_evidence_path": (
+                            f"classes/{CLASS_ID}/assignments/"
+                            f"{ASSIGNMENT_ID}/scans/"
+                            "response_stu_0001_pg_001.pdf"
+                        ),
+                        "evidence_role": "selected",
+                        "evidence_state": "active",
+                        "duplicate_number": None,
+                        "created_at": TIMESTAMP,
+                        "retained_source": None,
+                        "module_details": {},
+                    }
+                ],
+            }
+        ],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+    path = submission_manifest_path(
+        root,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    return write_submission_manifest(path, manifest)
+
+
+def _review_record() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": "in_progress",
+        "notes": [],
+        "tags": [
+            {
+                "tag_id": "tag_0001",
+                "label": "claim",
+                "polarity": "positive",
+                "standard_code": "W.1",
+                "created_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "scores": [
+            {
+                "score_id": "score_0001",
+                "criterion_id": "evidence",
+                "label": "Evidence",
+                "score": 3,
+                "max_score": 4,
+                "scale": "4 point",
+                "updated_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "comments": [
+            {
+                "comment_record_id": "comment_record_0001",
+                "label": "Feedback",
+                "text": "Good work.",
+                "source": "custom",
+                "include_in_feedback": True,
+                "created_at": TIMESTAMP,
+                "module_details": {},
+            },
+            {
+                "comment_record_id": "comment_record_0002",
+                "label": "Private note",
+                "text": "This should not appear in student feedback.",
+                "source": "custom",
+                "include_in_feedback": False,
+                "created_at": TIMESTAMP,
+                "module_details": {},
+            },
+        ],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def _write_review_record(root: Path, review: dict[str, Any]) -> Path:
+    path = review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    return write_review_record(path, review)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def test_assignment_review_actions_menu_includes_export_choices(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + _exit_assignment_review_actions_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Assignment Review Actions" in output
+    assert "2. Export class review summary" in output
+    assert "3. Export standards summary" in output
+
+
+def test_selected_student_review_menu_includes_feedback_export(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student() + _exit_selected_student_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Selected Student Review" in output
+    assert "7. Export student feedback" in output
+
+
+def test_menu_export_student_feedback_creates_feedback_file(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    feedback_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "exports"
+        / "feedback.md"
+    )
+    assert not feedback_path.exists()
+
+    manifest_path = submission_manifest_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    manifest_before = manifest_path.read_bytes()
+    review_path = review_record_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    review_before = review_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["7", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Exported student feedback:" in output
+    assert "Overwrote existing: no" in output
+    assert feedback_path.is_file()
+
+    feedback_text = feedback_path.read_text(encoding="utf-8")
+    assert "- Evidence: 3 / 4 (4 point)" in feedback_text
+    assert "- Good work." in feedback_text
+    assert "This should not appear in student feedback." not in feedback_text
+    assert manifest_path.read_bytes() == manifest_before
+    assert review_path.read_bytes() == review_before
+
+
+def test_menu_export_class_summary_creates_summary_file(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    summary_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+        / "class_summary.csv"
+    )
+    assert not summary_path.exists()
+
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + ["2", ""]
+        + _exit_after_assignment_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Exported class review summary:" in output
+    assert "Overwrote existing: no" in output
+    assert summary_path.is_file()
+
+
+def test_menu_export_standards_summary_creates_summary_file(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    summary_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+        / "standards_summary.csv"
+    )
+    assert not summary_path.exists()
+
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + ["3", ""]
+        + _exit_after_assignment_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Exported standards summary:" in output
+    assert "Overwrote existing: no" in output
+    assert summary_path.is_file()
+
+
+def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    feedback_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "exports"
+        / "feedback.md"
+    )
+    assert not feedback_path.exists()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["7", "maybe"]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Export canceled. Please enter y or n." in output
+    assert not feedback_path.exists()
+
+
+def test_menu_export_feedback_reports_missing_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    feedback_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "exports"
+        / "feedback.md"
+    )
+    assert not feedback_path.exists()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["7", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Error: could not export student feedback:" in output
+    assert "Review record does not exist" in output
+    assert not feedback_path.exists()
+
+
+def test_menu_export_feedback_requires_overwrite_when_existing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    feedback_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "exports"
+        / "feedback.md"
+    )
+    feedback_path.parent.mkdir(parents=True, exist_ok=True)
+    feedback_path.write_text("old feedback", encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["7", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Error: could not export student feedback:" in output
+    assert "Use --overwrite to replace it." in output
+    assert feedback_path.read_text(encoding="utf-8") == "old feedback"
+
+
+def test_menu_export_feedback_overwrites_existing_export(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    feedback_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "exports"
+        / "feedback.md"
+    )
+    feedback_path.parent.mkdir(parents=True, exist_ok=True)
+    feedback_path.write_text("old feedback", encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["7", "y"]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Exported student feedback:" in output
+    assert "Overwrote existing: yes" in output
+    assert feedback_path.read_text(encoding="utf-8") != "old feedback"
+
+
+def test_menu_export_class_summary_requires_overwrite_when_existing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    exports_dir = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+    )
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = exports_dir / "class_summary.csv"
+    summary_path.write_text("old content", encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + ["2", ""]
+        + _exit_after_assignment_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Error: could not export class review summary:" in output
+    assert "Use --overwrite to replace it." in output
+    assert summary_path.read_text(encoding="utf-8") == "old content"
+
+
+def test_menu_export_class_summary_overwrites_existing_export(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    exports_dir = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+    )
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = exports_dir / "class_summary.csv"
+    summary_path.write_text("old content", encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + ["2", "y"]
+        + _exit_after_assignment_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Exported class review summary:" in output
+    assert "Overwrote existing: yes" in output
+    assert summary_path.read_text(encoding="utf-8") != "old content"
+
+
+def test_menu_export_class_summary_invalid_overwrite_cancels_without_writing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+        / "class_summary.csv"
+    )
+    assert not summary_path.exists()
+
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + ["2", "maybe"]
+        + _exit_after_assignment_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Export canceled. Please enter y or n." in output
+    assert not summary_path.exists()
+
+
+def test_menu_export_standards_summary_overwrites_existing_export(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    exports_dir = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+    )
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = exports_dir / "standards_summary.csv"
+    summary_path.write_text("old summary", encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + ["3", "y"]
+        + _exit_after_assignment_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Exported standards summary:" in output
+    assert "Overwrote existing: yes" in output
+    assert summary_path.read_text(encoding="utf-8") != "old summary"
+
+
+def test_menu_export_standards_summary_requires_overwrite_when_existing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    exports_dir = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+    )
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = exports_dir / "standards_summary.csv"
+    summary_path.write_text("old summary", encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + ["3", ""]
+        + _exit_after_assignment_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Error: could not export standards summary:" in output
+    assert "Use --overwrite to replace it." in output
+    assert summary_path.read_text(encoding="utf-8") == "old summary"
+
+
+def test_menu_export_standards_summary_invalid_overwrite_cancels_without_writing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+        / "standards_summary.csv"
+    )
+    assert not summary_path.exists()
+
+    _menu_input(
+        monkeypatch,
+        _enter_assignment_review_actions()
+        + ["3", "maybe"]
+        + _exit_after_assignment_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Export canceled. Please enter y or n." in output
+    assert not summary_path.exists()

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -162,15 +162,15 @@ def _write_review_record(root: Path, review: dict[str, Any]) -> Path:
 
 
 def _enter_selected_student(student_choice: str = "1") -> list[str]:
-    return ["5", "1", "1", "1", student_choice]
+    return ["5", "1", "1", "1", "1", student_choice]
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["8", "", "2", "8"]
+    return ["9", "5", "", "2", "8"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "8", "", "2", "8"]
+    return ["", "9", "5", "", "2", "8"]
 
 
 @pytest.fixture

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -220,7 +220,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "8", "", "2", "8"])
+    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "1", "9", "5", "", "2", "8"])
 
     assert main(["menu"]) == 0
 
@@ -265,7 +265,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "8", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "1", "9", "5", "", "2", "8"],
     )
 
     assert main(["menu"]) == 0
@@ -313,7 +313,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "", "8", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "1", "1", "", "9", "5", "", "2", "8"],
     )
 
     assert main(["menu"]) == 0
@@ -331,7 +331,7 @@ def test_review_menu_reports_missing_openable_evidence(
 ) -> None:
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "2", "1", "", "8", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "2", "1", "", "9", "5", "", "2", "8"],
     )
 
     assert main(["menu"]) == 0
@@ -357,10 +357,12 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "1",
             "1",
             "1",
+            "1",
             "2",
             "This is a test note.",
             "",
-            "8",
+            "9",
+            "5",
             "",
             "2",
             "8",
@@ -398,10 +400,12 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "1",
+            "1",
             "6",
             "in_progress",
             "",
-            "8",
+            "9",
+            "5",
             "",
             "2",
             "8",


### PR DESCRIPTION
## Summary

* Added guided export actions to the teacher-facing `Review Student Work` menu.
* Added an assignment-level review actions menu with options to:

  * select a student/submission;
  * export class review summary;
  * export standards summary;
  * refresh submission status;
  * go back safely.
* Added selected-student export support for student feedback.
* Reused the existing export services and output formatters instead of adding parallel export logic.
* Updated existing menu tests for the new assignment-level submenu and selected-student menu numbering.
* Added focused tests for guided export menu actions.

## Behavior

The assignment-level review menu now supports:

```text
1. Select student/submission
2. Export class review summary
3. Export standards summary
4. Refresh submission status
5. Back
```

The selected-student review menu now supports:

```text
1. Open submission evidence
2. Add teacher note
3. Add structured tag
4. Select reusable comment
5. Set criterion score
6. Update submission review state
7. Export student feedback
8. Refresh summary
9. Back
```

## Export Safety

The guided export actions preserve existing overwrite protections.

Exports do not overwrite existing files unless the teacher explicitly confirms overwrite behavior through the menu prompt.

Invalid overwrite responses cancel safely without writing.

## Reused Services

The menu delegates to the existing export services:

* `export_student_feedback(...)`
* `export_class_review_summary(...)`
* `export_standards_summary(...)`

The menu also reuses the existing CLI output formatters:

* `print_exported_feedback(...)`
* `print_exported_class_summary(...)`
* `print_exported_standards_summary(...)`

No separate Markdown or CSV export logic was added to the menu layer.

## Non-Mutation Guarantees

Export actions create or replace export artifacts only.

They do not mutate:

* `submission.json`;
* `review.json`;
* routed evidence files;
* source scans;
* comment banks;
* assignment configs;
* roster data.

## Tests

Added `tests/test_menu_export_actions.py` covering:

* assignment-level export menu choices;
* selected-student feedback export menu choice;
* student feedback export creation;
* class summary export creation;
* standards summary export creation;
* invalid overwrite cancellation;
* missing review-record behavior;
* overwrite-required behavior;
* explicit overwrite behavior.

Updated existing menu tests for the new assignment-level submenu and selected-student menu numbering.

## Validation

Passed:

* `tests/test_menu_export_actions.py`: `15 passed`
* menu/export regression group: `33 passed`
* CLI/export regression group: `68 passed`
* full `.\run_tests.ps1`:

  * `pytest`: `993 passed`
  * `ruff`: all checks passed
  * `mypy`: success, no issues found in 110 source files
  * diff whitespace check: all checks passed

Closes #138.
