### PR TITLE
Add reusable tag bank workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Guided export actions preserve overwrite protection. Existing export files are n
 
 ### Review Materials
 
-The Review Materials menu is the preparation area for reusable teacher-authored review aids. It includes a Comment Banks submenu for creating, viewing, editing, extending, and validating shared reusable feedback banks. Tag banks, rubric/scoring profiles, and optional synthetic starter materials remain future workflows.
+The Review Materials menu is the preparation area for reusable teacher-authored review aids. It includes Comment Banks and Tag Banks submenus for creating, viewing, editing, extending, and validating shared reusable review materials. Rubric/scoring profiles and optional synthetic starter materials remain future workflows.
 
 These materials help teachers review written student work more quickly by selecting prepared comments, tags, and scoring criteria instead of typing everything during review.
 
@@ -277,9 +277,13 @@ Comment banks created through the menu are stored at `shared/comment_banks/<bank
 
 Comment banks store reusable teacher-authored feedback language. They do not grade work, imply mastery, generate comments automatically, or change student records by themselves. When a teacher selects a reusable comment during Review Student Work, Quillan snapshots the selected label and text into the review record with `source: "comment_bank"`, `bank_id`, and `comment_id`; later bank edits do not silently rewrite prior student review records.
 
+Tag banks created through the menu are stored at `shared/tag_banks/<tag_bank_id>.json` and validate against the version `1` tag-bank contract. Tag banks store reusable teacher-authored observations for quick review tagging. They are not grades, scores, mastery determinations, generated feedback, or automatic judgments. During Review Student Work -> Add structured tag, teachers can select a reusable tag by bank, category, and tag template, or choose a custom one-off tag. Selected reusable tags snapshot label, polarity, optional severity, optional standard/criterion metadata, teacher notes, and `source: "tag_bank"` provenance into `review.json.tags`.
+
 Optional `standard_ids` in comment metadata are durable pds-core references only. Quillan comment-bank authoring does not create, import, edit, retire, reactivate, or validate standards as authoritative.
 
-Comment-bank authoring does not modify student submissions, scans, rosters, assignments, exports, pds-core workspace preferences, pds-core route helpers, or pds-core standards. The authoring workflows write only confirmed, valid files under `shared/comment_banks/`.
+Optional `standard_ids` in tag templates are also durable pds-core references only. Optional `criterion_ids` are rubric/scoring metadata only. Quillan tag-bank authoring does not mutate pds-core standards, route helpers, workspace preferences, rosters, assignments, submissions, scans, exports, comment banks, or rubric files.
+
+Comment-bank authoring does not modify student submissions, scans, rosters, assignments, exports, pds-core workspace preferences, pds-core route helpers, or pds-core standards. Tag-bank authoring writes only confirmed, valid files under `shared/tag_banks/`; comment-bank authoring writes only confirmed, valid files under `shared/comment_banks/`.
 
 Review materials augment Quillan review workflows but do not replace pds-core ownership of standards, workspace resolution, or shared routes.
 
@@ -715,6 +719,12 @@ The comment-bank contract is documented in:
 
 ```text
 docs/comment_bank_contract.md
