### PR TITLE
Update v0.8.0 workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,97 +2,81 @@
 
 Quillan is a local-first standards-based writing evidence capture system for teachers.
 
-It is designed to help teachers tag, score, and respond to student writing by connecting specific locations in written work to standards, comments, rubric scores, and structured instructional data.
+It helps teachers organize, review, tag, score, and respond to student writing by connecting specific written work to standards, comments, rubric scores, review states, and structured instructional data.
 
 Quillan is part of the broader Paper Data Suite concept, alongside ScoreForm.
 
 ## Current Status
 
-Quillan is an early pre-1.0 foundation. The v0.7.0 milestone provides a
-teacher-controlled review and export foundation through direct CLI commands
-and Python APIs. The teacher-facing terminal menu currently covers assignment
-management, roster management, printable response pages, QR-aware scan intake,
-a read-only Review Student Work navigation skeleton, workspace settings,
-help, and exit; guided review entry and export remain direct CLI/API workflows
-or future menu work.
+Quillan is an early pre-1.0 foundation. The v0.8.0 milestone provides a teacher-controlled paper-response intake, review, and export workflow through both direct CLI commands and guided terminal-menu workflows.
 
 Quillan currently supports:
 
-- assignment configuration validation;
-- standards profile loading and validation;
-- validation of the legacy text-oriented submission metadata shape;
-- documented writing-evidence and teacher-review data contracts;
-- a validated shared reusable comment bank contract with a synthetic example
-  and direct teacher-controlled comment selection into `review.json`;
-- loading and validation for the version `1` reviewable-evidence submission
-  manifest through the distinct `quillan.submission_manifest` module;
-- assembly of new version `1` submission manifests from caller-provided routed
-  evidence metadata, including deterministic evidence IDs, missing and
-  duplicate page representation, replacement, damaged, needs-rescan, and
-  excluded evidence semantics, retained-source provenance, canonical paths,
-  validation, and overwrite protection without choosing among ambiguous
-  evidence;
-- assignment-level discovery and assembly of already-routed response evidence
-  through `quillan assemble-submissions`, with existing manifests skipped by
-  default and explicit full regeneration through `--overwrite`;
-- printable writing-response PDF generation with student, class, assignment,
-  and page identity;
-- QR codes containing canonical PDS1 Quillan response payloads on printable
-  response pages;
-- roster-aware printable response generation using shared `pds-core` roster
-  records and display-name helpers;
-- teacher-facing class roster creation, viewing, staged editing, and validation
-  through the Roster Management menu;
-- teacher-facing writing assignment config creation and read-only validation
-  through the Assignment Management menu;
-- teacher-facing generation of one combined printable response class packet
-  from an existing canonical roster and assignment config;
-- shared Paper Data Suite workspace status reporting;
-- assignment-local storage paths based on shared `pds-core` route helpers;
-- an internal, read-only decoded response-page route planner that validates
-  class, assignment, roster, and student relationships without writing files;
-- an internal successful-route evidence filing helper that retains selected
-  source scans under `scans/source/YYYY-MM-DD/`, files routed copies under the
-  assignment `scans/` directory, and returns source and route provenance
-  without assembling submissions;
-- an internal routing failure preservation API that writes shared `pds-core`
-  failure metadata under `scans/review/`, including retained-source provenance
-  when available, without copying review artifacts;
-- a direct `route-scan` command for already-decoded payloads, one supported
-  QR-bearing image, one QR-bearing PDF processed page by page, or a
-  non-recursive folder of supported QR-bearing scan files. It orchestrates the
-  existing parser, QR decoder, payload validator, route planner, evidence
-  filer, failure review helpers, and post-intake `assemble-submissions`
-  next-step guidance derived from the current intake summary;
-- read-only assignment submission status listing, workspace-safe local evidence
-  opening, and student-aware selected-evidence opening; and
-- explicit, teacher-controlled lightweight submission review-state updates
-  that change only review metadata;
-- direct teacher-controlled quick-note, structured-tag, reusable-comment, and
-  criterion-score updates to canonical `review.json` records;
-- derived student feedback, class summary, and standards summary exports; and
-- synthetic examples and fixtures for safe testing and documentation.
+* assignment configuration validation;
+* standards profile loading and validation;
+* validation of legacy text-oriented submission metadata;
+* documented writing-evidence and teacher-review data contracts;
+* validated shared reusable comment banks with synthetic examples;
+* teacher-controlled comment selection into `review.json`;
+* loading and validation for version `1` reviewable-evidence submission manifests;
+* assembly of version `1` submission manifests from routed response evidence;
+* deterministic evidence IDs;
+* missing, duplicate, damaged, needs-rescan, replacement, and excluded evidence semantics;
+* retained-source provenance;
+* canonical workspace-relative paths;
+* overwrite protection for generated canonical records and exports;
+* assignment-level discovery and assembly of already-routed response evidence through `quillan assemble-submissions`;
+* printable writing-response PDF generation with student, class, assignment, and page identity;
+* QR codes containing canonical PDS1 Quillan response payloads on printable response pages;
+* roster-aware printable response generation using shared `pds-core` roster records and display-name helpers;
+* teacher-facing class roster creation, viewing, staged editing, and validation through the Roster Management menu;
+* teacher-facing writing assignment config creation and validation through the Assignment Management menu;
+* teacher-facing generation of one combined printable response class packet from an existing canonical roster and assignment config;
+* shared Paper Data Suite workspace status reporting;
+* assignment-local storage paths based on shared `pds-core` route helpers;
+* decoded response-page route planning that validates class, assignment, roster, and student relationships before writing routed evidence;
+* successful-route evidence filing that retains selected source scans under `scans/source/YYYY-MM-DD/` and files routed response evidence under the assignment `scans/` directory;
+* routing failure preservation under `scans/review/`, including retained-source provenance when available;
+* a direct `route-scan` command for:
 
-Printable response generation is exposed through the teacher-facing menu and
-the Python API in `quillan.printable_response`. It is not exposed as a
-dedicated direct CLI command.
+  * already-decoded PDS1 payloads;
+  * one supported QR-bearing image;
+  * one QR-bearing PDF processed page by page;
+  * a non-recursive folder of supported QR-bearing scan files;
+* QR-aware scan-intake summaries with explicit post-intake `assemble-submissions` guidance;
+* read-only assignment submission status listing;
+* workspace-safe local evidence opening;
+* student-aware selected-evidence opening;
+* explicit lightweight submission review-state updates;
+* teacher-controlled quick-note, structured-tag, reusable-comment, and criterion-score updates to canonical `review.json` records;
+* guided teacher review-entry actions from the Review Student Work menu;
+* derived student feedback, class review summary, and standards summary exports;
+* guided export actions from the Review Student Work menu; and
+* synthetic examples and fixtures for safe testing and documentation.
 
-Current classroom-data workflows are local-first: they read and write the
-teacher-selected Paper Data Suite workspace and do not upload student work,
-review records, comment banks, or exports to a hosted service. Canonical v0.7
-records and exports live at:
+Printable response generation is exposed through the teacher-facing menu and the Python API in `quillan.printable_response`. It is not currently exposed as a dedicated direct CLI command.
+
+Current classroom-data workflows are local-first. They read and write the teacher-selected Paper Data Suite workspace and do not upload student work, review records, comment banks, rosters, scans, or exports to a hosted service.
+
+Canonical v0.8.0 records and exports live at:
 
 ```text
+classes/<class_id>/roster.csv
+classes/<class_id>/assignments/<assignment_id>/assignment.json
+classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
+classes/<class_id>/assignments/<assignment_id>/scans/
 classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
 classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
 classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
 classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
 classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+scans/source/YYYY-MM-DD/
+scans/review/
 shared/comment_banks/<bank_id>.json
+shared/standards/<standards_profile_id>.json
 ```
 
-Opening evidence delegates only to the local system viewer. Exports are
-derived files and never replace the canonical manifest or review record.
+Opening evidence delegates only to the local system viewer. Exports are derived files and never replace the canonical submission manifest or review record.
 
 ## Core Principle
 
@@ -100,262 +84,110 @@ Quillan is not an AI essay grader.
 
 It is a teacher-controlled system for turning student writing into structured instructional evidence.
 
-Teacher judgment remains primary. Quillan may eventually help summarize tags or draft feedback, but final scoring and feedback decisions belong to the teacher.
+Teacher judgment remains primary. Teachers read the work, decide what matters, choose tags and comments, enter scores, and decide review state.
 
-## Designed but Not Yet Implemented
+Quillan may eventually help summarize teacher-created data, but final scoring and feedback decisions belong to the teacher.
 
-The data contracts and design documents describe additional teacher-review
-and paper-ingest workflows that are not yet implemented end to end. In
-particular, Quillan does not currently provide:
+## Implemented v0.8.0 Workflow
 
-- end-to-end production inbox draining, source archiving, or cleanup after
-  scan intake;
-- OCR or handwriting interpretation;
-- automatic conversion of scans into reviewed submissions;
-- recursive raw scan folder intake;
-- merging newly routed evidence into existing teacher review state;
-- complete requirements-checking workflows;
-- AI tagging, AI scoring, or AI feedback;
-- AI suggestions or PDF text extraction;
-- automatic grading;
-- automatic mastery calculation, review-state decisions, or evidence
-  selection among duplicates;
-- guided teacher-facing review entry, notes, tags, comment selection, scoring,
-  feedback export, or summary export workflows;
-- complete teacher-facing assignment editing workflows; or
-- a dedicated printable-response command.
+Quillan’s v0.8.0 workflow separates retained source scans, routed evidence, submission manifests, teacher review records, and exports.
 
-The intended scan-routing rules and failure behavior are documented in
-[`docs/scan_routing_design.md`](docs/scan_routing_design.md). The implemented
-route planner, successful filing helper, and failure preservation helper follow
-the shared `pds-core` active scan contract: canonical retained sources belong
-in `scans/source/YYYY-MM-DD/`, canonical routing review records belong in
-`scans/review/`, and assignment-level `scans/` contains routed evidence rather
-than canonical source retention. OCR and review-state updates remain outside
-the direct routing and assembly commands.
+A **retained source scan** is the canonical active source copy Quillan keeps during scan intake.
 
-## Reviewable Evidence Workflow
+**Routed evidence** is a file copied or derived from retained source material and filed under an assignment’s `scans/` directory for student/assignment review.
 
-Quillan's v0.6 workflow separates retained source scans, routed evidence, and
-student submission manifests.
+A **student submission manifest** is the structured record connecting one student and assignment to pages, page states, selected evidence, alternate evidence, and provenance.
 
-A **retained source scan** is the canonical active source copy Quillan keeps in
-the source scan store during active scan intake. **Routed evidence** is a file
-copied or derived from retained source material and filed under an assignment's
-`scans/` directory for student/assignment review. A **student submission
-manifest** is the structured record connecting one student and assignment to
-pages, page states, one or more evidence records, selected evidence, and
-provenance.
+A **review record** is the teacher-controlled `review.json` containing notes, tags, selected comments, and criterion scores.
 
