### PR TITLE
Guide scan assembly review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,17 @@ Quillan's scan intake routes QR-identified paper responses. It does not read the
 
 Quillan's review tools record teacher decisions. They do not replace teacher judgment.
 
+## Guided Paper-Response Workflow
+
+From the Quillan menu, teachers select assignments by class and assignment name;
+they do not normally need to paste an `assignment.json` path. Scan Intake creates
+and lists the shared workspace `scans_inbox/` drop zone. Select a PDF or supported
+image there (or use the custom-path fallback), route its QR-bearing pages, then
+choose **Assemble submissions**. Routing preserves source scans and files routed
+evidence; assembly creates the review-ready `submission.json` record. Existing
+submission records are skipped by default, so teacher review records are not
+replaced. Review actions become available only after assembly.
+
 ## Development Workflow
 
 Use issue branches for changes:

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -563,3 +563,12 @@ Do not commit:
 * real grades;
 * real parent contact information;
 * real scanned student work.
+
+## Submission Readiness
+
+`submission.json` is the canonical review-ready submission record. Routed scan
+files alone are evidence, not a submission record. Menu workflows present this
+as an "assembled submission" or "submission record" to teachers, while the
+filename remains available as technical detail. Existing submission files are
+not overwritten by normal assembly; review records remain separate and are not
+rewritten by scan routing or assembly.

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -453,6 +453,16 @@ Each phase should add focused tests for validation, traversal resistance,
 collision races, preservation on failure, and the absence of unintended
 submission mutations.
 
+## Teacher Menu Intake
+
+The teacher-facing Scan Intake menu creates and uses `<workspace>/scans_inbox/`
+as a direct-child scan drop zone. It lists supported `.pdf`, `.png`, `.jpg`,
+`.jpeg`, `.tif`, and `.tiff` files without moving or deleting them. A custom
+file/folder path remains available for advanced use. Successful routing files
+routed evidence only; it does not create a review-ready submission, infer a
+score, or update review state. The menu offers explicit submission assembly for
+each routed class/assignment target.
+
 ## Out of Scope
 
 The v0.6 reviewable-evidence workflow does not implement:

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -235,6 +235,15 @@ the conceptual relationships among those records.
 v0.7 `review.json` shape and its identity, state, timestamp, path, reference,
 and mutation rules.
 
+## Review Readiness
+
+Routed scan evidence and a review-ready submission are distinct. Before a
+teacher adds notes, tags, comments, scores, review state, or feedback exports,
+Quillan requires an assembled submission record. When routed evidence exists
+but that record is missing, the review menu offers assignment-level assembly
+instead of actions that would fail. Assembly neither evaluates evidence nor
+changes review state, notes, tags, comments, scores, or exports.
+
 [`comment_bank_contract.md`](comment_bank_contract.md) defines reusable shared
 comment source data and its boundary from selected review comments.
 

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -306,3 +306,13 @@ caller-supplied decoded-payload slice. Canonical retained sources belong in
 `scans/source/YYYY-MM-DD/`, canonical failure records belong in
 `scans/review/`, and assignment-level `scans/` contains routed evidence. QR
 recognition, PDF splitting, batch raw-scan intake, and OCR remain future work.
+
+## Scan Intake and Submission Assembly
+
+`scans_inbox/` is the shared teacher drop zone for scans awaiting routing. Quillan
+creates it on entry to Scan Intake and never moves or deletes its source files.
+Routed assignment evidence belongs under the assignment's `scans/` directory.
+That evidence is not review-ready until explicit assembly writes
+`submissions/<student_id>/submission.json`. Assembly skips existing submission
+files by default; regenerating an existing submission is an explicit destructive
+choice because it can replace the submission record.

