### PR TITLE
Add comment bank authoring workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,13 +267,19 @@ Guided export actions preserve overwrite protection. Existing export files are n
 
 ### Review Materials
 
-The Review Materials menu is the preparation area for reusable teacher-authored review aids. It is intended for comment banks, tag banks, rubric/scoring profiles, and optional synthetic starter materials.
+The Review Materials menu is the preparation area for reusable teacher-authored review aids. It includes a Comment Banks submenu for creating, viewing, editing, extending, and validating shared reusable feedback banks. Tag banks, rubric/scoring profiles, and optional synthetic starter materials remain future workflows.
 
 These materials help teachers review written student work more quickly by selecting prepared comments, tags, and scoring criteria instead of typing everything during review.
 
 Review materials are subject-agnostic. They may support essays, constructed responses, lab reports, journals, reflections, creative writing, research papers, mathematical explanations, technical writing, and other local writing tasks.
 
-This menu does not modify student submissions, scans, rosters, assignments, exports, or pds-core standards. It does not create or edit review materials yet; those workflows are implemented in follow-up issues.
+Comment banks created through the menu are stored at `shared/comment_banks/<bank_id>.json` and validate against the same version `1` contract used by review-time selection. Banks are subject-agnostic and writing-type-aware, so they can support essays, constructed responses, lab reports, reflections, research papers, mathematical explanations, technical documentation, design rationale, portfolio reflection, and other local written-work contexts.
+
+Comment banks store reusable teacher-authored feedback language. They do not grade work, imply mastery, generate comments automatically, or change student records by themselves. When a teacher selects a reusable comment during Review Student Work, Quillan snapshots the selected label and text into the review record with `source: "comment_bank"`, `bank_id`, and `comment_id`; later bank edits do not silently rewrite prior student review records.
+
+Optional `standard_ids` in comment metadata are durable pds-core references only. Quillan comment-bank authoring does not create, import, edit, retire, reactivate, or validate standards as authoritative.
+
+Comment-bank authoring does not modify student submissions, scans, rosters, assignments, exports, pds-core workspace preferences, pds-core route helpers, or pds-core standards. The authoring workflows write only confirmed, valid files under `shared/comment_banks/`.
 
 Review materials augment Quillan review workflows but do not replace pds-core ownership of standards, workspace resolution, or shared routes.
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -437,8 +437,8 @@ mastery, generate AI feedback, or perform AI work.
 
 #### Review Materials
 