-A routed evidence file by itself is not a complete student submission. Routing
-does not mean that work is complete, reviewed, scored, or ready for feedback.
+An **export** is a derived artifact produced from canonical records.
 
-The supported teacher/developer sequence is:
+A routed evidence file by itself is not a complete student submission. Routing does not mean that work is complete, reviewed, scored, or ready for feedback.
 
-1. The teacher obtains or selects a local source file.
-2. Quillan receives an already-decoded Quillan PDS1 payload.
-3. `route-scan` retains the source scan and files routed assignment evidence.
-4. If routing cannot safely complete, Quillan preserves failure metadata under
-   `scans/review/` rather than silently discarding the failure.
-5. QR-aware `route-scan` reports which class/assignment pairs have newly
-   routed evidence and prints explicit `assemble-submissions` next steps.
-6. `assemble-submissions` creates missing student submission manifests from
-   routed evidence.
-7. `list-submissions` reports assignment status without writing files.
-8. `open-submission` opens the selected evidence for a specific student.
-9. The teacher reads and evaluates the evidence in the local system viewer.
-10. `add-note` appends a teacher-entered observation to the student's canonical
-   `review.json`.
-11. `add-tag` appends a teacher-entered structured observation to that review
-    record.
-12. `add-comment` selects student-facing teacher-authored language from a
-    shared comment bank into that review record as a stable snapshot.
-13. `set-score` sets or updates one explicitly teacher-entered criterion score.
-14. `export-feedback` writes selected comments and criterion scores to a
-    student-facing Markdown file.
-15. `export-class-summary` writes an assignment-level teacher review CSV.
-16. `export-standards-summary` writes an assignment-level standards-linked
-    tag and selected-comment CSV.
-17. `set-review-state` records lightweight submission-manifest progress when
-    the teacher chooses.
+The supported sequence is:
 
-Opening evidence and updating review state are separate teacher-controlled
-actions. Opening a file never marks a submission reviewed.
+1. The teacher creates or selects a local Paper Data Suite workspace.
+2. The teacher creates or loads a class roster.
+3. The teacher creates or loads a writing assignment config.
+4. The teacher generates printable response pages.
+5. Students write on the printed pages.
+6. The teacher scans the completed pages.
+7. Quillan routes QR-bearing response pages into assignment evidence storage.
+8. Quillan preserves retained source scans and handled failures for review.
+9. The teacher runs or follows post-intake submission assembly guidance.
+10. Quillan assembles submission manifests from routed evidence.
+11. The teacher lists submission status.
+12. The teacher opens selected evidence locally.
+13. The teacher adds notes, structured tags, reusable comments, and scores.
+14. The teacher updates lightweight submission review state when appropriate.
+15. The teacher exports student feedback, class review summary, and standards summary.
 
-The commands in this workflow are:
+Opening evidence and updating review state are separate teacher-controlled actions. Opening a file never marks a submission reviewed.
+
+## Teacher-Facing Menu
+
+Launch the teacher-facing terminal menu:
 
 ```powershell
-quillan route-scan <source-file> --payload "<PDS1 payload>"
-quillan route-scan <source-image> --decode-qr
-quillan route-scan <source-pdf> --decode-qr
-quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
-quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
-quillan open-evidence <workspace-relative-evidence-path>
-quillan open-submission <class_id> <assignment_id> <student_id>
-quillan add-note <class_id> <assignment_id> <student_id> --text "..."
-quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
-quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
-quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
-quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
-quillan export-class-summary <class_id> <assignment_id> [--overwrite]
-quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
-quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+quillan
 ```
 
-- `route-scan` retains selected source scans and files routed evidence from
-  either an already-decoded payload, one supported QR-bearing image, one
-  QR-bearing PDF, or a non-recursive folder of supported QR-bearing scan files.
-  PDF intake processes pages independently, files page evidence as PNG files,
-  and preserves handled failures under `scans/review/`; it does not archive
-  source files, run OCR, or assemble a submission. After
-  QR-aware intake, the command prints explicit `assemble-submissions` commands
-  for class/assignment pairs with newly routed pages in the current intake
-  summary. Preserved failures should still be reviewed before treating the
-  batch as complete.
-- `assemble-submissions` creates missing manifests from routed filenames, or
-  fully regenerates them with `--overwrite`; it does not inspect file contents
-  or choose among ambiguous duplicate evidence.
-- `list-submissions` gives a read-only overview of manifests, routed evidence,
-  missing, duplicate, needs-rescan, and excluded pages, present-but-unselected
-  evidence, and students needing assembly; it does not create or modify files.
-- `open-evidence` opens one workspace-relative local evidence file as a
-  low-level helper; it does not determine which student submission to review.
-- `open-submission` opens one student's selected evidence and requires exactly
-  one selected evidence item; it does not update review metadata.
-- `add-note` appends teacher-entered text to `review.json`, creating that
-  record only when the adjacent `submission.json` exists, validates, and
-  matches the requested student submission. It does not mutate evidence or
-  the submission manifest.
-- `add-tag` appends a teacher-entered structured tag to `review.json`. Tags
-  may reference a validated standard, reusable profile comment, page,
-  evidence ID, or writing location, but they do not score work, prove mastery,
-  or generate feedback.
-- `add-comment` validates a shared bank and appends one student-facing source
-  comment to `review.json.comments`. The selected record stores
-  `bank_id + comment_id` provenance and copies label and text, so later bank
-  edits do not change an existing review. Feedback inclusion uses the bank
-  default unless explicitly included or excluded; this command does not
-  export feedback.
-- `set-score` sets one teacher-entered criterion score in `review.json`.
-  Existing criteria update by `criterion_id`; unrelated review data is
-  preserved. Criterion IDs are not yet validated against rubric profiles, and
-  no overall score is calculated.
-- `export-feedback` reads a valid matching `submission.json` and `review.json`,
-  then writes
-  `submissions/<student_id>/exports/feedback.md`. It includes criterion scores
-  and only snapshotted comments marked `include_in_feedback: true`, without
-  reading source comment banks. Private notes, score notes, tags, and comment
-  provenance are excluded. Existing feedback is protected unless
-  `--overwrite` is supplied, and export does not mutate canonical records,
-  evidence, timestamps, or review state.
-- `export-class-summary` discovers immediate student directories under the
-  assignment `submissions/` directory and writes
-  `assignments/<assignment_id>/exports/class_summary.csv`. Each student gets
-  one deterministic row, including status rows for missing, invalid, or
-  identity-mismatched records. Ready rows summarize states, teacher-entered
-  score totals, selected comments, tags, notes, and feedback-file existence.
-  The totals are transparent arithmetic, not grades. The export does not read
-  evidence or comment banks and does not mutate canonical records.
-- `export-standards-summary` reads valid matching `submission.json` and
-  `review.json` records and writes
-  `assignments/<assignment_id>/exports/standards_summary.csv`. It creates one
-  sorted row per `standard_code` referenced by a structured tag or selected
-  comment, including tag polarity, feedback-inclusion, and distinct-student
-  counts. It does not include scores or notes, load standards profiles, infer
-  mastery or grades, read evidence or comment banks, use a roster, or mutate
-  canonical records. Existing output requires `--overwrite`.
-- `set-review-state` updates only the manifest's `submission_state` and
-  `updated_at`; it does not inspect evidence or make a review decision.
-
-Allowed review states are `unreviewed`, `in_progress`, `needs_rescan`, and
-`reviewed`. The review-state update is metadata-only and occurs only when the
-teacher explicitly requests it.
-
-Quillan does not perform OCR, handwriting recognition, PDF text
-extraction, AI scoring, AI feedback, AI suggestions, automatic grading,
-automatic review-state updates, automatic evidence selection among duplicates,
-rubric scoring, automatic feedback generation, standards mastery reporting, or
-roster-aware missing-student reporting. Quick
-notes and structured tags are teacher-entered
-records; they do not score or generate feedback by themselves.
-The teacher remains responsible for reading and evaluating student work.
-
-## Current Non-Goals
-
-- precise word-level annotation;
-- complex GUI development;
-- hosted/cloud workflows;
-- gradebook sync;
-- parent/student emailing;
-- district-level dashboards;
-- multi-user collaboration.
-
-These remain outside the current foundation. Quillan's implemented printable
-pages are identity-bearing writing surfaces; they do not evaluate student
-work or imply that scan ingestion and automated review exist.
-
-## Development
-
-Quillan is written in Python.
-
-Development priorities:
-
-- clear data models;
-- local-first file storage;
-- structured JSON/CSV outputs;
-- CLI-first workflow;
-- tests around validation, tagging, scoring, and reporting;
-- separated command-line logic and core business logic.
-
-## Local Setup
-
-`pds-core` is required for local Paper Data Suite development. Check out
-`pds-core` and `pds-quillan` as sibling repositories; the parent directory name
-and location can vary:
-
-```text
-Paper-Data-Suite/
-  pds-core/
-  pds-quillan/
-```
-
-Create and activate a virtual environment:
+or:
 
 ```powershell
-py -m venv .venv
-.\.venv\Scripts\Activate.ps1
+quillan menu
 ```
 
-From inside `pds-quillan`, install the project, development tools, and the
-editable sibling checkout of `pds-core`:
-
-```powershell
-python -m pip install --upgrade pip
-python -m pip install -r requirements-dev.txt
-```
-
-Installing only Quillan's ordinary third-party dependencies is not sufficient
-for Paper Data Suite development because Quillan depends on shared
-infrastructure from `pds-core`.
-
-Quillan uses `pds-core` workspace and route contracts. Assignment-local files
-follow this convention beneath the resolved shared workspace root:
+The current top-level menu is:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/
+1. Assignment Management
+2. Roster Management
+3. Printable Response Pages
+4. Scan Intake / Route Paper Responses
+5. Review Student Work
+6. Workspace Settings
+7. Help
+8. Exit
 ```
 
-Printable response PDFs are written to:
+### Assignment Management
+
+The Assignment Management menu supports:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
+1. Create writing assignment
+2. View/validate assignment
+3. Back
 ```
 
-Quillan consumes class rosters through the shared `pds-core` roster contract,
-including `pds_core.rosters.load_roster()` and shared student display-name
-helpers. Canonical roster columns are `class_id`, `student_id`, `last_name`,
-`first_name`, and `period`; student IDs remain strings so leading zeros are
-preserved.
+Assignment creation requires an existing canonical class roster and writes to:
+
+```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+```
+
+The creation workflow prompts for:
+
+* class;
+* assignment title;
+* assignment ID;
+* writing type;
+* standards profile ID;
+* tagging mode;
+* focus standards;
+* basic requirements;
+* rubric ID.
+
+`writing_type` is currently a required teacher-entered value, not a discovered list.
+
+`standards_profile_id` is currently a required teacher-entered value, not a discovered list.
+
+`tagging_mode` is constrained to the allowed values shown by the prompt.
+
+This menu creates and validates assignment configs. It does not edit existing assignments, delete assignments, check requirements, route scans, score work, tag work, generate feedback, or perform OCR or AI work.
+
+### Roster Management
 
 The Roster Management menu creates and reads canonical shared rosters at:
 
