### PR TITLE
Add review materials menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Quillan currently supports:
 * teacher-facing class roster creation, viewing, staged editing, and validation through the Roster Management menu;
 * teacher-facing writing assignment config creation and validation through the Assignment Management menu;
 * teacher-facing generation of one combined printable response class packet from an existing canonical roster and assignment config;
+* teacher-facing Review Materials guidance for reusable review aids;
 * shared Paper Data Suite workspace status reporting;
 * assignment-local storage paths based on shared `pds-core` route helpers;
 * decoded response-page route planning that validates class, assignment, roster, and student relationships before writing routed evidence;
@@ -146,9 +147,10 @@ The current top-level menu is:
 3. Printable Response Pages
 4. Scan Intake / Route Paper Responses
 5. Review Student Work
-6. Workspace Settings
-7. Help
-8. Exit
+6. Review Materials
+7. Workspace Settings
+8. Help
+9. Exit
 ```
 
 ### Assignment Management
@@ -262,6 +264,18 @@ The selected-student review menu is:
 These guided actions reuse the same underlying services and data contracts as the direct CLI commands. The menu does not implement separate export logic, scoring logic, routing logic, or AI logic.
 
 Guided export actions preserve overwrite protection. Existing export files are not replaced unless the teacher explicitly confirms overwrite behavior. Invalid overwrite responses cancel safely.
+
+### Review Materials
+
+The Review Materials menu is the preparation area for reusable teacher-authored review aids. It is intended for comment banks, tag banks, rubric/scoring profiles, and optional synthetic starter materials.
+
+These materials help teachers review written student work more quickly by selecting prepared comments, tags, and scoring criteria instead of typing everything during review.
+
+Review materials are subject-agnostic. They may support essays, constructed responses, lab reports, journals, reflections, creative writing, research papers, mathematical explanations, technical writing, and other local writing tasks.
+
+This menu does not modify student submissions, scans, rosters, assignments, exports, or pds-core standards. It does not create or edit review materials yet; those workflows are implemented in follow-up issues.
+
+Review materials augment Quillan review workflows but do not replace pds-core ownership of standards, workspace resolution, or shared routes.
 
 ### Workspace Settings
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -14,8 +14,8 @@ development. It records:
 The CLI includes a developer-oriented, scriptable command layer and a
 teacher-facing terminal menu. The menu now covers assignment management, roster
 management, printable response pages, QR-aware scan intake, review navigation,
-guided review-entry actions, guided export actions, workspace settings, help,
-and exit.
+guided review-entry actions, guided export actions, Review Materials guidance,
+workspace settings, help, and exit.
 
 This contract describes implemented behavior separately from future design. A
 command or workflow documented elsewhere as planned is not part of the current
@@ -198,9 +198,10 @@ The top-level menu provides:
 3. Printable Response Pages
 4. Scan Intake / Route Paper Responses
 5. Review Student Work
-6. Workspace Settings
-7. Help
-8. Exit
+6. Review Materials
+7. Workspace Settings
+8. Help
+9. Exit
 ```
 
 Menu workflows should orchestrate reusable application functions. They should
@@ -433,6 +434,35 @@ Invalid overwrite responses cancel safely.
 The Review Student Work menu does not automatically assemble submissions,
 route scans, run OCR, parse evidence contents, score work automatically, infer
 mastery, generate AI feedback, or perform AI work.
