### PR TITLE
Add v0.8.0 end-to-end smoke test

### DIFF
--- a/tests/test_v080_end_to_end_smoke.py
+++ b/tests/test_v080_end_to_end_smoke.py
@@ -1,0 +1,413 @@
+"""End-to-end smoke test for the v0.8.0 scan/review/export workflow."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from quillan.assignment_workflows import (
+build_assignment_config,
+write_assignment_config,
+)
+from quillan.cli import main
+import quillan.cli_app.handlers.exports as exports_handler
+import quillan.cli_app.handlers.review as review_handler
+import quillan.cli_app.handlers.routing as routing_handler
+import quillan.cli_app.handlers.submissions as submissions_handler
+from quillan.review_record_paths import review_record_path
+from quillan.submission_manifest_paths import submission_manifest_path
+
+CLASS_ID = "english12_p3_v080"
+ASSIGNMENT_ID = "argument_essay_v080"
+STUDENT_ID = "stu_0001"
+SECOND_STUDENT_ID = "stu_0002"
+BANK_ID = "general_writing_synthetic"
+COMMENT_ID = "focus_is_clear"
+STANDARD_CODE = "W.1"
+
+EXAMPLE_BANK_PATH = (
+Path(__file__).parents[1]
+/ "examples"
+/ "comment_banks"
+/ f"{BANK_ID}.json"
+)
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create an isolated synthetic workspace for the v0.8.0 smoke test."""
+    monkeypatch.setenv("PDS_WORKSPACE_ROOT", str(tmp_path))
+    _patch_workspace_resolution(monkeypatch, tmp_path)
+
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    _write_standards_profile(tmp_path)
+    _write_comment_bank(tmp_path)
+
+    return tmp_path
+
+
+def _patch_workspace_resolution(
+monkeypatch: pytest.MonkeyPatch,
+workspace_root: Path,
+) -> None:
+    """Route CLI handler workspace resolution into the temporary workspace."""
+    for module in (
+    exports_handler,
+    review_handler,
+    routing_handler,
+    submissions_handler,
+    ):
+        monkeypatch.setattr(
+        module,
+        "resolve_workspace_root",
+        lambda: workspace_root,
+        raising=False,
+        )
+
+def _write_roster(root: Path) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    class_dir.mkdir(parents=True, exist_ok=True)
+
+    roster_path = class_dir / "roster.csv"
+    with roster_path.open("w", encoding="utf-8", newline="") as roster_file:
+        writer = csv.DictWriter(
+            roster_file,
+            fieldnames=(
+                "class_id",
+                "student_id",
+                "last_name",
+                "first_name",
+                "period",
+            ),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Rivera",
+                "first_name": "Avery",
+                "period": "3",
+            }
+        )
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": SECOND_STUDENT_ID,
+                "last_name": "Patel",
+                "first_name": "Mina",
+                "period": "3",
+            }
+        )
+
+
+def _write_assignment(root: Path) -> Path:
+    assignment = build_assignment_config(
+    assignment_id=ASSIGNMENT_ID,
+    title="Synthetic Argument Essay",
+    class_id=CLASS_ID,
+    writing_type="argument",
+    standards_profile_id="synthetic_profile",
+    tagging_mode="focus",
+    focus_standards=[STANDARD_CODE],
+    basic_requirements={"paragraphs_min": 1},
+    rubric_id="synthetic_rubric",
+    )
+    return write_assignment_config(root, CLASS_ID, assignment)
+
+def _write_standards_profile(root: Path) -> None:
+    profile_path = root / "shared" / "standards" / "synthetic_profile.json"
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    profile_path.write_text(
+        json.dumps(
+            {
+                "profile_id": "synthetic_profile",
+                "subject": "English",
+                "course": "English 12",
+                "standards": [
+                    {
+                        "code": STANDARD_CODE,
+                        "short_name": "Argument Writing",
+                        "description": "Use claims, reasoning, and evidence.",
+                        "comments": [],
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+def _write_comment_bank(root: Path) -> None:
+    bank_path = root / "shared" / "comment_banks" / f"{BANK_ID}.json"
+    bank_path.parent.mkdir(parents=True, exist_ok=True)
+    bank_path.write_text(
+    EXAMPLE_BANK_PATH.read_text(encoding="utf-8"),
+    encoding="utf-8",
+    )
+
+def _response_payload(*, student_id: str = STUDENT_ID, page: int = 1) -> str:
+    return (
+    "PDS1|module=quillan|doc=response|"
+    f"class={CLASS_ID}|aid={ASSIGNMENT_ID}|"
+    f"sid={student_id}|page={page}"
+    )
+
+def _source_scan(root: Path) -> Path:
+    source_path = root / "incoming" / "avery_argument_response.pdf"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_bytes(b"%PDF-1.4\n% synthetic response scan\n%%EOF\n")
+    return source_path
+
+def test_v080_scan_review_export_end_to_end_smoke(
+workspace: Path,
+capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Exercise the integrated v0.8.0 teacher-controlled workflow path."""
+    assignment_path = (
+    workspace
+    / "classes"
+    / CLASS_ID
+    / "assignments"
+    / ASSIGNMENT_ID
+    / "assignment.json"
+    )
+    assert assignment_path.is_file()
+
+
+    assert main(["validate-assignment", str(assignment_path)]) == 0
+
+    source_path = _source_scan(workspace)
+    assert main(
+        [
+            "route-scan",
+            str(source_path),
+            "--payload",
+            _response_payload(),
+        ]
+    ) == 0
+
+    routed_files = sorted(
+        (
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "scans"
+        ).glob("response_*.pdf")
+    )
+    assert len(routed_files) == 1
+    assert not list(workspace.rglob("review.json"))
+    assert not list(workspace.rglob("submission.json"))
+
+    assert main(
+        [
+            "assemble-submissions",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            "--expected-pages",
+            "1",
+        ]
+    ) == 0
+
+    manifest_path = submission_manifest_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    assert manifest_path.is_file()
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["submission_state"] == "unreviewed"
+    assert manifest["expected_pages"] == 1
+    assert manifest["pages"][0]["page_state"] == "present"
+
+    selected_evidence_id = manifest["pages"][0]["selected_evidence_id"]
+    assert isinstance(selected_evidence_id, str)
+    assert selected_evidence_id
+
+    assert main(
+        [
+            "list-submissions",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            "--expected-pages",
+            "1",
+        ]
+    ) == 0
+
+    assert main(
+        [
+            "add-note",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--text",
+            "Teacher observation: the claim is clear.",
+        ]
+    ) == 0
+
+    assert main(
+        [
+            "add-tag",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--label",
+            "claim",
+            "--polarity",
+            "positive",
+            "--standard",
+            STANDARD_CODE,
+            "--note",
+            "Claim is clear and defensible.",
+            "--page",
+            "1",
+            "--evidence-id",
+            selected_evidence_id,
+        ]
+    ) == 0
+
+    assert main(
+        [
+            "add-comment",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--bank",
+            BANK_ID,
+            "--comment-id",
+            COMMENT_ID,
+            "--include-in-feedback",
+        ]
+    ) == 0
+
+    assert main(
+        [
+            "set-score",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--criterion",
+            "evidence",
+            "--label",
+            "Evidence",
+            "--score",
+            "3",
+            "--max-score",
+            "4",
+            "--scale",
+            "4 point",
+            "--note",
+            "Uses relevant quoted evidence.",
+        ]
+    ) == 0
+
+    assert main(
+        [
+            "set-review-state",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "reviewed",
+        ]
+    ) == 0
+
+    review_path = review_record_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    assert review_path.is_file()
+
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review["review_state"] == "in_progress"
+    assert review["notes"][0]["text"] == "Teacher observation: the claim is clear."
+    assert review["tags"][0]["standard_code"] == STANDARD_CODE
+    assert review["tags"][0]["label"] == "claim"
+    assert review["tags"][0]["evidence_id"] == selected_evidence_id
+    assert review["comments"][0]["source"] == "comment_bank"
+    assert review["comments"][0]["bank_id"] == BANK_ID
+    assert review["comments"][0]["comment_id"] == COMMENT_ID
+    assert review["comments"][0]["include_in_feedback"] is True
+    assert review["scores"][0]["criterion_id"] == "evidence"
+    assert review["scores"][0]["score"] == 3
+    assert review["scores"][0]["max_score"] == 4
+
+    updated_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert updated_manifest["submission_state"] == "reviewed"
+
+    assert main(
+        [
+            "export-feedback",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        ]
+    ) == 0
+    assert main(["export-class-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
+    assert main(["export-standards-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
+
+    feedback_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "exports"
+        / "feedback.md"
+    )
+    class_summary_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+        / "class_summary.csv"
+    )
+    standards_summary_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "exports"
+        / "standards_summary.csv"
+    )
+
+    assert feedback_path.is_file()
+    assert class_summary_path.is_file()
+    assert standards_summary_path.is_file()
+
+    feedback_text = feedback_path.read_text(encoding="utf-8")
+    selected_comment_text = str(review["comments"][0]["text"])
+    assert f"Assignment: {ASSIGNMENT_ID}" in feedback_text
+    assert "Evidence: 3 / 4" in feedback_text
+    assert selected_comment_text in feedback_text
+
+    class_summary_text = class_summary_path.read_text(encoding="utf-8")
+    assert STUDENT_ID in class_summary_text
+    assert "in_progress" in class_summary_text
+
+    standards_summary_text = standards_summary_path.read_text(encoding="utf-8")
+    assert STANDARD_CODE in standards_summary_text
+    assert "student_count" in standards_summary_text
+    assert "tag_student_count" in standards_summary_text
+    assert "positive_tag_count" in standards_summary_text
+    assert "review_tags_and_comments" in standards_summary_text
+
+    output = capsys.readouterr().out
+    assert "Routed Quillan response page." in output
+    assert "Exported student feedback:" in output
+    assert "Exported class review summary:" in output
+    assert "Exported standards summary:" in output


### PR DESCRIPTION
## Summary

* Added `tests/test_v080_end_to_end_smoke.py`.
* Added a focused v0.8.0 end-to-end smoke test covering the integrated QR-aware scan intake, submission assembly, teacher review, and export workflow.
* The test uses an isolated synthetic workspace and does not mutate repository fixtures or user data.

## Workflow Covered

The smoke test verifies the current v0.8.0 workflow path:

* creates a synthetic class roster;
* creates and validates a writing assignment config;
* creates a synthetic standards profile;
* copies a synthetic reusable comment bank;
* routes a synthetic response scan using a decoded Quillan response payload;
* assembles a submission manifest from routed evidence;
* verifies routed evidence and submission state;
* adds a teacher note;
* adds a structured standards-linked tag;
* selects a reusable comment;
* sets a criterion score;
* updates submission review state;
* exports student feedback;
* exports class review summary;
* exports standards summary;
* verifies expected export files and key exported content.

## Safety / Scope

This test uses only synthetic data.

It does not add or require:

* OCR;
* handwriting recognition;
* PDF text extraction;
* AI scoring;
* AI tagging;
* AI feedback;
* automatic grading;
* cloud services;
* LMS integration;
* email delivery;
* changes to `pds-core`;
* changes to `pds-scoreform`.

## Validation

Passed:

```text
.\.venv\Scripts\python.exe -m pytest tests/test_v06_reviewable_evidence_smoke.py tests/test_v070_smoke.py tests/test_v080_end_to_end_smoke.py --basetemp .\.pytest-tmp -q
3 passed in 0.51s
```

Passed full validation:

```text
.\run_tests.ps1
994 passed in 14.83s
Ruff: All checks passed
mypy: Success, no issues found in 111 source files
diff whitespace: All checks passed
```

Closes #139.