@@ -363,312 +195,101 @@ The Roster Management menu creates and reads canonical shared rosters at:
 <PDS workspace root>/classes/<class_id>/roster.csv
 ```
 
-Existing optional columns are displayed and preserved when students are
-added, edited, or removed. Edits remain in memory until the teacher types
-`SAVE`; canceling changed data requires `DISCARD`. Removing a student changes
-only the active roster and does not delete assignments, submissions,
-printable PDFs, scans, reports, tags, scores, feedback, or historical
-evidence.
-
-The Assignment Management menu creates validated writing assignment configs
-from prompts and can view/validate an explicit existing assignment JSON file.
-Creation requires an existing canonical class roster and saves to:
+Canonical roster columns are:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+class_id, student_id, last_name, first_name, period
 ```
 
-Generated configs use Quillan's existing assignment validation contract. This
-menu does not edit, delete, import, score, tag, check requirements, generate
-feedback or reports, route scans, or perform OCR or AI work.
+Student IDs remain strings so leading zeros are preserved.
 
-The Printable Response Pages menu selects an existing canonical class roster
-and assignment config, prompts for a positive number of pages per student, and
-generates one combined class packet at:
+Existing optional columns are displayed and preserved when students are added, edited, or removed. Edits remain staged until the teacher saves them. Removing a student changes only the active roster and does not delete assignments, submissions, printable PDFs, scans, exports, tags, scores, feedback, or historical evidence.
+
+### Printable Response Pages
+
+The Printable Response Pages menu selects an existing canonical class roster and assignment config, prompts for a positive number of pages per student, and generates one combined class packet at:
 
 ```text
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
 ```
 
-Replacing an existing packet requires exact `OVERWRITE` confirmation.
-Generation does not alter the roster or assignment config. Generated PDFs are
-local workspace artifacts and should not be committed.
+Replacing an existing packet requires exact overwrite confirmation.
 
-Reusable teacher-authored comment banks live at
-`shared/comment_banks/<bank_id>.json`. The version `1` source-data contract,
-category and comment shapes, future assignment activation, and snapshot
-boundary with `review.json.comments` are documented in
-[`docs/comment_bank_contract.md`](docs/comment_bank_contract.md). The direct
-`add-comment` workflow validates a bank and copies selected teacher-authored
-language into the canonical review record.
+Generated response pages include student, class, assignment, page identity, and QR codes containing canonical Quillan PDS1 response payloads.
 
-Quillan also consumes the shared PDS1 payload conventions and helpers from
-`pds-core`. Each generated response page embeds a QR code containing a
-canonical payload such as:
+Generation does not alter the roster or assignment config. Generated PDFs are local workspace artifacts and should not be committed.
 
-```text
-PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page_number>|doc=response
-```
+### Scan Intake / Route Paper Responses
 
-Generating this QR code is implemented. Quillan can route selected scans by
-decoding QR payloads from supported image files, PDF pages, or direct files in
-a non-recursive folder. It does not perform OCR.
-
-## Running Quillan
-
-Launch the initial teacher-facing menu skeleton:
+The Scan Intake / Route Paper Responses menu asks for an image, PDF, or non-recursive folder path and uses the same QR-aware behavior as:
 
 ```powershell
-quillan
+quillan route-scan <source> --decode-qr
 ```
 
-`quillan menu` launches the same menu as an explicit alias.
+It prints the structured scan-intake summary, preserves handled failures for review, and shows explicit `assemble-submissions` next steps when pages were routed.
 
-The menu provides writing assignment config creation and validation through
-Assignment Management, class roster creation, viewing, staged editing, and
-validation through Roster Management, combined class-packet generation through
-Printable Response Pages, and guided QR scan intake through Scan Intake /
-Route Paper Responses. Workspace Settings can show, set, validate/create, and
-reset the shared Paper Data Suite workspace root. Help summarizes Quillan's
-teacher-controlled purpose and safe-data expectations.
+It does not expose direct payload mode. It does not move or archive original source files, assemble submissions automatically, run OCR, score work, tag work, or generate feedback.
 
-The scan-intake menu asks for an image, PDF, or non-recursive folder path and
-uses the same QR-aware behavior as `quillan route-scan <source> --decode-qr`.
-It prints the structured scan intake summary, preserves handled failures for
-review, and shows explicit `assemble-submissions` next steps when pages were
-routed. It does not expose payload mode, move or archive original source
-files, assemble submissions automatically, run OCR, score work, or perform AI
-feedback.
+### Review Student Work
 
-The Review Student Work menu is a navigation/context-selection skeleton. It
-lets a teacher select a class, assignment, and student/submission; view the
-current submission status and a brief review summary; and open selected
-submission evidence through the same safe local-opening behavior as
-`open-submission`. It is read-only except for launching the local file viewer:
-it does not create or mutate `review.json` or `submission.json`, automatically
-assemble submissions, run OCR, score work, add notes or tags, select
-comment-bank comments, enter scores, export feedback, export summaries, or use
-AI.
+The Review Student Work menu supports class, assignment, and student/submission navigation plus guided review actions.
+
+The assignment-level review actions menu is:
+
+```text
+1. Select student/submission
+2. Export class review summary
+3. Export standards summary
+4. Refresh submission status
+5. Back
+```
+
+The selected-student review menu is:
+
+```text
+1. Open submission evidence
+2. Add teacher note
+3. Add structured tag
+4. Select reusable comment
+5. Set criterion score
+6. Update submission review state
+7. Export student feedback
+8. Refresh summary
+9. Back
+```
+
+These guided actions reuse the same underlying services and data contracts as the direct CLI commands. The menu does not implement separate export logic, scoring logic, routing logic, or AI logic.
+
+Guided export actions preserve overwrite protection. Existing export files are not replaced unless the teacher explicitly confirms overwrite behavior. Invalid overwrite responses cancel safely.
+
+### Workspace Settings
+
+Workspace Settings can:
+
+```text
+1. Show current workspace
+2. Set workspace folder
+3. Validate/create current workspace
+4. Reset saved workspace preference
+5. Back
+```
+
+Quillan uses the shared `pds-core` workspace configuration. It does not create a Quillan-specific workspace config.
+
+Setting a root validates or creates it and saves the shared preference, but does not move or migrate existing files.
+
+Resetting clears only the saved preference and does not delete workspace files.
+
+`PDS_WORKSPACE_ROOT` takes precedence over the saved preference when it is set.
+
+## Direct CLI Commands
 
 Show direct CLI help:
 
 ```powershell
 quillan --help
 ```
-
-Inspect the shared Paper Data Suite workspace root:
-
-```powershell
-quillan workspace show
-```
-
-This read-only command reports the resolved root, resolution source, config
-path, default root, and basic filesystem status using the shared `pds-core`
-workspace status API.
-
-The same shared workspace operations are also available directly:
-
-```powershell
-quillan workspace set <folder>
-quillan workspace validate
-quillan workspace reset
-```
-
-Quillan uses the shared `pds-core` workspace configuration; it does not create
-a Quillan-specific workspace config. Setting a root validates/creates it and
-saves the shared preference, but does not move or migrate existing files.
-Resetting clears only the saved preference and does not delete workspace
-files. In both cases, `PDS_WORKSPACE_ROOT` still takes precedence over the
-saved preference when it is set.
-
-Open one local evidence file with the system default application:
-
-```powershell
-quillan open-evidence classes/<class_id>/assignments/<assignment_id>/scans/<file>
-```
-
-The path must be relative to and remain inside the active PDS workspace.
-Quillan validates that it identifies an existing file, then delegates the
-platform-specific opening behavior to `pds-core`. This command does not
-inspect, parse, modify, select, score, tag, review, or generate feedback from
-the evidence.
-
-Open the selected routed evidence for one student's canonical submission:
-
-```powershell
-quillan open-submission <class_id> <assignment_id> <student_id>
-```
-
-Quillan loads and validates the student's manifest, verifies its identity, and
-uses the same local evidence-opening support as `open-evidence`. Exactly one
-selected evidence item is currently required. Use `list-submissions` first for
-missing, duplicate, needs-rescan, or unselected submissions. Opening is
-read-only: it does not change review state or select, score, tag, evaluate,
-inspect, OCR, or generate feedback from evidence.
-
-Explicitly update one submission's lightweight teacher review state:
-
-```powershell
-quillan set-review-state <class_id> <assignment_id> <student_id> <state>
-```
-
-Allowed states are `unreviewed`, `in_progress`, `needs_rescan`, and `reviewed`.
-The command changes only `submission_state` and `updated_at` in the validated
-manifest. Opening a submission does not update its state. This command does
-not open or inspect evidence, score, tag, evaluate, run OCR, or generate
-feedback.
-
-Append a quick teacher note to one student's canonical review record:
-
-```powershell
-quillan add-note <class_id> <assignment_id> <student_id> --text "Strong claim, but evidence explanation needs work."
-```
-
-Notes are stored in `review.json` with stable local IDs and timezone-aware
-timestamps. If `review.json` does not exist, Quillan creates it only after the
-adjacent `submission.json` validates and matches the requested class,
-assignment, and student. Adding a note never mutates `submission.json`, routed
-evidence, or retained source scans, and it does not score, tag, or generate
-feedback.
-
-Append a structured teacher tag:
-
-```powershell
-quillan add-tag <class_id> <assignment_id> <student_id> --label "Evidence needs more explanation" --polarity developing
-```
-
-Tags are stored in the `tags` array of the student's canonical `review.json`.
-Optional flags can reference a standard (`--standard`), profile comment
-(`--comment-id`), severity, teacher note, page, evidence ID, and controlled
-location. Assignment `standards_profile_id` and `focus_standards` values are
-shared `pds-core` standards-library references: `focus_standards` stores
-durable `standard_id` values, not teacher-facing display codes. Quillan-owned
-comments, hotwords, feedback templates, and review scaffolding remain module
-data that can reference those shared IDs. A missing review record is created
-only for a valid matching `submission.json`.
-
-Tags remain teacher-entered review artifacts. Adding one does not mutate the
-submission manifest or evidence, calculate a score, establish standard
-mastery, analyze writing, or generate feedback.
-
-Set or update one teacher-entered criterion score:
-
-```powershell
-quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
-```
-
-Scores are stored in the `scores` array of the student's canonical
-`review.json`. A missing review record is created only when the adjacent
-`submission.json` validates and matches the requested identity. Repeating the
-command for the same `criterion_id` preserves its score ID, updates that
-criterion, and preserves unrelated notes, tags, scores, comments, and
-metadata. Optional `--scale` and `--note` values describe the latest explicit
-teacher input; omitting them during an update removes stale prior values.
-
-Quillan does not derive scores from student writing, tags, notes, comments,
-requirements, standards references, or evidence metadata. This command does
-not calculate totals, weighted scores, percentages, grades, mastery, or any
-other overall score. Rubric-profile criterion validation is future work.
-
-Validate a standards profile:
-
-```powershell
-quillan validate-standards <standards-profile.json>
-```
-
-Expected output:
-
-```text
-Valid standards profile: english_12_njsls_synthetic
-```
-
-Validate an assignment configuration:
-
-```powershell
-quillan validate-assignment <assignment.json>
-```
-
-This command keeps structural assignment validation available without a
-workspace standards library. Workspace-aware validation can additionally check
-that `standards_profile_id` exists in the shared `pds-core` standards library
-and that each `focus_standards` entry is a shared `standard_id` in that
-profile. Quillan does not maintain an independent standards universe.
-
-Route one selected scan using an already-decoded Quillan PDS1 payload:
-
-```powershell
-quillan route-scan <source-file> --payload "PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page>|doc=response"
-```
-
-Or route one supported local image, PDF, or non-recursive folder by decoding
-Quillan response-page QR payloads:
-
-```powershell
-quillan route-scan <source-image> --decode-qr
-quillan route-scan <source-pdf> --decode-qr
-quillan route-scan <source-folder> --decode-qr
-```
-
-Successful routing retains the selected source under
-`scans/source/YYYY-MM-DD/` and files response evidence under the assignment
-`scans/` directory. PDF intake converts pages independently and files routed
-page evidence as PNG files, preserving the physical `source_page_number`
-separately from the decoded `payload_page_number`. Decode, payload, planning,
-filing, and PDF conversion failures are preserved under `scans/review/` when
-possible. QR-aware image and PDF intake prints a structured summary with
-source, page, routed, preserved, failed, skipped unsupported, and
-review-required counts. Folder intake produces one aggregate summary across all
-processed sources and continues after recoverable failures that can be
-preserved for review. Partial success is explicit: exit code `0` can mean every
-page routed or that expected failures were safely preserved for review.
-Preserved failures require review before intake is treated as complete. Exit
-code `1` means an unexpected or unpreserved failure occurred.
-
-Folder intake is QR-aware only; `--payload` requires a source file and rejects
-folders. It processes only direct child files in deterministic filename order,
-does not recurse, and skips unsupported files while reporting their count.
-QR-aware intake supports `.jpeg`, `.jpg`, `.pdf`, `.png`, `.tif`, and `.tiff`.
-PDF conversion uses `pdf2image` and requires Poppler installed on the user's
-machine. The command does not move, delete, or archive source files, run OCR,
-score, tag, generate feedback, assemble submissions, create review records,
-or create reports. The Scan Intake / Route Paper Responses menu uses this same
-QR-aware route-scan behavior.
-
-After QR-aware intake, `route-scan` derives class/assignment assembly targets
-from the current structured intake summary and prints safe next-step commands,
-such as `quillan assemble-submissions <class_id> <assignment_id>`, for newly
-routed evidence. It does not rescan assignment `scans/` directories and does
-not include preserved or failed pages as assembly targets. If review is
-required, the message warns that preserved failures should be reviewed before
-the batch is treated as complete. Submission assembly remains the explicit step
-that creates or refreshes manifests.
-
-Assemble all student manifests discoverable from routed filenames in an
-assignment's `scans/` directory:
-
-```powershell
-quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
-```
-
-Discovery recognizes routed PDF and image filenames such as
-`response_00107_pg_003.pdf` and
-`response_00107_pg_003__dup_001.png`. It does not inspect evidence file
-contents or reconstruct retained-source provenance. Existing manifests are
-skipped by default; `--overwrite` fully regenerates them without preserving
-prior review state or teacher selections.
-
-List current manifest and routed-evidence status without changing any files:
-
-```powershell
-quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
-```
-
-The status includes submission and page states, present-but-unselected pages,
-students with routed evidence but no manifest, unassembled routed files, and
-skipped malformed or unrelated scan filenames. Existing manifests are loaded
-and validated; an invalid manifest is an error. The command does not open
-evidence, assemble or update manifests, select evidence, score, tag, run OCR,
-or generate feedback.
 
 The current command surface is:
 