+
+#### Review Materials
+
+Review Materials provides an informational preparation area for reusable
+teacher-authored review aids:
+
+```text
+1. Comment Banks
+2. Tag Banks
+3. Rubrics / Scoring Profiles
+4. Starter Materials
+5. Back
+```
+
+The menu is subject-agnostic and is intended for teachers reviewing written
+student work such as essays, constructed responses, lab reports, journals,
+reflections, research papers, mathematical explanations, technical writing, and
+other local writing tasks.
+
+The current screens explain the purpose of comment banks, tag banks,
+rubrics/scoring profiles, and optional starter materials. They are guidance
+only. They do not create directories, edit files, install starter data, mutate
+student submissions, route scans, change rosters or assignments, write exports,
+or update review records.
+
+Review materials are Quillan-owned teaching and review aids. They may later
+reference durable pds-core `profile_id` and `standard_id` values, but this menu
+does not duplicate or replace pds-core ownership of standards, workspace
+resolution, shared class routes, roster routes, scan routes, or route helpers.
 
 #### Workspace Settings
 

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -256,6 +256,13 @@ def launch_review_student_work_menu() -> None:
     launch()
 
 
+def launch_review_materials_menu() -> None:
+    """Launch the teacher-facing review materials preparation menu."""
+    from quillan.review_materials_menu import launch_review_materials_menu as launch
+
+    launch()
+
+
 def launch_workspace_menu(
     workspace_show: WorkspaceShowHandler,
     workspace_set: WorkspaceSetHandler,
@@ -331,9 +338,10 @@ def launch_menu(
             print("3. Printable Response Pages")
             print("4. Scan Intake / Route Paper Responses")
             print("5. Review Student Work")
-            print("6. Workspace Settings")
-            print("7. Help")
-            print("8. Exit")
+            print("6. Review Materials")
+            print("7. Workspace Settings")
+            print("8. Help")
+            print("9. Exit")
             print()
 
             choice = input("Select an option: ").strip()
@@ -350,22 +358,24 @@ def launch_menu(
             elif choice == "5":
                 launch_review_student_work_menu()
             elif choice == "6":
+                launch_review_materials_menu()
+            elif choice == "7":
                 launch_workspace_menu(
                     workspace_show,
                     workspace_set,
                     workspace_validate,
                     workspace_reset,
                 )
-            elif choice == "7":
+            elif choice == "8":
                 clear_screen()
                 print_menu_help()
                 print()
                 pause_for_user()
-            elif choice == "8":
+            elif choice == "9":
                 print("Goodbye.")
                 return 0
             else:
-                print("Invalid selection. Please enter a number from 1 to 8.")
+                print("Invalid selection. Please enter a number from 1 to 9.")
                 print()
                 pause_for_user()
     except KeyboardInterrupt:

--- a/quillan/review_materials_menu.py
+++ b/quillan/review_materials_menu.py
@@ -1,0 +1,133 @@
+"""Teacher-facing Review Materials preparation menu."""
+
+from __future__ import annotations
+
+
+def launch_review_materials_menu() -> int:
+    """Launch informational review-material preparation screens."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Review Materials")
+            print(
+                "Reusable review materials help teachers prepare comments, "
+                "tags, and scoring tools before reviewing student work."
+            )
+            print()
+            print("1. Comment Banks")
+            print("2. Tag Banks")
+            print("3. Rubrics / Scoring Profiles")
+            print("4. Starter Materials")
+            print("5. Back")
+            print()
+
+            choice = input("Select an option: ").strip()
+            print()
+
+            if choice in {"", "5"}:
+                return 0
+            if choice == "1":
+                _show_comment_banks_info()
+            elif choice == "2":
+                _show_tag_banks_info()
+            elif choice == "3":
+                _show_rubrics_info()
+            elif choice == "4":
+                _show_starter_materials_info()
+            else:
+                print("Invalid selection. Please enter a number from 1 to 5.")
+                print()
+                pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting review materials menu.")
+        return 0
+
+
+def _show_comment_banks_info() -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    clear_screen()
+    print_menu_header("Comment Banks")
+    print("Comment banks are reusable teacher-authored feedback comments.")
+    print(
+        "They can be selected during review and copied into a student's "
+        "review record."
+    )
+    print()
+    print("Comment bank creation and editing will be implemented in #165.")
+    print()
+    print("Expected workspace location:")
+    print("shared/comment_banks/")
+    print()
+    print("No files were changed.")
+    print()
+    pause_for_user()
+
+
+def _show_tag_banks_info() -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    clear_screen()
+    print_menu_header("Tag Banks")
+    print(
+        "Tag banks will store reusable teacher observations for quick "
+        "review tagging."
+    )
+    print(
+        "Tags are teacher-controlled review aids; they are not grades or "
+        "automatic mastery judgments."
+    )
+    print()
+    print(
+        "Tag-bank creation and review-time tag selection will be "
+        "implemented in #166."
+    )
+    print()
+    print("Expected future workspace location:")
+    print("shared/tag_banks/")
+    print()
+    print("No files were changed.")
+    print()
+    pause_for_user()
+
+
+def _show_rubrics_info() -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    clear_screen()
+    print_menu_header("Rubrics / Scoring Profiles")
+    print(
+        "Rubrics and scoring profiles will help teachers score prepared "
+        "criteria without typing criterion IDs during review."
+    )
+    print()
+    print(
+        "Rubric profile creation and enumerated scoring will be implemented "
+        "in #167."
+    )
+    print()
+    print("Expected future workspace location:")
+    print("shared/rubrics/")
+    print()
+    print("No files were changed.")
+    print()
+    pause_for_user()
+
+
+def _show_starter_materials_info() -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    clear_screen()
+    print_menu_header("Starter Materials")
+    print(
+        "Starter materials will provide optional synthetic examples for "
+        "local testing and setup."
+    )
+    print()
+    print("Starter material installation will be implemented in #169.")
+    print()
+    print("No files were changed.")
+    print()
+    pause_for_user()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_cli_without_command_displays_menu_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["8"])
+    _menu_input(monkeypatch, ["9"])
 
     assert main([]) == 0
 
@@ -73,6 +73,7 @@ def test_cli_without_command_displays_menu_options_and_exits(
     assert "Printable Response Pages" in output
     assert "Scan Intake / Route Paper Responses" in output
     assert "Review Student Work" in output
+    assert "Review Materials" in output
     assert "Workspace Settings" in output
     assert "Help" in output
     assert "Exit" in output
@@ -353,7 +354,7 @@ def test_menu_dispatch_displays_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["8"])
+    _menu_input(monkeypatch, ["9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -364,6 +365,7 @@ def test_menu_dispatch_displays_options_and_exits(
     assert "Printable Response Pages" in output
     assert "Scan Intake / Route Paper Responses" in output
     assert "Review Student Work" in output
+    assert "Review Materials" in output
     assert "Workspace Settings" in output
     assert "Help" in output
     assert "Exit" in output
@@ -374,7 +376,7 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["7", "", "8"])
+    _menu_input(monkeypatch, ["8", "", "9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -392,7 +394,7 @@ def test_main_menu_opens_printable_response_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["3", "2", "8"])
+    _menu_input(monkeypatch, ["3", "2", "9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -406,7 +408,7 @@ def test_main_menu_opens_assignment_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["1", "3", "8"])
+    _menu_input(monkeypatch, ["1", "3", "9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -421,7 +423,7 @@ def test_main_menu_opens_roster_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "5", "8"])
+    _menu_input(monkeypatch, ["2", "5", "9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -447,7 +449,7 @@ def test_workspace_menu_reuses_workspace_show_handler(
         return 0
 
     monkeypatch.setattr(cli_workspace, "show_workspace", handle_workspace_show)
-    _menu_input(monkeypatch, ["6", "1", "", "5", "8"])
+    _menu_input(monkeypatch, ["7", "1", "", "5", "9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -478,7 +480,7 @@ def test_workspace_menu_sets_workspace_folder(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["6", "2", str(workspace_root), "", "5", "8"])
+    _menu_input(monkeypatch, ["7", "2", str(workspace_root), "", "5", "9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -502,7 +504,7 @@ def test_workspace_menu_blank_set_cancels_without_change(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["6", "2", "  ", "", "5", "8"])
+    _menu_input(monkeypatch, ["7", "2", "  ", "", "5", "9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -529,7 +531,7 @@ def test_workspace_menu_validates_current_workspace(
         "validate_workspace",
         handle_workspace_validate,
     )
-    _menu_input(monkeypatch, ["6", "3", "", "5", "8"])
+    _menu_input(monkeypatch, ["7", "3", "", "5", "9"])
 
     assert main(["menu"]) == 0
     assert calls == 1
@@ -556,7 +558,7 @@ def test_workspace_menu_resets_saved_preference(
         "reset_workspace",
         handle_workspace_reset,
     )
-    _menu_input(monkeypatch, ["6", "4", "", "5", "8"])
+    _menu_input(monkeypatch, ["7", "4", "", "5", "9"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -44,11 +44,11 @@ def _enter_assignment_review_actions() -> list[str]:
 
 
 def _exit_assignment_review_actions_to_main() -> list[str]:
-    return ["6", "", "2", "8"]
+    return ["6", "", "2", "9"]
 
 
 def _exit_after_assignment_action_to_main() -> list[str]:
-    return ["", "6", "", "2", "8"]
+    return ["", "6", "", "2", "9"]
 
 
 def _enter_selected_student(student_choice: str = "1") -> list[str]:

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -166,11 +166,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["9", "6", "", "2", "8"]
+    return ["9", "6", "", "2", "9"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "9", "6", "", "2", "8"]
+    return ["", "9", "6", "", "2", "9"]
 
 
 @pytest.fixture

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -192,7 +192,7 @@ def test_main_menu_shows_and_opens_review_student_work(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["5", "2", "8"])
+    _menu_input(monkeypatch, ["5", "2", "9"])
 
     assert main(["menu"]) == 0
 
@@ -220,7 +220,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "1", "9", "6", "", "2", "8"])
+    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "1", "9", "6", "", "2", "9"])
 
     assert main(["menu"]) == 0
 
@@ -265,7 +265,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "9", "6", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "1", "9", "6", "", "2", "9"],
     )
 
     assert main(["menu"]) == 0
@@ -313,7 +313,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "1", "", "9", "6", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "1", "1", "", "9", "6", "", "2", "9"],
     )
 
     assert main(["menu"]) == 0
@@ -331,7 +331,7 @@ def test_review_menu_reports_missing_openable_evidence(
 ) -> None:
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "2", "1", "", "6", "", "2", "8"],
+        ["5", "1", "1", "1", "1", "2", "1", "", "6", "", "2", "9"],
     )
 
     assert main(["menu"]) == 0
@@ -366,7 +366,7 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "6",
             "",
             "2",
-            "8",
+            "9",
         ],
     )
 
@@ -409,7 +409,7 @@ def test_review_menu_updates_submission_review_state(
             "6",
             "",
             "2",
-            "8",
+            "9",
         ],
     )
 
@@ -431,7 +431,7 @@ def test_review_menu_no_classes_and_invalid_selection_back_out_safely(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
-    _menu_input(monkeypatch, ["5", "9", "", "1", "", "2", "8"])
+    _menu_input(monkeypatch, ["5", "9", "", "1", "", "2", "9"])
 
     assert main(["menu"]) == 0
 

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -170,7 +170,7 @@ def test_main_menu_exposes_scan_intake_option(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["8"])
+    _menu_input(monkeypatch, ["9"])
 
     assert main(["menu"]) == 0
 
@@ -182,7 +182,7 @@ def test_menu_scan_intake_empty_input_cancels(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["4", "  ", "", "8"])
+    _menu_input(monkeypatch, ["4", "  ", "", "9"])
 
     assert main(["menu"]) == 0
 
@@ -198,7 +198,7 @@ def test_menu_scan_intake_invalid_path_does_not_create_review_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     missing_source = workspace / "missing-scan.pdf"
-    _menu_input(monkeypatch, ["4", str(missing_source), "", "b", "8"])
+    _menu_input(monkeypatch, ["4", str(missing_source), "", "b", "9"])
 
     assert main(["menu"]) == 0
 
@@ -216,7 +216,7 @@ def test_menu_scan_intake_with_quoted_qr_image_routes_and_prints_next_step(
     source = tmp_path / "synthetic response.png"
     _write_qr_image(source, _valid_payload())
     original_bytes = source.read_bytes()
-    _menu_input(monkeypatch, ["4", f'  "{source}"  ', "", "b", "8"])
+    _menu_input(monkeypatch, ["4", f'  "{source}"  ', "", "b", "9"])
 
     assert main(["menu"]) == 0
 
@@ -250,7 +250,7 @@ def test_menu_scan_intake_pdf_uses_existing_qr_page_intake(
             _make_qr_image(_valid_payload(student_id=SECOND_STUDENT_ID, page=2)),
         ),
     )
-    _menu_input(monkeypatch, ["4", str(source), "", "b", "8"])
+    _menu_input(monkeypatch, ["4", str(source), "", "b", "9"])
 
     assert main(["menu"]) == 0
 
@@ -281,7 +281,7 @@ def test_menu_scan_intake_mixed_pdf_prints_review_warning(
             _blank_image(),
         ),
     )
-    _menu_input(monkeypatch, ["4", str(source), "", "b", "8"])
+    _menu_input(monkeypatch, ["4", str(source), "", "b", "9"])
 
     assert main(["menu"]) == 0
 
@@ -307,7 +307,7 @@ def test_menu_scan_intake_folder_processes_supported_files_and_skips_unsupported
     folder.mkdir()
     _write_qr_image(folder / "response.png", _valid_payload())
     (folder / "notes.txt").write_text("ignore me", encoding="utf-8")
-    _menu_input(monkeypatch, ["4", str(folder), "", "b", "8"])
+    _menu_input(monkeypatch, ["4", str(folder), "", "b", "9"])
 
     assert main(["menu"]) == 0
 

--- a/tests/test_review_materials_menu.py
+++ b/tests/test_review_materials_menu.py
@@ -1,0 +1,159 @@
+"""Tests for the teacher-facing Review Materials menu shell."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from quillan.cli import main
+from quillan.review_materials_menu import launch_review_materials_menu
+
+
+def _menu_input(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[str],
+) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError(
+                "Menu requested more input than the test provided."
+            ) from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _file_tree(root: Path) -> tuple[tuple[str, str, bytes | None], ...]:
+    entries: list[tuple[str, str, bytes | None]] = []
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        if path.is_file():
+            entries.append(("file", relative, path.read_bytes()))
+        elif path.is_dir():
+            entries.append(("dir", relative, None))
+    return tuple(entries)
+
+
+def test_main_menu_includes_review_materials_and_exits_cleanly(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["9"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "5. Review Student Work" in output
+    assert "6. Review Materials" in output
+    assert "7. Workspace Settings" in output
+    assert "8. Help" in output
+    assert "9. Exit" in output
+    assert "Goodbye." in output
+
+
+def test_main_menu_invalid_selection_uses_new_range(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["bad", "", "9"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Invalid selection. Please enter a number from 1 to 9." in output
+
+
+def test_review_materials_menu_navigation_returns_to_main_menu(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["6", "5", "9"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Review Materials" in output
+    assert (
+        "Reusable review materials help teachers prepare comments, tags, "
+        "and scoring tools before reviewing student work."
+    ) in output
+    assert "1. Comment Banks" in output
+    assert "2. Tag Banks" in output
+    assert "3. Rubrics / Scoring Profiles" in output
+    assert "4. Starter Materials" in output
+    assert "5. Back" in output
+    assert "Goodbye." in output
+
+
+@pytest.mark.parametrize(
+    ("choice", "header", "future_issue", "path_text"),
+    [
+        ("1", "Comment Banks", "#165", "shared/comment_banks/"),
+        ("2", "Tag Banks", "#166", "shared/tag_banks/"),
+        ("3", "Rubrics / Scoring Profiles", "#167", "shared/rubrics/"),
+        ("4", "Starter Materials", "#169", ""),
+    ],
+)
+def test_review_materials_informational_screens_return_safely(
+    choice: str,
+    header: str,
+    future_issue: str,
+    path_text: str,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, [choice, "", "5"])
+
+    assert launch_review_materials_menu() == 0
+
+    output = capsys.readouterr().out
+    assert header in output
+    assert future_issue in output
+    assert "No files were changed." in output
+    if path_text:
+        assert path_text in output
+
+
+def test_review_materials_invalid_selection_is_helpful(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["x", "", "5"])
+
+    assert launch_review_materials_menu() == 0
+
+    output = capsys.readouterr().out
+    assert "Invalid selection. Please enter a number from 1 to 5." in output
+
+
+def test_review_materials_menu_has_no_workspace_side_effects(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    classes = tmp_path / "classes"
+    scans = tmp_path / "scans"
+    scans_inbox = tmp_path / "scans_inbox"
+    standards = tmp_path / "shared" / "standards"
+    for folder in (classes, scans, scans_inbox, standards):
+        folder.mkdir(parents=True)
+        (folder / "existing.txt").write_text("keep", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    before = _file_tree(tmp_path)
+    _menu_input(monkeypatch, ["6", "1", "", "2", "", "3", "", "4", "", "5", "9"])
+
+    assert main(["menu"]) == 0
+
+    capsys.readouterr()
+    assert _file_tree(tmp_path) == before
+    assert not (tmp_path / "shared" / "comment_banks").exists()
+    assert not (tmp_path / "shared" / "tag_banks").exists()
+    assert not (tmp_path / "shared" / "rubrics").exists()
+    assert not list(tmp_path.rglob("review.json"))
+    assert not list(tmp_path.rglob("submission.json"))
+    assert not list(tmp_path.rglob("exports"))


### PR DESCRIPTION
## Summary

Adds the Review Materials menu shell for reusable teacher-authored review aids.

Closes #164

## Changes

* Added `quillan/review_materials_menu.py`.
* Added a new top-level `Review Materials` menu entry.
* Updated main menu numbering:

  * `6. Review Materials`
  * `7. Workspace Settings`
  * `8. Help`
  * `9. Exit`
* Added informational submenu pages for:

  * Comment Banks
  * Tag Banks
  * Rubrics / Scoring Profiles
  * Starter Materials
* Updated invalid main-menu selection guidance from `1 to 8` to `1 to 9`.
* Updated menu tests affected by the shifted numbering.
* Added `tests/test_review_materials_menu.py`.
* Updated `README.md`.
* Updated `docs/cli_contract.md`.

## Behavior

The new Review Materials menu is informational only.

It explains the future preparation area for reusable teacher-authored review aids before grading, including comment banks, tag banks, rubric/scoring profiles, and starter materials.

No review-material creation or editing is implemented in this issue. Those workflows are reserved for follow-up issues under #163.

## Safety

* No review-material directories or files are created.
* No student submissions are modified.
* No scans are modified.
* No rosters are modified.
* No assignments are modified.
* No exports are modified.
* No review records are modified.
* No standards files are modified.
* No sibling repositories were modified.
* pds-core ownership of workspace resolution, shared routes, and standards remains intact.

## Architecture

This preserves the intended Paper Data Suite boundary:

```text
pds-core owns shared workspace resolution, route helpers, rosters/classes, scan routes, standards profiles, and durable standard IDs.

Quillan owns teacher-facing review workflows and Quillan-specific review materials that may later reference pds-core IDs without redefining standards or routes.
```

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `932 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