+```
+
+The tag-bank contract is documented in:
+
+```text
+docs/tag_bank_contract.md
 ```
 
 Synthetic example files are available in:

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -418,6 +418,13 @@ quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
+`Add structured tag` opens an Add Tag chooser. Teachers can select a reusable
+tag from `shared/tag_banks/<tag_bank_id>.json` by bank, category, and tag
+template, or choose Custom tag to use the existing one-off tag prompts. Reusable
+tag selections snapshot template values into `review.json.tags` with
+`source: "tag_bank"`, `tag_bank_id`, and `tag_template_id`; custom tags and the
+direct `add-tag` command remain compatible.
+
 Guided export actions reuse the same underlying export services as the direct
 commands:
 
@@ -476,14 +483,36 @@ records by themselves. Review selection snapshots the chosen label and text
 into `review.json.comments`; later bank edits do not silently rewrite previous
 review records.
 
-The Tag Banks, Rubrics / Scoring Profiles, and Starter Materials screens remain
-guidance-only. They do not create directories, edit files, install starter data,
-mutate student submissions, route scans, change rosters or assignments, write
-exports, or update review records.
+Tag Banks opens a submenu:
+
+```text
+1. Create tag bank
+2. View tag banks
+3. Edit tag bank
+4. Add category
+5. Add tag template
+6. Validate tag bank
+7. Back
+```
+
+Tag-bank authoring writes confirmed, valid version `1` banks only under
+`shared/tag_banks/<tag_bank_id>.json`. It builds complete banks in memory,
+validates before writing, refuses accidental overwrites unless the teacher types
+exactly `OVERWRITE`, and does not write invalid partial files.
+
+Tag banks are teacher-authored reusable observations for quick tagging. They do
+not grade work, imply mastery, generate automatic feedback, or mutate student
+records by themselves.
+
+Rubrics / Scoring Profiles and Starter Materials remain guidance-only. They do
+not create directories, edit files, install starter data, mutate student
+submissions, route scans, change rosters or assignments, write exports, or
+update review records.
 
 Review materials are Quillan-owned teaching and review aids. They may later
 reference durable pds-core `profile_id` and `standard_id` values. Optional
-comment-bank `standard_ids` are pds-core references only; Quillan does not
+comment-bank and tag-bank `standard_ids` are pds-core references only; optional
+tag-bank `criterion_ids` are rubric/scoring metadata only. Quillan does not
 create, import, edit, retire, reactivate, or authoritatively validate standards.
 The menu does not duplicate or replace pds-core ownership of standards,
 workspace resolution, shared class routes, roster routes, scan routes, or route

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -3,18 +3,17 @@
 Quillan stores structured evidence about student writing using local files.
 
 These contracts describe the expected file formats for standards profiles,
-shared comment banks, assignments, submissions, teacher review, requirements
-checks, feedback exports, and reports.
+shared comment banks, shared tag banks, assignments, submissions, teacher
+review, requirements checks, feedback exports, and reports.
 
 Standards profiles, assignment configurations, the legacy text-oriented
-submission metadata shape, comment banks, review records, and the
+submission metadata shape, comment banks, tag banks, review records, and the
 reviewable-evidence submission manifest have implemented Python validation
 support. Routed-evidence discovery and manifest assembly, explicit
-teacher-controlled review updates, reusable-comment selection, and student,
-class, and standards exports are implemented through direct CLI commands and
-Python APIs. The writing-response payload contract is implemented and used by
-printable PDF generation. Requirements checking and guided teacher-facing
-review remain future work.
+teacher-controlled review updates, reusable-comment selection, reusable-tag
+selection, and student, class, and standards exports are implemented through
+direct CLI commands, guided menus, and Python APIs. The writing-response payload
+contract is implemented and used by printable PDF generation.
 
 For the expected workspace layout and file lifecycle of these records, see
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
@@ -31,6 +30,12 @@ For reusable teacher-authored feedback language stored at
 `shared/comment_banks/<bank_id>.json`, including categories, writing-type
 filters, standards and criterion links, and future assignment activation, see
 [`comment_bank_contract.md`](comment_bank_contract.md).
+
+For reusable teacher-authored tag observations stored at
+`shared/tag_banks/<tag_bank_id>.json`, including categories, writing-type
+filters, optional standards references, optional criterion metadata, and
+review-time snapshot behavior, see
+[`tag_bank_contract.md`](tag_bank_contract.md).
 
 For the required structure and human-readable elements of a printable
 writing-response page, see
@@ -57,9 +62,12 @@ Quillan stores only durable pds-core references:
 
 * assignment `standards_profile_id` stores a pds-core `profile_id`;
 * assignment `focus_standards` stores pds-core `standard_id` values;
-* review tags and selected reusable comments may store optional pds-core `standard_id` provenance.
+* review tags and selected reusable comments may store optional pds-core `standard_id` provenance;
+* reusable tag templates may store optional pds-core `standard_ids` as source metadata.
 
-Quillan does not store or validate an independent standards-profile JSON shape. Legacy Quillan standards-profile files were removed before production use as a pre-1.0 breaking cleanup, with no production-data migration.## Shared Comment Bank
+Quillan does not store or validate an independent standards-profile JSON shape. Legacy Quillan standards-profile files were removed before production use as a pre-1.0 breaking cleanup, with no production-data migration.
+
+## Shared Comment Bank
 
 A shared comment bank is reusable teacher-authored source data stored at:
 
@@ -92,6 +100,39 @@ Comment banks are subject-agnostic and writing-type-aware teacher-authored
 review materials. Optional `standard_ids` are pds-core durable references only;
 Quillan does not create, import, edit, retire, reactivate, or authoritatively
 validate standards through comment-bank workflows.
+
+## Shared Tag Bank
+
+A shared tag bank is reusable teacher-authored source data stored at:
+
+```text
+shared/tag_banks/<tag_bank_id>.json
+```
+
+It organizes short teacher observations with writing types, categories,
+polarity, optional standard references, optional rubric/scoring criterion
+metadata, optional severity defaults, and optional teacher-note prompts. Tag
+banks are not student records, grades, scores, mastery determinations,
+generated feedback, automatic judgments, or automatic suggestions.
+
+Teachers can create, view, edit, extend, and validate shared tag banks from
+Review Materials -> Tag Banks. The workflows write only confirmed, valid
+version `1` bank files under `shared/tag_banks/`, never invalid partial files.
+Existing banks are not overwritten unless the teacher explicitly confirms with
+`OVERWRITE`.
+
+Review Student Work -> Add structured tag can select a reusable tag by bank,
+category, and tag template. The selected values are copied into
+`review.json.tags` with `source: "tag_bank"`, `tag_bank_id`, and
+`tag_template_id`, plus snapshotted label, polarity, optional severity,
+optional `standard_id`, optional `criterion_id`, and optional teacher note.
+Custom one-off tags remain available, and existing direct CLI add-tag behavior
+remains compatible.
+
+Tag banks are Quillan-owned review materials. Optional `standard_ids` are
+pds-core durable references only; Quillan does not create, import, edit,
+retire, reactivate, or authoritatively validate standards through tag-bank
+workflows. Optional `criterion_ids` are rubric/scoring metadata only.
 
 ## Assignment
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -170,9 +170,9 @@ silently replace existing notes.
 ## Tags
 
 `tags` contains teacher-created or teacher-confirmed observations. A tag may
-refer to a standard, reusable comment, page, evidence candidate, location, or
-the whole submission. It is not a score, proof that a standard was met or
-missed, or an instruction to calculate a score.
+refer to a standard, reusable tag template, reusable comment, page, evidence
+candidate, location, or the whole submission. It is not a score, proof that a
+standard was met or missed, or an instruction to calculate a score.
 
 Each tag contains:
 
@@ -206,6 +206,10 @@ Required tag fields are:
 
 Optional tag fields are:
 
+* `source`;
+* `tag_bank_id`;
+* `tag_template_id`;
+* `criterion_id`;
 * `standard_id`;
 * `comment_id`;
 * `severity`;
@@ -223,6 +227,13 @@ Tag field rules are:
   not a score.
 * `teacher_note`, when present, is a non-empty string.
 * `page_number`, when present, is a positive integer.
+* `source`, when present, is one of `tag_bank` or `custom`.
+* `tag_bank_id` and `tag_template_id` are required when `source` is
+  `tag_bank`. They identify the source file under
+  `shared/tag_banks/<tag_bank_id>.json` and the selected template inside that
+  bank.
+* `criterion_id`, when present, is optional rubric/scoring metadata and is not
+  validated against a rubric profile in schema version `1`.
 * `standard_id` and `comment_id`, when present, are non-empty strings.
   `standard_id` is pds-core provenance; `comment_id` identifies reusable
   Quillan comment-bank language when paired with `bank_id`.
@@ -258,6 +269,32 @@ For `whole_submission`, `value` must be `null`. For `page`, `paragraph`,
 `scene`, `stanza`, and `custom`, `value` must be either a positive integer or
 a non-empty string. A `page` location must agree with `page_number` when both
 are present.
+
+### Reusable Tag Snapshots
+
+When a teacher selects a reusable tag from a Quillan tag bank, the review
+record stores a snapshot, not a live reference:
+
+```json
+{
+  "tag_id": "tag_0001",
+  "source": "tag_bank",
+  "tag_bank_id": "general_written_response_tags",
+  "tag_template_id": "explanation_needs_more_detail",
+  "label": "Explanation needs more detail",
+  "polarity": "developing",
+  "criterion_id": "explanation",
+  "severity": 2,
+  "teacher_note": "The explanation names the idea but does not explain why it matters.",
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+Later edits to the source tag bank do not rewrite prior review records.
+Optional reusable-template `standard_ids` remain pds-core durable references
+only, and optional `criterion_ids` remain rubric/scoring metadata only.
+Existing direct CLI tags may omit `source` and all tag-bank provenance fields.
 
 Tags are append-only for the MVP. Editing, deletion, deduplication, and any
 interpretation of severity are future work. Tags must never calculate or

--- a/docs/tag_bank_contract.md
+++ b/docs/tag_bank_contract.md
@@ -1,0 +1,89 @@
+# Quillan Tag Bank Contract
+
+A tag bank is reusable, teacher-authored source data for selecting short
+structured review observations during student-work review.
+
+Tag banks are stored under the active pds-core workspace root:
+
+```text
+shared/tag_banks/<tag_bank_id>.json
+```
+
+Tags are review aids. They are not grades, scores, mastery determinations,
+generated feedback, automatic judgments, or automatic tag suggestions.
+
+Quillan owns tag-bank review-material files. Optional `standard_ids` are
+pds-core durable standard references only; Quillan does not create, import,
+edit, retire, reactivate, or otherwise manage standards through tag banks.
+Optional `criterion_ids` are rubric/scoring metadata only.
+
+## Schema Version 1
+
+Every version `1` tag bank contains:
+
+```json
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "tag_bank",
+  "tag_bank_id": "general_written_response_tags",
+  "title": "General Written Response Tags",
+  "description": "Reusable teacher observations for written responses.",
+  "scope": "shared",
+  "writing_types": ["general", "constructed_response"],
+  "categories": [],
+  "tags": [],
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "updated_at": "2026-06-26T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+For the MVP, `scope` is `shared`. `writing_types` are open strings and must be
+non-empty. `tag_bank_id` must pass shared identifier validation and match the
+filename stem.
+
+`categories` and `tags` must both be non-empty before a bank is written.
+
+## Categories
+
+Each category requires `category_id` and `label`. Optional fields are
+`description`, `sort_order`, and `module_details`.
+
+`category_id` must pass shared identifier validation and be unique within the
+bank. `label` must be non-empty. `sort_order`, when present, is an integer.
+
+## Tag Templates
+
+Each tag template requires `tag_template_id`, `label`, `category_id`,
+`polarity`, and `module_details`.
+
+Optional fields are `description`, `writing_types`, `standard_ids`,
+`criterion_ids`, `severity_default`, `teacher_note_prompt`,
+`student_facing_default`, `sort_order`, `created_at`, and `updated_at`.
+
+`polarity` is one of `positive`, `developing`, `negative`, or `neutral`.
+`category_id` must reference a category in the same bank. Template
+`writing_types`, when present, must be a subset of the bank-level
+`writing_types`.
+
+## Runtime Behavior
+
+Tag banks are created and edited from:
+
+```text
+Quillan -> Review Materials -> Tag Banks
+```
+
+The workflow builds banks in memory, validates the complete bank before
+writing, writes only valid files, atomically replaces existing files, and
+requires exact `OVERWRITE` confirmation before replacing an existing bank.
+Canceling creation does not create `shared/tag_banks/` or partial files.
+
+Review mode can select reusable tags by bank, category, and template. Selected
+values are snapshotted into `review.json.tags` with `source: "tag_bank"`,
+`tag_bank_id`, and `tag_template_id`. Later edits to the source tag bank do not
+rewrite prior review records.
+
+Custom one-off tags remain available and existing direct CLI add-tag behavior
+remains compatible.

--- a/quillan/review_materials_menu.py
+++ b/quillan/review_materials_menu.py
@@ -33,7 +33,9 @@ def launch_review_materials_menu() -> int:
 
                 launch_comment_banks_menu()
             elif choice == "2":
-                _show_tag_banks_info()
+                from quillan.tag_bank_workflows import launch_tag_banks_menu
+
+                launch_tag_banks_menu()
             elif choice == "3":
                 _show_rubrics_info()
             elif choice == "4":

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -39,6 +39,7 @@ from quillan.standards_summary_export import (
     export_standards_summary,
 )
 from quillan.comment_banks import CommentBankError, load_comment_bank
+from quillan.tag_bank_writing import list_valid_tag_banks
 from quillan.review_comments import ReviewCommentError, add_review_comment
 from quillan.review_notes import ReviewNoteError, add_review_note
 from quillan.review_record import (
@@ -498,7 +499,61 @@ def _menu_add_review_tag(
     assignment_id: str,
     student_id: str,
 ) -> None:
-    label = input("Tag label: ").strip()
+    print("Add Tag")
+    print()
+    print("Tags are short teacher observations used for organization and summaries.")
+    print("Choose a reusable tag, or create a one-time custom tag.")
+    print()
+    print("1. Select reusable tag")
+    print("2. Custom tag")
+    print("3. Back")
+    print()
+    choice = input("Select an option: ").strip()
+    if choice in {"", "3"}:
+        print("Add tag canceled.")
+        return
+    if choice == "1":
+        _menu_add_reusable_review_tag(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        return
+    if choice == "2":
+        _menu_add_custom_review_tag(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        return
+
+    # Compatibility with the prior direct menu prompt sequence: if a caller
+    # supplies a tag label immediately after choosing Add structured tag, treat
+    # that first response as the custom label.
+    _menu_add_custom_review_tag(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        initial_label=choice,
+    )
+
+
+def _menu_add_custom_review_tag(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    initial_label: str | None = None,
+) -> None:
+    print("Custom Tag")
+    print()
+    print("Use this when none of the reusable tags fit.")
+    print()
+    label = initial_label if initial_label is not None else input("Tag label: ").strip()
     if not label:
         print("Add tag canceled. Tag label is required.")
         return
@@ -582,12 +637,270 @@ def _menu_add_review_tag(
             evidence_id=evidence_id,
             location_type=location_type,
             location_value=location_value,
+            source="custom",
         )
     except (ReviewTagError, OSError) as error:
         print(f"Error: could not add structured tag: {error}")
         return
 
     print_added_review_tag(added)
+
+
+def _menu_add_reusable_review_tag(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    files = list_valid_tag_banks(workspace_root)
+    if not files:
+        print("No valid shared tag banks found.")
+        print("Create one from Review Materials -> Tag Banks -> Create tag bank.")
+        print()
+        print("1. Custom tag")
+        print("2. Back")
+        selection = input("Select an option: ").strip()
+        if selection == "1":
+            _menu_add_custom_review_tag(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+        else:
+            print("Add tag canceled.")
+        return
+
+    bank = _prompt_tag_bank(files)
+    if bank is None:
+        return
+    category = _prompt_tag_category(bank)
+    if category is None:
+        return
+    tag = _prompt_tag_template(bank, category)
+    if tag is None:
+        return
+    if tag is _CUSTOM_TAG:
+        _menu_add_custom_review_tag(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        return
+
+    assert isinstance(tag, dict)
+    standard_id = _prompt_tag_standard_id(tag)
+    criterion_id = _prompt_tag_criterion_id(tag)
+    teacher_note = _prompt_template_teacher_note(tag)
+    severity = tag.get("severity_default")
+    severity_value = severity if isinstance(severity, int) and not isinstance(severity, bool) else None
+
+    try:
+        added = add_review_tag(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            label=str(tag["label"]),
+            polarity=str(tag["polarity"]),
+            standard_id=standard_id,
+            criterion_id=criterion_id,
+            severity=severity_value,
+            teacher_note=teacher_note,
+            source="tag_bank",
+            tag_bank_id=str(bank["tag_bank_id"]),
+            tag_template_id=str(tag["tag_template_id"]),
+        )
+    except (ReviewTagError, OSError) as error:
+        if standard_id is not None:
+            print("This tag's saved standard IDs are not active for this assignment.")
+            print("The tag can still be added without a standard reference.")
+            print()
+            print("1. Add tag without standard")
+            print("2. Back")
+            if input("Select an option: ").strip() == "1":
+                try:
+                    added = add_review_tag(
+                        workspace_root,
+                        class_id,
+                        assignment_id,
+                        student_id,
+                        label=str(tag["label"]),
+                        polarity=str(tag["polarity"]),
+                        criterion_id=criterion_id,
+                        severity=severity_value,
+                        teacher_note=teacher_note,
+                        source="tag_bank",
+                        tag_bank_id=str(bank["tag_bank_id"]),
+                        tag_template_id=str(tag["tag_template_id"]),
+                    )
+                except (ReviewTagError, OSError) as retry_error:
+                    print(f"Error: could not add structured tag: {retry_error}")
+                    return
+            else:
+                print("Add tag canceled.")
+                return
+        else:
+            print(f"Error: could not add structured tag: {error}")
+            return
+
+    print_added_review_tag(added)
+
+
+def _prompt_tag_bank(files: tuple[Any, ...]) -> dict[str, Any] | None:
+    print("Available tag banks:")
+    banks: list[dict[str, Any]] = []
+    for item in files:
+        assert item.bank is not None
+        banks.append(item.bank)
+    for index, bank in enumerate(banks, start=1):
+        title = bank.get("title")
+        label = str(title).strip() if isinstance(title, str) and title.strip() else bank["tag_bank_id"]
+        print(f"{index}. {label}")
+    print("B. Back")
+    print()
+    selection = input("Select tag bank: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Select tag canceled.")
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(banks):
+        return banks[int(selection) - 1]
+    for bank in banks:
+        if bank["tag_bank_id"] == selection:
+            return bank
+    print("Invalid tag bank selection. Please choose a listed bank or Back.")
+    return None
+
+
+def _prompt_tag_category(bank: dict[str, Any]) -> dict[str, Any] | None:
+    categories = _sorted_records(bank["categories"])
+    print("Categories:")
+    for index, category in enumerate(categories, start=1):
+        print(f"{index}. {category['label']}")
+    print("B. Back")
+    print()
+    selection = input("Select category: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Select tag canceled.")
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(categories):
+        return categories[int(selection) - 1]
+    print("Invalid category selection. Please choose a listed category or Back.")
+    return None
+
+
+_CUSTOM_TAG = object()
+
+
+def _prompt_tag_template(bank: dict[str, Any], category: dict[str, Any]) -> dict[str, Any] | object | None:
+    tags = [
+        tag
+        for tag in _sorted_records(bank["tags"])
+        if tag.get("category_id") == category["category_id"]
+    ]
+    print(f"{category['label']} Tags:")
+    for index, tag in enumerate(tags, start=1):
+        print(f"{index}. {tag['label']}")
+    custom_index = len(tags) + 1
+    print(f"{custom_index}. Custom tag")
+    print("B. Back")
+    print()
+    selection = input("Select tag: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Select tag canceled.")
+        return None
+    if selection.isdigit():
+        selected = int(selection)
+        if 1 <= selected <= len(tags):
+            return tags[selected - 1]
+        if selected == custom_index:
+            return _CUSTOM_TAG
+    print("Invalid tag selection. Please choose a listed tag or Back.")
+    return None
+
+
+def _sorted_records(records: list[Any]) -> list[dict[str, Any]]:
+    valid = [record for record in records if isinstance(record, dict)]
+    return sorted(
+        valid,
+        key=lambda item: (
+            item.get("sort_order") if isinstance(item.get("sort_order"), int) else 999999,
+            str(item.get("label", "")).casefold(),
+        ),
+    )
+
+
+def _prompt_tag_standard_id(tag: dict[str, Any]) -> str | None:
+    standard_ids = [
+        standard_id
+        for standard_id in tag.get("standard_ids", [])
+        if isinstance(standard_id, str) and standard_id.strip()
+    ]
+    if not standard_ids:
+        return None
+    if len(standard_ids) == 1:
+        return standard_ids[0]
+    print("Standard ID options:")
+    for index, standard_id in enumerate(standard_ids, start=1):
+        print(f"{index}. {standard_id}")
+    print(f"{len(standard_ids) + 1}. Skip standard")
+    print("B. Back")
+    print()
+    selection = input("Select standard ID: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit():
+        selected = int(selection)
+        if 1 <= selected <= len(standard_ids):
+            return standard_ids[selected - 1]
+        if selected == len(standard_ids) + 1:
+            return None
+    if selection in standard_ids:
+        return selection
+    print("Invalid standard ID selection. Standard omitted.")
+    return None
+
+
+def _prompt_tag_criterion_id(tag: dict[str, Any]) -> str | None:
+    criterion_ids = [
+        criterion_id
+        for criterion_id in tag.get("criterion_ids", [])
+        if isinstance(criterion_id, str) and criterion_id.strip()
+    ]
+    if not criterion_ids:
+        return None
+    if len(criterion_ids) == 1:
+        return criterion_ids[0]
+    print("Criterion ID options:")
+    for index, criterion_id in enumerate(criterion_ids, start=1):
+        print(f"{index}. {criterion_id}")
+    print(f"{len(criterion_ids) + 1}. Skip criterion")
+    print("B. Back")
+    print()
+    selection = input("Select criterion ID: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit():
+        selected = int(selection)
+        if 1 <= selected <= len(criterion_ids):
+            return criterion_ids[selected - 1]
+        if selected == len(criterion_ids) + 1:
+            return None
+    if selection in criterion_ids:
+        return selection
+    print("Invalid criterion ID selection. Criterion omitted.")
+    return None
+
+
+def _prompt_template_teacher_note(tag: dict[str, Any]) -> str | None:
+    prompt = tag.get("teacher_note_prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return None
+    print("Teacher note:")
+    print(prompt.strip())
+    print()
+    return input("Leave blank to skip: ").strip() or None
 
 
 def _load_available_comment_banks(

--- a/quillan/review_record.py
+++ b/quillan/review_record.py
@@ -38,6 +38,10 @@ REQUIRED_TAG_FIELDS: Final[frozenset[str]] = frozenset(
 )
 OPTIONAL_TAG_FIELDS: Final[frozenset[str]] = frozenset(
     {
+        "source",
+        "tag_bank_id",
+        "tag_template_id",
+        "criterion_id",
         "standard_id",
         "comment_id",
         "severity",
@@ -84,6 +88,9 @@ ALLOWED_TAG_POLARITIES: Final[frozenset[str]] = frozenset(
 )
 ALLOWED_COMMENT_SOURCES: Final[frozenset[str]] = frozenset(
     {"comment_bank", "custom"}
+)
+ALLOWED_TAG_SOURCES: Final[frozenset[str]] = frozenset(
+    {"tag_bank", "custom"}
 )
 ALLOWED_LOCATION_TYPES: Final[frozenset[str]] = frozenset(
     {
@@ -217,6 +224,7 @@ def _validate_tags(value: Any) -> None:
             item["polarity"], f"{context}.polarity", ALLOWED_TAG_POLARITIES
         )
         for field in (
+            "criterion_id",
             "standard_id",
             "comment_id",
             "teacher_note",
@@ -224,6 +232,22 @@ def _validate_tags(value: Any) -> None:
         ):
             if field in item:
                 _validate_non_empty_string(item[field], f"{context}.{field}")
+        if "tag_bank_id" in item:
+            _validate_identifier(item["tag_bank_id"], f"{context}.tag_bank_id")
+        if "tag_template_id" in item:
+            _validate_identifier(
+                item["tag_template_id"], f"{context}.tag_template_id"
+            )
+        if "source" in item:
+            source = _validate_allowed_value(
+                item["source"], f"{context}.source", ALLOWED_TAG_SOURCES
+            )
+            _validate_tag_provenance(item, source, context)
+        elif "tag_bank_id" in item or "tag_template_id" in item:
+            raise ReviewRecordError(
+                f"Field '{context}.source' is required when tag-bank "
+                "provenance fields are present."
+            )
         if "severity" in item:
             _validate_non_negative_integer(
                 item["severity"], f"{context}.severity"
@@ -238,6 +262,24 @@ def _validate_tags(value: Any) -> None:
             )
         _validate_timestamp(item["created_at"], f"{context}.created_at")
         _validate_json_object(item["module_details"], f"{context}.module_details")
+
+
+def _validate_tag_provenance(item: dict[str, Any], source: str, context: str) -> None:
+    if source == "tag_bank":
+        for field in ("tag_bank_id", "tag_template_id"):
+            if field not in item:
+                raise ReviewRecordError(
+                    f"Field '{context}.{field}' is required when "
+                    f"'{context}.source' is 'tag_bank'."
+                )
+        return
+
+    for field in ("tag_bank_id", "tag_template_id"):
+        if field in item:
+            raise ReviewRecordError(
+                f"Field '{context}.{field}' must be absent when "
+                f"'{context}.source' is 'custom'."
+            )
 
 
 def _validate_location(

--- a/quillan/review_tags.py
+++ b/quillan/review_tags.py
@@ -73,6 +73,10 @@ def add_review_tag(
     polarity: str,
     standard_id: str | None = None,
     comment_id: str | None = None,
+    criterion_id: str | None = None,
+    source: str | None = None,
+    tag_bank_id: str | None = None,
+    tag_template_id: str | None = None,
     severity: int | None = None,
     teacher_note: str | None = None,
     page_number: int | None = None,
@@ -86,6 +90,12 @@ def add_review_tag(
     normalized_polarity = _normalize_polarity(polarity)
     normalized_standard = _normalize_optional_string(standard_id, "standard_id")
     normalized_comment = _normalize_optional_string(comment_id, "comment_id")
+    normalized_criterion = _normalize_optional_string(criterion_id, "criterion_id")
+    normalized_source = _normalize_optional_source(source)
+    normalized_tag_bank = _normalize_optional_identifier(tag_bank_id, "tag_bank_id")
+    normalized_tag_template = _normalize_optional_identifier(
+        tag_template_id, "tag_template_id"
+    )
     normalized_note = _normalize_optional_string(teacher_note, "teacher_note")
     normalized_evidence = _normalize_optional_string(evidence_id, "evidence_id")
     _validate_severity(severity)
@@ -95,6 +105,22 @@ def add_review_tag(
 
     if normalized_comment is not None and normalized_standard is None:
         raise ReviewTagError("comment_id requires standard_id.")
+    if normalized_source == "tag_bank" and (
+        normalized_tag_bank is None or normalized_tag_template is None
+    ):
+        raise ReviewTagError("tag_bank source requires tag_bank_id and tag_template_id.")
+    if normalized_source == "custom" and (
+        normalized_tag_bank is not None or normalized_tag_template is not None
+    ):
+        raise ReviewTagError(
+            "tag_bank_id and tag_template_id must be omitted for custom tags."
+        )
+    if normalized_source is None and (
+        normalized_tag_bank is not None or normalized_tag_template is not None
+    ):
+        raise ReviewTagError(
+            "source is required when tag_bank_id or tag_template_id is supplied."
+        )
 
     try:
         resolved_workspace_root = Path(workspace_root).resolve(strict=False)
@@ -206,8 +232,12 @@ def add_review_tag(
         "module_details": {},
     }
     optional_fields = {
+        "source": normalized_source,
+        "tag_bank_id": normalized_tag_bank,
+        "tag_template_id": normalized_tag_template,
         "standard_id": normalized_standard,
         "comment_id": normalized_comment,
+        "criterion_id": normalized_criterion,
         "severity": severity,
         "teacher_note": normalized_note,
         "page_number": page_number,
@@ -271,6 +301,27 @@ def _normalize_polarity(value: str) -> str:
             f"Invalid polarity {value!r}. Allowed values: {allowed}."
         )
     return value
+
+
+def _normalize_optional_source(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = _normalize_required_string(value, "source")
+    if normalized not in {"tag_bank", "custom"}:
+        raise ReviewTagError(
+            "Invalid source "
+            f"{normalized!r}. Allowed values: custom, tag_bank."
+        )
+    return normalized
+
+
+def _normalize_optional_identifier(value: str | None, field: str) -> str | None:
+    normalized = _normalize_optional_string(value, field)
+    if normalized is None:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", normalized):
+        raise ReviewTagError(f"{field} must be a valid identifier.")
+    return normalized
 
 
 def _validate_severity(value: int | None) -> None:

--- a/quillan/tag_bank_workflows.py
+++ b/quillan/tag_bank_workflows.py
@@ -1,0 +1,653 @@
+"""Teacher-facing tag-bank creation and editing workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.tag_banks import ALLOWED_POLARITIES, TagBankError, load_tag_bank
+from quillan.tag_bank_writing import (
+    build_tag_bank,
+    build_tag_category,
+    build_tag_template,
+    current_timestamp,
+    ensure_unique_identifier,
+    list_tag_bank_files,
+    list_valid_tag_banks,
+    parse_comma_separated_values,
+    summarize_tag_bank,
+    suggest_identifier,
+    touch_updated_at,
+    write_tag_bank,
+)
+
+_CATEGORY_SUGGESTIONS: tuple[tuple[str, str], ...] = (
+    ("Content Accuracy", "Teacher observations about accuracy or completeness."),
+    ("Evidence / Support", "Teacher observations about support, examples, sources, or data."),
+    ("Reasoning / Explanation", "Teacher observations about reasoning, analysis, or explanation."),
+    ("Organization", "Teacher observations about structure, sequence, or transitions."),
+    ("Process / Method", "Teacher observations about procedure, process, method, or steps."),
+    ("Reflection", "Teacher observations about reflection, insight, or self-assessment."),
+    ("Creativity / Design", "Teacher observations about design choices or creative decisions."),
+    ("Conventions", "Teacher observations about clarity, mechanics, or formatting."),
+)
+
+
+def launch_tag_banks_menu() -> int:
+    """Launch the teacher-facing Tag Banks submenu."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Tag Banks")
+            print("Tag banks store reusable teacher observations for quick review tagging.")
+            print("Tags are review aids; they are not grades or automatic mastery judgments.")
+            print("Implemented in #166. Shared storage: shared/tag_banks/")
+            print("Opening this screen: No files were changed.")
+            print()
+            print("1. Create tag bank")
+            print("2. View tag banks")
+            print("3. Edit tag bank")
+            print("4. Add category")
+            print("5. Add tag template")
+            print("6. Validate tag bank")
+            print("7. Back")
+            print()
+            choice = input("Select an option: ").strip()
+            print()
+            if choice in {"", "7"}:
+                return 0
+            workflows = {
+                "1": prompt_create_tag_bank,
+                "2": prompt_view_tag_banks,
+                "3": prompt_edit_tag_bank,
+                "4": prompt_add_category,
+                "5": prompt_add_tag_template,
+                "6": prompt_validate_tag_bank,
+            }
+            workflow = workflows.get(choice)
+            if workflow is None:
+                print("Invalid selection. Please enter a number from 1 to 7.")
+            else:
+                clear_screen()
+                workflow()
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting tag banks menu.")
+        return 0
+
+
+def prompt_create_tag_bank() -> int:
+    """Prompt for and save one complete valid tag bank."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Create Tag Bank")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    try:
+        title = _required_input("Tag bank title:\nExample: General Written Response Tags\n")
+        suggestion = suggest_identifier(title)
+        print(f"Suggested tag_bank_id:\n{suggestion}")
+        tag_bank_id = input(
+            "Press Enter to accept, or type a different tag_bank_id: "
+        ).strip()
+        if not tag_bank_id:
+            tag_bank_id = suggestion
+        description = input(
+            "Description:\n"
+            "Example: Reusable teacher observations for written responses across subjects.\n"
+        ).strip()
+        writing_types = _prompt_writing_types()
+        print()
+        print("Now add at least one category and one tag template before saving.")
+        print()
+        category = _prompt_new_category(existing_ids=set())
+        if category is None:
+            print("Create tag bank canceled. No file was created.")
+            return 1
+        tag = _prompt_new_tag_template(
+            categories=[category],
+            bank_writing_types=writing_types,
+            existing_ids=set(),
+        )
+        if tag is None:
+            print("Create tag bank canceled. No file was created.")
+            return 1
+        bank = build_tag_bank(
+            tag_bank_id=tag_bank_id,
+            title=title,
+            description=description,
+            writing_types=writing_types,
+            categories=[category],
+            tags=[tag],
+        )
+    except (TagBankError, ValueError) as error:
+        print(f"Error: {error}")
+        print("No file was created.")
+        return 1
+
+    path = Path(workspace_root) / "shared" / "tag_banks" / f"{tag_bank_id}.json"
+    print()
+    print("Ready to save tag bank:")
+    print()
+    print(f"Tag Bank ID: {bank['tag_bank_id']}")
+    print(f"Title: {bank['title']}")
+    print(f"Writing types: {', '.join(bank['writing_types'])}")
+    print(f"Categories: {len(bank['categories'])}")
+    print(f"Tags: {len(bank['tags'])}")
+    print(f"Path: {path}")
+    print()
+    print("1. Save")
+    print("2. Cancel")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Create tag bank canceled. No file was created.")
+        return 1
+
+    overwrite = False
+    if path.exists():
+        confirmation = input("Type OVERWRITE to replace it: ").strip()
+        if confirmation != "OVERWRITE":
+            print("Canceled: existing tag bank was not changed.")
+            return 1
+        overwrite = True
+    try:
+        saved_path = write_tag_bank(workspace_root, bank, overwrite=overwrite)
+    except (TagBankError, OSError) as error:
+        print(f"Error: {error}")
+        return 1
+    print(f"Saved tag bank: {saved_path}")
+    return 0
+
+
+def prompt_view_tag_banks() -> int:
+    """List tag banks and optionally show one bank summary."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Tag Banks")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    files = list_tag_bank_files(workspace_root)
+    valid = [item for item in files if item.is_valid and item.bank is not None]
+    invalid = [item for item in files if not item.is_valid]
+    if not valid:
+        print("No valid shared tag banks found.")
+        print()
+        print("Create one from Review Materials -> Tag Banks -> Create tag bank.")
+        print()
+        print("Expected location:")
+        print("shared/tag_banks/")
+    else:
+        print("Tag Banks")
+        print()
+        for index, item in enumerate(valid, start=1):
+            bank = item.bank
+            assert bank is not None
+            print(f"{index}. {bank['tag_bank_id']} - {bank['title']}")
+            print(f"   Writing types: {', '.join(bank['writing_types'])}")
+            print(f"   Categories: {len(bank['categories'])}")
+            print(f"   Tags: {len(bank['tags'])}")
+            print()
+        print("B. Back")
+        print()
+        selection = input("Select tag bank to view, or Back: ").strip()
+        if selection.isdigit() and 1 <= int(selection) <= len(valid):
+            item = valid[int(selection) - 1]
+            assert item.bank is not None
+            print()
+            print(summarize_tag_bank(item.bank, item.path))
+        elif selection and selection.casefold() != "b":
+            print("Invalid selection. Please choose a listed bank or Back.")
+    _print_invalid_files(invalid)
+    return 0
+
+
+def prompt_edit_tag_bank() -> int:
+    """Safely edit title, description, or writing types for one valid bank."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Edit Tag Bank")
+    selected = _prompt_valid_bank()
+    if selected is None:
+        return 1
+    path, bank = selected
+    print()
+    print("1. Edit title")
+    print("2. Edit description")
+    print("3. Edit writing types")
+    print("4. Back")
+    print()
+    choice = input("Select an option: ").strip()
+    if choice in {"", "4"}:
+        print("Edit tag bank canceled. No file was changed.")
+        return 0
+    updated = touch_updated_at(bank)
+    try:
+        if choice == "1":
+            updated["title"] = _required_input("Tag bank title: ")
+        elif choice == "2":
+            updated["description"] = input("Description: ").strip()
+        elif choice == "3":
+            updated["writing_types"] = _prompt_writing_types()
+        else:
+            print("Invalid selection. Please enter a number from 1 to 4.")
+            return 1
+        write_tag_bank(path.parents[2], updated, overwrite=True)
+    except (TagBankError, ValueError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing tag bank was not changed.")
+        return 1
+    print(f"Saved tag bank: {path}")
+    return 0
+
+
+def prompt_add_category() -> int:
+    """Add a category to an existing valid bank."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Add Category")
+    selected = _prompt_valid_bank()
+    if selected is None:
+        return 1
+    path, bank = selected
+    print()
+    _print_categories(bank)
+    existing_ids = {
+        str(category["category_id"])
+        for category in bank["categories"]
+        if isinstance(category, dict)
+    }
+    try:
+        category = _prompt_new_category(existing_ids=existing_ids)
+    except (TagBankError, ValueError) as error:
+        print(f"Error: {error}")
+        print("Add category canceled. No file was changed.")
+        return 1
+    if category is None:
+        print("Add category canceled. No file was changed.")
+        return 1
+    updated = touch_updated_at(bank)
+    updated["categories"] = [dict(item) for item in bank["categories"]] + [category]
+    print()
+    print(f"Add category '{category['label']}' to {bank['tag_bank_id']}?")
+    print("1. Save")
+    print("2. Cancel")
+    if input("Select an option: ").strip() != "1":
+        print("Add category canceled. No file was changed.")
+        return 1
+    try:
+        write_tag_bank(path.parents[2], updated, overwrite=True)
+    except (TagBankError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing tag bank was not changed.")
+        return 1
+    print(f"Saved tag bank: {path}")
+    return 0
+
+
+def prompt_add_tag_template() -> int:
+    """Add a tag template to an existing valid bank."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Add Tag Template")
+    selected = _prompt_valid_bank()
+    if selected is None:
+        return 1
+    path, bank = selected
+    existing_ids = {
+        str(tag["tag_template_id"])
+        for tag in bank["tags"]
+        if isinstance(tag, dict)
+    }
+    try:
+        tag = _prompt_new_tag_template(
+            categories=list(bank["categories"]),
+            bank_writing_types=list(bank["writing_types"]),
+            existing_ids=existing_ids,
+        )
+    except (TagBankError, ValueError) as error:
+        print(f"Error: {error}")
+        print("Add tag template canceled. No file was changed.")
+        return 1
+    if tag is None:
+        print("Add tag template canceled. No file was changed.")
+        return 1
+    updated = touch_updated_at(bank)
+    updated["tags"] = [dict(item) for item in bank["tags"]] + [tag]
+    print()
+    print(f"Add tag template '{tag['label']}' to {bank['tag_bank_id']}?")
+    print("1. Save")
+    print("2. Cancel")
+    if input("Select an option: ").strip() != "1":
+        print("Add tag template canceled. No file was changed.")
+        return 1
+    try:
+        write_tag_bank(path.parents[2], updated, overwrite=True)
+    except (TagBankError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing tag bank was not changed.")
+        return 1
+    print(f"Saved tag bank: {path}")
+    return 0
+
+
+def prompt_validate_tag_bank() -> int:
+    """Validate one existing tag-bank file without modifying it."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Validate Tag Bank")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    files = list_tag_bank_files(workspace_root)
+    if not files:
+        print("No tag bank files found.")
+        print("Expected location: shared/tag_banks/")
+        return 1
+    for index, item in enumerate(files, start=1):
+        print(f"{index}. {item.path}")
+    print("B. Back")
+    print()
+    selection = input("Select tag bank file: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Validate tag bank canceled.")
+        return 0
+    if not selection.isdigit() or not 1 <= int(selection) <= len(files):
+        print("Invalid selection. Please choose a listed file or Back.")
+        return 1
+    path = files[int(selection) - 1].path
+    try:
+        bank = load_tag_bank(path)
+    except (TagBankError, OSError) as error:
+        print("Tag bank is invalid.")
+        print()
+        print(f"Path: {path}")
+        print(f"Error: {error}")
+        return 1
+    print("Tag bank is valid.")
+    print()
+    print(f"Tag Bank ID: {bank['tag_bank_id']}")
+    print(f"Title: {bank['title']}")
+    print(f"Categories: {len(bank['categories'])}")
+    print(f"Tags: {len(bank['tags'])}")
+    print(f"Path: {path}")
+    return 0
+
+
+def _workspace_root() -> Path | None:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return None
+
+
+def _required_input(prompt: str) -> str:
+    value = input(prompt).strip()
+    if not value:
+        raise ValueError("This field is required.")
+    return value
+
+
+def _prompt_writing_types() -> list[str]:
+    value = input(
+        "Writing types, comma-separated:\n"
+        "Examples: general, lab_report, reflection, research, constructed_response\n"
+    )
+    writing_types = parse_comma_separated_values(value)
+    if not writing_types:
+        raise ValueError("At least one writing type is required.")
+    return writing_types
+
+
+def _prompt_new_category(existing_ids: set[str]) -> dict[str, Any] | None:
+    print("Add Category")
+    print()
+    print("Categories help teachers find tags quickly during review.")
+    print()
+    print("Suggested categories:")
+    for index, (label, _description) in enumerate(_CATEGORY_SUGGESTIONS, start=1):
+        print(f"{index}. {label}")
+    custom_index = len(_CATEGORY_SUGGESTIONS) + 1
+    print(f"{custom_index}. Custom category")
+    print("B. Back")
+    print()
+    selection = input("Select suggestion or choose Custom: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(_CATEGORY_SUGGESTIONS):
+        label, description = _CATEGORY_SUGGESTIONS[int(selection) - 1]
+    elif selection == str(custom_index):
+        label = _required_input("Category label:\nExample: Process / Method\n")
+        description = input(
+            "Description:\n"
+            "Example: Teacher observations about procedure, process, method, or steps.\n"
+        ).strip()
+    else:
+        print("Invalid category selection.")
+        return None
+    suggestion = suggest_identifier(label)
+    print(f"Suggested category_id:\n{suggestion}")
+    category_id = input(
+        "Press Enter to accept, or type a different category_id: "
+    ).strip()
+    if not category_id:
+        category_id = suggestion
+    sort_order = _parse_optional_nonnegative_int(
+        input("Sort order (leave blank to auto-assign): ")
+    )
+    if sort_order is None:
+        sort_order = len(existing_ids) + 1
+    ensure_unique_identifier(category_id, existing_ids, "category_id")
+    return build_tag_category(
+        category_id=category_id,
+        label=label,
+        description=description,
+        sort_order=sort_order,
+    )
+
+
+def _prompt_new_tag_template(
+    *,
+    categories: list[dict[str, Any]],
+    bank_writing_types: list[str],
+    existing_ids: set[str],
+) -> dict[str, Any] | None:
+    print()
+    print("Add Tag Template")
+    print()
+    label = _required_input("Tag label:\nExample: Explanation needs more detail\n")
+    suggestion = suggest_identifier(label)
+    print(f"Suggested tag_template_id:\n{suggestion}")
+    tag_template_id = input(
+        "Press Enter to accept, or type a different tag_template_id: "
+    ).strip()
+    if not tag_template_id:
+        tag_template_id = suggestion
+    ensure_unique_identifier(tag_template_id, existing_ids, "tag_template_id")
+    category_id = _prompt_category_id(categories)
+    if category_id is None:
+        return None
+    polarity = _prompt_polarity()
+    if polarity is None:
+        return None
+    metadata = _prompt_optional_metadata(bank_writing_types)
+    if metadata is None:
+        return None
+    return build_tag_template(
+        tag_template_id=tag_template_id,
+        label=label,
+        category_id=category_id,
+        polarity=polarity,
+        module_details={},
+        optional_metadata=metadata,
+    )
+
+
+def _prompt_category_id(categories: list[dict[str, Any]]) -> str | None:
+    print()
+    print("Category:")
+    for index, category in enumerate(categories, start=1):
+        print(f"{index}. {category['label']}")
+    print("B. Back")
+    print()
+    selection = input("Select category: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(categories):
+        return str(categories[int(selection) - 1]["category_id"])
+    print("Invalid category selection.")
+    return None
+
+
+def _prompt_polarity() -> str | None:
+    polarities = ("positive", "developing", "negative", "neutral")
+    print()
+    print("Polarity:")
+    for index, polarity in enumerate(polarities, start=1):
+        print(f"{index}. {polarity}")
+    print("B. Back")
+    print()
+    selection = input("Select polarity: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(polarities):
+        return polarities[int(selection) - 1]
+    if selection in ALLOWED_POLARITIES:
+        return selection
+    print("Invalid polarity selection.")
+    return None
+
+
+def _prompt_optional_metadata(bank_writing_types: list[str]) -> dict[str, Any] | None:
+    print()
+    response = input("Add optional metadata? (y/N): ").strip().lower()
+    if response in {"", "n", "no"}:
+        return {}
+    if response not in {"y", "yes"}:
+        print("Invalid selection. Optional metadata skipped by canceling.")
+        return None
+    metadata: dict[str, Any] = {}
+    description = input("description (leave blank to omit): ").strip()
+    if description:
+        metadata["description"] = description
+    writing_types = parse_comma_separated_values(
+        input("Tag writing types, comma-separated (leave blank to omit): ")
+    )
+    if writing_types:
+        outside = set(writing_types) - set(bank_writing_types)
+        if outside:
+            print(
+                "Invalid tag writing types. They must be part of the bank "
+                f"writing types: {', '.join(bank_writing_types)}."
+            )
+            return None
+        metadata["writing_types"] = writing_types
+    for field in ("standard_ids", "criterion_ids"):
+        values = parse_comma_separated_values(
+            input(f"{field}, comma-separated (leave blank to omit): ")
+        )
+        if values:
+            metadata[field] = values
+    severity = _parse_optional_nonnegative_int(
+        input("severity_default (leave blank to omit): ")
+    )
+    if severity is not None:
+        metadata["severity_default"] = severity
+    teacher_note_prompt = input(
+        "teacher_note_prompt (leave blank to omit): "
+    ).strip()
+    if teacher_note_prompt:
+        metadata["teacher_note_prompt"] = teacher_note_prompt
+    student_facing = _parse_optional_boolean(
+        input("student_facing_default (y/n, leave blank to omit): ")
+    )
+    if student_facing is not None:
+        metadata["student_facing_default"] = student_facing
+    sort_order = _parse_optional_nonnegative_int(
+        input("sort_order (leave blank to omit): ")
+    )
+    if sort_order is not None:
+        metadata["sort_order"] = sort_order
+    timestamp = current_timestamp()
+    metadata["created_at"] = timestamp
+    metadata["updated_at"] = timestamp
+    return metadata
+
+
+def _prompt_valid_bank() -> tuple[Path, dict[str, Any]] | None:
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return None
+    files = list_valid_tag_banks(workspace_root)
+    if not files:
+        print("No valid shared tag banks found.")
+        print("Create one from Review Materials -> Tag Banks -> Create tag bank.")
+        return None
+    print("Available tag banks:")
+    for index, item in enumerate(files, start=1):
+        assert item.bank is not None
+        print(f"{index}. {item.bank['tag_bank_id']} - {item.bank['title']}")
+    print("B. Back")
+    print()
+    selection = input("Select tag bank: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Tag bank selection canceled.")
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(files):
+        item = files[int(selection) - 1]
+        assert item.bank is not None
+        return item.path, item.bank
+    for item in files:
+        assert item.bank is not None
+        if item.bank["tag_bank_id"] == selection:
+            return item.path, item.bank
+    print("Invalid tag bank selection. Please choose a listed bank or Back.")
+    return None
+
+
+def _print_categories(bank: dict[str, Any]) -> None:
+    print("Existing categories:")
+    for index, category in enumerate(bank["categories"], start=1):
+        print(f"{index}. {category['category_id']} - {category['label']}")
+
+
+def _print_invalid_files(invalid: list[Any]) -> None:
+    if not invalid:
+        return
+    print()
+    print("Invalid tag bank files:")
+    print()
+    for item in invalid:
+        print(f"- {item.path}")
+        print(f"  Error: {item.error}")
+
+
+def _parse_optional_nonnegative_int(value: str) -> int | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = int(text)
+    except ValueError as error:
+        raise ValueError("Value must be a non-negative integer.") from error
+    if parsed < 0:
+        raise ValueError("Value must be a non-negative integer.")
+    return parsed
+
+
+def _parse_optional_boolean(value: str) -> bool | None:
+    text = value.strip().lower()
+    if text in {"", "none"}:
+        return None
+    if text in {"y", "yes", "true", "t", "1"}:
+        return True
+    if text in {"n", "no", "false", "f", "2"}:
+        return False
+    raise ValueError("Boolean value must be y/n or blank.")

--- a/quillan/tag_bank_writing.py
+++ b/quillan/tag_bank_writing.py
@@ -1,0 +1,220 @@
+"""Construction, listing, and safe writes for Quillan tag banks."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.tag_banks import (
+    TagBankError,
+    load_tag_bank,
+    tag_bank_path,
+    validate_tag_bank,
+)
+
+
+@dataclass(frozen=True)
+class TagBankFile:
+    """One discovered tag bank file and its validation state."""
+
+    path: Path
+    bank: dict[str, Any] | None
+    error: str | None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.bank is not None and self.error is None
+
+
+def current_timestamp() -> str:
+    """Return a timezone-aware ISO 8601 timestamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def suggest_identifier(label: str) -> str:
+    """Suggest a shared identifier from teacher-facing text."""
+    normalized = unicodedata.normalize("NFKD", label)
+    ascii_label = normalized.encode("ascii", "ignore").decode("ascii")
+    suggestion = re.sub(r"[^A-Za-z0-9_-]+", "_", ascii_label.strip())
+    suggestion = suggestion.strip("_-").lower()
+    return suggestion or "tag_bank"
+
+
+def parse_comma_separated_values(value: str) -> list[str]:
+    """Return trimmed nonblank values from comma-separated input."""
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def build_tag_category(
+    *,
+    category_id: str,
+    label: str,
+    description: str = "",
+    sort_order: int | None = None,
+) -> dict[str, Any]:
+    """Build one category record."""
+    validate_identifier(category_id, "category_id")
+    if not label.strip():
+        raise TagBankError("Category label is required.")
+    category: dict[str, Any] = {
+        "category_id": category_id,
+        "label": label.strip(),
+        "module_details": {},
+    }
+    if description.strip():
+        category["description"] = description.strip()
+    if sort_order is not None:
+        category["sort_order"] = sort_order
+    return category
+
+
+def build_tag_template(
+    *,
+    tag_template_id: str,
+    label: str,
+    category_id: str,
+    polarity: str,
+    module_details: Mapping[str, Any] | None = None,
+    optional_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one reusable tag template record."""
+    validate_identifier(tag_template_id, "tag_template_id")
+    validate_identifier(category_id, "category_id")
+    if not label.strip():
+        raise TagBankError("Tag label is required.")
+    tag: dict[str, Any] = {
+        "tag_template_id": tag_template_id,
+        "label": label.strip(),
+        "category_id": category_id,
+        "polarity": polarity,
+        "module_details": dict(module_details or {}),
+    }
+    if optional_metadata:
+        tag.update(dict(optional_metadata))
+    return tag
+
+
+def build_tag_bank(
+    *,
+    tag_bank_id: str,
+    title: str,
+    description: str,
+    writing_types: Sequence[str],
+    categories: Sequence[Mapping[str, Any]],
+    tags: Sequence[Mapping[str, Any]],
+    created_at: str | None = None,
+    updated_at: str | None = None,
+    module_details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build and validate a version 1 Quillan shared tag bank."""
+    timestamp = current_timestamp()
+    bank: dict[str, Any] = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "tag_bank",
+        "tag_bank_id": tag_bank_id,
+        "title": title.strip(),
+        "description": description.strip(),
+        "scope": "shared",
+        "writing_types": list(writing_types),
+        "categories": [dict(category) for category in categories],
+        "tags": [dict(tag) for tag in tags],
+        "created_at": created_at or timestamp,
+        "updated_at": updated_at or timestamp,
+        "module_details": dict(module_details or {}),
+    }
+    validate_tag_bank(bank)
+    return bank
+
+
+def list_tag_bank_files(workspace_root: str | Path) -> tuple[TagBankFile, ...]:
+    """List shared tag-bank files without raising on invalid files."""
+    directory = Path(workspace_root) / "shared" / "tag_banks"
+    if not directory.is_dir():
+        return ()
+    files: list[TagBankFile] = []
+    for path in sorted(directory.glob("*.json"), key=lambda item: item.name.casefold()):
+        try:
+            files.append(TagBankFile(path, load_tag_bank(path), None))
+        except (OSError, TagBankError) as error:
+            files.append(TagBankFile(path, None, str(error)))
+    return tuple(files)
+
+
+def list_valid_tag_banks(workspace_root: str | Path) -> tuple[TagBankFile, ...]:
+    """Return valid shared tag-bank files only."""
+    return tuple(item for item in list_tag_bank_files(workspace_root) if item.is_valid)
+
+
+def summarize_tag_bank(bank: Mapping[str, Any], path: str | Path) -> str:
+    """Return a concise teacher-facing summary for one bank."""
+    writing_types = ", ".join(str(item) for item in bank["writing_types"])
+    return "\n".join(
+        [
+            f"Tag Bank ID: {bank['tag_bank_id']}",
+            f"Title: {bank['title']}",
+            f"Description: {bank['description']}",
+            f"Scope: {bank['scope']}",
+            f"Writing types: {writing_types}",
+            f"Categories: {len(bank['categories'])}",
+            f"Tags: {len(bank['tags'])}",
+            f"Path: {Path(path)}",
+        ]
+    )
+
+
+def write_tag_bank(
+    workspace_root: str | Path,
+    bank: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Validate and atomically write a shared tag bank."""
+    bank_data = dict(bank)
+    validate_tag_bank(bank_data)
+    bank_id = str(bank_data["tag_bank_id"])
+    path = tag_bank_path(workspace_root, bank_id)
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"Tag bank already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            json.dump(bank_data, file, indent=2, ensure_ascii=False)
+            file.write("\n")
+        os.replace(temporary_path, path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def touch_updated_at(bank: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a mutable copy with a refreshed updated_at value."""
+    updated = dict(bank)
+    updated["updated_at"] = current_timestamp()
+    return updated
+
+
+def ensure_unique_identifier(identifier: str, existing: set[str], field: str) -> None:
+    """Validate an identifier and reject duplicates."""
+    try:
+        validate_identifier(identifier, field)
+    except IdentifierValidationError as error:
+        raise TagBankError(str(error)) from error
+    if identifier in existing:
+        raise TagBankError(f"Duplicate {field} '{identifier}'.")

--- a/quillan/tag_banks.py
+++ b/quillan/tag_banks.py
@@ -1,0 +1,334 @@
+"""Loading, canonical paths, and validation for shared tag banks."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+REQUIRED_BANK_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "module",
+        "record_type",
+        "tag_bank_id",
+        "title",
+        "description",
+        "scope",
+        "writing_types",
+        "categories",
+        "tags",
+        "created_at",
+        "updated_at",
+        "module_details",
+    }
+)
+REQUIRED_CATEGORY_FIELDS: Final[frozenset[str]] = frozenset(
+    {"category_id", "label"}
+)
+OPTIONAL_CATEGORY_FIELDS: Final[frozenset[str]] = frozenset(
+    {"description", "sort_order", "module_details"}
+)
+REQUIRED_TAG_FIELDS: Final[frozenset[str]] = frozenset(
+    {"tag_template_id", "label", "category_id", "polarity", "module_details"}
+)
+OPTIONAL_TAG_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "description",
+        "writing_types",
+        "standard_ids",
+        "criterion_ids",
+        "severity_default",
+        "teacher_note_prompt",
+        "student_facing_default",
+        "sort_order",
+        "created_at",
+        "updated_at",
+    }
+)
+ALLOWED_SCOPES: Final[frozenset[str]] = frozenset({"shared"})
+ALLOWED_POLARITIES: Final[frozenset[str]] = frozenset(
+    {"positive", "developing", "negative", "neutral"}
+)
+
+
+class TagBankError(ValueError):
+    """Raised when a shared tag bank is missing or invalid."""
+
+
+def tag_bank_path(workspace_root: str | Path, tag_bank_id: str) -> Path:
+    """Return the canonical path for one shared tag bank."""
+    _validate_identifier(tag_bank_id, "tag_bank_id")
+    return Path(workspace_root) / "shared" / "tag_banks" / f"{tag_bank_id}.json"
+
+
+def load_tag_bank(path: str | Path) -> dict[str, Any]:
+    """Load and validate a version 1 shared tag bank."""
+    bank_path = Path(path)
+    try:
+        with bank_path.open("r", encoding="utf-8") as file:
+            value = json.load(file)
+    except FileNotFoundError as error:
+        raise TagBankError(f"Tag bank not found: {bank_path}") from error
+    except json.JSONDecodeError as error:
+        raise TagBankError(f"Tag bank is not valid JSON: {bank_path}") from error
+    except OSError as error:
+        raise TagBankError(f"Could not read tag bank {bank_path}: {error}") from error
+
+    if not isinstance(value, dict):
+        raise TagBankError(f"Tag bank must be a JSON object: {bank_path}")
+    bank = cast(dict[str, Any], value)
+    validate_tag_bank(bank)
+    if bank["tag_bank_id"] != bank_path.stem:
+        raise TagBankError(
+            f"Tag bank tag_bank_id is {bank['tag_bank_id']!r}, expected "
+            f"{bank_path.stem!r} from its filename."
+        )
+    return bank
+
+
+def validate_tag_bank(bank: dict[str, Any]) -> None:
+    """Validate the intrinsic version 1 shared tag-bank contract."""
+    if not isinstance(bank, dict):
+        raise TagBankError("Tag bank must be an object.")
+    _validate_fields(bank, REQUIRED_BANK_FIELDS, frozenset(), "tag bank")
+    _validate_exact(bank["schema_version"], "schema_version", "1")
+    _validate_exact(bank["module"], "module", "quillan")
+    _validate_exact(bank["record_type"], "record_type", "tag_bank")
+    _validate_identifier(bank["tag_bank_id"], "tag_bank_id")
+    _validate_non_empty_string(bank["title"], "title")
+    _validate_string(bank["description"], "description")
+    _validate_allowed(bank["scope"], "scope", ALLOWED_SCOPES)
+    writing_types = _validate_unique_strings(
+        bank["writing_types"], "writing_types", require_non_empty=True
+    )
+    category_ids = _validate_categories(bank["categories"])
+    _validate_tags(bank["tags"], category_ids, set(writing_types))
+    created_at = _validate_timestamp(bank["created_at"], "created_at")
+    updated_at = _validate_timestamp(bank["updated_at"], "updated_at")
+    if updated_at < created_at:
+        raise TagBankError("Field 'updated_at' must not precede field 'created_at'.")
+    _validate_object(bank["module_details"], "module_details")
+
+
+def _validate_categories(value: Any) -> set[str]:
+    categories = _validate_list(value, "categories")
+    if not categories:
+        raise TagBankError("Field 'categories' must be a non-empty list.")
+    seen: set[str] = set()
+    for index, value_item in enumerate(categories):
+        context = f"categories[{index}]"
+        item = _validate_record(value_item, context)
+        _validate_fields(
+            item, REQUIRED_CATEGORY_FIELDS, OPTIONAL_CATEGORY_FIELDS, context
+        )
+        category_id = _validate_identifier(
+            item["category_id"], f"{context}.category_id"
+        )
+        if category_id in seen:
+            raise TagBankError(f"Duplicate category_id '{category_id}'.")
+        seen.add(category_id)
+        _validate_non_empty_string(item["label"], f"{context}.label")
+        if "description" in item:
+            _validate_string(item["description"], f"{context}.description")
+        if "sort_order" in item:
+            _validate_integer(item["sort_order"], f"{context}.sort_order")
+        if "module_details" in item:
+            _validate_object(item["module_details"], f"{context}.module_details")
+    return seen
+
+
+def _validate_tags(
+    value: Any, category_ids: set[str], bank_writing_types: set[str]
+) -> None:
+    tags = _validate_list(value, "tags")
+    if not tags:
+        raise TagBankError("Field 'tags' must be a non-empty list.")
+    seen: set[str] = set()
+    for index, value_item in enumerate(tags):
+        context = f"tags[{index}]"
+        item = _validate_record(value_item, context)
+        _validate_fields(item, REQUIRED_TAG_FIELDS, OPTIONAL_TAG_FIELDS, context)
+        tag_template_id = _validate_identifier(
+            item["tag_template_id"], f"{context}.tag_template_id"
+        )
+        if tag_template_id in seen:
+            raise TagBankError(f"Duplicate tag_template_id '{tag_template_id}'.")
+        seen.add(tag_template_id)
+        _validate_non_empty_string(item["label"], f"{context}.label")
+        category_id = _validate_identifier(
+            item["category_id"], f"{context}.category_id"
+        )
+        if category_id not in category_ids:
+            raise TagBankError(
+                f"Field '{context}.category_id' references unknown category "
+                f"'{category_id}'."
+            )
+        _validate_allowed(item["polarity"], f"{context}.polarity", ALLOWED_POLARITIES)
+        _validate_object(item["module_details"], f"{context}.module_details")
+        if "description" in item:
+            _validate_string(item["description"], f"{context}.description")
+        if "teacher_note_prompt" in item:
+            _validate_non_empty_string(
+                item["teacher_note_prompt"], f"{context}.teacher_note_prompt"
+            )
+        if "writing_types" in item:
+            values = _validate_unique_strings(
+                item["writing_types"],
+                f"{context}.writing_types",
+                require_non_empty=True,
+            )
+            outside = set(values) - bank_writing_types
+            if outside:
+                raise TagBankError(
+                    f"Field '{context}.writing_types' contains value outside "
+                    f"bank writing_types: {sorted(outside)[0]!r}."
+                )
+        for field in ("standard_ids", "criterion_ids"):
+            if field in item:
+                _validate_unique_strings(item[field], f"{context}.{field}")
+        if "severity_default" in item:
+            value_severity = item["severity_default"]
+            if (
+                isinstance(value_severity, bool)
+                or not isinstance(value_severity, int)
+                or value_severity < 0
+            ):
+                raise TagBankError(
+                    f"Field '{context}.severity_default' must be a "
+                    "non-negative integer."
+                )
+        if "student_facing_default" in item and not isinstance(
+            item["student_facing_default"], bool
+        ):
+            raise TagBankError(
+                f"Field '{context}.student_facing_default' must be a boolean."
+            )
+        if "sort_order" in item:
+            _validate_integer(item["sort_order"], f"{context}.sort_order")
+        created_at = (
+            _validate_timestamp(item["created_at"], f"{context}.created_at")
+            if "created_at" in item
+            else None
+        )
+        updated_at = (
+            _validate_timestamp(item["updated_at"], f"{context}.updated_at")
+            if "updated_at" in item
+            else None
+        )
+        if created_at is not None and updated_at is not None and updated_at < created_at:
+            raise TagBankError(
+                f"Field '{context}.updated_at' must not precede "
+                f"field '{context}.created_at'."
+            )
+
+
+def _validate_fields(
+    data: dict[str, Any],
+    required: frozenset[str],
+    optional: frozenset[str],
+    context: str,
+) -> None:
+    missing = required - data.keys()
+    if missing:
+        raise TagBankError(
+            f"Missing required field '{sorted(missing)[0]}' in {context}."
+        )
+    unknown = data.keys() - required - optional
+    if unknown:
+        raise TagBankError(f"Unknown field '{sorted(unknown)[0]}' in {context}.")
+
+
+def _validate_record(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TagBankError(f"{context} must be an object.")
+    return cast(dict[str, Any], value)
+
+
+def _validate_list(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise TagBankError(f"Field '{field}' must be a list.")
+    return value
+
+
+def _validate_unique_strings(
+    value: Any, field: str, *, require_non_empty: bool = False
+) -> list[str]:
+    values = _validate_list(value, field)
+    if require_non_empty and not values:
+        raise TagBankError(f"Field '{field}' must be a non-empty list.")
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in values:
+        text = _validate_non_empty_string(item, field)
+        if text in seen:
+            raise TagBankError(f"Field '{field}' contains duplicate {text!r}.")
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _validate_identifier(value: Any, field: str) -> str:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise TagBankError(str(error)) from error
+    return cast(str, value)
+
+
+def _validate_non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TagBankError(f"Field '{field}' must be a non-empty string.")
+    return value
+
+
+def _validate_string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise TagBankError(f"Field '{field}' must be a string.")
+    return value
+
+
+def _validate_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TagBankError(f"Field '{field}' must be an integer.")
+    return value
+
+
+def _validate_object(value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        raise TagBankError(f"Field '{field}' must be an object.")
+
+
+def _validate_exact(value: Any, field: str, expected: str) -> None:
+    if value != expected:
+        raise TagBankError(f"Field '{field}' must be the string '{expected}'.")
+
+
+def _validate_allowed(
+    value: Any, field: str, allowed_values: frozenset[str]
+) -> str:
+    if not isinstance(value, str) or value not in allowed_values:
+        allowed = ", ".join(sorted(allowed_values))
+        raise TagBankError(f"Invalid {field} {value!r}. Allowed values: {allowed}.")
+    return value
+
+
+def _validate_timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise TagBankError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise TagBankError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise TagBankError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    return parsed

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -13,6 +13,12 @@ from quillan.cli import main
 import quillan.comment_bank_workflows as comment_bank_workflows
 import quillan.review_menu as review_menu
 from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.tag_bank_writing import (
+    build_tag_bank,
+    build_tag_category,
+    build_tag_template,
+    write_tag_bank,
+)
 from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
@@ -157,6 +163,34 @@ def _write_bank(root: Path) -> None:
     bank_path.write_text(EXAMPLE_BANK_PATH.read_text(encoding="utf-8"), encoding="utf-8")
 
 
+def _write_tag_bank(root: Path) -> None:
+    category = build_tag_category(
+        category_id="reasoning_explanation",
+        label="Reasoning / Explanation",
+        description="Teacher observations about reasoning.",
+    )
+    tag = build_tag_template(
+        tag_template_id="explanation_needs_more_detail",
+        label="Explanation needs more detail",
+        category_id="reasoning_explanation",
+        polarity="developing",
+        optional_metadata={
+            "severity_default": 2,
+            "criterion_ids": ["explanation"],
+            "teacher_note_prompt": "What part needs more detail?",
+        },
+    )
+    bank = build_tag_bank(
+        tag_bank_id="general_written_response_tags",
+        title="General Written Response Tags",
+        description="Reusable synthetic tag templates.",
+        writing_types=["general"],
+        categories=[category],
+        tags=[tag],
+    )
+    write_tag_bank(root, bank)
+
+
 def _write_review_record(root: Path, review: dict[str, Any]) -> Path:
     path = review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     return write_review_record(path, review)
@@ -259,6 +293,50 @@ def test_review_menu_adds_structured_tag_to_review_record(
     assert review["tags"][0]["label"] == "claim"
     assert review["tags"][0]["polarity"] == "positive"
     assert review["review_state"] == "in_progress"
+
+
+def test_review_menu_selects_reusable_tag_by_bank_and_category(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_tag_bank(workspace)
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["3", "1", "1", "1", "1", "The explanation names the idea only."]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "General Written Response Tags" in output
+    assert "Explanation needs more detail" in output
+    review = json.loads(
+        review_record_path(
+            workspace,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+        ).read_text(encoding="utf-8")
+    )
+    tag = review["tags"][0]
+    assert tag["source"] == "tag_bank"
+    assert tag["tag_bank_id"] == "general_written_response_tags"
+    assert tag["tag_template_id"] == "explanation_needs_more_detail"
+    assert tag["label"] == "Explanation needs more detail"
+    assert tag["polarity"] == "developing"
+    assert tag["severity"] == 2
+    assert tag["criterion_id"] == "explanation"
+    assert tag["teacher_note"] == "The explanation names the idea only."
+    assert "standard_id" not in tag
+    assert review["review_state"] == "in_progress"
+    assert manifest_path.read_bytes() == manifest_before
 
 
 def test_review_menu_blank_tag_cancels_without_review_record(

--- a/tests/test_review_record.py
+++ b/tests/test_review_record.py
@@ -317,6 +317,49 @@ def test_duplicate_tag_id_is_rejected() -> None:
         validate_review_record(record)
 
 
+def test_tag_bank_provenance_and_criterion_id_are_valid() -> None:
+    record = _record()
+    tag = _tag()
+    tag.update(
+        {
+            "source": "tag_bank",
+            "tag_bank_id": "general_written_response_tags",
+            "tag_template_id": "explanation_needs_more_detail",
+            "criterion_id": "explanation",
+        }
+    )
+    record["tags"] = [tag]
+
+    validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("tag_bank_id", "tag_bank_id"),
+        ("tag_template_id", "tag_template_id"),
+    ],
+)
+def test_tag_bank_source_requires_provenance_fields(
+    field: str,
+    message: str,
+) -> None:
+    record = _record()
+    tag = _tag()
+    tag.update(
+        {
+            "source": "tag_bank",
+            "tag_bank_id": "general_written_response_tags",
+            "tag_template_id": "explanation_needs_more_detail",
+        }
+    )
+    del tag[field]
+    record["tags"] = [tag]
+
+    with pytest.raises(ReviewRecordError, match=message):
+        validate_review_record(record)
+
+
 @pytest.mark.parametrize(
     "location",
     [

--- a/tests/test_tag_bank_workflows.py
+++ b/tests/test_tag_bank_workflows.py
@@ -1,0 +1,245 @@
+"""Tests for teacher-facing tag-bank workflows."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.tag_bank_workflows as workflows
+from quillan.tag_banks import load_tag_bank
+from quillan.tag_bank_writing import (
+    build_tag_bank,
+    build_tag_category,
+    build_tag_template,
+    write_tag_bank,
+)
+
+
+def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError(
+                "Menu requested more input than the test provided."
+            ) from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _patch_workspace(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: root)
+
+
+def _sample_bank(tag_bank_id: str = "general_tags") -> dict[str, Any]:
+    category = build_tag_category(
+        category_id="reasoning",
+        label="Reasoning / Explanation",
+        description="Teacher observations about reasoning.",
+    )
+    tag = build_tag_template(
+        tag_template_id="explain_more",
+        label="Explain more",
+        category_id="reasoning",
+        polarity="developing",
+    )
+    return build_tag_bank(
+        tag_bank_id=tag_bank_id,
+        title="General Tags",
+        description="Reusable synthetic tags.",
+        writing_types=["general", "reflection"],
+        categories=[category],
+        tags=[tag],
+    )
+
+
+def test_create_tag_bank_writes_valid_minimal_bank(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "General Written Response Tags",
+            "",
+            "Reusable observations for written responses across subjects.",
+            "general, constructed_response",
+            "3",
+            "",
+            "",
+            "Explanation needs more detail",
+            "",
+            "1",
+            "2",
+            "",
+            "1",
+        ],
+    )
+
+    assert workflows.prompt_create_tag_bank() == 0
+
+    path = tmp_path / "shared" / "tag_banks" / "general_written_response_tags.json"
+    bank = load_tag_bank(path)
+    assert bank["tag_bank_id"] == path.stem
+    assert bank["categories"]
+    assert bank["tags"]
+    assert bank["tags"][0]["polarity"] == "developing"
+    assert bank["created_at"].endswith("+00:00")
+    assert "Saved tag bank" in capsys.readouterr().out
+
+
+def test_create_cancel_before_save_writes_no_partial_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "General Written Response Tags",
+            "",
+            "Reusable observations.",
+            "general",
+            "1",
+            "",
+            "",
+            "Useful detail",
+            "",
+            "1",
+            "1",
+            "",
+            "2",
+        ],
+    )
+
+    assert workflows.prompt_create_tag_bank() == 1
+
+    capsys.readouterr()
+    assert not (tmp_path / "shared" / "tag_banks").exists()
+
+
+def test_create_existing_bank_requires_exact_overwrite_confirmation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = _sample_bank("general_written_response_tags")
+    path = write_tag_bank(tmp_path, existing)
+    before = path.read_bytes()
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "General Written Response Tags",
+            "",
+            "New description.",
+            "general",
+            "1",
+            "",
+            "",
+            "New tag",
+            "",
+            "1",
+            "4",
+            "",
+            "1",
+            "overwrite",
+        ],
+    )
+
+    assert workflows.prompt_create_tag_bank() == 1
+
+    output = capsys.readouterr().out
+    assert "existing tag bank was not changed" in output
+    assert path.read_bytes() == before
+
+
+def test_view_tag_banks_lists_valid_and_invalid_files(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_tag_bank(tmp_path, _sample_bank())
+    invalid = tmp_path / "shared" / "tag_banks" / "draft.json"
+    invalid.write_text(json.dumps({"tag_bank_id": "draft"}), encoding="utf-8")
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1"])
+
+    assert workflows.prompt_view_tag_banks() == 0
+
+    output = capsys.readouterr().out
+    assert "general_tags - General Tags" in output
+    assert "Invalid tag bank files" in output
+    assert "draft.json" in output
+    assert "Tags: 1" in output
+
+
+def test_add_tag_template_stores_optional_metadata(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = write_tag_bank(tmp_path, _sample_bank())
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "1",
+            "Needs clearer evidence",
+            "",
+            "1",
+            "2",
+            "y",
+            "Evidence description.",
+            "general",
+            "standard-1",
+            "criterion_1",
+            "2",
+            "What evidence needs clarification?",
+            "n",
+            "10",
+            "1",
+        ],
+    )
+
+    assert workflows.prompt_add_tag_template() == 0
+
+    bank = load_tag_bank(path)
+    added = bank["tags"][-1]
+    assert added["tag_template_id"] == "needs_clearer_evidence"
+    assert added["standard_ids"] == ["standard-1"]
+    assert added["criterion_ids"] == ["criterion_1"]
+    assert added["severity_default"] == 2
+    assert added["teacher_note_prompt"] == "What evidence needs clarification?"
+    assert added["student_facing_default"] is False
+    capsys.readouterr()
+
+
+def test_validate_tag_bank_reports_invalid_without_modifying_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "shared" / "tag_banks"
+    directory.mkdir(parents=True)
+    invalid = directory / "draft.json"
+    invalid.write_text("{", encoding="utf-8")
+    before = invalid.read_bytes()
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1"])
+
+    assert workflows.prompt_validate_tag_bank() == 1
+
+    output = capsys.readouterr().out
+    assert "Tag bank is invalid." in output
+    assert "not valid JSON" in output
+    assert invalid.read_bytes() == before

--- a/tests/test_tag_banks.py
+++ b/tests/test_tag_banks.py
@@ -1,0 +1,175 @@
+"""Tests for shared tag-bank loading and validation."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.tag_banks import (
+    TagBankError,
+    load_tag_bank,
+    tag_bank_path,
+    validate_tag_bank,
+)
+from quillan.tag_bank_writing import (
+    build_tag_bank,
+    build_tag_category,
+    build_tag_template,
+    write_tag_bank,
+)
+
+TIMESTAMP = "2026-06-26T00:00:00+00:00"
+
+
+def _bank(tag_bank_id: str = "general_written_response_tags") -> dict[str, Any]:
+    category = build_tag_category(
+        category_id="reasoning_explanation",
+        label="Reasoning / Explanation",
+        description="Teacher observations about reasoning.",
+    )
+    tag = build_tag_template(
+        tag_template_id="explanation_needs_more_detail",
+        label="Explanation needs more detail",
+        category_id="reasoning_explanation",
+        polarity="developing",
+        optional_metadata={
+            "standard_ids": ["synthetic-standard"],
+            "criterion_ids": ["explanation"],
+            "severity_default": 2,
+            "teacher_note_prompt": "What needs more detail?",
+            "student_facing_default": False,
+            "writing_types": ["general"],
+            "created_at": TIMESTAMP,
+            "updated_at": TIMESTAMP,
+        },
+    )
+    return build_tag_bank(
+        tag_bank_id=tag_bank_id,
+        title="General Written Response Tags",
+        description="Reusable synthetic observations.",
+        writing_types=["general", "constructed_response"],
+        categories=[category],
+        tags=[tag],
+        created_at=TIMESTAMP,
+        updated_at=TIMESTAMP,
+    )
+
+
+def test_valid_tag_bank_writes_and_loads_from_shared_path(tmp_path: Path) -> None:
+    path = write_tag_bank(tmp_path, _bank())
+
+    assert path == (
+        tmp_path
+        / "shared"
+        / "tag_banks"
+        / "general_written_response_tags.json"
+    )
+    loaded = load_tag_bank(path)
+    assert loaded["tag_bank_id"] == path.stem
+    assert loaded["categories"][0]["category_id"] == "reasoning_explanation"
+    assert loaded["tags"][0]["criterion_ids"] == ["explanation"]
+
+
+def test_canonical_path_validates_identifier(tmp_path: Path) -> None:
+    assert tag_bank_path(tmp_path, "general_tags") == (
+        tmp_path / "shared" / "tag_banks" / "general_tags.json"
+    )
+    with pytest.raises(TagBankError, match="tag_bank_id"):
+        tag_bank_path(tmp_path, "../unsafe")
+
+
+def test_filename_tag_bank_id_mismatch_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "different.json"
+    path.write_text(json.dumps(_bank()), encoding="utf-8")
+    with pytest.raises(TagBankError, match="filename"):
+        load_tag_bank(path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("schema_version", "2", "schema_version"),
+        ("module", "other", "module"),
+        ("record_type", "other", "record_type"),
+        ("tag_bank_id", "../unsafe", "tag_bank_id"),
+        ("title", " ", "title"),
+        ("scope", "private", "scope"),
+        ("writing_types", [], "non-empty"),
+        ("categories", [], "non-empty"),
+        ("tags", [], "non-empty"),
+        ("created_at", "2026-06-26T00:00:00", "timezone-aware"),
+    ],
+)
+def test_invalid_top_level_values_are_rejected(
+    field: str,
+    value: Any,
+    message: str,
+) -> None:
+    bank = _bank()
+    bank[field] = value
+    with pytest.raises(TagBankError, match=message):
+        validate_tag_bank(bank)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("duplicate_category", "Duplicate category_id"),
+        ("duplicate_tag", "Duplicate tag_template_id"),
+        ("unknown_category", "unknown category"),
+        ("invalid_polarity", "polarity"),
+        ("invalid_severity", "severity_default"),
+        ("invalid_student_facing", "student_facing_default"),
+        ("outside_writing_type", "outside"),
+        ("duplicate_standard", "duplicate"),
+    ],
+)
+def test_nested_contract_failures_are_rejected(
+    mutation: str,
+    message: str,
+) -> None:
+    bank = copy.deepcopy(_bank())
+    tag = bank["tags"][0]
+    if mutation == "duplicate_category":
+        bank["categories"].append(copy.deepcopy(bank["categories"][0]))
+    elif mutation == "duplicate_tag":
+        bank["tags"].append(copy.deepcopy(tag))
+    elif mutation == "unknown_category":
+        tag["category_id"] = "missing"
+    elif mutation == "invalid_polarity":
+        tag["polarity"] = "mixed"
+    elif mutation == "invalid_severity":
+        tag["severity_default"] = True
+    elif mutation == "invalid_student_facing":
+        tag["student_facing_default"] = "no"
+    elif mutation == "outside_writing_type":
+        tag["writing_types"] = ["lab_report"]
+    else:
+        tag["standard_ids"].append(tag["standard_ids"][0])
+
+    with pytest.raises(TagBankError, match=message):
+        validate_tag_bank(bank)
+
+
+def test_write_refuses_overwrite_without_confirmation(tmp_path: Path) -> None:
+    path = write_tag_bank(tmp_path, _bank())
+    before = path.read_bytes()
+
+    with pytest.raises(FileExistsError):
+        write_tag_bank(tmp_path, _bank(), overwrite=False)
+
+    assert path.read_bytes() == before
+
+
+def test_write_validates_before_creating_directory(tmp_path: Path) -> None:
+    bank = _bank()
+    bank["tags"] = []
+
+    with pytest.raises(TagBankError):
+        write_tag_bank(tmp_path, bank)
+
+    assert not (tmp_path / "shared" / "tag_banks").exists()


### PR DESCRIPTION
## Summary

Adds reusable tag-bank workflows and review-time reusable tag selection.

Closes #166

## Changes

* Added tag-bank runtime support:

  * `quillan/tag_banks.py`
  * `quillan/tag_bank_writing.py`
  * `quillan/tag_bank_workflows.py`
* Wired `Review Materials -> Tag Banks` to a real teacher-facing submenu.
* Added tag-bank creation, viewing, editing, extension, and validation workflows.
* Updated Review Student Work → Add structured tag to support:

  * reusable tag selection;
  * bank → category → tag navigation;
  * custom one-off tag fallback.
* Extended review tag writing and validation to support reusable tag-bank provenance.
* Added `docs/tag_bank_contract.md`.
* Updated README and existing CLI/data/review-record documentation.
* Added validation, workflow, menu, and review-record tests.

## Behavior

Tag banks are stored at:

```text
shared/tag_banks/<tag_bank_id>.json
```

Tag banks validate against schema version `1`.

Creation and editing workflows:

* build complete records in memory;
* validate before writing;
* write atomically;
* refuse overwrite unless the teacher types exact `OVERWRITE`;
* avoid writing invalid partial files;
* keep tag banks subject-agnostic and writing-type-aware.

Review mode now lets teachers select reusable tags by:

```text
tag bank -> category -> tag
```

Selected reusable tags snapshot the relevant values into `review.json.tags`, including:

* label;
* polarity;
* severity default, when present;
* teacher note, when supplied;
* optional standard metadata;
* optional criterion metadata;
* `source: "tag_bank"` provenance.

Custom one-off tags remain available.

Existing direct CLI `add-tag` behavior remains compatible.

Existing tags without reusable tag-bank provenance still validate.

## Safety

* Tag-bank authoring writes only confirmed, valid files under `shared/tag_banks/`.
* Optional standards metadata remains pds-core reference-only.
* No pds-core standards files are created, edited, retired, reactivated, imported, or mutated.
* No pds-core route/workspace ownership is duplicated.
* Tag-bank authoring does not modify submissions, scans, rosters, assignments, exports, comment banks, or sibling repositories.
* Review records are modified only during explicit review-time tag selection.

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `974 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