@@ -680,6 +301,7 @@ quillan validate-assignment <assignment.json>
 quillan route-scan <source-file> --payload "<PDS1|...>"
 quillan route-scan <source-image> --decode-qr
 quillan route-scan <source-pdf> --decode-qr
+quillan route-scan <source-folder> --decode-qr
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-path>
@@ -699,8 +321,464 @@ quillan workspace reset
 quillan menu
 ```
 
-Legacy text-oriented submission metadata validation and printable response
-generation currently use Python APIs rather than dedicated CLI commands.
+Legacy text-oriented submission metadata validation and printable response generation currently use Python APIs rather than dedicated CLI commands.
+
+## Scan Intake and Routing
+
+Route one selected scan using an already-decoded Quillan PDS1 payload:
+
+```powershell
+quillan route-scan <source-file> --payload "PDS1|module=quillan|doc=response|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page>"
+```
+
+Route one supported local image, PDF, or non-recursive folder by decoding Quillan response-page QR payloads:
+
+```powershell
+quillan route-scan <source-image> --decode-qr
+quillan route-scan <source-pdf> --decode-qr
+quillan route-scan <source-folder> --decode-qr
+```
+
+Successful routing retains the selected source under:
+
+```text
+scans/source/YYYY-MM-DD/
+```
+
+and files response evidence under:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/scans/
+```
+
+PDF intake converts pages independently and files routed page evidence as PNG files, preserving the physical `source_page_number` separately from the decoded `payload_page_number`.
+
+Decode, payload, planning, filing, and PDF conversion failures are preserved under:
+
+```text
+scans/review/
+```
+
+when possible.
+
+QR-aware image and PDF intake prints a structured summary with source, page, routed, preserved, failed, skipped unsupported, and review-required counts.
+
+Folder intake produces one aggregate summary across all processed sources and continues after recoverable failures that can be preserved for review.
+
+Partial success is explicit: exit code `0` can mean every page routed or that expected failures were safely preserved for review. Exit code `1` means an unexpected or unpreserved failure occurred.
+
+Preserved failures require review before intake is treated as complete.
+
+Folder intake is QR-aware only. `--payload` requires a source file and rejects folders.
+
+Folder intake processes only direct child files in deterministic filename order. It does not recurse. Unsupported files are skipped and counted.
+
+QR-aware intake supports:
+
+```text
+.jpeg
+.jpg
+.pdf
+.png
+.tif
+.tiff
+```
+
+PDF conversion uses `pdf2image` and requires Poppler installed on the user's machine.
+
+Scan intake does not:
+
+* move original source files;
+* delete original source files;
+* archive original source files;
+* run OCR;
+* perform handwriting recognition;
+* extract PDF text;
+* score work;
+* tag work;
+* generate feedback;
+* assemble submissions automatically;
+* create review records;
+* create reports.
+
+After QR-aware intake, `route-scan` derives class/assignment assembly targets from the current structured intake summary and prints safe next-step commands, such as:
+
+```powershell
+quillan assemble-submissions <class_id> <assignment_id>
+```
+
+It does not rescan assignment `scans/` directories and does not include preserved or failed pages as assembly targets.
+
+Submission assembly remains an explicit teacher-controlled step.
+
+## Submission Assembly and Status
+
+Assemble all student manifests discoverable from routed filenames in an assignment's `scans/` directory:
+
+```powershell
+quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
+```
+
+Discovery recognizes routed PDF and image filenames such as:
+
+```text
+response_00107_pg_003.pdf
+response_00107_pg_003__dup_001.png
+```
+
+`assemble-submissions` creates missing manifests from routed filenames. Existing manifests are skipped by default. `--overwrite` fully regenerates them without preserving prior review state or teacher selections.
+
+It does not inspect evidence file contents, OCR writing, or choose among ambiguous duplicate evidence.
+
+List current manifest and routed-evidence status without changing files:
+
+```powershell
+quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+```
+
+The status includes:
+
+* submission states;
+* page states;
+* present-but-unselected pages;
+* students with routed evidence but no manifest;
+* unassembled routed files;
+* malformed or unrelated routed filenames;
+* missing pages;
+* duplicate pages;
+* needs-rescan pages;
+* excluded pages.
+
+Existing manifests are loaded and validated. An invalid manifest is an error.
+
+`list-submissions` does not open evidence, assemble or update manifests, select evidence, score work, tag work, run OCR, or generate feedback.
+
+Allowed submission review states are:
+
+```text
+unreviewed
+in_progress
+needs_rescan
+reviewed
+```
+
+## Opening Evidence
+
+Open one local evidence file with the system default application:
+
+```powershell
+quillan open-evidence classes/<class_id>/assignments/<assignment_id>/scans/<file>
+```
+
+The path must be relative to and remain inside the active PDS workspace.
+
+Open the selected routed evidence for one student's canonical submission:
+
+```powershell
+quillan open-submission <class_id> <assignment_id> <student_id>
+```
+
+Quillan loads and validates the student's manifest, verifies its identity, and uses the same local evidence-opening support as `open-evidence`.
+
+Exactly one selected evidence item is currently required. Use `list-submissions` first for missing, duplicate, needs-rescan, or unselected submissions.
+
+Opening is read-only. It does not change review state, select evidence, score work, tag work, evaluate writing, inspect file content, run OCR, or generate feedback.
+
+## Teacher Review Records
+
+Append a quick teacher note:
+
+```powershell
+quillan add-note <class_id> <assignment_id> <student_id> --text "Strong claim, but evidence explanation needs work."
+```
+
+Notes are stored in `review.json` with stable local IDs and timezone-aware timestamps.
+
+If `review.json` does not exist, Quillan creates it only after the adjacent `submission.json` validates and matches the requested class, assignment, and student.
+
+Adding a note never mutates `submission.json`, routed evidence, or retained source scans. It does not score, tag, or generate feedback.
+
+Append a structured teacher tag:
+
+```powershell
+quillan add-tag <class_id> <assignment_id> <student_id> --label "Evidence needs more explanation" --polarity developing
+```
+
+Tags are stored in the `tags` array of the student's canonical `review.json`.
+
+Optional flags can reference:
+
+* a standard;
+* a profile comment;
+* severity;
+* teacher note;
+* page;
+* evidence ID;
+* controlled location metadata.
+
+A missing review record is created only for a valid matching `submission.json`.
+
+Tags remain teacher-entered review artifacts. Adding one does not mutate the submission manifest or evidence, calculate a score, establish standard mastery, analyze writing, or generate feedback.
+
+Select a reusable teacher-authored comment:
+
+```powershell
+quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
+```
+
+Reusable teacher-authored comment banks live at:
+
+```text
+shared/comment_banks/<bank_id>.json
+```
+
+The direct `add-comment` workflow validates a bank and copies selected teacher-authored language into the canonical review record.
+
+The selected review comment stores `bank_id + comment_id` provenance and copies label and text, so later bank edits do not change an existing review.
+
+Feedback inclusion uses the bank default unless explicitly included or excluded. This command does not export feedback.
+
+Set or update one teacher-entered criterion score:
+
+```powershell
+quillan set-score <class_id> <assignment_id> <student_id> --criterion evidence --label "Evidence" --score 3 --max-score 4
+```
+
+Scores are stored in the `scores` array of the student's canonical `review.json`.
+
+Repeating the command for the same `criterion_id` preserves its score ID, updates that criterion, and preserves unrelated notes, tags, scores, comments, and metadata.
+
+Optional `--scale` and `--note` values describe the latest explicit teacher input. Omitting them during an update removes stale prior values.
+
+Quillan does not derive scores from student writing, tags, notes, comments, requirements, standards references, or evidence metadata.
+
+This command does not calculate totals, weighted scores, percentages, grades, mastery, or any other overall score.
+
+Rubric-profile criterion validation is future work.
+
+Explicitly update one submission's lightweight teacher review state:
+
+```powershell
+quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+```
+
+Allowed states are:
+
+```text
+unreviewed
+in_progress
+needs_rescan
+reviewed
+```
+
+The command changes only `submission_state` and `updated_at` in the validated manifest. Opening a submission does not update its state.
+
+This command does not open or inspect evidence, score work, tag work, evaluate writing, run OCR, or generate feedback.
+
+## Exports
+
+Export student feedback:
+
+```powershell
+quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
+```
+
+This reads a valid matching `submission.json` and `review.json`, then writes:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+```
+
+It includes criterion scores and only snapshotted comments marked:
+
+```json
+"include_in_feedback": true
+```
+
+Private notes, score notes, tags, and comment provenance are excluded.
+
+Existing feedback is protected unless `--overwrite` is supplied.
+
+Export a class review summary:
+
+```powershell
+quillan export-class-summary <class_id> <assignment_id> [--overwrite]
+```
+
+This discovers immediate student directories under the assignment `submissions/` directory and writes:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
+```
+
+Each student gets one deterministic row, including status rows for missing, invalid, or identity-mismatched records.
+
+Ready rows summarize states, teacher-entered score totals, selected comments, tags, notes, and feedback-file existence.
+
+The totals are transparent arithmetic, not grades.
+
+Export a standards summary:
+
+```powershell
+quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
+```
+
+This reads valid matching `submission.json` and `review.json` records and writes:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+```
+
+It creates one sorted row per `standard_code` referenced by a structured tag or selected comment, including tag polarity, feedback-inclusion, and distinct-student counts.
+
+It does not include individual student IDs, scores, notes, mastery determinations, or grades.
+
+All exports are derived files. Exports do not mutate:
+
+* `submission.json`;
+* `review.json`;
+* routed evidence files;
+* retained source scans;
+* rosters;
+* assignment configs;
+* comment banks;
+* standards profiles.
+
+The guided menu export actions reuse these same export services and output formatters. The menu does not implement a second export system.
+
+## Standards and Assignment Validation
+
+Validate a standards profile:
+
+```powershell
+quillan validate-standards <standards-profile.json>
+```
+
+Expected output:
+
+```text
+Valid standards profile: english_12_njsls_synthetic
+```
+
+Validate an assignment configuration:
+
+```powershell
+quillan validate-assignment <assignment.json>
+```
+
+This command keeps structural assignment validation available without requiring a workspace standards library.
+
+Workspace-aware review workflows can additionally check that `standards_profile_id` exists in the shared standards library and that referenced standards are valid for that profile.
+
+Quillan does not maintain an independent standards universe.
+
+## Data Contracts
+
+Quillan's data contracts are documented in:
+
+```text
+docs/data_contracts.md
+```
+
+The canonical teacher-review `review.json` contract is documented in:
+
+```text
+docs/review_record_contract.md
+```
+
+The printable response contract and implemented generator are described in:
+
+```text
+docs/printable_response_template.md
+```
+
+The shared workspace layout and the distinction between active and reserved paths are documented in:
+
+```text
+docs/workspace_lifecycle.md
+```
+
+The scan-routing rules and failure behavior are documented in:
+
+```text
+docs/scan_routing_design.md
+```
+
+The comment-bank contract is documented in:
+
+```text
+docs/comment_bank_contract.md
+```
+
+Synthetic example files are available in:
+
+```text
+examples/
+```
+
+## v0.8.0 Smoke Test
+
+The v0.8.0 workflow is covered by an end-to-end smoke test:
+
+```text
+tests/test_v080_end_to_end_smoke.py
+```
+
+This test uses an isolated synthetic workspace and verifies the integrated path for:
+
+* synthetic class roster setup;
+* assignment config creation and validation;
+* standards profile setup;
+* comment bank setup;
+* scan routing from a Quillan response payload;
+* submission manifest assembly;
+* selected evidence discovery;
+* teacher note entry;
+* structured standards-linked tag entry;
+* reusable comment selection;
+* criterion score entry;
+* submission review-state update;
+* student feedback export;
+* class review summary export;
+* standards summary export.
+
+It is a high-level integration confidence check. It is not a replacement for the focused unit and workflow tests.
+
+## Local Setup
+
+`pds-core` is required for local Paper Data Suite development.
+
+Check out `pds-core` and `pds-quillan` as sibling repositories. The parent directory name and location can vary:
+
+```text
+Paper-Data-Suite/
+  pds-core/
+  pds-quillan/
+```
+
+Create and activate a virtual environment:
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+From inside `pds-quillan`, install the project, development tools, and the editable sibling checkout of `pds-core`:
+
+```powershell
+python -m pip install --upgrade pip
+python -m pip install -r requirements-dev.txt
+```
+
+Installing only Quillan's ordinary third-party dependencies is not sufficient for Paper Data Suite development because Quillan depends on shared infrastructure from `pds-core`.
+
+PDF scan intake uses `pdf2image` and requires Poppler installed on the user's machine.
+
+Quillan uses `pds-core` workspace and route contracts. Assignment-local files follow this convention beneath the resolved shared workspace root:
+
+```text
+<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/
+```
 
 ## Quality Checks
 
@@ -736,23 +814,6 @@ Run the complete validation sequence, including the diff whitespace check:
 .\run_tests.ps1
 ```
 