-Review Materials provides an informational preparation area for reusable
-teacher-authored review aids:
+Review Materials provides a preparation area for reusable teacher-authored
+review aids:
 
 ```text
 1. Comment Banks
@@ -453,16 +453,41 @@ student work such as essays, constructed responses, lab reports, journals,
 reflections, research papers, mathematical explanations, technical writing, and
 other local writing tasks.
 
-The current screens explain the purpose of comment banks, tag banks,
-rubrics/scoring profiles, and optional starter materials. They are guidance
-only. They do not create directories, edit files, install starter data, mutate
-student submissions, route scans, change rosters or assignments, write exports,
-or update review records.
+Comment Banks opens a submenu:
+
+```text
+1. Create comment bank
+2. View comment banks
+3. Edit comment bank
+4. Add category
+5. Add comment
+6. Validate comment bank
+7. Back
+```
+
+Comment-bank authoring writes confirmed, valid version `1` banks only under
+`shared/comment_banks/<bank_id>.json`. New banks are immediately available to
+Review Student Work -> Select reusable comment because they use the same
+schema, loading logic, and validation as review-time selection.
+
+Comment banks are teacher-authored reusable feedback language. They do not
+grade work, imply mastery, generate automatic feedback, or mutate student
+records by themselves. Review selection snapshots the chosen label and text
+into `review.json.comments`; later bank edits do not silently rewrite previous
+review records.
+
+The Tag Banks, Rubrics / Scoring Profiles, and Starter Materials screens remain
+guidance-only. They do not create directories, edit files, install starter data,
+mutate student submissions, route scans, change rosters or assignments, write
+exports, or update review records.
 
 Review materials are Quillan-owned teaching and review aids. They may later
-reference durable pds-core `profile_id` and `standard_id` values, but this menu
-does not duplicate or replace pds-core ownership of standards, workspace
-resolution, shared class routes, roster routes, scan routes, or route helpers.
+reference durable pds-core `profile_id` and `standard_id` values. Optional
+comment-bank `standard_ids` are pds-core references only; Quillan does not
+create, import, edit, retire, reactivate, or authoritatively validate standards.
+The menu does not duplicate or replace pds-core ownership of standards,
+workspace resolution, shared class routes, roster routes, scan routes, or route
+helpers.
 
 #### Workspace Settings
 

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -24,9 +24,31 @@ does not evaluate writing, imply standards mastery, or place a comment in a
 student's review by itself.
 
 This document defines comment bank schema version `1`. Runtime loading,
-validation, and direct student-facing selection are implemented; bank editing,
-assignment activation, menus, feedback export, automatic suggestions, and
-AI-generated comments are not.
+validation, direct student-facing selection, and teacher-facing creation and
+editing through Review Materials -> Comment Banks are implemented. Assignment
+activation, automatic suggestions, and AI-generated comments are not.
+
+Teachers can create, view, edit, extend, and validate shared banks from:
+
+```text
+Quillan -> Review Materials -> Comment Banks
+```
+
+The authoring workflow writes only confirmed, valid banks under
+`shared/comment_banks/<bank_id>.json`. It does not write invalid partial banks,
+and it does not overwrite an existing bank unless the teacher explicitly types
+`OVERWRITE`. Created banks are immediately available from Review Student Work
+-> Select reusable comment because the menu uses the same schema and validation
+as review-time loading.
+
+Comment-bank authoring is subject-agnostic and writing-type-aware. Banks may
+support essays, constructed responses, lab reports, reflections, research
+papers, mathematical explanations, technical documentation, design rationale,
+portfolio reflection, and other local written-work contexts.
+
+Optional `standard_ids` are durable pds-core references only. Quillan stores
+them as metadata but does not create, import, edit, retire, reactivate, or
+authoritatively validate standards.
 
 ## Top-Level Structure
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -72,6 +72,12 @@ standards and criterion references, polarity, severity defaults, search
 metadata, and student-facing controls. Banks are not student records, do not
 grade work, and do not generate feedback by themselves.
 
+Teachers can create, view, edit, extend, and validate shared banks from Review
+Materials -> Comment Banks. The workflows write only confirmed, valid version
+`1` bank files under `shared/comment_banks/`, never invalid partial files.
+Existing banks are not overwritten unless the teacher explicitly confirms with
+`OVERWRITE`.
+
 Future assignments may optionally activate banks through `comment_bank_ids`.
 The implemented direct shared-bank selection copies chosen language into
 `review.json.comments` with `source: "comment_bank"`, `bank_id`, and
@@ -81,6 +87,11 @@ a stable snapshot rather than a live reference. The complete version `1`
 shape and validation rules are defined in
 [`comment_bank_contract.md`](comment_bank_contract.md). Runtime validation and
 direct selection are implemented; assignment activation remains future work.
+
+Comment banks are subject-agnostic and writing-type-aware teacher-authored
+review materials. Optional `standard_ids` are pds-core durable references only;
+Quillan does not create, import, edit, retire, reactivate, or authoritatively
+validate standards through comment-bank workflows.
 
 ## Assignment
 

--- a/quillan/comment_bank_workflows.py
+++ b/quillan/comment_bank_workflows.py
@@ -1,0 +1,693 @@
+"""Teacher-facing comment-bank creation and editing workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.comment_banks import (
+    ALLOWED_POLARITIES,
+    CommentBankError,
+    load_comment_bank,
+)
+from quillan.comment_bank_writing import (
+    build_comment,
+    build_comment_bank,
+    build_comment_category,
+    current_timestamp,
+    ensure_unique_identifier,
+    list_comment_bank_files,
+    list_valid_comment_banks,
+    parse_comma_separated_values,
+    summarize_comment_bank,
+    suggest_identifier,
+    touch_updated_at,
+    write_comment_bank,
+)
+
+_CATEGORY_SUGGESTIONS: tuple[tuple[str, str], ...] = (
+    ("Content Accuracy", "Comments about correctness, accuracy, or completeness."),
+    ("Evidence / Support", "Comments about support, examples, sources, or data."),
+    ("Reasoning / Explanation", "Comments about reasoning, analysis, or explanation."),
+    ("Organization", "Comments about structure, sequence, or transitions."),
+    ("Process / Method", "Comments about procedure, process, method, or steps."),
+    ("Reflection", "Comments about reflection, insight, or self-assessment."),
+    ("Creativity / Design", "Comments about design choices or creative decisions."),
+    ("Conventions", "Comments about clarity, grammar, mechanics, or formatting."),
+)
+
+
+def launch_comment_banks_menu() -> int:
+    """Launch the teacher-facing Comment Banks submenu."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Comment Banks")
+            print("Comment banks store reusable teacher-authored feedback comments.")
+            print(
+                "They can be selected during review and copied into a "
+                "student's review record."
+            )
+            print()
+            print("1. Create comment bank")
+            print("2. View comment banks")
+            print("3. Edit comment bank")
+            print("4. Add category")
+            print("5. Add comment")
+            print("6. Validate comment bank")
+            print("7. Back")
+            print()
+
+            choice = input("Select an option: ").strip()
+            print()
+            if choice in {"", "7"}:
+                return 0
+            workflows = {
+                "1": prompt_create_comment_bank,
+                "2": prompt_view_comment_banks,
+                "3": prompt_edit_comment_bank,
+                "4": prompt_add_category,
+                "5": prompt_add_comment,
+                "6": prompt_validate_comment_bank,
+            }
+            workflow = workflows.get(choice)
+            if workflow is None:
+                print("Invalid selection. Please enter a number from 1 to 7.")
+            else:
+                clear_screen()
+                workflow()
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting comment banks menu.")
+        return 0
+
+
+def prompt_create_comment_bank() -> int:
+    """Prompt for and save one complete valid comment bank."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Create Comment Bank")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+
+    try:
+        title = _required_input(
+            "Bank title:\nExample: General Written Response Comments\n"
+        )
+        suggestion = suggest_identifier(title)
+        print(f"Suggested bank_id:\n{suggestion}")
+        bank_id = input("Press Enter to accept, or type a different bank_id: ").strip()
+        if not bank_id:
+            bank_id = suggestion
+        description = input(
+            "Description:\n"
+            "Example: Reusable comments for written responses across subjects.\n"
+        ).strip()
+        writing_types = _prompt_writing_types()
+        print()
+        print("Now add at least one category and one comment before saving.")
+        print()
+        category = _prompt_new_category(existing_ids=set())
+        if category is None:
+            print("Create comment bank canceled. No file was created.")
+            return 1
+        comment = _prompt_new_comment(
+            categories=[category],
+            bank_writing_types=writing_types,
+            existing_ids=set(),
+        )
+        if comment is None:
+            print("Create comment bank canceled. No file was created.")
+            return 1
+        bank = build_comment_bank(
+            bank_id=bank_id,
+            title=title,
+            description=description,
+            writing_types=writing_types,
+            categories=[category],
+            comments=[comment],
+        )
+    except (CommentBankError, ValueError) as error:
+        print(f"Error: {error}")
+        print("No file was created.")
+        return 1
+
+    path = Path(workspace_root) / "shared" / "comment_banks" / f"{bank_id}.json"
+    print()
+    print("Ready to save comment bank:")
+    print()
+    print(f"Bank ID: {bank['bank_id']}")
+    print(f"Title: {bank['title']}")
+    print(f"Writing types: {', '.join(bank['writing_types'])}")
+    print(f"Categories: {len(bank['categories'])}")
+    print(f"Comments: {len(bank['comments'])}")
+    print(f"Path: {path}")
+    print()
+    print("1. Save")
+    print("2. Cancel")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Create comment bank canceled. No file was created.")
+        return 1
+
+    overwrite = False
+    if path.exists():
+        confirmation = input("Type OVERWRITE to replace it: ").strip()
+        if confirmation != "OVERWRITE":
+            print("Canceled: existing comment bank was not changed.")
+            return 1
+        overwrite = True
+
+    try:
+        saved_path = write_comment_bank(workspace_root, bank, overwrite=overwrite)
+    except (CommentBankError, OSError) as error:
+        print(f"Error: {error}")
+        return 1
+    print(f"Saved comment bank: {saved_path}")
+    return 0
+
+
+def prompt_view_comment_banks() -> int:
+    """List comment banks and optionally show one bank summary."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Comment Banks")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    files = list_comment_bank_files(workspace_root)
+    valid = [item for item in files if item.is_valid and item.bank is not None]
+    invalid = [item for item in files if not item.is_valid]
+
+    if not valid:
+        print("No valid shared comment banks found.")
+        print()
+        print(
+            "Create one from Review Materials -> Comment Banks -> "
+            "Create comment bank."
+        )
+        print()
+        print("Expected location:")
+        print("shared/comment_banks/")
+    else:
+        print("Comment Banks")
+        print()
+        for index, item in enumerate(valid, start=1):
+            bank = item.bank
+            assert bank is not None
+            print(f"{index}. {bank['bank_id']} - {bank['title']}")
+            print(f"   Writing types: {', '.join(bank['writing_types'])}")
+            print(f"   Categories: {len(bank['categories'])}")
+            print(f"   Comments: {len(bank['comments'])}")
+            print()
+        print("B. Back")
+        print()
+        selection = input("Select comment bank to view, or Back: ").strip()
+        if selection.isdigit() and 1 <= int(selection) <= len(valid):
+            item = valid[int(selection) - 1]
+            assert item.bank is not None
+            print()
+            print(summarize_comment_bank(item.bank, item.path))
+        elif selection and selection.casefold() != "b":
+            print("Invalid selection. Please choose a listed bank or Back.")
+
+    _print_invalid_files(invalid)
+    return 0
+
+
+def prompt_edit_comment_bank() -> int:
+    """Safely edit title, description, or writing types for one valid bank."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Edit Comment Bank")
+    selected = _prompt_valid_bank()
+    if selected is None:
+        return 1
+    path, bank = selected
+    print()
+    print("1. Edit title")
+    print("2. Edit description")
+    print("3. Edit writing types")
+    print("4. Back")
+    print()
+    choice = input("Select an option: ").strip()
+    if choice in {"", "4"}:
+        print("Edit comment bank canceled. No file was changed.")
+        return 0
+
+    updated = touch_updated_at(bank)
+    try:
+        if choice == "1":
+            updated["title"] = _required_input("Bank title: ")
+        elif choice == "2":
+            updated["description"] = input("Description: ").strip()
+        elif choice == "3":
+            updated["writing_types"] = _prompt_writing_types()
+        else:
+            print("Invalid selection. Please enter a number from 1 to 4.")
+            return 1
+        write_comment_bank(path.parents[2], updated, overwrite=True)
+    except (CommentBankError, ValueError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing comment bank was not changed.")
+        return 1
+    print(f"Saved comment bank: {path}")
+    return 0
+
+
+def prompt_add_category() -> int:
+    """Add a category to an existing valid bank."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Add Category")
+    selected = _prompt_valid_bank()
+    if selected is None:
+        return 1
+    path, bank = selected
+    print()
+    _print_categories(bank)
+    existing_ids = {
+        str(category["category_id"])
+        for category in bank["categories"]
+        if isinstance(category, dict)
+    }
+    try:
+        category = _prompt_new_category(existing_ids=existing_ids)
+    except (CommentBankError, ValueError) as error:
+        print(f"Error: {error}")
+        print("Add category canceled. No file was changed.")
+        return 1
+    if category is None:
+        print("Add category canceled. No file was changed.")
+        return 1
+    updated = touch_updated_at(bank)
+    updated["categories"] = [dict(item) for item in bank["categories"]] + [category]
+    print()
+    print(f"Add category '{category['label']}' to {bank['bank_id']}?")
+    print("1. Save")
+    print("2. Cancel")
+    if input("Select an option: ").strip() != "1":
+        print("Add category canceled. No file was changed.")
+        return 1
+    try:
+        write_comment_bank(path.parents[2], updated, overwrite=True)
+    except (CommentBankError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing comment bank was not changed.")
+        return 1
+    print(f"Saved comment bank: {path}")
+    return 0
+
+
+def prompt_add_comment() -> int:
+    """Add a comment to an existing valid bank."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Add Comment")
+    selected = _prompt_valid_bank()
+    if selected is None:
+        return 1
+    path, bank = selected
+    existing_ids = {
+        str(comment["comment_id"])
+        for comment in bank["comments"]
+        if isinstance(comment, dict)
+    }
+    try:
+        comment = _prompt_new_comment(
+            categories=list(bank["categories"]),
+            bank_writing_types=list(bank["writing_types"]),
+            existing_ids=existing_ids,
+        )
+    except (CommentBankError, ValueError) as error:
+        print(f"Error: {error}")
+        print("Add comment canceled. No file was changed.")
+        return 1
+    if comment is None:
+        print("Add comment canceled. No file was changed.")
+        return 1
+    updated = touch_updated_at(bank)
+    updated["comments"] = [dict(item) for item in bank["comments"]] + [comment]
+    print()
+    print(f"Add comment '{comment['label']}' to {bank['bank_id']}?")
+    print("1. Save")
+    print("2. Cancel")
+    if input("Select an option: ").strip() != "1":
+        print("Add comment canceled. No file was changed.")
+        return 1
+    try:
+        write_comment_bank(path.parents[2], updated, overwrite=True)
+    except (CommentBankError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing comment bank was not changed.")
+        return 1
+    print(f"Saved comment bank: {path}")
+    return 0
+
+
+def prompt_validate_comment_bank() -> int:
+    """Validate one existing comment-bank file without modifying it."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Validate Comment Bank")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    files = list_comment_bank_files(workspace_root)
+    if not files:
+        print("No comment bank files found.")
+        print("Expected location: shared/comment_banks/")
+        return 1
+    for index, item in enumerate(files, start=1):
+        print(f"{index}. {item.path}")
+    print("B. Back")
+    print()
+    selection = input("Select comment bank file: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Validate comment bank canceled.")
+        return 0
+    if not selection.isdigit() or not 1 <= int(selection) <= len(files):
+        print("Invalid selection. Please choose a listed file or Back.")
+        return 1
+    path = files[int(selection) - 1].path
+    try:
+        bank = load_comment_bank(path)
+    except (CommentBankError, OSError) as error:
+        print("Comment bank is invalid.")
+        print()
+        print(f"Path: {path}")
+        print(f"Error: {error}")
+        return 1
+    print("Comment bank is valid.")
+    print()
+    print(f"Bank ID: {bank['bank_id']}")
+    print(f"Title: {bank['title']}")
+    print(f"Categories: {len(bank['categories'])}")
+    print(f"Comments: {len(bank['comments'])}")
+    print(f"Path: {path}")
+    return 0
+
+
+def _workspace_root() -> Path | None:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return None
+
+
+def _required_input(prompt: str) -> str:
+    value = input(prompt).strip()
+    if not value:
+        raise ValueError("This field is required.")
+    return value
+
+
+def _prompt_writing_types() -> list[str]:
+    value = input(
+        "Writing types, comma-separated:\n"
+        "Examples: general, lab_report, reflection, research, constructed_response\n"
+    )
+    writing_types = parse_comma_separated_values(value)
+    if not writing_types:
+        raise ValueError("At least one writing type is required.")
+    return writing_types
+
+
+def _prompt_new_category(existing_ids: set[str]) -> dict[str, Any] | None:
+    print("Add Category")
+    print()
+    print("Categories help teachers find comments quickly during review.")
+    print()
+    print("Suggested categories:")
+    for index, (label, _description) in enumerate(_CATEGORY_SUGGESTIONS, start=1):
+        print(f"{index}. {label}")
+    custom_index = len(_CATEGORY_SUGGESTIONS) + 1
+    print(f"{custom_index}. Custom category")
+    print("B. Back")
+    print()
+    selection = input("Select suggestion or choose Custom: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(_CATEGORY_SUGGESTIONS):
+        label, description = _CATEGORY_SUGGESTIONS[int(selection) - 1]
+    elif selection == str(custom_index):
+        label = _required_input("Category label:\nExample: Process / Method\n")
+        description = input(
+            "Description:\n"
+            "Example: Comments about procedure, process, method, or steps.\n"
+        ).strip()
+    else:
+        print("Invalid category selection.")
+        return None
+    suggestion = suggest_identifier(label)
+    print(f"Suggested category_id:\n{suggestion}")
+    category_id = input(
+        "Press Enter to accept, or type a different category_id: "
+    ).strip()
+    if not category_id:
+        category_id = suggestion
+    sort_order = _parse_optional_nonnegative_int(
+        input("Sort order (leave blank to auto-assign): ")
+    )
+    if sort_order is None:
+        sort_order = len(existing_ids) + 1
+    ensure_unique_identifier(category_id, existing_ids, "category_id")
+    return build_comment_category(
+        category_id=category_id,
+        label=label,
+        description=description,
+        sort_order=sort_order,
+    )
+
+
+def _prompt_new_comment(
+    *,
+    categories: list[dict[str, Any]],
+    bank_writing_types: list[str],
+    existing_ids: set[str],
+) -> dict[str, Any] | None:
+    print()
+    print("Add Comment")
+    print()
+    label = _required_input("Comment label:\nExample: Explanation needs more detail\n")
+    suggestion = suggest_identifier(label)
+    print(f"Suggested comment_id:\n{suggestion}")
+    comment_id = input(
+        "Press Enter to accept, or type a different comment_id: "
+    ).strip()
+    if not comment_id:
+        comment_id = suggestion
+    ensure_unique_identifier(comment_id, existing_ids, "comment_id")
+    text = _required_input(
+        "Student-facing feedback text:\n"
+        "Example: Your response identifies the idea, but explain your "
+        "reasoning more fully.\n"
+    )
+    category_id = _prompt_category_id(categories)
+    if category_id is None:
+        return None
+    polarity = _prompt_polarity()
+    if polarity is None:
+        return None
+    include_default = _prompt_yes_no(
+        "Include in feedback by default?",
+        default=True,
+    )
+    if include_default is None:
+        return None
+    student_facing = _prompt_yes_no("Student-facing comment?", default=True)
+    if student_facing is None:
+        return None
+    metadata = _prompt_optional_metadata(bank_writing_types)
+    if metadata is None:
+        return None
+    return build_comment(
+        comment_id=comment_id,
+        label=label,
+        text=text,
+        category_id=category_id,
+        polarity=polarity,
+        include_in_feedback_default=include_default,
+        student_facing=student_facing,
+        module_details={},
+        optional_metadata=metadata,
+    )
+
+
+def _prompt_category_id(categories: list[dict[str, Any]]) -> str | None:
+    print()
+    print("Category:")
+    for index, category in enumerate(categories, start=1):
+        print(f"{index}. {category['label']}")
+    print("B. Back")
+    print()
+    selection = input("Select category: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(categories):
+        return str(categories[int(selection) - 1]["category_id"])
+    print("Invalid category selection.")
+    return None
+
+
+def _prompt_polarity() -> str | None:
+    polarities = ("positive", "developing", "negative", "neutral")
+    print()
+    print("Polarity:")
+    for index, polarity in enumerate(polarities, start=1):
+        print(f"{index}. {polarity}")
+    print("B. Back")
+    print()
+    selection = input("Select polarity: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(polarities):
+        return polarities[int(selection) - 1]
+    if selection in ALLOWED_POLARITIES:
+        return selection
+    print("Invalid polarity selection.")
+    return None
+
+
+def _prompt_yes_no(label: str, *, default: bool) -> bool | None:
+    default_label = "Y/n" if default else "y/N"
+    print()
+    print(f"{label}")
+    print(f"1. Yes{' (default)' if default else ''}")
+    print(f"2. No{' (default)' if not default else ''}")
+    print("B. Back")
+    selection = input(f"Select an option ({default_label}): ").strip().lower()
+    if selection == "":
+        return default
+    if selection in {"1", "y", "yes", "true"}:
+        return True
+    if selection in {"2", "n", "no", "false"}:
+        return False
+    if selection == "b":
+        return None
+    print("Invalid selection. Please choose Yes, No, or Back.")
+    return None
+
+
+def _prompt_optional_metadata(bank_writing_types: list[str]) -> dict[str, Any] | None:
+    print()
+    response = input("Add optional metadata? (y/N): ").strip().lower()
+    if response in {"", "n", "no"}:
+        return {}
+    if response not in {"y", "yes"}:
+        print("Invalid selection. Optional metadata skipped by canceling.")
+        return None
+    metadata: dict[str, Any] = {}
+    for field in (
+        "short_text",
+        "subcategory",
+        "teacher_note",
+        "follow_up_prompt",
+        "revision_action",
+    ):
+        value = input(f"{field} (leave blank to omit): ").strip()
+        if value:
+            metadata[field] = value
+    writing_types = parse_comma_separated_values(
+        input("Comment writing types, comma-separated (leave blank to omit): ")
+    )
+    if writing_types:
+        outside = set(writing_types) - set(bank_writing_types)
+        if outside:
+            print(
+                "Invalid comment writing types. They must be part of the bank "
+                f"writing types: {', '.join(bank_writing_types)}."
+            )
+            return None
+        metadata["writing_types"] = writing_types
+    for field in ("standard_ids", "criterion_ids", "tags", "hotwords"):
+        values = parse_comma_separated_values(
+            input(f"{field}, comma-separated (leave blank to omit): ")
+        )
+        if values:
+            metadata[field] = values
+    severity = _parse_optional_nonnegative_int(
+        input("severity_default (leave blank to omit): ")
+    )
+    if severity is not None:
+        metadata["severity_default"] = severity
+    sort_order = _parse_optional_nonnegative_int(
+        input("sort_order (leave blank to omit): ")
+    )
+    if sort_order is not None:
+        metadata["sort_order"] = sort_order
+    timestamp = current_timestamp()
+    metadata["created_at"] = timestamp
+    metadata["updated_at"] = timestamp
+    return metadata
+
+
+def _prompt_valid_bank() -> tuple[Path, dict[str, Any]] | None:
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return None
+    files = list_valid_comment_banks(workspace_root)
+    if not files:
+        print("No valid shared comment banks found.")
+        print(
+            "Create one from Review Materials -> Comment Banks -> "
+            "Create comment bank."
+        )
+        return None
+    print("Available comment banks:")
+    for index, item in enumerate(files, start=1):
+        assert item.bank is not None
+        print(f"{index}. {item.bank['bank_id']} - {item.bank['title']}")
+    print("B. Back")
+    print()
+    selection = input("Select comment bank: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Comment bank selection canceled.")
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(files):
+        item = files[int(selection) - 1]
+        assert item.bank is not None
+        return item.path, item.bank
+    for item in files:
+        assert item.bank is not None
+        if item.bank["bank_id"] == selection:
+            return item.path, item.bank
+    print("Invalid comment bank selection. Please choose a listed bank or Back.")
+    return None
+
+
+def _print_categories(bank: dict[str, Any]) -> None:
+    print("Existing categories:")
+    for index, category in enumerate(bank["categories"], start=1):
+        print(f"{index}. {category['category_id']} - {category['label']}")
+
+
+def _print_invalid_files(invalid: list[Any]) -> None:
+    if not invalid:
+        return
+    print()
+    print("Invalid comment bank files:")
+    print()
+    for item in invalid:
+        print(f"- {item.path}")
+        print(f"  Error: {item.error}")
+
+
+def _parse_optional_nonnegative_int(value: str) -> int | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = int(text)
+    except ValueError as error:
+        raise ValueError("Value must be a non-negative integer.") from error
+    if parsed < 0:
+        raise ValueError("Value must be a non-negative integer.")
+    return parsed

--- a/quillan/comment_bank_writing.py
+++ b/quillan/comment_bank_writing.py
@@ -1,0 +1,231 @@
+"""Construction, listing, and safe writes for Quillan comment banks."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.comment_banks import (
+    CommentBankError,
+    comment_bank_path,
+    load_comment_bank,
+    validate_comment_bank,
+)
+
+
+@dataclass(frozen=True)
+class CommentBankFile:
+    """One discovered comment bank file and its validation state."""
+
+    path: Path
+    bank: dict[str, Any] | None
+    error: str | None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.bank is not None and self.error is None
+
+
+def current_timestamp() -> str:
+    """Return a timezone-aware ISO 8601 timestamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def suggest_identifier(label: str) -> str:
+    """Suggest a shared identifier from teacher-facing text."""
+    normalized = unicodedata.normalize("NFKD", label)
+    ascii_label = normalized.encode("ascii", "ignore").decode("ascii")
+    suggestion = re.sub(r"[^A-Za-z0-9_-]+", "_", ascii_label.strip())
+    suggestion = suggestion.strip("_-").lower()
+    return suggestion or "comment_bank"
+
+
+def parse_comma_separated_values(value: str) -> list[str]:
+    """Return trimmed nonblank values from comma-separated input."""
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def build_comment_category(
+    *,
+    category_id: str,
+    label: str,
+    description: str = "",
+    sort_order: int | None = None,
+) -> dict[str, Any]:
+    """Build and validate one category record."""
+    validate_identifier(category_id, "category_id")
+    if not label.strip():
+        raise CommentBankError("Category label is required.")
+    category: dict[str, Any] = {
+        "category_id": category_id,
+        "label": label.strip(),
+    }
+    if description.strip():
+        category["description"] = description.strip()
+    if sort_order is not None:
+        category["sort_order"] = sort_order
+    return category
+
+
+def build_comment(
+    *,
+    comment_id: str,
+    label: str,
+    text: str,
+    category_id: str,
+    polarity: str,
+    include_in_feedback_default: bool = True,
+    student_facing: bool = True,
+    module_details: Mapping[str, Any] | None = None,
+    optional_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one comment record."""
+    validate_identifier(comment_id, "comment_id")
+    validate_identifier(category_id, "category_id")
+    if not label.strip():
+        raise CommentBankError("Comment label is required.")
+    if not text.strip():
+        raise CommentBankError("Student-facing feedback text is required.")
+    comment: dict[str, Any] = {
+        "comment_id": comment_id,
+        "label": label.strip(),
+        "text": text.strip(),
+        "category_id": category_id,
+        "polarity": polarity,
+        "include_in_feedback_default": include_in_feedback_default,
+        "student_facing": student_facing,
+        "module_details": dict(module_details or {}),
+    }
+    if optional_metadata:
+        comment.update(dict(optional_metadata))
+    return comment
+
+
+def build_comment_bank(
+    *,
+    bank_id: str,
+    title: str,
+    description: str,
+    writing_types: Sequence[str],
+    categories: Sequence[Mapping[str, Any]],
+    comments: Sequence[Mapping[str, Any]],
+    created_at: str | None = None,
+    updated_at: str | None = None,
+    module_details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build and validate a version 1 Quillan shared comment bank."""
+    timestamp = current_timestamp()
+    bank: dict[str, Any] = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "comment_bank",
+        "bank_id": bank_id,
+        "title": title.strip(),
+        "description": description.strip(),
+        "scope": "shared",
+        "writing_types": list(writing_types),
+        "categories": [dict(category) for category in categories],
+        "comments": [dict(comment) for comment in comments],
+        "created_at": created_at or timestamp,
+        "updated_at": updated_at or timestamp,
+        "module_details": dict(module_details or {}),
+    }
+    validate_comment_bank(bank)
+    return bank
+
+
+def list_comment_bank_files(workspace_root: str | Path) -> tuple[CommentBankFile, ...]:
+    """List shared comment-bank files without raising on invalid files."""
+    directory = Path(workspace_root) / "shared" / "comment_banks"
+    if not directory.is_dir():
+        return ()
+    files: list[CommentBankFile] = []
+    for path in sorted(directory.glob("*.json"), key=lambda item: item.name.casefold()):
+        try:
+            files.append(CommentBankFile(path, load_comment_bank(path), None))
+        except (OSError, CommentBankError) as error:
+            files.append(CommentBankFile(path, None, str(error)))
+    return tuple(files)
+
+
+def list_valid_comment_banks(
+    workspace_root: str | Path,
+) -> tuple[CommentBankFile, ...]:
+    """Return valid shared comment-bank files only."""
+    return tuple(
+        item for item in list_comment_bank_files(workspace_root) if item.is_valid
+    )
+
+
+def summarize_comment_bank(bank: Mapping[str, Any], path: str | Path) -> str:
+    """Return a concise teacher-facing summary for one bank."""
+    writing_types = ", ".join(str(item) for item in bank["writing_types"])
+    return "\n".join(
+        [
+            f"Bank ID: {bank['bank_id']}",
+            f"Title: {bank['title']}",
+            f"Description: {bank['description']}",
+            f"Scope: {bank['scope']}",
+            f"Writing types: {writing_types}",
+            f"Categories: {len(bank['categories'])}",
+            f"Comments: {len(bank['comments'])}",
+            f"Path: {Path(path)}",
+        ]
+    )
+
+
+def write_comment_bank(
+    workspace_root: str | Path,
+    bank: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Validate and atomically write a shared comment bank."""
+    bank_data = dict(bank)
+    validate_comment_bank(bank_data)
+    bank_id = str(bank_data["bank_id"])
+    path = comment_bank_path(workspace_root, bank_id)
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"Comment bank already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            json.dump(bank_data, file, indent=2, ensure_ascii=False)
+            file.write("\n")
+        os.replace(temporary_path, path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def touch_updated_at(bank: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a mutable copy with a refreshed updated_at value."""
+    updated = dict(bank)
+    updated["updated_at"] = current_timestamp()
+    return updated
+
+
+def ensure_unique_identifier(identifier: str, existing: set[str], field: str) -> None:
+    """Validate an identifier and reject duplicates."""
+    try:
+        validate_identifier(identifier, field)
+    except IdentifierValidationError as error:
+        raise CommentBankError(str(error)) from error
+    if identifier in existing:
+        raise CommentBankError(f"Duplicate {field} '{identifier}'.")

--- a/quillan/review_materials_menu.py
+++ b/quillan/review_materials_menu.py
@@ -29,7 +29,9 @@ def launch_review_materials_menu() -> int:
             if choice in {"", "5"}:
                 return 0
             if choice == "1":
-                _show_comment_banks_info()
+                from quillan.comment_bank_workflows import launch_comment_banks_menu
+
+                launch_comment_banks_menu()
             elif choice == "2":
                 _show_tag_banks_info()
             elif choice == "3":
@@ -43,27 +45,6 @@ def launch_review_materials_menu() -> int:
     except KeyboardInterrupt:
         print("\nExiting review materials menu.")
         return 0
-
-
-def _show_comment_banks_info() -> None:
-    from quillan.menu import clear_screen, pause_for_user, print_menu_header
-
-    clear_screen()
-    print_menu_header("Comment Banks")
-    print("Comment banks are reusable teacher-authored feedback comments.")
-    print(
-        "They can be selected during review and copied into a student's "
-        "review record."
-    )
-    print()
-    print("Comment bank creation and editing will be implemented in #165.")
-    print()
-    print("Expected workspace location:")
-    print("shared/comment_banks/")
-    print()
-    print("No files were changed.")
-    print()
-    pause_for_user()
 
 
 def _show_tag_banks_info() -> None:

--- a/tests/test_comment_bank_workflows.py
+++ b/tests/test_comment_bank_workflows.py
@@ -1,0 +1,294 @@
+"""Tests for teacher-facing comment-bank workflows."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.comment_bank_workflows as workflows
+from quillan.comment_banks import load_comment_bank
+from quillan.comment_bank_writing import (
+    build_comment,
+    build_comment_bank,
+    build_comment_category,
+    write_comment_bank,
+)
+
+
+def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError(
+                "Menu requested more input than the test provided."
+            ) from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _patch_workspace(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: root)
+
+
+def _sample_bank(bank_id: str = "general_comments") -> dict[str, Any]:
+    category = build_comment_category(
+        category_id="reasoning",
+        label="Reasoning / Explanation",
+        description="Comments about reasoning.",
+    )
+    comment = build_comment(
+        comment_id="explain_more",
+        label="Explain more",
+        text="Explain your reasoning more fully.",
+        category_id="reasoning",
+        polarity="developing",
+    )
+    return build_comment_bank(
+        bank_id=bank_id,
+        title="General Comments",
+        description="Reusable synthetic comments.",
+        writing_types=["general", "reflection"],
+        categories=[category],
+        comments=[comment],
+    )
+
+
+def test_create_comment_bank_writes_valid_minimal_bank(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "General Written Response Comments",
+            "",
+            "Reusable comments for written responses across subjects.",
+            "general, constructed_response",
+            "5",
+            "",
+            "",
+            "Explanation needs more detail",
+            "",
+            "Your response identifies the idea, but explain your reasoning more fully.",
+            "1",
+            "2",
+            "",
+            "",
+            "",
+            "1",
+        ],
+    )
+
+    assert workflows.prompt_create_comment_bank() == 0
+
+    path = (
+        tmp_path
+        / "shared"
+        / "comment_banks"
+        / "general_written_response_comments.json"
+    )
+    bank = load_comment_bank(path)
+    assert bank["bank_id"] == path.stem
+    assert bank["categories"]
+    assert bank["comments"]
+    assert bank["comments"][0]["polarity"] == "developing"
+    assert bank["comments"][0]["include_in_feedback_default"] is True
+    assert bank["comments"][0]["student_facing"] is True
+    assert bank["created_at"].endswith("+00:00")
+    assert bank["updated_at"].endswith("+00:00")
+    output = capsys.readouterr().out
+    assert "Saved comment bank" in output
+
+
+def test_create_cancel_before_save_writes_no_partial_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "General Written Response Comments",
+            "",
+            "Reusable comments.",
+            "general",
+            "1",
+            "",
+            "",
+            "Useful detail",
+            "",
+            "This detail helps the reader follow your thinking.",
+            "1",
+            "1",
+            "",
+            "",
+            "",
+            "2",
+        ],
+    )
+
+    assert workflows.prompt_create_comment_bank() == 1
+
+    capsys.readouterr()
+    assert not (tmp_path / "shared" / "comment_banks").exists()
+
+
+def test_create_existing_bank_requires_exact_overwrite_confirmation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = _sample_bank("general_written_response_comments")
+    path = write_comment_bank(tmp_path, existing)
+    before = path.read_bytes()
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "General Written Response Comments",
+            "",
+            "New description.",
+            "general",
+            "1",
+            "",
+            "",
+            "New comment",
+            "",
+            "A new comment text.",
+            "1",
+            "4",
+            "",
+            "",
+            "",
+            "1",
+            "overwrite",
+        ],
+    )
+
+    assert workflows.prompt_create_comment_bank() == 1
+
+    output = capsys.readouterr().out
+    assert "existing comment bank was not changed" in output
+    assert path.read_bytes() == before
+
+
+def test_view_comment_banks_lists_valid_and_invalid_files(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_comment_bank(tmp_path, _sample_bank())
+    invalid = tmp_path / "shared" / "comment_banks" / "draft.json"
+    invalid.write_text(json.dumps({"bank_id": "draft"}), encoding="utf-8")
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1"])
+
+    assert workflows.prompt_view_comment_banks() == 0
+
+    output = capsys.readouterr().out
+    assert "general_comments - General Comments" in output
+    assert "Invalid comment bank files" in output
+    assert "draft.json" in output
+    assert "Comments: 1" in output
+
+
+def test_edit_comment_bank_updates_title_and_preserves_created_at(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = write_comment_bank(tmp_path, _sample_bank())
+    before = load_comment_bank(path)
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1", "1", "Updated General Comments"])
+
+    assert workflows.prompt_edit_comment_bank() == 0
+
+    after = load_comment_bank(path)
+    assert after["title"] == "Updated General Comments"
+    assert after["created_at"] == before["created_at"]
+    assert after["updated_at"] >= before["updated_at"]
+    capsys.readouterr()
+
+
+def test_add_category_rejects_duplicate_without_changing_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = write_comment_bank(tmp_path, _sample_bank())
+    before = path.read_bytes()
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1", "3", "reasoning", ""])
+
+    assert workflows.prompt_add_category() == 1
+
+    output = capsys.readouterr().out
+    assert "Duplicate category_id" in output
+    assert path.read_bytes() == before
+
+
+def test_add_comment_stores_required_fields_and_validates(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = write_comment_bank(tmp_path, _sample_bank())
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "1",
+            "Needs clearer evidence",
+            "",
+            "Add a specific example or detail to support this point.",
+            "1",
+            "2",
+            "2",
+            "1",
+            "",
+            "1",
+        ],
+    )
+
+    assert workflows.prompt_add_comment() == 0
+
+    bank = load_comment_bank(path)
+    added = bank["comments"][-1]
+    assert added["comment_id"] == "needs_clearer_evidence"
+    assert added["polarity"] == "developing"
+    assert added["include_in_feedback_default"] is False
+    assert added["student_facing"] is True
+    assert added["module_details"] == {}
+    capsys.readouterr()
+
+
+def test_validate_comment_bank_reports_invalid_without_modifying_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "shared" / "comment_banks"
+    directory.mkdir(parents=True)
+    invalid = directory / "draft.json"
+    invalid.write_text("{", encoding="utf-8")
+    before = invalid.read_bytes()
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1"])
+
+    assert workflows.prompt_validate_comment_bank() == 1
+
+    output = capsys.readouterr().out
+    assert "Comment bank is invalid." in output
+    assert "not valid JSON" in output
+    assert invalid.read_bytes() == before

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from quillan.cli import main
+import quillan.comment_bank_workflows as comment_bank_workflows
 import quillan.review_menu as review_menu
 from quillan.review_record_paths import review_record_path, write_review_record
 from quillan.submission_manifest_paths import (
@@ -339,6 +340,70 @@ def test_review_menu_selects_reusable_comment_by_number(
     assert review["comments"][0]["comment_id"] == "focus_is_clear"
     assert review["review_state"] == "in_progress"
     assert manifest_path.read_bytes() == manifest_before
+
+
+def test_comment_bank_created_by_workflow_is_selectable_in_review(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        comment_bank_workflows,
+        "resolve_workspace_root",
+        lambda: workspace,
+    )
+    _menu_input(
+        monkeypatch,
+        [
+            "General Written Response Comments",
+            "",
+            "Reusable comments for written responses across subjects.",
+            "general",
+            "3",
+            "",
+            "",
+            "Explanation needs more detail",
+            "",
+            "Your response identifies the idea, but explain your reasoning more fully.",
+            "1",
+            "2",
+            "",
+            "",
+            "",
+            "1",
+        ],
+    )
+
+    assert comment_bank_workflows.prompt_create_comment_bank() == 0
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["4", "1", "1", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "general_written_response_comments" in output
+    assert "Explanation needs more detail" in output
+    review = json.loads(
+        review_record_path(
+            workspace,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        ).read_text(encoding="utf-8")
+    )
+    comment = review["comments"][0]
+    assert comment["source"] == "comment_bank"
+    assert comment["bank_id"] == "general_written_response_comments"
+    assert comment["comment_id"] == "explanation_needs_more_detail"
+    assert comment["label"] == "Explanation needs more detail"
+    assert (
+        comment["text"]
+        == "Your response identifies the idea, but explain your reasoning more fully."
+    )
 
 
 def test_review_menu_sets_criterion_score(

--- a/tests/test_review_materials_menu.py
+++ b/tests/test_review_materials_menu.py
@@ -93,7 +93,6 @@ def test_review_materials_menu_navigation_returns_to_main_menu(
 @pytest.mark.parametrize(
     ("choice", "header", "future_issue", "path_text"),
     [
-        ("1", "Comment Banks", "#165", "shared/comment_banks/"),
         ("2", "Tag Banks", "#166", "shared/tag_banks/"),
         ("3", "Rubrics / Scoring Profiles", "#167", "shared/rubrics/"),
         ("4", "Starter Materials", "#169", ""),
@@ -117,6 +116,21 @@ def test_review_materials_informational_screens_return_safely(
     assert "No files were changed." in output
     if path_text:
         assert path_text in output
+
+
+def test_review_materials_comment_banks_opens_submenu(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["1", "7", "5"])
+
+    assert launch_review_materials_menu() == 0
+
+    output = capsys.readouterr().out
+    assert "Comment banks store reusable teacher-authored feedback comments." in output
+    assert "1. Create comment bank" in output
+    assert "6. Validate comment bank" in output
+    assert "7. Back" in output
 
 
 def test_review_materials_invalid_selection_is_helpful(
@@ -145,7 +159,10 @@ def test_review_materials_menu_has_no_workspace_side_effects(
         (folder / "existing.txt").write_text("keep", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     before = _file_tree(tmp_path)
-    _menu_input(monkeypatch, ["6", "1", "", "2", "", "3", "", "4", "", "5", "9"])
+    _menu_input(
+        monkeypatch,
+        ["6", "1", "7", "2", "", "3", "", "4", "", "5", "9"],
+    )
 
     assert main(["menu"]) == 0
 


### PR DESCRIPTION
## Summary

Adds teacher-facing comment-bank creation and editing workflows under Review Materials.

Closes #165

## Changes

* Added `quillan/comment_bank_writing.py`.
* Added `quillan/comment_bank_workflows.py`.
* Updated `quillan/review_materials_menu.py` so `Review Materials -> Comment Banks` opens the real Comment Banks submenu.
* Added workflows to:

  * create comment banks;
  * view comment banks;
  * edit comment-bank title, description, and writing types;
  * add categories;
  * add comments;
  * validate comment-bank files.
* Updated docs:

  * `README.md`
  * `docs/cli_contract.md`
  * `docs/comment_bank_contract.md`
  * `docs/data_contracts.md`
* Added/updated tests:

  * `tests/test_comment_bank_workflows.py`
  * `tests/test_review_materials_menu.py`
  * `tests/test_menu_review_entry_actions.py`

## Behavior

Comment banks can now be created entirely through the teacher-facing menu.

New banks are written to:

```text
shared/comment_banks/<bank_id>.json
```

Created banks use schema version `1` and are validated through the existing `quillan.comment_banks` validation before writing.

Creation requires at least one category and one comment, so invalid partial banks are not saved.

Existing banks require exact `OVERWRITE` confirmation before replacement.

Edits and additions validate the complete bank before atomic replacement.

A bank created through the workflow is immediately selectable from Review Student Work.

## Review Integration

The review workflow can select comments from banks created through the new menu.

Selected comments are snapshotted into the review record with:

* `source: "comment_bank"`
* `bank_id`
* `comment_id`
* label
* text

Later edits to a source bank do not silently rewrite prior review records.

## Safety

* Comment-bank authoring writes only confirmed, valid files under `shared/comment_banks/`.
* Invalid partial banks are not written.
* Existing banks are not overwritten without exact confirmation.
* Optional `standard_ids` remain metadata-only pds-core durable references.
* No pds-core standards files are created, edited, retired, reactivated, imported, or authoritatively validated by Quillan.
* No submissions are modified.
* No scans are modified.
* No rosters are modified.
* No assignments are modified.
* No exports are modified.
* No review records are modified by authoring workflows.
* No sibling repositories were modified.

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `941 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