--- a/quillan/assignment_picker.py
+++ b/quillan/assignment_picker.py
@@ -1,0 +1,106 @@
+"""Shared teacher-facing class and assignment selection helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pds_core.classes import list_class_folders
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.storage import assignment_config_path
+
+
+@dataclass(frozen=True, slots=True)
+class AssignmentChoice:
+    """A canonical assignment available in one roster-backed class."""
+
+    class_id: str
+    assignment_id: str
+    title: str | None
+    path: Path
+
+
+def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
+    """Let a teacher choose a roster class and its canonical assignment."""
+    folders = list_class_folders(workspace_root, require_roster=True)
+    if not folders:
+        print("No classes found in the current workspace.")
+        return None
+
+    print("Available classes:")
+    for index, folder in enumerate(folders, start=1):
+        print(f"{index}. {folder.class_id}")
+    print("B. Back")
+    print()
+    while True:
+        selection = input("Select class: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            print("Class selection canceled.")
+            return None
+        if selection.isdigit() and 1 <= int(selection) <= len(folders):
+            class_id = folders[int(selection) - 1].class_id
+            break
+        class_matches = [
+            folder for folder in folders if folder.class_id == selection
+        ]
+        if class_matches:
+            class_id = class_matches[0].class_id
+            break
+        print("Invalid class selection. Please choose a listed class or Back.")
+
+    assignments = available_assignments(workspace_root, class_id)
+    if not assignments:
+        print(f"No valid assignments found for class {class_id}.")
+        return None
+    print()
+    print(f"Assignments for {class_id}:")
+    for index, assignment in enumerate(assignments, start=1):
+        label = assignment.assignment_id
+        if assignment.title:
+            label += f" - {assignment.title}"
+        print(f"{index}. {label}")
+    print("B. Back")
+    print()
+    while True:
+        selection = input("Select assignment: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            print("Assignment selection canceled.")
+            return None
+        if selection.isdigit() and 1 <= int(selection) <= len(assignments):
+            return assignments[int(selection) - 1]
+        assignment_matches = [
+            item for item in assignments if item.assignment_id == selection
+        ]
+        if assignment_matches:
+            return assignment_matches[0]
+        print("Invalid assignment selection. Please choose a listed assignment or Back.")
+
+
+def available_assignments(
+    workspace_root: Path, class_id: str
+) -> tuple[AssignmentChoice, ...]:
+    """Return valid canonical assignment configs for one class."""
+    assignments_dir = workspace_root / "classes" / class_id / "assignments"
+    if not assignments_dir.is_dir():
+        return ()
+    choices: list[AssignmentChoice] = []
+    for assignment_dir in sorted(
+        (path for path in assignments_dir.iterdir() if path.is_dir()),
+        key=lambda path: path.name.casefold(),
+    ):
+        path = assignment_config_path(workspace_root, class_id, assignment_dir.name)
+        try:
+            assignment = load_assignment_config(path)
+        except (AssignmentConfigError, OSError):
+            continue
+        title = assignment.get("title")
+        choices.append(
+            AssignmentChoice(
+                class_id=class_id,
+                assignment_id=assignment_dir.name,
+                title=title if isinstance(title, str) and title.strip() else None,
+                path=path,
+            )
+        )
+    return tuple(choices)

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -26,6 +26,7 @@ from quillan.assignments import (
     load_assignment_config,
     validate_assignment_config,
 )
+from quillan.assignment_picker import prompt_assignment_choice
 from quillan.storage import assignment_config_path
 
 _NUMERIC_REQUIREMENTS = (
@@ -378,21 +379,23 @@ def _normalize_path_input(value: str) -> str:
 
 
 def prompt_view_validate_assignment() -> int:
-    """Load, validate, and summarize an explicit assignment JSON path."""
+    """Select, load, validate, and summarize a canonical assignment config."""
     from quillan.menu import print_menu_header
 
     print_menu_header("View/Validate Assignment")
-    assignment_path = _normalize_path_input(input("Assignment JSON path: "))
-    if not assignment_path:
-        print("Error: assignment JSON path is required.")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
         return 1
+    choice = prompt_assignment_choice(workspace_root)
+    if choice is None:
+        return 0
     try:
-        assignment = load_assignment_config(assignment_path)
+        assignment = load_assignment_config(choice.path)
     except (AssignmentConfigError, OSError) as error:
         print(f"Error: {error}")
         return 1
     print("Assignment config is valid.")
-    print(format_assignment_summary(assignment, assignment_path))
+    print(format_assignment_summary(assignment, choice.path))
     return 0
 
 

--- a/quillan/cli_app/handlers/routing.py
+++ b/quillan/cli_app/handlers/routing.py
@@ -6,11 +6,15 @@ import argparse
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from collections.abc import Callable
 from typing import Literal, cast
 
 import cv2
 from pds_core.pds1 import Pds1PayloadError, parse_pds1_payload
-from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+from pds_core.workspace import (
+    WorkspaceRootError,
+    resolve_workspace_root as _resolve_workspace_root,
+)
 
 from quillan.cli_app.output import (
     print_evidence_filing_review,
@@ -67,6 +71,11 @@ from quillan.scan_intake_summary import (
 SUPPORTED_SCAN_EXTENSIONS = frozenset({*SUPPORTED_IMAGE_EXTENSIONS, ".pdf"})
 
 
+def resolve_workspace_root() -> Path:
+    """Resolve the workspace through pds-core for routing and menu workflows."""
+    return _resolve_workspace_root()
+
+
 def handle_route_scan(args: argparse.Namespace) -> int:
     """Route source scans from caller-supplied payload text or QR."""
     source_file: Path = args.source_file
@@ -117,6 +126,7 @@ def run_qr_scan_intake(
     workspace_root: Path | None = None,
     *,
     created_at: datetime | None = None,
+    on_summary: Callable[[ScanIntakeSummary], None] | None = None,
 ) -> int:
     """Run QR-aware scan intake for one image, PDF, or direct child folder."""
     intake_timestamp = (
@@ -141,6 +151,7 @@ def run_qr_scan_intake(
             resolved_workspace_root,
             source_folder=source_path,
             created_at=intake_timestamp,
+            on_summary=on_summary,
         )
     if not _validate_source_file(source_path):
         return 1
@@ -148,6 +159,7 @@ def run_qr_scan_intake(
         resolved_workspace_root,
         source_file=source_path,
         created_at=intake_timestamp,
+        on_summary=on_summary,
     )
 
 
@@ -156,6 +168,7 @@ def _route_source_file_qr(
     *,
     source_file: Path,
     created_at: datetime,
+    on_summary: Callable[[ScanIntakeSummary], None] | None = None,
 ) -> int:
     source_result = _intake_source_file_qr(
         workspace_root,
@@ -166,6 +179,8 @@ def _route_source_file_qr(
     print()
     print(format_scan_intake_summary(summary))
     _print_submission_assembly_next_steps(summary)
+    if on_summary is not None:
+        on_summary(summary)
     return 1 if summary.has_failures else 0
 
 
@@ -174,6 +189,7 @@ def _route_source_folder_qr(
     *,
     source_folder: Path,
     created_at: datetime,
+    on_summary: Callable[[ScanIntakeSummary], None] | None = None,
 ) -> int:
     if not _validate_source_folder(source_folder):
         return 1
@@ -212,6 +228,8 @@ def _route_source_folder_qr(
     )
     print(format_scan_intake_summary(summary))
     _print_submission_assembly_next_steps(summary)
+    if on_summary is not None:
+        on_summary(summary)
     return 1 if summary.has_failures else 0
 
 

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -21,6 +21,7 @@ from quillan.submission_manifest_paths import (
     submission_dir,
     submission_manifest_path,
 )
+from quillan.submission_guidance import missing_submission_guidance
 
 
 class FeedbackExportError(Exception):
@@ -89,10 +90,7 @@ def export_student_feedback(
         raise FeedbackExportError(str(error)) from error
 
     if not manifest_path.exists():
-        raise FeedbackExportError(
-            "Submission manifest does not exist for "
-            f"class={class_id}, assignment={assignment_id}, student={student_id}."
-        )
+        raise FeedbackExportError(missing_submission_guidance())
     try:
         manifest = load_submission_manifest(manifest_path)
     except (OSError, SubmissionManifestError) as error:

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -7,6 +7,8 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from pds_core.scan_routes import scans_inbox_dir
+
 WorkspaceShowHandler = Callable[[], int]
 WorkspaceSetHandler = Callable[[str], int]
 WorkspaceActionHandler = Callable[[], int]
@@ -99,21 +101,152 @@ def _normalize_menu_path(raw_path: str) -> Path | None:
 
 
 def launch_scan_intake_workflow() -> None:
-    """Prompt for a scan source and run QR-aware routing intake."""
-    from quillan.cli_app.handlers.routing import run_qr_scan_intake
+    """Route scans from the shared inbox, with a power-user path fallback."""
+    from quillan.assignment_submission_assembly import assemble_assignment_submissions
+    from quillan.cli_app.handlers import routing
+    from quillan.cli_app.output import print_assignment_submission_assembly
+    from quillan.intake_assembly import assembly_targets_from_intake_summary
+    from quillan.scan_intake_summary import ScanIntakeSummary
 
-    clear_screen()
-    print_menu_header("Scan Intake / Route Paper Responses")
-    raw_source_path = input("Scan file or folder path (leave blank to cancel): ")
-    print()
+    try:
+        workspace_root = routing.resolve_workspace_root()
+    except Exception as error:
+        clear_screen()
+        print_menu_header("Scan Intake / Route Paper Responses")
+        print(f"Error: could not resolve the PDS workspace: {error}")
+        print()
+        pause_for_user()
+        return
+    inbox = scans_inbox_dir(workspace_root)
+    inbox.mkdir(parents=True, exist_ok=True)
+    exit_to_main = False
 
-    source_path = _normalize_menu_path(raw_source_path)
-    if source_path is None:
-        print("Scan intake canceled. No scan files were routed.")
-    else:
-        run_qr_scan_intake(source_path)
-    print()
-    pause_for_user()
+    def post_route(summary: ScanIntakeSummary) -> None:
+        nonlocal exit_to_main
+        targets = assembly_targets_from_intake_summary(summary)
+        if not targets:
+            return
+        while True:
+            print()
+            print("Scan routed successfully.")
+            print("Routed evidence was filed for:")
+            for index, target in enumerate(targets, start=1):
+                print(
+                    f"{index}. Class: {target.class_id}; "
+                    f"Assignment: {target.assignment_id}"
+                )
+            print()
+            print("Submission records are required before review.")
+            if len(targets) == 1:
+                print("1. Assemble submissions now")
+                print("2. View submission status")
+                print("3. Return to Scan Intake")
+                print("4. Back to Main Menu")
+                choice = input("Select an option: ").strip()
+                if choice == "1":
+                    target = targets[0]
+                    result = assemble_assignment_submissions(
+                        workspace_root, target.class_id, target.assignment_id
+                    )
+                    print_assignment_submission_assembly(result, workspace_root)
+                    continue
+                if choice == "2":
+                    from quillan.submission_status import list_assignment_submission_status
+                    from quillan.cli_app.output import print_assignment_submission_status
+
+                    target = targets[0]
+                    print_assignment_submission_status(
+                        list_assignment_submission_status(
+                            workspace_root, target.class_id, target.assignment_id
+                        ),
+                        workspace_root,
+                    )
+                    continue
+                if choice == "4":
+                    exit_to_main = True
+                return
+            print(
+                "Choose a numbered target to assemble it, or B to return "
+                "to Scan Intake."
+            )
+            choice = input("Select target: ").strip()
+            if choice == "" or choice.casefold() == "b":
+                return
+            if choice.isdigit() and 1 <= int(choice) <= len(targets):
+                target = targets[int(choice) - 1]
+                result = assemble_assignment_submissions(
+                    workspace_root, target.class_id, target.assignment_id
+                )
+                print_assignment_submission_assembly(result, workspace_root)
+            else:
+                print(
+                    "Invalid selection. Please choose a routed assignment "
+                    "or Back."
+                )
+
+    while True:
+        clear_screen()
+        print_menu_header("Scan Intake / Route Paper Responses")
+        print(f"Scan inbox:\n{inbox}\n")
+        scans = sorted(
+            (
+                path
+                for path in inbox.iterdir()
+                if path.is_file()
+                and path.suffix.casefold() in routing.SUPPORTED_SCAN_EXTENSIONS
+            ),
+            key=lambda path: path.name.casefold(),
+        )
+        if scans:
+            print("Available scans:")
+            for index, scan in enumerate(scans, start=1):
+                print(f"{index}. {scan.name}")
+        else:
+            print("No supported scans found in scans_inbox.")
+            print(f"\nPlace scanned PDFs or images in:\n{inbox}")
+        print("C. Choose custom file/folder path")
+        print("R. Refresh")
+        print("B. Back")
+        print()
+        selection = input("Select scan: ").strip()
+        if selection.casefold() == "b":
+            return
+        if selection == "":
+            print("Scan intake canceled. No scan files were routed.")
+            print()
+            pause_for_user()
+            return
+        selected_inbox_scan = False
+        if selection.casefold() == "r":
+            continue
+        if selection.casefold() == "c":
+            source_path = _normalize_menu_path(
+                input("Scan file or folder path (leave blank to cancel): ")
+            )
+            if source_path is None:
+                print("Scan intake canceled. No scan files were routed.")
+                pause_for_user()
+                continue
+        elif selection.isdigit() and 1 <= int(selection) <= len(scans):
+            source_path = scans[int(selection) - 1]
+            selected_inbox_scan = True
+        else:
+            # Preserve pasted-path convenience for experienced users of earlier menus.
+            source_path = _normalize_menu_path(selection)
+            if source_path is None:
+                print("Invalid selection. Please choose a scan, C, R, or B.")
+                pause_for_user()
+                continue
+        print()
+        routing.run_qr_scan_intake(
+            source_path,
+            workspace_root,
+            on_summary=post_route if selected_inbox_scan else None,
+        )
+        print()
+        pause_for_user()
+        if exit_to_main:
+            return
 
 
 def launch_review_student_work_menu() -> None:

--- a/quillan/review_comments.py
+++ b/quillan/review_comments.py
@@ -34,6 +34,7 @@ from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
 )
+from quillan.submission_guidance import missing_submission_guidance
 
 _SEQUENTIAL_COMMENT_ID = re.compile(r"^comment_record_(\d{4})$")
 
@@ -138,10 +139,7 @@ def add_review_comment(
     )
 
     if not manifest_path.exists():
-        raise ReviewCommentError(
-            "Submission manifest does not exist for "
-            f"class={class_id}, assignment={assignment_id}, student={student_id}."
-        )
+        raise ReviewCommentError(missing_submission_guidance())
     try:
         manifest = load_submission_manifest(manifest_path)
     except (OSError, SubmissionManifestError) as error:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +9,12 @@ from pds_core.classes import list_class_folders, load_class_roster
 from pds_core.rosters import RosterError
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
+from quillan.assignment_picker import (
+    AssignmentChoice,
+    available_assignments,
+    prompt_assignment_choice,
+)
+from quillan.assignment_submission_assembly import assemble_assignment_submissions
 from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.class_summary_export import (
     ClassSummaryExportError,
@@ -45,7 +50,6 @@ from quillan.review_record import (
 from quillan.review_record_paths import review_record_path
 from quillan.review_scores import ReviewScoreError, set_review_score
 from quillan.review_tags import ReviewTagError, add_review_tag
-from quillan.storage import assignment_config_path
 from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
     open_student_submission_for_review,
@@ -60,14 +64,6 @@ from quillan.submission_status import (
     StudentSubmissionStatus,
     list_assignment_submission_status,
 )
-
-
-@dataclass(frozen=True, slots=True)
-class AssignmentChoice:
-    """One assignment available for teacher review navigation."""
-
-    assignment_id: str
-    title: str | None
 
 
 def launch_review_student_work_menu() -> int:
@@ -109,17 +105,13 @@ def _run_review_selection_workflow() -> int:
     if workspace_root is None:
         return 1
 
-    class_id = _prompt_class_id(workspace_root)
-    if class_id is None:
-        return 0
-
-    assignment = _prompt_assignment(workspace_root, class_id)
+    assignment = prompt_assignment_choice(workspace_root)
     if assignment is None:
         return 0
 
     return _launch_assignment_review_actions(
         workspace_root,
-        class_id,
+        assignment.class_id,
         assignment.assignment_id,
     )
 
@@ -196,30 +188,8 @@ def _available_assignments(
     workspace_root: Path,
     class_id: str,
 ) -> tuple[AssignmentChoice, ...]:
-    assignments_dir = workspace_root / "classes" / class_id / "assignments"
-    if not assignments_dir.is_dir():
-        return ()
-
-    choices: list[AssignmentChoice] = []
-    for assignment_dir in sorted(
-        (path for path in assignments_dir.iterdir() if path.is_dir()),
-        key=lambda path: path.name.casefold(),
-    ):
-        config_path = assignment_config_path(
-            workspace_root,
-            class_id,
-            assignment_dir.name,
-        )
-        if not config_path.is_file():
-            continue
-        title = _load_assignment_title(config_path)
-        choices.append(
-            AssignmentChoice(
-                assignment_id=assignment_dir.name,
-                title=title,
-            )
-        )
-    return tuple(choices)
+    """Compatibility wrapper for callers of the original review helper."""
+    return available_assignments(workspace_root, class_id)
 
 
 def _load_assignment_title(config_path: Path) -> str | None:
@@ -340,6 +310,56 @@ def _launch_selected_student_review(
             student_id,
         )
         print()
+        status = _load_submission_status(workspace_root, class_id, assignment_id)
+        student_status = _student_submission_status(status, student_id)
+        if student_status is None:
+            print("No routed evidence has been found for this student yet.")
+            print(
+                "Route a scan for this assignment, then assemble submissions "
+                "before review."
+            )
+            print()
+            print("1. View routed evidence status")
+            print("2. Refresh summary")
+            print("3. Back")
+            print()
+            choice = input("Select an option: ").strip()
+            print()
+            if choice in {"", "3"}:
+                return 0
+            if choice in {"1", "2"}:
+                continue
+            print("Invalid selection. Please enter a number from 1 to 3.")
+            input("Press Enter to continue...")
+            continue
+        if student_status.manifest_path is None:
+            print(
+                "This student has routed evidence, but the review-ready "
+                "submission record has not been assembled yet."
+            )
+            print(
+                "Assemble submissions before reviewing, tagging, scoring, "
+                "or exporting."
+            )
+            print()
+            print("1. Assemble this assignment now")
+            print("2. View routed evidence status")
+            print("3. Refresh summary")
+            print("4. Back")
+            print()
+            choice = input("Select an option: ").strip()
+            print()
+            if choice in {"", "4"}:
+                return 0
+            if choice == "1":
+                _assemble_assignment(workspace_root, class_id, assignment_id)
+                input("Press Enter to continue...")
+            elif choice in {"2", "3"}:
+                continue
+            else:
+                print("Invalid selection. Please enter a number from 1 to 4.")
+                input("Press Enter to continue...")
+            continue
         print("1. Open submission evidence")
         print("2. Add teacher note")
         print("3. Add structured tag")
@@ -417,6 +437,33 @@ def _launch_selected_student_review(
         else:
             print("Invalid selection. Please enter a number from 1 to 9.")
             input("Press Enter to continue...")
+
+
+def _student_submission_status(
+    status: AssignmentSubmissionStatus | None, student_id: str
+) -> StudentSubmissionStatus | None:
+    if status is None:
+        return None
+    return next(
+        (item for item in status.student_statuses if item.student_id == student_id),
+        None,
+    )
+
+
+def _assemble_assignment(
+    workspace_root: Path, class_id: str, assignment_id: str
+) -> None:
+    """Assemble routed evidence without replacing existing teacher records."""
+    from quillan.cli_app.output import print_assignment_submission_assembly
+
+    try:
+        result = assemble_assignment_submissions(
+            workspace_root, class_id, assignment_id, overwrite=False
+        )
+    except Exception as error:
+        print(f"Error: could not assemble submissions: {error}")
+        return
+    print_assignment_submission_assembly(result, workspace_root)
 
 
 def _menu_add_review_note(
@@ -1086,16 +1133,17 @@ def _launch_assignment_review_actions(
         print()
 
         print("1. Select student/submission")
-        print("2. Export class review summary")
-        print("3. Export standards summary")
-        print("4. Refresh submission status")
-        print("5. Back")
+        print("2. Assemble routed submissions")
+        print("3. Export class review summary")
+        print("4. Export standards summary")
+        print("5. Refresh submission status")
+        print("6. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "5"}:
+        if choice in {"", "6"}:
             return 0
         elif choice == "1":
             student_id = _prompt_student_id(workspace_root, class_id, status)
@@ -1107,13 +1155,16 @@ def _launch_assignment_review_actions(
                     student_id,
                 )
         elif choice == "2":
-            _menu_export_class_summary(workspace_root, class_id, assignment_id)
+            _assemble_assignment(workspace_root, class_id, assignment_id)
             input("Press Enter to continue...")
         elif choice == "3":
-            _menu_export_standards_summary(workspace_root, class_id, assignment_id)
+            _menu_export_class_summary(workspace_root, class_id, assignment_id)
             input("Press Enter to continue...")
         elif choice == "4":
+            _menu_export_standards_summary(workspace_root, class_id, assignment_id)
+            input("Press Enter to continue...")
+        elif choice == "5":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 5.")
+            print("Invalid selection. Please enter a number from 1 to 6.")
             input("Press Enter to continue...")

--- a/quillan/review_notes.py
+++ b/quillan/review_notes.py
@@ -27,6 +27,7 @@ from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
 )
+from quillan.submission_guidance import missing_submission_guidance
 
 _SEQUENTIAL_NOTE_ID = re.compile(r"^note_(\d{4})$")
 
@@ -85,10 +86,7 @@ def add_review_note(
         raise ReviewNoteError(str(error)) from error
 
     if not manifest_path.exists():
-        raise ReviewNoteError(
-            "Submission manifest does not exist for "
-            f"class={class_id}, assignment={assignment_id}, student={student_id}."
-        )
+        raise ReviewNoteError(missing_submission_guidance())
 
     try:
         manifest = load_submission_manifest(manifest_path)

--- a/quillan/review_scores.py
+++ b/quillan/review_scores.py
@@ -28,6 +28,7 @@ from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
 )
+from quillan.submission_guidance import missing_submission_guidance
 
 _SEQUENTIAL_SCORE_ID = re.compile(r"^score_(\d{4})$")
 
@@ -108,10 +109,7 @@ def set_review_score(
         raise ReviewScoreError(str(error)) from error
 
     if not manifest_path.exists():
-        raise ReviewScoreError(
-            "Submission manifest does not exist for "
-            f"class={class_id}, assignment={assignment_id}, student={student_id}."
-        )
+        raise ReviewScoreError(missing_submission_guidance())
 
     try:
         manifest = load_submission_manifest(manifest_path)

--- a/quillan/review_tags.py
+++ b/quillan/review_tags.py
@@ -39,6 +39,7 @@ from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
 )
+from quillan.submission_guidance import missing_submission_guidance
 
 _SEQUENTIAL_TAG_ID = re.compile(r"^tag_(\d{4})$")
 
@@ -118,10 +119,7 @@ def add_review_tag(
         raise ReviewTagError(str(error)) from error
 
     if not manifest_path.exists():
-        raise ReviewTagError(
-            "Submission manifest does not exist for "
-            f"class={class_id}, assignment={assignment_id}, student={student_id}."
-        )
+        raise ReviewTagError(missing_submission_guidance())
 
     try:
         manifest = load_submission_manifest(manifest_path)

--- a/quillan/submission_guidance.py
+++ b/quillan/submission_guidance.py
@@ -1,0 +1,12 @@
+"""Teacher-facing guidance for submission records that are not ready to review."""
+
+from __future__ import annotations
+
+
+def missing_submission_guidance() -> str:
+    """Explain the action required when routed evidence has no submission file."""
+    return (
+        "This submission is not review-ready yet. The scan was routed, but "
+        "Quillan has not assembled the student's submission record. Choose "
+        '"Assemble submissions" for this assignment, then return to review.'
+    )

--- a/quillan/submission_review_opening.py
+++ b/quillan/submission_review_opening.py
@@ -15,6 +15,7 @@ from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
 )
+from quillan.submission_guidance import missing_submission_guidance
 
 
 class SubmissionReviewOpeningError(Exception):
@@ -57,10 +58,7 @@ def open_student_submission_for_review(
         raise SubmissionReviewOpeningError(str(error)) from error
 
     if not manifest_path.exists():
-        raise SubmissionReviewOpeningError(
-            "Submission manifest does not exist for "
-            f"class={class_id}, assignment={assignment_id}, student={student_id}."
-        )
+        raise SubmissionReviewOpeningError(missing_submission_guidance())
 
     try:
         manifest = load_submission_manifest(manifest_path)

--- a/quillan/submission_review_state.py
+++ b/quillan/submission_review_state.py
@@ -19,6 +19,7 @@ from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
 )
+from quillan.submission_guidance import missing_submission_guidance
 
 
 class SubmissionReviewStateError(Exception):
@@ -67,10 +68,7 @@ def update_submission_review_state(
         raise SubmissionReviewStateError(str(error)) from error
 
     if not manifest_path.exists():
-        raise SubmissionReviewStateError(
-            "Submission manifest does not exist for "
-            f"class={class_id}, assignment={assignment_id}, student={student_id}."
-        )
+        raise SubmissionReviewStateError(missing_submission_guidance())
 
     try:
         relative_path = manifest_path.resolve(strict=False).relative_to(

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -396,13 +396,15 @@ def test_view_validate_assignment_prints_summary_without_rewriting(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    _write_roster(tmp_path)
     path = workflows.write_assignment_config(
         tmp_path,
         "english_12_p3",
         _assignment(),
     )
     original_bytes = path.read_bytes()
-    _inputs(monkeypatch, [f'"{path}"'])
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    prompts = _inputs(monkeypatch, ["1", "1"])
 
     assert workflows.prompt_view_validate_assignment() == 0
     output = capsys.readouterr().out
@@ -415,6 +417,7 @@ def test_view_validate_assignment_prints_summary_without_rewriting(
     assert "Tagging mode: focus" in output
     assert "Focus standards (2)" in output
     assert "Rubric ID: synthetic_argument_v1" in output
+    assert "Assignment JSON path" not in prompts
     assert path.read_bytes() == original_bytes
 
 
@@ -423,14 +426,25 @@ def test_view_validate_assignment_reports_error_without_traceback(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    path = tmp_path / "invalid.json"
+    _write_roster(tmp_path)
+    path = (
+        tmp_path
+        / "classes"
+        / "english_12_p3"
+        / "assignments"
+        / "invalid"
+        / "assignment.json"
+    )
+    path.parent.mkdir(parents=True)
     path.write_text(json.dumps({"assignment_id": "incomplete"}), encoding="utf-8")
     original_bytes = path.read_bytes()
-    _inputs(monkeypatch, [str(path)])
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    prompts = _inputs(monkeypatch, ["1"])
 
-    assert workflows.prompt_view_validate_assignment() == 1
+    assert workflows.prompt_view_validate_assignment() == 0
     output = capsys.readouterr().out
-    assert "Error:" in output
+    assert "No valid assignments found for class english_12_p3." in output
+    assert "Assignment JSON path" not in prompts
     assert "Traceback" not in output
     assert path.read_bytes() == original_bytes
 

--- a/tests/test_cli_review_scores.py
+++ b/tests/test_cli_review_scores.py
@@ -218,4 +218,4 @@ def test_cli_missing_submission_returns_one(
             "4",
         ]
     ) == 1
-    assert "does not exist" in capsys.readouterr().out
+    assert "This submission is not review-ready yet" in capsys.readouterr().out

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -175,11 +175,16 @@ def test_empty_scores_and_comments_have_clear_messages(tmp_path: Path) -> None:
     assert "No feedback comments selected." in content
 
 
-@pytest.mark.parametrize("record_kind", ["submission", "review"])
-def test_missing_record_is_rejected(tmp_path: Path, record_kind: str) -> None:
+@pytest.mark.parametrize(
+    ("record_kind", "message"),
+    [("submission", "not review-ready yet"), ("review", "does not exist")],
+)
+def test_missing_record_is_rejected(
+    tmp_path: Path, record_kind: str, message: str
+) -> None:
     if record_kind == "review":
         _write_manifest(tmp_path)
-    with pytest.raises(FeedbackExportError, match="does not exist"):
+    with pytest.raises(FeedbackExportError, match=message):
         export_student_feedback(
             tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
         )

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -44,11 +44,11 @@ def _enter_assignment_review_actions() -> list[str]:
 
 
 def _exit_assignment_review_actions_to_main() -> list[str]:
-    return ["5", "", "2", "8"]
+    return ["6", "", "2", "8"]
 
 
 def _exit_after_assignment_action_to_main() -> list[str]:
-    return ["", "5", "", "2", "8"]
+    return ["", "6", "", "2", "8"]
 
 
 def _enter_selected_student(student_choice: str = "1") -> list[str]:
@@ -267,8 +267,9 @@ def test_assignment_review_actions_menu_includes_export_choices(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Assignment Review Actions" in output
-    assert "2. Export class review summary" in output
-    assert "3. Export standards summary" in output
+    assert "2. Assemble routed submissions" in output
+    assert "3. Export class review summary" in output
+    assert "4. Export standards summary" in output
 
 
 def test_selected_student_review_menu_includes_feedback_export(
@@ -362,7 +363,7 @@ def test_menu_export_class_summary_creates_summary_file(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["2", ""]
+        + ["3", ""]
         + _exit_after_assignment_action_to_main(),
     )
 
@@ -393,7 +394,7 @@ def test_menu_export_standards_summary_creates_summary_file(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["3", ""]
+        + ["4", ""]
         + _exit_after_assignment_action_to_main(),
     )
 
@@ -557,7 +558,7 @@ def test_menu_export_class_summary_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["2", ""]
+        + ["3", ""]
         + _exit_after_assignment_action_to_main(),
     )
 
@@ -589,7 +590,7 @@ def test_menu_export_class_summary_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["2", "y"]
+        + ["3", "y"]
         + _exit_after_assignment_action_to_main(),
     )
 
@@ -619,7 +620,7 @@ def test_menu_export_class_summary_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["2", "maybe"]
+        + ["3", "maybe"]
         + _exit_after_assignment_action_to_main(),
     )
 
@@ -650,7 +651,7 @@ def test_menu_export_standards_summary_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["3", "y"]
+        + ["4", "y"]
         + _exit_after_assignment_action_to_main(),
     )
 
@@ -682,7 +683,7 @@ def test_menu_export_standards_summary_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["3", ""]
+        + ["4", ""]
         + _exit_after_assignment_action_to_main(),
     )
 
@@ -712,7 +713,7 @@ def test_menu_export_standards_summary_invalid_overwrite_cancels_without_writing
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["3", "maybe"]
+        + ["4", "maybe"]
         + _exit_after_assignment_action_to_main(),
     )
 

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -166,11 +166,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["9", "5", "", "2", "8"]
+    return ["9", "6", "", "2", "8"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "9", "5", "", "2", "8"]
+    return ["", "9", "6", "", "2", "8"]
 
 
 @pytest.fixture

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -220,7 +220,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "1", "9", "5", "", "2", "8"])
+    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "1", "9", "6", "", "2", "8"])
 
     assert main(["menu"]) == 0
 
@@ -265,7 +265,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "9", "5", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "1", "9", "6", "", "2", "8"],
     )
 
     assert main(["menu"]) == 0
@@ -313,7 +313,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "1", "", "9", "5", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "1", "1", "", "9", "6", "", "2", "8"],
     )
 
     assert main(["menu"]) == 0
@@ -331,7 +331,7 @@ def test_review_menu_reports_missing_openable_evidence(
 ) -> None:
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "2", "1", "", "9", "5", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "2", "1", "", "6", "", "2", "8"],
     )
 
     assert main(["menu"]) == 0
@@ -339,7 +339,8 @@ def test_review_menu_reports_missing_openable_evidence(
     output = capsys.readouterr().out
     assert f"Student: {SECOND_STUDENT_ID}" in output
     assert "Submission: not assembled" in output
-    assert "Error: could not open student submission" in output
+    assert "No routed evidence has been found for this student yet." in output
+    assert "1. Assemble this assignment now" not in output
     assert not list(workspace.rglob("review.json"))
 
 
@@ -362,7 +363,7 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "This is a test note.",
             "",
             "9",
-            "5",
+            "6",
             "",
             "2",
             "8",
@@ -405,7 +406,7 @@ def test_review_menu_updates_submission_review_state(
             "in_progress",
             "",
             "9",
-            "5",
+            "6",
             "",
             "2",
             "8",

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -198,7 +198,7 @@ def test_menu_scan_intake_invalid_path_does_not_create_review_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     missing_source = workspace / "missing-scan.pdf"
-    _menu_input(monkeypatch, ["4", str(missing_source), "", "8"])
+    _menu_input(monkeypatch, ["4", str(missing_source), "", "b", "8"])
 
     assert main(["menu"]) == 0
 
@@ -216,7 +216,7 @@ def test_menu_scan_intake_with_quoted_qr_image_routes_and_prints_next_step(
     source = tmp_path / "synthetic response.png"
     _write_qr_image(source, _valid_payload())
     original_bytes = source.read_bytes()
-    _menu_input(monkeypatch, ["4", f'  "{source}"  ', "", "8"])
+    _menu_input(monkeypatch, ["4", f'  "{source}"  ', "", "b", "8"])
 
     assert main(["menu"]) == 0
 
@@ -250,7 +250,7 @@ def test_menu_scan_intake_pdf_uses_existing_qr_page_intake(
             _make_qr_image(_valid_payload(student_id=SECOND_STUDENT_ID, page=2)),
         ),
     )
-    _menu_input(monkeypatch, ["4", str(source), "", "8"])
+    _menu_input(monkeypatch, ["4", str(source), "", "b", "8"])
 
     assert main(["menu"]) == 0
 
@@ -281,7 +281,7 @@ def test_menu_scan_intake_mixed_pdf_prints_review_warning(
             _blank_image(),
         ),
     )
-    _menu_input(monkeypatch, ["4", str(source), "", "8"])
+    _menu_input(monkeypatch, ["4", str(source), "", "b", "8"])
 
     assert main(["menu"]) == 0
 
@@ -307,7 +307,7 @@ def test_menu_scan_intake_folder_processes_supported_files_and_skips_unsupported
     folder.mkdir()
     _write_qr_image(folder / "response.png", _valid_payload())
     (folder / "notes.txt").write_text("ignore me", encoding="utf-8")
-    _menu_input(monkeypatch, ["4", str(folder), "", "8"])
+    _menu_input(monkeypatch, ["4", str(folder), "", "b", "8"])
 
     assert main(["menu"]) == 0
 

--- a/tests/test_review_comments.py
+++ b/tests/test_review_comments.py
@@ -206,7 +206,7 @@ def test_narrow_review_state_transition(
         ("missing_bank", "not found"),
         ("invalid_bank", "not valid JSON"),
         ("missing_comment", "has no comment"),
-        ("missing_submission", "does not exist"),
+        ("missing_submission", "not review-ready yet"),
         ("invalid_review", "not valid JSON"),
     ],
 )

--- a/tests/test_review_notes.py
+++ b/tests/test_review_notes.py
@@ -330,7 +330,7 @@ def test_blank_text_is_rejected_without_creating_review(
 def test_missing_submission_is_rejected_without_creating_review(
     tmp_path: Path,
 ) -> None:
-    with pytest.raises(ReviewNoteError, match="does not exist"):
+    with pytest.raises(ReviewNoteError, match="not review-ready yet"):
         add_review_note(
             tmp_path,
             CLASS_ID,

--- a/tests/test_review_scores.py
+++ b/tests/test_review_scores.py
@@ -360,7 +360,7 @@ def test_timezone_aware_datetime_is_normalized(tmp_path: Path) -> None:
 
 
 def test_missing_submission_is_rejected(tmp_path: Path) -> None:
-    with pytest.raises(ReviewScoreError, match="does not exist"):
+    with pytest.raises(ReviewScoreError, match="not review-ready yet"):
         set_review_score(
             tmp_path,
             CLASS_ID,

--- a/tests/test_review_tags.py
+++ b/tests/test_review_tags.py
@@ -673,7 +673,7 @@ def test_timezone_aware_datetime_is_normalized(tmp_path: Path) -> None:
 
 
 def test_missing_submission_is_rejected(tmp_path: Path) -> None:
-    with pytest.raises(ReviewTagError, match="does not exist"):
+    with pytest.raises(ReviewTagError, match="not review-ready yet"):
         add_review_tag(
             tmp_path,
             CLASS_ID,

--- a/tests/test_submission_review_opening.py
+++ b/tests/test_submission_review_opening.py
@@ -137,7 +137,7 @@ def test_success_opens_selected_evidence_and_returns_context(
 
 
 def test_missing_manifest_raises(tmp_path: Path) -> None:
-    with pytest.raises(SubmissionReviewOpeningError, match="does not exist"):
+    with pytest.raises(SubmissionReviewOpeningError, match="not review-ready yet"):
         open_student_submission_for_review(
             tmp_path,
             CLASS_ID,
@@ -379,4 +379,4 @@ def test_cli_missing_manifest_returns_one(
     assert (
         main(["open-submission", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 1
     )
-    assert "Submission manifest does not exist" in capsys.readouterr().out
+    assert "This submission is not review-ready yet" in capsys.readouterr().out

--- a/tests/test_submission_review_state.py
+++ b/tests/test_submission_review_state.py
@@ -168,7 +168,7 @@ def test_invalid_state_raises_without_rewriting(tmp_path: Path) -> None:
 
 
 def test_missing_manifest_raises(tmp_path: Path) -> None:
-    with pytest.raises(SubmissionReviewStateError, match="does not exist"):
+    with pytest.raises(SubmissionReviewStateError, match="not review-ready yet"):
         update_submission_review_state(
             tmp_path,
             CLASS_ID,


### PR DESCRIPTION
## Summary

Implements the guided Quillan teacher workflow from scan intake to review-ready submissions.

Closes #161

## Changes

* Added a shared class/assignment picker.
* Updated View/Validate Assignment so teachers select from available assignments instead of typing an `assignment.json` path.
* Updated Scan Intake to create and use `<workspace>/scans_inbox/`.
* Added enumerated scan selection from `scans_inbox/`.
* Added refresh, back, and custom-path options for scan intake.
* Added immediate safe submission assembly after inbox-selected scan routing.
* Updated Review Student Work menus to gate unassembled submissions.
* Added review-menu assembly options when routed evidence exists but no submission record exists.
* Fixed no-evidence student messaging so assembly is offered only when routed evidence exists.
* Moved assignment assembly before export actions.
* Fixed Scan Intake Back so it returns immediately without an extra pause.
* Improved missing-manifest errors so they explain how to assemble submissions and return to review.
* Updated README and relevant workflow/data-contract documentation.
* Updated assignment-picker, scan-intake, review-menu, and actionable-error tests.

## Workflow Impact

The teacher-facing flow now supports:

```text
create assignment
→ print response page
→ scan response
→ place scan in scans_inbox
→ select scan from menu
→ route scan
→ assemble submission
→ review/tag/comment/score/export
```

Teachers no longer need to copy/paste scan file paths for ordinary scan intake.

Teachers no longer need to copy/paste assignment JSON paths for ordinary View/Validate Assignment.

Review actions are no longer presented as if ready when routed evidence exists but the submission has not been assembled.

Students with no routed evidence now receive accurate messaging instead of being told to assemble evidence that does not exist.

## Safety

* Source inbox files are not moved or deleted.
* Existing submission manifests are skipped by default.
* Existing manifests are not overwritten automatically.
* Review records are not overwritten automatically.
* Review state is not changed automatically.
* Scan routing does not infer review state, scores, grades, mastery, or feedback.
* No ScoreForm-specific folders are created.
* No sibling repositories were modified.
* Examples and fixtures remain synthetic.

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `923 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