-## Data Contracts
-
-Quillan's data contracts are documented in
-[`docs/data_contracts.md`](docs/data_contracts.md).
-
-The canonical v0.7 teacher-review `review.json` contract is documented in
-[`docs/review_record_contract.md`](docs/review_record_contract.md).
-
-The printable response contract and implemented generator are described in
-[`docs/printable_response_template.md`](docs/printable_response_template.md).
-
-The shared workspace layout and the distinction between active and reserved
-paths are documented in
-[`docs/workspace_lifecycle.md`](docs/workspace_lifecycle.md).
-
-Synthetic example files are available in [`examples/`](examples/).
-
 ## Synthetic Data Policy
 
 The repository should not include real student data.
@@ -763,7 +824,10 @@ Committed examples and tests should use:
 * fake class IDs;
 * synthetic writing samples;
 * synthetic scores;
-* synthetic teacher comments.
+* synthetic teacher comments;
+* synthetic rosters;
+* synthetic standards profiles;
+* synthetic scans or scan-like fixtures.
 
 Do not commit:
 
@@ -772,7 +836,46 @@ Do not commit:
 * real student writing;
 * real grades;
 * real parent contact information;
-* real scanned student work.
+* real scanned student work;
+* real review notes;
+* real feedback;
+* real exports;
+* real screenshots of student work or workspace data.
+
+Local workspace artifacts should not be committed.
+
+## Current Non-Goals
+
+Quillan does not currently provide:
+
+* OCR;
+* handwriting recognition;
+* PDF text extraction;
+* AI tagging;
+* AI scoring;
+* AI feedback;
+* automatic grading;
+* automatic mastery calculation;
+* automatic evidence selection among duplicates;
+* automatic review-state decisions;
+* complete requirements-checking workflows;
+* recursive raw scan folder intake;
+* production inbox draining;
+* source cleanup/archive automation;
+* LMS integration;
+* cloud sync;
+* gradebook sync;
+* parent/student emailing;
+* district dashboards;
+* hosted multi-user collaboration;
+* a mobile app workflow;
+* a complex GUI.
+
+Quillan's implemented printable pages are identity-bearing writing surfaces. They do not evaluate student work.
+
+Quillan's scan intake routes QR-identified paper responses. It does not read the student's writing.
+
+Quillan's review tools record teacher decisions. They do not replace teacher judgment.
 
 ## Development Workflow
 
@@ -789,12 +892,13 @@ Recommended pull request workflow:
 
 1. Make a focused change.
 2. Run `pytest`, `ruff check .`, and `mypy .`.
-3. Commit and push the branch.
-4. Open a pull request into `main`.
-5. Link the relevant issue using `Closes #<issue-number>`.
-6. Use squash merge for most feature branches.
-7. Delete the remote branch after merging.
-8. Pull the updated `main` branch locally.
+3. Prefer `.\run_tests.ps1` before merge.
+4. Commit and push the branch.
+5. Open a pull request into `main`.
+6. Link the relevant issue using `Closes #<issue-number>`.
+7. Use squash merge for most feature branches.
+8. Delete the remote branch after merging.
+9. Pull the updated `main` branch locally.
 
 ## License
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -6,14 +6,17 @@ This document defines Quillan's command-line contract during pre-1.0
 development. It records:
 
 * the command surface that is implemented now;
-* the boundary between direct commands and the initial interactive menu;
+* the boundary between direct commands and the interactive menu;
 * conventions for help, errors, paths, output, and exit status; and
 * the compatibility expectations contributors should use when changing the
   CLI.
 
-The CLI includes a developer-oriented, scriptable command layer and an initial
-teacher-facing menu with shared-roster management, scan intake, and read-only
-review navigation. It is not a complete teacher-facing application.
+The CLI includes a developer-oriented, scriptable command layer and a
+teacher-facing terminal menu. The menu now covers assignment management, roster
+management, printable response pages, QR-aware scan intake, review navigation,
+guided review-entry actions, guided export actions, workspace settings, help,
+and exit.
+
 This contract describes implemented behavior separately from future design. A
 command or workflow documented elsewhere as planned is not part of the current
 CLI until it is implemented, tested, and added here.
@@ -51,6 +54,7 @@ quillan validate-assignment <path>
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
 quillan route-scan <source-image> --decode-qr
 quillan route-scan <source-pdf> --decode-qr
+quillan route-scan <source-folder> --decode-qr
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 quillan open-evidence <workspace-relative-evidence-path>
@@ -71,10 +75,9 @@ quillan workspace --help
 quillan menu
 ```
 
-Running `quillan` without a command launches the initial teacher-facing
-terminal menu. Running `quillan workspace` without a subcommand prints
-top-level help and exits successfully; it does not inspect or modify the
-workspace.
+Running `quillan` without a command launches the teacher-facing terminal menu.
+Running `quillan workspace` without a subcommand prints top-level help and
+exits successfully; it does not inspect or modify the workspace.
 
 The teacher-facing menu may also be launched explicitly:
 
@@ -83,7 +86,7 @@ quillan menu
 ```
 
 Bare `quillan` and the explicit `menu` command launch the same interactive
-menu skeleton. The other commands remain direct and non-interactive.
+menu. The other commands remain direct and non-interactive.
 
 ### `validate-standards`
 
@@ -202,9 +205,10 @@ without the menu.
 
 ### Interactive menu
 
-Bare `quillan` launches the current menu, which is a small discovery and
-navigation shell. `quillan menu` is an explicit alias for the same behavior.
-The menu provides:
+Bare `quillan` launches the current menu. `quillan menu` is an explicit alias
+for the same behavior.
+
+The top-level menu provides:
 
 ```text
 1. Assignment Management
@@ -217,6 +221,55 @@ The menu provides:
 8. Exit
 ```
 
+Menu workflows should orchestrate reusable application functions. They should
+not become the only route to core operations, and they should not duplicate
+business rules that already live in CLI handlers or domain modules.
+
+#### Assignment Management
+
+Assignment Management provides:
+
+```text
+1. Create writing assignment
+2. View/validate assignment
+3. Back
+```
+
+Creation selects one class with an existing canonical roster, prompts for the
+fields in the existing assignment config contract, and writes:
+
+```text
+<workspace_root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+```
+
+Assignment creation prompts for:
+
+* assignment title;
+* assignment ID;
+* writing type;
+* standards profile ID;
+* tagging mode;
+* focus standards;
+* basic requirements; and
+* rubric ID.
+
+`writing_type` is currently a typed teacher-entered value, not a discovered or
+selectable list.
+
+`standards_profile_id` is currently a typed teacher-entered value, not a
+discovered or selectable list.
+
+An existing config is replaced only after exact `OVERWRITE` confirmation.
+
+View/validate accepts an explicit JSON path, uses the existing assignment
+loader and validator, prints a concise summary, and does not rewrite the file.
+
+These workflows do not add assignment editing, deletion, import, scoring,
+feedback, tagging execution, requirements checking, reports, scan routing,
+OCR, AI, or printable packet generation.
+
+#### Roster Management
+
 Roster Management provides:
 
 ```text
@@ -228,34 +281,23 @@ Roster Management provides:
 ```
 
 These menu-only workflows use shared `pds-core` class and roster APIs.
-Canonical rosters are stored at
-`<workspace_root>/classes/<class_id>/roster.csv`. Student IDs remain strings,
-including leading zeros, and existing optional columns remain in their
-original order. Viewing and validation are read-only.
-
-Editing stages shared immutable roster mutations in memory. Add, edit, and
-active-roster removal do not write immediately. Saving requires typing
-`SAVE`; canceling staged changes requires typing `DISCARD`. Active-roster
-removal never deletes assignments, submissions, printable PDFs, scans,
-reports, tags, scores, feedback, or historical evidence.
-
-Assignment Management provides:
+Canonical rosters are stored at:
 
 ```text
-1. Create writing assignment
-2. View/validate assignment
-3. Back
+<workspace_root>/classes/<class_id>/roster.csv
 ```
 
-Creation selects one class with an existing canonical roster, prompts for the
-fields in the existing assignment config contract, and writes
-`<workspace_root>/classes/<class_id>/assignments/<assignment_id>/assignment.json`.
-An existing config is replaced only after exact `OVERWRITE` confirmation.
-View/validate accepts an explicit JSON path, uses the existing assignment
-loader and validator, prints a concise summary, and does not rewrite the file.
-These workflows do not add assignment editing, deletion, import, scoring,
-feedback, tagging execution, requirements checking, reports, scan routing,
-OCR, AI, or printable packet generation.
+Student IDs remain strings, including leading zeros, and existing optional
+columns remain in their original order. Viewing and validation are read-only.
+
+Editing stages shared immutable roster mutations in memory. Add, edit, and
+active-roster removal do not write immediately. Saving requires typing `SAVE`;
+canceling staged changes requires typing `DISCARD`.
+
+Active-roster removal never deletes assignments, submissions, printable PDFs,
+scans, reports, tags, scores, feedback, or historical evidence.
+
+#### Printable Response Pages
 
 Printable Response Pages provides:
 
@@ -267,8 +309,10 @@ Printable Response Pages provides:
 Generation selects a class with an existing canonical roster, then selects a
 canonical assignment config for that class. Invalid configs are identified and
 cannot be selected; the assignment must include the selected class in
-`class_ids`. Blank pages-per-student input defaults to `1`, and nonblank input
-must be a positive integer.
+`class_ids`.
+
+Blank pages-per-student input defaults to `1`, and nonblank input must be a
+positive integer.
 
 The current output mode is one combined class packet PDF:
 
@@ -277,10 +321,13 @@ The current output mode is one combined class packet PDF:
 ```
 
 An existing packet is replaced only after exact `OVERWRITE` confirmation.
+
 The workflow uses the existing roster-aware printable generator and does not
 alter roster or assignment data. It does not add individual PDFs, scan
 routing, OCR, review, scoring, feedback, reports, AI, or a direct printable
 CLI command.
+
+#### Scan Intake / Route Paper Responses
 
 Scan Intake / Route Paper Responses prompts for a local scan source path:
 
@@ -288,23 +335,42 @@ Scan Intake / Route Paper Responses prompts for a local scan source path:
 Scan file or folder path (leave blank to cancel):
 ```
 
-Blank input cancels without routing files. Nonblank input trims surrounding
-whitespace and removes one matching pair of surrounding quotes, so pasted
-Windows paths such as `"C:\Users\Teacher\Desktop\scan folder"` work as a
-single path. The source may be a supported image file, a PDF, or a
-non-recursive folder containing supported image/PDF scan files. The workflow
-uses the same QR-aware implementation path as
-`quillan route-scan <source> --decode-qr`; it does not expose payload mode.
+Blank input cancels without routing files.
+
+Nonblank input trims surrounding whitespace and removes one matching pair of
+surrounding quotes, so pasted Windows paths such as
+`"C:\Users\Teacher\Desktop\scan folder"` work as a single path.
+
+The source may be a supported image file, a PDF, or a non-recursive folder
+containing supported image/PDF scan files.
+
+The workflow uses the same QR-aware implementation path as:
+
+```powershell
+quillan route-scan <source> --decode-qr
+```
+
+It does not expose payload mode.
+
 It prints the structured scan intake summary, including processed sources,
-attempted pages, routed, preserved, failed, skipped unsupported, review
-required, and failure-category counts. If routed evidence exists, it prints
-the same explicit `assemble-submissions` next-step guidance as the direct
-command. If review is required, the preserved-failure caution is printed.
+attempted pages, routed, preserved, failed, skipped unsupported,
+review-required, and failure-category counts.
+
+If routed evidence exists, it prints the same explicit
+`assemble-submissions` next-step guidance as the direct command.
+
+If review is required, the preserved-failure caution is printed.
+
 The workflow does not automatically assemble submissions, move or archive the
 teacher's original source files, create `submission.json` or `review.json`,
 run OCR, score, tag, generate feedback, or perform AI work.
 
-Review Student Work provides a read-only guided navigation skeleton:
+#### Review Student Work
+
+Review Student Work provides guided class, assignment, and student/submission
+navigation plus review-entry and export actions.
+
+The first Review Student Work menu provides:
 
 ```text
 1. Select class and assignment
@@ -312,29 +378,80 @@ Review Student Work provides a read-only guided navigation skeleton:
 ```
 
 The workflow lists available classes from the active workspace, lists
-assignments for the selected class, prints the current assignment submission
-status through the existing status formatting path, and lets the teacher pick a
-student/submission by number. Roster students remain visible even when they do
-not yet have an assembled submission. The selected-student view shows a brief
-current review summary with class, assignment, student, manifest/evidence
-status, review state, and existing `review.json` counts when a valid review
-record is already present.
+assignments for the selected class, and prints the current assignment
+submission status through the existing status formatting path.
 
-The selected-student view offers:
+Roster students remain visible even when they do not yet have an assembled
+submission.
+
+After a class and assignment are selected, the assignment-level review actions
+menu provides:
+
+```text
+1. Select student/submission
+2. Export class review summary
+3. Export standards summary
+4. Refresh submission status
+5. Back
+```
+
+Selecting a student/submission lets the teacher pick a student by number. The
+selected-student view shows a current review summary with class, assignment,
+student, manifest/evidence status, review state, and existing `review.json`
+counts when a valid review record is already present.
+
+The selected-student review menu provides:
 
 ```text
 1. Open submission evidence
-2. Refresh summary
-3. Back
+2. Add teacher note
+3. Add structured tag
+4. Select reusable comment
+5. Set criterion score
+6. Update submission review state
+7. Export student feedback
+8. Refresh summary
+9. Back
 ```
 
 Opening submission evidence delegates to the same existing safe selected
-evidence-opening path as `quillan open-submission <class_id> <assignment_id>
-<student_id>`. Missing manifests or missing selected evidence are reported
-clearly. The workflow does not automatically assemble submissions, create or
-mutate `submission.json` or `review.json`, update review state, add notes,
-tags, comments, or scores, export feedback or summaries, run OCR, parse
-evidence contents, score work, or perform AI work.
+evidence-opening path as:
+
+```powershell
+quillan open-submission <class_id> <assignment_id> <student_id>
+```
+
+Missing manifests or missing selected evidence are reported clearly.
+
+Guided review-entry actions reuse the same underlying review services as the
+direct commands:
+
+```powershell
+quillan add-note <class_id> <assignment_id> <student_id> --text "..."
+quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity <polarity>
+quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
+quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
+quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+```
+
+Guided export actions reuse the same underlying export services as the direct
+commands:
+
+```powershell
+quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
+quillan export-class-summary <class_id> <assignment_id> [--overwrite]
+quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
+```
+
+Menu export actions preserve overwrite protection. Existing export files are
+not replaced unless the teacher explicitly confirms overwrite behavior.
+Invalid overwrite responses cancel safely.
+
+The Review Student Work menu does not automatically assemble submissions,
+route scans, run OCR, parse evidence contents, score work automatically, infer
+mastery, generate AI feedback, or perform AI work.
+
+#### Workspace Settings
 
 Workspace Settings provides:
 
@@ -346,38 +463,40 @@ Workspace Settings provides:
 5. Back
 ```
 
-Showing the workspace calls the same status behavior as
-`quillan workspace show` and remains read-only. Setting prompts for a folder;
-blank input cancels without changing the saved preference. Nonblank input
-validates/creates the folder and saves it through shared `pds-core`
-configuration. Validate/create operates on the currently resolved root.
+Showing the workspace calls the same status behavior as:
+
+```powershell
+quillan workspace show
+```
+
+and remains read-only.
+
+Setting prompts for a folder; blank input cancels without changing the saved
+preference. Nonblank input validates/creates the folder and saves it through
+shared `pds-core` configuration.
+
+Validate/create operates on the currently resolved root.
+
 Reset clears only the saved preference and then reports the current resolved
-root. The menu warns that setting does not migrate files, resetting does not
-delete files, and `PDS_WORKSPACE_ROOT` still takes precedence.
+root.
 
-The workspace submenu does not include school-year settings. The overall menu
-remains a guided shell rather than a complete teacher-facing application.
+The menu warns that setting does not migrate files, resetting does not delete
+files, and `PDS_WORKSPACE_ROOT` still takes precedence.
 
-The menu does not currently guide teachers through review-state changes, notes,
-tags, comment-bank selection, criterion scoring, feedback export, class or
-standards summary export, or submission assembly. Those implemented review,
-export, and assembly operations are available through the direct commands
-documented below and through focused Python APIs.
+The workspace submenu does not include school-year settings.
+
+#### Help, Exit, and Shared Menu Behavior
 
 Menu help describes Quillan as a local-first, teacher-controlled
 writing-evidence tool; keeps teacher judgment primary; states that Quillan is
-not automated grading software; identifies currently unsupported AI, OCR, and
-review workflows; notes that guided scan intake routes QR-coded response pages
-only; and summarizes repository safe-data expectations and current direct
-commands.
+not automated grading software; identifies unsupported AI and OCR workflows;
+notes that guided scan intake routes QR-coded response pages only; and
+summarizes repository safe-data expectations and current direct commands.
 
 The menu clears the screen only when both standard input and standard output
-are interactive terminals. A normal exit or `KeyboardInterrupt` returns status
-`0`.
+are interactive terminals.
 
-A future menu may guide teachers through additional multi-step work after
-those workflows are actually implemented. It should orchestrate reusable
-application functions rather than becoming the only route to core operations.
+A normal exit or `KeyboardInterrupt` returns status `0`.
 
 CLI parser construction lives in `quillan/cli_app/parser.py`; argument
 conversion, output helpers, top-level dispatch, and command handlers live
@@ -449,49 +568,90 @@ quillan route-scan <source-folder> --decode-qr
 This command routes selected scan sources using exactly one payload source:
 caller-supplied canonical PDS1 text through `--payload`, or QR payloads
 decoded from a supported local image, each page of a PDF, or every supported
-scan file directly inside a folder through `--decode-qr`. Folder intake is
-QR-aware only; `--payload` requires a file and rejects folders. Supported scan
-extensions are `.jpeg`, `.jpg`, `.pdf`, `.png`, `.tif`, and `.tiff`. PDF intake
-uses `pdf2image`, which requires Poppler installed on the user's machine.
+scan file directly inside a folder through `--decode-qr`.
+
+Folder intake is QR-aware only; `--payload` requires a file and rejects
+folders.
+
+Supported scan extensions are:
+
+```text
+.jpeg
+.jpg
+.pdf
+.png
+.tif
+.tiff
+```
+
+PDF intake uses `pdf2image`, which requires Poppler installed on the user's
+machine.
 
 Folder intake is non-recursive. It processes only direct child files in
 deterministic order by case-insensitive filename with a stable filename
 tie-breaker. Unsupported files such as `.txt`, `.csv`, `.DS_Store`, or
 `Thumbs.db` are skipped, counted in the structured summary, and are not
-failures. An empty folder, or a folder with no supported scan files, prints a
-clear error and exits `1`.
+failures.
 
-On success it retains the source under `scans/source/YYYY-MM-DD/` and files
-routed evidence under the target assignment's `scans/` directory. PDF pages
-route independently and successful PDF page evidence is filed as PNG files;
-`source_page_number` records the physical PDF page separately from the decoded
-`payload_page_number`. Decode, payload, planning, filing, or PDF conversion
-failures are preserved under `scans/review/` when they can be handled safely.
+An empty folder, or a folder with no supported scan files, prints a clear
+error and exits `1`.
+
+On success, route-scan retains the source under:
+
+```text
+scans/source/YYYY-MM-DD/
+```
+
+and files routed evidence under the target assignment's `scans/` directory.
+
+PDF pages route independently and successful PDF page evidence is filed as PNG
+files. `source_page_number` records the physical PDF page separately from the
+decoded `payload_page_number`.
+
+Decode, payload, planning, filing, or PDF conversion failures are preserved
+under:
+
+```text
+scans/review/
+```
+
+when they can be handled safely.
+
 QR-aware image and PDF intake prints a structured scan intake summary with
 source, page, routed, preserved, failed, skipped unsupported, and
-review-required counts. Folder intake produces one aggregate summary across all
-processed sources. Partial success is explicit: exit `0` can mean all pages
-routed or that expected failures were safely preserved for review, including
-when later files continued after a preserved failure. Preserved failures require
-review before intake is treated as complete. Exit `1` means an unexpected
-failure occurred or a failure could not be preserved safely.
+review-required counts. Folder intake produces one aggregate summary across
+all processed sources.
+
+Partial success is explicit: exit `0` can mean all pages routed or that
+expected failures were safely preserved for review, including when later files
+continued after a preserved failure. Preserved failures require review before
+intake is treated as complete. Exit `1` means an unexpected failure occurred
+or a failure could not be preserved safely.
 
 After QR-aware intake, the command derives assembly targets from routed
-`ScanIntakePageResult` entries in the current `ScanIntakeSummary`. Routed pages
-with both `class_id` and `assignment_id` are grouped by class/assignment and
-reported in deterministic order as explicit `quillan assemble-submissions
-<class_id> <assignment_id>` next-step commands. Preserved, failed, skipped, and
-malformed routed pages without complete class/assignment identity do not create
-assembly targets. The command does not scan assignment `scans/` directories to
-find targets, so the guidance only reflects evidence routed by the current
-intake run. When review is required, the next-step message warns that preserved
-failures should be reviewed before the batch is treated as complete.
+`ScanIntakePageResult` entries in the current `ScanIntakeSummary`. Routed
+pages with both `class_id` and `assignment_id` are grouped by class/assignment
+and reported in deterministic order as explicit next-step commands:
 
-The command does not move, delete, or archive source files after folder intake.
-The Scan Intake / Route Paper Responses menu invokes this same QR-aware intake
-path. QR-aware scan intake does not assemble submissions, create review
-records, run OCR, or identify a student from raw scan content without a valid
-payload.
+```powershell
+quillan assemble-submissions <class_id> <assignment_id>
+```
+
+Preserved, failed, skipped, and malformed routed pages without complete
+class/assignment identity do not create assembly targets.
+
+The command does not scan assignment `scans/` directories to find targets, so
+the guidance only reflects evidence routed by the current intake run.
+
+When review is required, the next-step message warns that preserved failures
+should be reviewed before the batch is treated as complete.
+
+The command does not move, delete, or archive source files after folder
+intake. The Scan Intake / Route Paper Responses menu invokes this same
+QR-aware intake path.
+
+QR-aware scan intake does not assemble submissions, create review records, run
+OCR, or identify a student from raw scan content without a valid payload.
 
 ## Submission Assembly and Status
 
@@ -501,15 +661,19 @@ quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
 ```
 
 `assemble-submissions` discovers already-routed PDF and image evidence by the
-assignment filename convention and creates canonical student
-`submission.json` manifests. Existing manifests are skipped unless
-`--overwrite` requests full regeneration. Assembly does not inspect evidence
-contents, recover provenance absent from filenames, or choose among ambiguous
-duplicate evidence.
+assignment filename convention and creates canonical student `submission.json`
+manifests.
+
+Existing manifests are skipped unless `--overwrite` requests full
+regeneration. Assembly does not inspect evidence contents, recover provenance
+absent from filenames, or choose among ambiguous duplicate evidence.
 
 `list-submissions` is read-only. It reports manifest and page states,
 present-but-unselected evidence, students needing assembly, unassembled routed
 files, and skipped filenames without creating or modifying records.
+
+These commands do not open evidence, update review state, create review
+records, score work, tag work, generate feedback, run OCR, or perform AI work.
 
 ## Evidence and Submission Opening
 
@@ -519,9 +683,14 @@ quillan open-submission <class_id> <assignment_id> <student_id>
 ```
 
 `open-evidence` opens one existing file that resolves inside the active
-workspace. `open-submission` validates one canonical manifest and opens its
-single selected evidence item. Both commands are read-only and do not inspect
-content, select evidence, or update review state.
+workspace.
+
+`open-submission` validates one canonical manifest and opens its single
+selected evidence item.
+
+Both commands are read-only. They do not inspect content, select evidence,
+score work, tag work, create review records, generate feedback, or update
+review state.
 
 ## Submission Review State
 
@@ -529,10 +698,18 @@ content, select evidence, or update review state.
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
-The allowed states are `unreviewed`, `in_progress`, `needs_rescan`, and
-`reviewed`. This command updates only `submission_state` and `updated_at` in
-the validated manifest. It does not open or inspect evidence or make an
-automatic review decision.
+The allowed states are:
+
+```text
+unreviewed
+in_progress
+needs_rescan
+reviewed
+```
+
+This command updates only `submission_state` and `updated_at` in the validated
+manifest. It does not open or inspect evidence or make an automatic review
+decision.
 
 ## Quick Teacher Notes
 
@@ -542,8 +719,9 @@ quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 
 This direct command appends one teacher-entered note to canonical
 `review.json`, creating the record only when the adjacent `submission.json`
-exists, validates, and matches the requested identity. It preserves the
-manifest, evidence, and unrelated review content.
+exists, validates, and matches the requested identity.
+
+It preserves the manifest, evidence, and unrelated review content.
 
 ## Structured Review Tags
 
@@ -553,15 +731,28 @@ quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity
 
 This direct command appends one teacher-entered tag to the canonical
 `review.json`, creating that record only when the adjacent `submission.json`
-exists, validates, and matches the requested identity. Optional flags are
-`--standard`, `--comment-id`, `--severity`, `--note`, `--page`,
-`--evidence-id`, `--location-type`, and `--location-value`.
+exists, validates, and matches the requested identity.
 
-Handled workspace, record, and tag-validation failures return `1`. Success
-returns `0` and reports the class, assignment, student, tag ID, polarity,
-review state, and workspace-relative review-record path. The command never
-mutates the submission manifest, routed evidence, or retained source scans,
-and it does not score, analyze, or generate feedback.
+Optional flags are:
+
+```text
+--standard
+--comment-id
+--severity
+--note
+--page
+--evidence-id
+--location-type
+--location-value
+```
+
+Handled workspace, record, and tag-validation failures return `1`.
+
+Success returns `0` and reports the class, assignment, student, tag ID,
+polarity, review state, and workspace-relative review-record path.
+
+The command never mutates the submission manifest, routed evidence, or
+retained source scans, and it does not score, analyze, or generate feedback.
 
 ## Reusable Comment Selection
 
@@ -570,12 +761,20 @@ quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --c
 ```
 
 This direct command validates a shared comment bank and appends one
-teacher-selected student-facing comment to canonical `review.json`. Optional
-`--standard`, `--include-in-feedback`, and `--exclude-from-feedback` flags
-refine the snapshot. The command copies label and text and preserves
-`bank_id + comment_id` provenance, so later bank edits do not change the
-review. It does not export feedback or mutate the source bank, manifest, or
-evidence.
+teacher-selected student-facing comment to canonical `review.json`.
+
+Optional flags are:
+
+```text
+--standard
+--include-in-feedback
+--exclude-from-feedback
+```
+
+The command copies label and text and preserves `bank_id + comment_id`
+provenance, so later bank edits do not change the review.
+
+It does not export feedback or mutate the source bank, manifest, or evidence.
 
 ## Criterion Scores
 
@@ -584,17 +783,24 @@ quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion
 ```
 
 This direct command sets or updates one explicitly teacher-entered criterion
-score in canonical `review.json`. Optional flags are `--scale` and `--note`.
+score in canonical `review.json`.
+
+Optional flags are `--scale` and `--note`.
+
 The command creates a missing review record only when the adjacent
 `submission.json` validates and matches the requested identity.
 
 Success returns `0` and reports the class, assignment, student, criterion,
 score and maximum, score ID, created-or-updated action, review state, and
-workspace-relative review-record path. Handled workspace, score, and record
-failures return `1`. Updating by `criterion_id` preserves the existing score
-ID and unrelated review sections. The command does not validate criteria
-against a rubric profile, calculate an overall score, infer scores, or mutate
-the submission manifest or evidence.
+workspace-relative review-record path.
+
+Handled workspace, score, and record failures return `1`.
+
+Updating by `criterion_id` preserves the existing score ID and unrelated
+review sections.
+
+The command does not validate criteria against a rubric profile, calculate an
+overall score, infer scores, or mutate the submission manifest or evidence.
 
 ## Student Feedback Export
 
@@ -603,18 +809,29 @@ quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 ```
 
 This direct command requires valid matching canonical `submission.json` and
-`review.json` records, then writes the derived
-`submissions/<student_id>/exports/feedback.md` artifact. It includes ordered
-criterion scores and snapshotted comments marked `include_in_feedback: true`.
+`review.json` records, then writes the derived artifact:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+```
+
+It includes ordered criterion scores and snapshotted comments marked
+`include_in_feedback: true`.
+
 It excludes private notes, score notes, structured tags, excluded comments,
 and comment source/provenance fields, and it does not read source comment
 banks.
 
 Success returns `0` and reports the identity, included-comment count, score
-count, overwrite status, and workspace-relative feedback path. Handled
-workspace, validation, missing-record, and overwrite failures return `1`.
-Without `--overwrite`, an existing feedback file is preserved. The command
-does not mutate review state, timestamps, canonical records, or evidence.
+count, overwrite status, and workspace-relative feedback path.
+
+Handled workspace, validation, missing-record, and overwrite failures return
+`1`.
+
+Without `--overwrite`, an existing feedback file is preserved.
+
+The command does not mutate review state, timestamps, canonical records, or
+evidence.
 
 ## Class Review Summary Export
 
@@ -623,24 +840,35 @@ quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 ```
 
 This direct command discovers immediate student directories under the
-assignment's canonical `submissions/` directory and writes
-`assignments/<assignment_id>/exports/class_summary.csv`. Rows are sorted by
-`student_id`. Valid matching records produce `ready` rows with submission and
-review states, score counts and simple score/max-score totals, selected and
-included comment counts, tag and note counts, feedback-export existence, and
+assignment's canonical `submissions/` directory and writes:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
+```
+
+Rows are sorted by `student_id`.
+
+Valid matching records produce `ready` rows with submission and review states,
+score counts and simple score/max-score totals, selected and included comment
+counts, tag and note counts, feedback-export existence, and
 workspace-relative paths.
 
 Missing, invalid, and identity-mismatched student records produce
 `missing_submission`, `invalid_submission`, `missing_review`,
 `invalid_review`, or `identity_mismatch` rows rather than aborting the whole
-export. A missing assignment submissions directory is a handled failure.
+export.
+
+A missing assignment submissions directory is a handled failure.
+
 Success returns `0` and prints row/status counts, overwrite status, and the
-summary path; handled failures return `1`.
+summary path. Handled failures return `1`.
 
 The export is read-only with respect to canonical records. It does not read
 evidence files or comment banks, use a roster, infer missing students,
 calculate percentages, grades, mastery, or weighted results, or generate a
-standards summary. Existing CSV files require `--overwrite`.
+standards summary.
+
+Existing CSV files require `--overwrite`.
 
 ## Standards Summary Export
 
@@ -649,22 +877,56 @@ quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
 ```
 
 This command discovers immediate student directories under the assignment
-`submissions/` directory and writes the derived
-`assignments/<assignment_id>/exports/standards_summary.csv`. It validates each
-available `submission.json` and `review.json`, counts missing, invalid, and
-identity-mismatched records without aborting the assignment export, and emits
-one row per referenced standard sorted by `standard_code`.
+`submissions/` directory and writes:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+```
+
+It validates each available `submission.json` and `review.json`, counts
+missing, invalid, and identity-mismatched records without aborting the
+assignment export, and emits one row per referenced standard sorted by
+`standard_code`.
 
 Rows aggregate standards-linked structured tags by polarity and selected
-comments by feedback inclusion, plus distinct student counts. Artifacts
-without `standard_code` are ignored. If no valid linked artifacts exist, the
-command writes a header-only CSV. Success returns `0`; handled workspace,
-validation, missing-directory, and overwrite failures return `1`.
+comments by feedback inclusion, plus distinct student counts.
+
+Artifacts without `standard_code` are ignored.
+
+If no valid linked artifacts exist, the command writes a header-only CSV.
+
+Success returns `0`. Handled workspace, validation, missing-directory, and
+overwrite failures return `1`.
 
 The export does not include notes or scores, map criteria to standards, load a
 standards profile, inspect student writing or evidence, read comment banks,
 use AI, calculate grades or mastery, use a roster, or mutate canonical
-records. Existing CSV files require `--overwrite`.
+records.
+
+Existing CSV files require `--overwrite`.
+
+## Export and Menu Overwrite Behavior
+
+Direct export commands require `--overwrite` to replace existing export
+artifacts.
+
+Guided menu export actions prompt before replacing an existing export file.
+
+Invalid overwrite responses cancel safely.
+
+Exports do not mutate:
+
+* `submission.json`;
+* `review.json`;
+* routed evidence files;
+* retained source scans;
+* rosters;
+* assignment configs;
+* comment banks; or
+* standards profiles.
+
+The menu delegates to the same export services and output formatters as the
+direct CLI handlers. It does not implement a parallel export system.
 
 ## Output and Error Handling
 
@@ -709,12 +971,12 @@ examples, or trace output.
 
 The process exit status is part of the CLI contract:
 
-| Status | Meaning |
-| --- | --- |
-| `0` | The requested operation or menu session completed successfully, or help was requested or printed for a no-operation command-specific parser level. |
-| `1` | The command was understood, but validation or an operational action failed. |
-| `2` | Command-line usage was invalid, as reported by `argparse`. |
-| Other nonzero | An unexpected failure or a future explicitly documented category. |
+| Status        | Meaning                                                                                                                                            |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`           | The requested operation or menu session completed successfully, or help was requested or printed for a no-operation command-specific parser level. |
+| `1`           | The command was understood, but validation or an operational action failed.                                                                        |
+| `2`           | Command-line usage was invalid, as reported by `argparse`.                                                                                         |
+| Other nonzero | An unexpected failure or a future explicitly documented category.                                                                                  |
 
 Examples of status `1` include a missing or invalid JSON input and failure to
 resolve workspace status. Examples of status `2` include an unknown command,
@@ -739,10 +1001,10 @@ Until Quillan reaches 1.0:
   migrated, but pre-1.0 changes do not promise a fixed deprecation period.
 
 The source of truth for the current surface is the combination of
-`quillan.cli_app`, the public `quillan/cli.py` facade, CLI tests, and this
-document. If they disagree, the implementation and tests describe executable
-behavior, and the mismatch should be corrected rather than treated as an
-undocumented feature.
+`quillan.cli_app`, the public `quillan/cli.py` facade, CLI tests, menu tests,
+and this document. If they disagree, the implementation and tests describe
+executable behavior, and the mismatch should be corrected rather than treated
+as an undocumented feature.
 
 ## Not Currently Part of the CLI
 
@@ -751,14 +1013,18 @@ explicitly outside the current end-to-end foundation:
 
 * printable response generation as a dedicated command;
 * submission validation as a dedicated command;
-* guided teacher-facing review and export workflows;
 * recursive scan folder intake, source-file archiving, inbox draining, or
   automatic production scan routing;
 * OCR or handwriting interpretation;
+* PDF text extraction;
 * complete requirements-checking workflows;
-* AI grading, scoring, tagging, or feedback; and
+* AI grading, scoring, tagging, or feedback;
 * automatic grading, mastery calculation, review-state decisions, or
-  duplicate-evidence selection.
+  duplicate-evidence selection;
+* LMS integration;
+* cloud sync;
+* email delivery; and
+* dashboard/reporting automation.
 
 Their presence in design documents or Python modules does not add them to the
 CLI contract.


### PR DESCRIPTION
## Summary

* Updated `README.md` to reflect the completed v0.8.0 Quillan workflow.
* Updated `docs/cli_contract.md` to align the CLI/menu contract with the current implemented behavior.
* Documented the current teacher-facing menu structure, assignment workflow, scan intake, submission assembly, review workflow, guided review actions, guided export actions, export paths, safety boundaries, non-goals, and v0.8.0 smoke test coverage.

## Key Updates

### README

* Reframed Quillan’s current status around the completed v0.8.0 paper-response intake, review, and export workflow.
* Added current workflow coverage for:

  * assignment management;
  * roster management;
  * printable response pages;
  * QR-aware scan intake;
  * submission assembly;
  * Review Student Work;
  * guided review-entry actions;
  * guided export actions;
  * direct CLI workflows.
* Clarified local-first, teacher-controlled, evidence-safe, non-AI boundaries.
* Documented where routed scans, retained sources, submission manifests, review records, and exports live.
* Added a v0.8.0 smoke test reference for `tests/test_v080_end_to_end_smoke.py`.
* Updated non-goals to avoid implying support for OCR, handwriting recognition, PDF text extraction, AI scoring, automatic grading, cloud sync, LMS integration, email delivery, or dashboard automation.

### CLI Contract

* Replaced stale “read-only Review Student Work” language with the current implemented Review Student Work workflow.
* Documented current assignment-level review actions:

  * select student/submission;
  * export class review summary;
  * export standards summary;
  * refresh submission status;
  * back.
* Documented current selected-student review actions:

  * open submission evidence;
  * add teacher note;
  * add structured tag;
  * select reusable comment;
  * set criterion score;
  * update submission review state;
  * export student feedback;
  * refresh summary;
  * back.
* Clarified that guided menu actions reuse the same services as direct CLI commands.
* Clarified export overwrite behavior and safe cancellation.
* Removed guided review/export workflows from “Not Currently Part of the CLI.”

## Safety / Scope

This is a documentation-only update.

No implementation behavior was changed.

The docs continue to state that Quillan does not perform:

* OCR;
* handwriting recognition;
* PDF text extraction;
* AI scoring;
* AI tagging;
* AI feedback;
* automatic grading;
* LMS integration;
* cloud sync;
* email delivery;
* dashboard/reporting automation.

The documentation continues to emphasize synthetic-only repository examples and no committed real student data.

## Validation

Passed:

```text
.\run_tests.ps1
```

Also checked:

```text
git diff --check
```

Closes #140.
