### PR TITLE
Add rubric scoring profile workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Guided export actions preserve overwrite protection. Existing export files are n
 
 ### Review Materials
 
-The Review Materials menu is the preparation area for reusable teacher-authored review aids. It includes Comment Banks and Tag Banks submenus for creating, viewing, editing, extending, and validating shared reusable review materials. Rubric/scoring profiles and optional synthetic starter materials remain future workflows.
+The Review Materials menu is the preparation area for reusable teacher-authored review aids. It includes Comment Banks, Tag Banks, and Rubrics / Scoring Profiles submenus for creating, viewing, editing, extending, and validating shared reusable review materials. Optional synthetic starter materials remain a future workflow.
 
 These materials help teachers review written student work more quickly by selecting prepared comments, tags, and scoring criteria instead of typing everything during review.
 
@@ -278,6 +278,8 @@ Comment banks created through the menu are stored at `shared/comment_banks/<bank
 Comment banks store reusable teacher-authored feedback language. They do not grade work, imply mastery, generate comments automatically, or change student records by themselves. When a teacher selects a reusable comment during Review Student Work, Quillan snapshots the selected label and text into the review record with `source: "comment_bank"`, `bank_id`, and `comment_id`; later bank edits do not silently rewrite prior student review records.
 
 Tag banks created through the menu are stored at `shared/tag_banks/<tag_bank_id>.json` and validate against the version `1` tag-bank contract. Tag banks store reusable teacher-authored observations for quick review tagging. They are not grades, scores, mastery determinations, generated feedback, or automatic judgments. During Review Student Work -> Add structured tag, teachers can select a reusable tag by bank, category, and tag template, or choose a custom one-off tag. Selected reusable tags snapshot label, polarity, optional severity, optional standard/criterion metadata, teacher notes, and `source: "tag_bank"` provenance into `review.json.tags`.
+
+Rubrics / scoring profiles created through the menu are stored at `shared/rubrics/<rubric_id>.json` and validate against the version `1` rubric contract. Assignment creation can select a valid shared rubric by number, while custom or unresolved rubric IDs remain allowed for compatibility. During Review Student Work -> Set criterion score, teachers can score from the assignment rubric by selecting a criterion and level, or choose Custom criterion score. Selected rubric scores snapshot the criterion ID, label, selected score, max score, scale, and optional teacher note into the existing `review.json.scores` shape. Rubric level feedback metadata does not automatically create comments or feedback entries.
 
 Optional `standard_ids` in comment metadata are durable pds-core references only. Quillan comment-bank authoring does not create, import, edit, retire, reactivate, or validate standards as authoritative.
 
@@ -575,9 +577,7 @@ Optional `--scale` and `--note` values describe the latest explicit teacher inpu
 
 Quillan does not derive scores from student writing, tags, notes, comments, requirements, standards references, or evidence metadata.
 
-This command does not calculate totals, weighted scores, percentages, grades, mastery, or any other overall score.
-
-Rubric-profile criterion validation is future work.
+This command does not calculate totals, weighted scores, percentages, grades, mastery, or any other overall score. The guided review menu can additionally select criteria and levels from a resolved shared rubric, but the direct command remains manual and compatible.
 
 Explicitly update one submission's lightweight teacher review state:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -425,6 +425,11 @@ tag selections snapshot template values into `review.json.tags` with
 `source: "tag_bank"`, `tag_bank_id`, and `tag_template_id`; custom tags and the
 direct `add-tag` command remain compatible.
 
+`Set criterion score` opens a score chooser. Teachers can score from a valid
+shared rubric resolved through `assignment.rubric_id`, or choose Custom
+criterion score to use the same manual fields as the direct `set-score`
+command. Rubric level feedback metadata is not converted into comments.
+
 Guided export actions reuse the same underlying export services as the direct
 commands:
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -37,6 +37,11 @@ filters, optional standards references, optional criterion metadata, and
 review-time snapshot behavior, see
 [`tag_bank_contract.md`](tag_bank_contract.md).
 
+For reusable teacher-authored rubric / scoring profile records stored at
+`shared/rubrics/<rubric_id>.json`, including criteria, score levels,
+assignment linkage, and review-time score snapshots, see
+[`rubric_contract.md`](rubric_contract.md).
+
 For the required structure and human-readable elements of a printable
 writing-response page, see
 [`printable_response_template.md`](printable_response_template.md).
@@ -199,6 +204,11 @@ library, and `focus_standards` should contain shared `standard_id` values
 rather than teacher-facing display codes. Quillan-specific comments, hotwords,
 feedback templates, review tags, and writing-review scaffolding remain
 module-owned; Quillan does not maintain an independent standards universe.
+
+The `rubric_id` field may resolve to a shared Quillan rubric profile at
+`shared/rubrics/<rubric_id>.json`. Unresolved custom rubric IDs remain
+structurally valid assignment data; they simply cannot power rubric-based menu
+scoring until a matching valid shared rubric exists.
 
 ## Submission Manifest
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -341,7 +341,8 @@ Score field rules are:
 
 * `score_id` is unique within `scores`.
 * `criterion_id` is non-empty and unique within `scores`. Schema version `1`
-  validates this field intrinsically; rubric-profile lookup is future work.
+  validates this field intrinsically; rubric-profile lookup is workflow-level
+  context, not a review-record schema requirement.
 * `label` is a non-empty, teacher-readable string.
 * `score` is a finite number greater than or equal to zero.
 * `max_score` is a finite number greater than zero.
@@ -361,6 +362,13 @@ when the criterion is not already present. It does not replace the entire
 `scores` array or erase unrelated criteria. Omitting optional `scale` or
 `teacher_note` values removes prior values from the updated criterion so the
 record reflects the latest explicit teacher input.
+
+Review mode can also set a criterion score from a valid shared rubric resolved
+through the assignment's `rubric_id`. That workflow snapshots the selected
+criterion and level into the same score shape. It does not store a live
+reference that changes when the rubric is later edited, and rubric level
+`student_facing_feedback` does not automatically create a comment or feedback
+export entry.
 
 ## Comments
 
@@ -579,10 +587,10 @@ unrelated notes, tags, scores, comments, top-level metadata, and
 `created_at`; validates the complete proposed record before an atomic write;
 and never mutates submission manifests, routed evidence, or retained scans.
 
-Criterion IDs are validated only as non-empty local identifiers in this
-workflow. The assignment's `rubric_id` does not provide a criterion contract;
-rubric-profile loading and criterion lookup remain future work. Quillan does
-not infer criterion scores or calculate an overall, weighted, percentage,
+Criterion IDs are validated only as non-empty local identifiers in the review
+record schema. The assignment's `rubric_id` may resolve to a shared rubric for
+menu selection, but unresolved rubric IDs remain structurally valid. Quillan
+does not infer criterion scores or calculate an overall, weighted, percentage,
 grade, or mastery score.
 
 ## Reusable Comment Selection
@@ -660,7 +668,6 @@ selected comment is stored in
 
 This contract does not implement:
 
-* rubric-profile loading, validation, or criterion lookup;
 * overall, weighted, percentage, grade, or mastery score calculation;
 * assignment-driven comment-bank activation, bank editing, or guided
   reusable-comment management;

--- a/docs/rubric_contract.md
+++ b/docs/rubric_contract.md
@@ -1,0 +1,134 @@
+# Quillan Rubric / Scoring Profile Contract
+
+Rubrics and scoring profiles are teacher-authored reusable review materials.
+They let a teacher score prepared criteria by selecting a criterion and level
+during review instead of typing raw score fields.
+
+Quillan stores shared rubric profiles at:
+
+```text
+shared/rubrics/<rubric_id>.json
+```
+
+Rubrics are Quillan-owned review materials under the active pds-core workspace.
+They may contain optional `standard_ids` as durable pds-core references, but
+Quillan does not create, import, edit, retire, reactivate, or otherwise manage
+pds-core standards through rubric workflows.
+
+## Version 1
+
+Required top-level fields:
+
+* `schema_version`: string, currently `"1"`;
+* `module`: string, `"quillan"`;
+* `record_type`: string, `"rubric"`;
+* `rubric_id`: shared identifier, matching the filename stem;
+* `title`: non-empty teacher-facing title;
+* `description`: string;
+* `scope`: `"shared"` for the MVP;
+* `writing_types`: non-empty list of open strings;
+* `criteria`: non-empty list of criterion records;
+* `created_at`: timezone-aware ISO 8601 timestamp;
+* `updated_at`: timezone-aware ISO 8601 timestamp;
+* `module_details`: object.
+
+Example:
+
+```json
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "rubric",
+  "rubric_id": "general_constructed_response_4pt",
+  "title": "General Constructed Response 4-Point Rubric",
+  "description": "Reusable scoring profile for written constructed responses.",
+  "scope": "shared",
+  "writing_types": ["general", "constructed_response"],
+  "criteria": [
+    {
+      "criterion_id": "reasoning_explanation",
+      "label": "Reasoning / Explanation",
+      "description": "Score how clearly the response explains its thinking.",
+      "max_score": 4,
+      "scale": "4_point",
+      "standard_ids": [],
+      "sort_order": 20,
+      "levels": [
+        {
+          "score": 3,
+          "label": "Clear explanation",
+          "description": "The response explains its reasoning clearly.",
+          "student_facing_feedback": "Your explanation is clear.",
+          "teacher_note": "Use when reasoning is clear but not fully developed.",
+          "sort_order": 30,
+          "module_details": {}
+        }
+      ],
+      "module_details": {}
+    }
+  ],
+  "created_at": "2026-06-26T00:00:00+00:00",
+  "updated_at": "2026-06-26T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+## Criteria
+
+Required criterion fields:
+
+* `criterion_id`: shared identifier, unique within the rubric;
+* `label`: non-empty teacher-facing label;
+* `max_score`: positive finite number;
+* `scale`: non-empty string;
+* `levels`: non-empty list of level records;
+* `module_details`: object.
+
+Optional criterion fields are `description`, `standard_ids`, and `sort_order`.
+`standard_ids` are metadata references only; rubric workflows never mutate
+pds-core standards files.
+
+## Levels
+
+Required level fields:
+
+* `score`: finite number greater than or equal to zero and no greater than the
+  criterion `max_score`;
+* `label`: non-empty teacher-facing label;
+* `module_details`: object.
+
+Optional level fields are `description`, `student_facing_feedback`,
+`teacher_note`, and `sort_order`. Level feedback is metadata in this version.
+Selecting a level does not automatically create a comment or feedback export
+entry.
+
+Duplicate level score values within one criterion are invalid.
+
+## Assignment Linkage
+
+Assignment configs store `rubric_id`. A valid rubric resolves at:
+
+```text
+shared/rubrics/<rubric_id>.json
+```
+
+Unresolved rubric IDs remain structurally valid assignment data. They cannot
+power rubric-based review scoring until a matching valid shared rubric exists,
+but teachers may still use custom criterion scoring.
+
+## Review Scoring
+
+Review-time rubric scoring snapshots selected values into the existing
+`review.json` score record shape:
+
+* `criterion_id`;
+* `label`;
+* `score`;
+* `max_score`;
+* `scale`;
+* optional `teacher_note`;
+* `updated_at`;
+* `module_details`.
+
+The score record is not a live rubric reference. Later edits to a rubric do not
+retroactively change previously recorded review scores.

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -27,6 +27,8 @@ from quillan.assignments import (
     validate_assignment_config,
 )
 from quillan.assignment_picker import prompt_assignment_choice
+from quillan.rubric_writing import list_valid_rubrics
+from quillan.rubrics import RubricError, load_rubric, rubric_path
 from quillan.storage import assignment_config_path
 
 _NUMERIC_REQUIREMENTS = (
@@ -125,24 +127,44 @@ def write_assignment_config(
 def format_assignment_summary(
     assignment: Mapping[str, Any],
     assignment_path: str | Path,
+    workspace_root: str | Path | None = None,
 ) -> str:
     """Return a concise human-readable assignment summary."""
     class_ids = ", ".join(str(value) for value in assignment["class_ids"])
     focus_standards = [str(value) for value in assignment["focus_standards"]]
     focus_text = ", ".join(focus_standards) if focus_standards else "(none)"
-    return "\n".join(
-        [
-            f"Assignment path: {Path(assignment_path)}",
-            f"Assignment ID: {assignment['assignment_id']}",
-            f"Title: {assignment['title']}",
-            f"Class IDs: {class_ids}",
-            f"Writing type: {assignment['writing_type']}",
-            f"Standards profile ID: {assignment['standards_profile_id']}",
-            f"Tagging mode: {assignment['tagging_mode']}",
-            f"Focus standards ({len(focus_standards)}): {focus_text}",
-            f"Rubric ID: {assignment['rubric_id']}",
-        ]
-    )
+    lines = [
+        f"Assignment path: {Path(assignment_path)}",
+        f"Assignment ID: {assignment['assignment_id']}",
+        f"Title: {assignment['title']}",
+        f"Class IDs: {class_ids}",
+        f"Writing type: {assignment['writing_type']}",
+        f"Standards profile ID: {assignment['standards_profile_id']}",
+        f"Tagging mode: {assignment['tagging_mode']}",
+        f"Focus standards ({len(focus_standards)}): {focus_text}",
+        f"Rubric ID: {assignment['rubric_id']}",
+    ]
+    if workspace_root is not None:
+        rubric = resolve_assignment_rubric(workspace_root, assignment)
+        if rubric is None:
+            lines.append("Rubric profile: not found in shared/rubrics/")
+        else:
+            lines.append(f"Rubric profile: resolved - {rubric['title']}")
+    return "\n".join(lines)
+
+
+def resolve_assignment_rubric(
+    workspace_root: str | Path,
+    assignment: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Load a valid shared rubric for an assignment, if one resolves."""
+    rubric_id = assignment.get("rubric_id")
+    if not isinstance(rubric_id, str) or not rubric_id.strip():
+        return None
+    try:
+        return load_rubric(rubric_path(workspace_root, rubric_id))
+    except (OSError, RubricError):
+        return None
 
 
 def _workspace_root() -> Path | None:
@@ -200,6 +222,36 @@ def _prompt_basic_requirements() -> dict[str, Any]:
     if required_elements:
         requirements["required_elements"] = required_elements
     return requirements
+
+
+def _prompt_rubric_id(workspace_root: Path) -> str:
+    rubrics = list_valid_rubrics(workspace_root)
+    if not rubrics:
+        print("No valid shared rubrics found.")
+        print()
+        print("Create one from Review Materials -> Rubrics / Scoring Profiles.")
+        print("You may still enter a custom rubric_id for now.")
+        print()
+        return _required_input("Rubric ID: ", "Rubric ID")
+
+    print("Available rubrics / scoring profiles:")
+    for index, item in enumerate(rubrics, start=1):
+        assert item.rubric is not None
+        print(f"{index}. {item.rubric['title']}")
+    custom_index = len(rubrics) + 1
+    print(f"{custom_index}. Custom rubric ID")
+    print()
+    selection = input("Select rubric: ").strip()
+    if selection.isdigit():
+        selected = int(selection)
+        if 1 <= selected <= len(rubrics):
+            rubric = rubrics[selected - 1].rubric
+            assert rubric is not None
+            return str(rubric["rubric_id"])
+        if selected == custom_index:
+            return _required_input("Rubric ID: ", "Rubric ID")
+    print(f"Error: rubric selection not found: {selection}")
+    raise ValueError("Rubric selection is required.")
 
 
 def _prompt_numbered_selection(
@@ -328,7 +380,7 @@ def prompt_create_assignment() -> int:
             allowed = "/".join(sorted(ALLOWED_TAGGING_MODES))
             raise ValueError(f"Tagging mode must be one of: {allowed}.")
         basic_requirements = _prompt_basic_requirements()
-        rubric_id = _required_input("Rubric ID: ", "Rubric ID")
+        rubric_id = _prompt_rubric_id(workspace_root)
         assignment = build_assignment_config(
             assignment_id=assignment_id,
             title=title,
@@ -395,7 +447,7 @@ def prompt_view_validate_assignment() -> int:
         print(f"Error: {error}")
         return 1
     print("Assignment config is valid.")
-    print(format_assignment_summary(assignment, choice.path))
+    print(format_assignment_summary(assignment, choice.path, workspace_root))
     return 0
 
 

--- a/quillan/review_materials_menu.py
+++ b/quillan/review_materials_menu.py
@@ -37,7 +37,9 @@ def launch_review_materials_menu() -> int:
 
                 launch_tag_banks_menu()
             elif choice == "3":
-                _show_rubrics_info()
+                from quillan.rubric_workflows import launch_rubrics_menu
+
+                launch_rubrics_menu()
             elif choice == "4":
                 _show_starter_materials_info()
             else:
@@ -70,29 +72,6 @@ def _show_tag_banks_info() -> None:
     print()
     print("Expected future workspace location:")
     print("shared/tag_banks/")
-    print()
-    print("No files were changed.")
-    print()
-    pause_for_user()
-
-
-def _show_rubrics_info() -> None:
-    from quillan.menu import clear_screen, pause_for_user, print_menu_header
-
-    clear_screen()
-    print_menu_header("Rubrics / Scoring Profiles")
-    print(
-        "Rubrics and scoring profiles will help teachers score prepared "
-        "criteria without typing criterion IDs during review."
-    )
-    print()
-    print(
-        "Rubric profile creation and enumerated scoring will be implemented "
-        "in #167."
-    )
-    print()
-    print("Expected future workspace location:")
-    print("shared/rubrics/")
     print()
     print("No files were changed.")
     print()

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -50,7 +50,9 @@ from quillan.review_record import (
 )
 from quillan.review_record_paths import review_record_path
 from quillan.review_scores import ReviewScoreError, set_review_score
+from quillan.rubrics import RubricError, load_rubric, rubric_path
 from quillan.review_tags import ReviewTagError, add_review_tag
+from quillan.storage import assignment_config_path
 from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
     open_student_submission_for_review,
@@ -1110,7 +1112,200 @@ def _menu_set_review_score(
     assignment_id: str,
     student_id: str,
 ) -> None:
-    criterion_id = input("Criterion ID: ").strip()
+    print("Set Score")
+    print()
+    print("Use the assignment rubric, or enter a custom criterion.")
+    print()
+    print("1. Score from rubric")
+    print("2. Custom criterion score")
+    print("3. Back")
+    print()
+    choice = input("Select an option: ").strip()
+    if choice in {"", "3"}:
+        print("Set score canceled.")
+        return
+    if choice == "1":
+        _menu_set_review_score_from_rubric(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        return
+    if choice == "2":
+        _menu_set_custom_review_score(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        return
+
+    # Compatibility with the prior direct menu prompt sequence: if a caller
+    # supplies a criterion ID immediately after choosing Set criterion score,
+    # treat that first response as the custom criterion ID.
+    _menu_set_custom_review_score(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        initial_criterion_id=choice,
+    )
+
+
+def _menu_set_review_score_from_rubric(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    assignment = _load_assignment_for_review(workspace_root, class_id, assignment_id)
+    if assignment is None:
+        return
+    rubric_id = assignment.get("rubric_id")
+    if not isinstance(rubric_id, str) or not rubric_id.strip():
+        _menu_missing_rubric(workspace_root, class_id, assignment_id, student_id, "")
+        return
+    try:
+        rubric = load_rubric(rubric_path(workspace_root, rubric_id))
+    except (OSError, RubricError):
+        _menu_missing_rubric(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            rubric_id,
+        )
+        return
+
+    criterion = _prompt_score_criterion(rubric)
+    if criterion is None:
+        return
+    level = _prompt_score_level(criterion)
+    if level is None:
+        return
+    teacher_note = input("Teacher note (leave blank to skip): ").strip() or None
+    try:
+        updated = set_review_score(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            criterion_id=criterion["criterion_id"],
+            label=criterion["label"],
+            score=level["score"],
+            max_score=criterion["max_score"],
+            scale=criterion["scale"],
+            teacher_note=teacher_note,
+        )
+    except (ReviewScoreError, OSError) as error:
+        print(f"Error: could not set review score: {error}")
+        return
+    print_updated_review_score(updated)
+
+
+def _menu_missing_rubric(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    rubric_id: str,
+) -> None:
+    print(
+        "This assignment's rubric_id does not resolve to a valid shared "
+        "rubric profile."
+    )
+    print()
+    print(f"Rubric ID: {rubric_id}")
+    print()
+    print(
+        "Create or fix the rubric from Review Materials -> "
+        "Rubrics / Scoring Profiles."
+    )
+    print()
+    print("1. Custom criterion score")
+    print("2. Back")
+    print()
+    choice = input("Select an option: ").strip()
+    if choice == "1":
+        _menu_set_custom_review_score(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    else:
+        print("Set score canceled.")
+
+
+def _load_assignment_for_review(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> dict[str, Any] | None:
+    try:
+        return load_assignment_config(
+            assignment_config_path(workspace_root, class_id, assignment_id)
+        )
+    except (AssignmentConfigError, OSError) as error:
+        print(f"Error: could not load assignment config: {error}")
+        return None
+
+
+def _prompt_score_criterion(rubric: dict[str, Any]) -> dict[str, Any] | None:
+    criteria = _sorted_records(rubric["criteria"])
+    print(f"Rubric: {rubric['title']}")
+    print()
+    for index, criterion in enumerate(criteria, start=1):
+        print(f"{index}. {criterion['label']}")
+    print()
+    print("B. Back")
+    print()
+    selection = input("Select criterion: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Set score canceled.")
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(criteria):
+        return criteria[int(selection) - 1]
+    print("Invalid criterion selection. Please choose a listed criterion or Back.")
+    return None
+
+
+def _prompt_score_level(criterion: dict[str, Any]) -> dict[str, Any] | None:
+    levels = _sorted_records(criterion["levels"])
+    print(criterion["label"])
+    print()
+    for index, level in enumerate(levels, start=1):
+        print(f"{index}. {level['score']} - {level['label']}")
+    print()
+    print("B. Back")
+    print()
+    selection = input("Select score: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Set score canceled.")
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(levels):
+        return levels[int(selection) - 1]
+    for level in levels:
+        if selection == str(level["score"]):
+            return level
+    print("Invalid score selection. Please choose a listed score or Back.")
+    return None
+
+
+def _menu_set_custom_review_score(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    initial_criterion_id: str | None = None,
+) -> None:
+    criterion_id = (
+        initial_criterion_id
+        if initial_criterion_id is not None
+        else input("Criterion ID: ").strip()
+    )
     if not criterion_id:
         print("Set score canceled. criterion_id is required.")
         return

--- a/quillan/rubric_workflows.py
+++ b/quillan/rubric_workflows.py
@@ -1,0 +1,636 @@
+"""Teacher-facing rubric creation and editing workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.rubrics import RubricError, load_rubric
+from quillan.rubric_writing import (
+    build_rubric,
+    build_rubric_criterion,
+    build_rubric_level,
+    ensure_unique_identifier,
+    list_rubric_files,
+    list_valid_rubrics,
+    parse_comma_separated_values,
+    summarize_rubric,
+    suggest_identifier,
+    touch_updated_at,
+    write_rubric,
+)
+
+_CRITERION_SUGGESTIONS: tuple[tuple[str, str], ...] = (
+    ("Content Accuracy", "Score accuracy, completeness, or correctness."),
+    ("Evidence / Support", "Score support, examples, sources, or data."),
+    ("Reasoning / Explanation", "Score reasoning, analysis, or explanation."),
+    ("Organization", "Score structure, sequence, or transitions."),
+    ("Process / Method", "Score procedure, process, method, or steps."),
+    ("Reflection", "Score reflection, insight, or self-assessment."),
+    ("Creativity / Design", "Score design choices or creative decisions."),
+    ("Conventions", "Score clarity, mechanics, formatting, or presentation."),
+)
+
+
+def launch_rubrics_menu() -> int:
+    """Launch the teacher-facing Rubrics submenu."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Rubrics / Scoring Profiles")
+            print(
+                "Rubrics and scoring profiles help teachers score prepared "
+                "criteria without typing criterion IDs during review."
+            )
+            print()
+            print("1. Create rubric / scoring profile")
+            print("2. View rubrics / scoring profiles")
+            print("3. Edit rubric / scoring profile")
+            print("4. Add criterion")
+            print("5. Add level to criterion")
+            print("6. Validate rubric / scoring profile")
+            print("7. Back")
+            print()
+            choice = input("Select an option: ").strip()
+            print()
+            if choice in {"", "7"}:
+                return 0
+            workflows = {
+                "1": prompt_create_rubric,
+                "2": prompt_view_rubrics,
+                "3": prompt_edit_rubric,
+                "4": prompt_add_criterion,
+                "5": prompt_add_level,
+                "6": prompt_validate_rubric,
+            }
+            workflow = workflows.get(choice)
+            if workflow is None:
+                print("Invalid selection. Please enter a number from 1 to 7.")
+            else:
+                clear_screen()
+                workflow()
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting rubrics menu.")
+        return 0
+
+
+def prompt_create_rubric() -> int:
+    """Prompt for and save one complete valid rubric."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Create Rubric / Scoring Profile")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    try:
+        title = _required_input(
+            "Rubric title:\nExample: General Constructed Response 4-Point Rubric\n"
+        )
+        suggestion = suggest_identifier(title)
+        print(f"Suggested rubric_id:\n{suggestion}")
+        rubric_id = input(
+            "Press Enter to accept, or type a different rubric_id: "
+        ).strip()
+        if not rubric_id:
+            rubric_id = suggestion
+        description = input(
+            "Description:\n"
+            "Example: Reusable scoring profile for written responses.\n"
+        ).strip()
+        writing_types = _prompt_writing_types()
+        print()
+        print("Now add at least one criterion and score level before saving.")
+        print()
+        criterion = _prompt_new_criterion(existing_ids=set(), criterion_count=0)
+        if criterion is None:
+            print("Create rubric canceled. No file was created.")
+            return 1
+        rubric = build_rubric(
+            rubric_id=rubric_id,
+            title=title,
+            description=description,
+            writing_types=writing_types,
+            criteria=[criterion],
+        )
+    except (RubricError, ValueError) as error:
+        print(f"Error: {error}")
+        print("No file was created.")
+        return 1
+
+    path = Path(workspace_root) / "shared" / "rubrics" / f"{rubric_id}.json"
+    print()
+    print("Ready to save rubric / scoring profile:")
+    print()
+    print(f"Rubric ID: {rubric['rubric_id']}")
+    print(f"Title: {rubric['title']}")
+    print(f"Writing types: {', '.join(rubric['writing_types'])}")
+    print(f"Criteria: {len(rubric['criteria'])}")
+    print(f"Levels: {sum(len(item['levels']) for item in rubric['criteria'])}")
+    print(f"Path: {path}")
+    print()
+    print("1. Save")
+    print("2. Cancel")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Create rubric canceled. No file was created.")
+        return 1
+
+    overwrite = False
+    if path.exists():
+        confirmation = input("Type OVERWRITE to replace it: ").strip()
+        if confirmation != "OVERWRITE":
+            print("Canceled: existing rubric was not changed.")
+            return 1
+        overwrite = True
+    try:
+        saved_path = write_rubric(workspace_root, rubric, overwrite=overwrite)
+    except (RubricError, OSError) as error:
+        print(f"Error: {error}")
+        return 1
+    print(f"Saved rubric: {saved_path}")
+    return 0
+
+
+def prompt_view_rubrics() -> int:
+    """List rubrics and optionally show one rubric summary."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Rubrics / Scoring Profiles")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    files = list_rubric_files(workspace_root)
+    valid = [item for item in files if item.is_valid and item.rubric is not None]
+    invalid = [item for item in files if not item.is_valid]
+    if not valid:
+        print("No valid shared rubrics found.")
+        print()
+        print(
+            "Create one from Review Materials -> Rubrics / Scoring Profiles -> "
+            "Create rubric / scoring profile."
+        )
+        print()
+        print("Expected location:")
+        print("shared/rubrics/")
+    else:
+        print("Rubrics / Scoring Profiles")
+        print()
+        for index, item in enumerate(valid, start=1):
+            rubric = item.rubric
+            assert rubric is not None
+            criteria = rubric["criteria"]
+            levels = sum(len(criterion["levels"]) for criterion in criteria)
+            print(f"{index}. {rubric['rubric_id']} - {rubric['title']}")
+            print(f"   Writing types: {', '.join(rubric['writing_types'])}")
+            print(f"   Criteria: {len(criteria)}")
+            print(f"   Levels: {levels}")
+            print()
+        print("B. Back")
+        print()
+        selection = input("Select rubric to view, or Back: ").strip()
+        if selection.isdigit() and 1 <= int(selection) <= len(valid):
+            item = valid[int(selection) - 1]
+            assert item.rubric is not None
+            print()
+            print(summarize_rubric(item.rubric, item.path))
+        elif selection and selection.casefold() != "b":
+            print("Invalid selection. Please choose a listed rubric or Back.")
+    _print_invalid_files(invalid)
+    return 0
+
+
+def prompt_edit_rubric() -> int:
+    """Safely edit title, description, or writing types for one valid rubric."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Edit Rubric / Scoring Profile")
+    selected = _prompt_valid_rubric()
+    if selected is None:
+        return 1
+    path, rubric = selected
+    print()
+    print("1. Edit title")
+    print("2. Edit description")
+    print("3. Edit writing types")
+    print("4. Back")
+    print()
+    choice = input("Select an option: ").strip()
+    if choice in {"", "4"}:
+        print("Edit rubric canceled. No file was changed.")
+        return 0
+    updated = touch_updated_at(rubric)
+    try:
+        if choice == "1":
+            updated["title"] = _required_input("Rubric title: ")
+        elif choice == "2":
+            updated["description"] = input("Description: ").strip()
+        elif choice == "3":
+            updated["writing_types"] = _prompt_writing_types()
+        else:
+            print("Invalid selection. Please enter a number from 1 to 4.")
+            return 1
+        write_rubric(path.parents[2], updated, overwrite=True)
+    except (RubricError, ValueError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing rubric was not changed.")
+        return 1
+    print(f"Saved rubric: {path}")
+    return 0
+
+
+def prompt_add_criterion() -> int:
+    """Add a criterion to an existing valid rubric."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Add Criterion")
+    selected = _prompt_valid_rubric()
+    if selected is None:
+        return 1
+    path, rubric = selected
+    _print_criteria(rubric)
+    existing_ids = {
+        str(criterion["criterion_id"])
+        for criterion in rubric["criteria"]
+        if isinstance(criterion, dict)
+    }
+    try:
+        criterion = _prompt_new_criterion(
+            existing_ids=existing_ids,
+            criterion_count=len(existing_ids),
+        )
+    except (RubricError, ValueError) as error:
+        print(f"Error: {error}")
+        print("Add criterion canceled. No file was changed.")
+        return 1
+    if criterion is None:
+        print("Add criterion canceled. No file was changed.")
+        return 1
+    updated = touch_updated_at(rubric)
+    updated["criteria"] = [dict(item) for item in rubric["criteria"]] + [criterion]
+    print()
+    print(f"Add criterion '{criterion['label']}' to {rubric['rubric_id']}?")
+    print("1. Save")
+    print("2. Cancel")
+    if input("Select an option: ").strip() != "1":
+        print("Add criterion canceled. No file was changed.")
+        return 1
+    try:
+        write_rubric(path.parents[2], updated, overwrite=True)
+    except (RubricError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing rubric was not changed.")
+        return 1
+    print(f"Saved rubric: {path}")
+    return 0
+
+
+def prompt_add_level() -> int:
+    """Add a score level to an existing rubric criterion."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Add Level to Criterion")
+    selected = _prompt_valid_rubric()
+    if selected is None:
+        return 1
+    path, rubric = selected
+    criterion = _prompt_criterion(rubric)
+    if criterion is None:
+        return 1
+    try:
+        level = _prompt_new_level(
+            max_score=criterion["max_score"],
+            existing_scores={level["score"] for level in criterion["levels"]},
+            level_count=len(criterion["levels"]),
+        )
+    except (RubricError, ValueError) as error:
+        print(f"Error: {error}")
+        print("Add level canceled. No file was changed.")
+        return 1
+    if level is None:
+        print("Add level canceled. No file was changed.")
+        return 1
+    updated = touch_updated_at(rubric)
+    updated_criteria = [dict(item) for item in rubric["criteria"]]
+    for item in updated_criteria:
+        if item["criterion_id"] == criterion["criterion_id"]:
+            item["levels"] = [dict(level_item) for level_item in item["levels"]] + [
+                level
+            ]
+            break
+    updated["criteria"] = updated_criteria
+    print()
+    print(f"Add level '{level['label']}' to {criterion['label']}?")
+    print("1. Save")
+    print("2. Cancel")
+    if input("Select an option: ").strip() != "1":
+        print("Add level canceled. No file was changed.")
+        return 1
+    try:
+        write_rubric(path.parents[2], updated, overwrite=True)
+    except (RubricError, OSError) as error:
+        print(f"Error: {error}")
+        print("Existing rubric was not changed.")
+        return 1
+    print(f"Saved rubric: {path}")
+    return 0
+
+
+def prompt_validate_rubric() -> int:
+    """Validate one existing rubric file without modifying it."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Validate Rubric / Scoring Profile")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    files = list_rubric_files(workspace_root)
+    if not files:
+        print("No rubric files found.")
+        print("Expected location: shared/rubrics/")
+        return 1
+    for index, item in enumerate(files, start=1):
+        print(f"{index}. {item.path}")
+    print("B. Back")
+    print()
+    selection = input("Select rubric file: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Validate rubric canceled.")
+        return 0
+    if not selection.isdigit() or not 1 <= int(selection) <= len(files):
+        print("Invalid selection. Please choose a listed file or Back.")
+        return 1
+    path = files[int(selection) - 1].path
+    try:
+        rubric = load_rubric(path)
+    except (RubricError, OSError) as error:
+        print("Rubric is invalid.")
+        print()
+        print(f"Path: {path}")
+        print(f"Error: {error}")
+        return 1
+    print("Rubric is valid.")
+    print()
+    print(f"Rubric ID: {rubric['rubric_id']}")
+    print(f"Title: {rubric['title']}")
+    print(f"Criteria: {len(rubric['criteria'])}")
+    print(f"Levels: {sum(len(item['levels']) for item in rubric['criteria'])}")
+    print(f"Path: {path}")
+    return 0
+
+
+def _workspace_root() -> Path | None:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return None
+
+
+def _required_input(prompt: str) -> str:
+    value = input(prompt).strip()
+    if not value:
+        raise ValueError("This field is required.")
+    return value
+
+
+def _prompt_writing_types() -> list[str]:
+    value = input(
+        "Writing types, comma-separated:\n"
+        "Examples: general, lab_report, reflection, research, constructed_response\n"
+    )
+    writing_types = parse_comma_separated_values(value)
+    if not writing_types:
+        raise ValueError("At least one writing type is required.")
+    return writing_types
+
+
+def _prompt_new_criterion(
+    *,
+    existing_ids: set[str],
+    criterion_count: int,
+) -> dict[str, Any] | None:
+    print("Add Criterion")
+    print()
+    print("Criteria are the parts of student writing you want to score.")
+    print()
+    print("Suggested criteria:")
+    for index, (label, _description) in enumerate(_CRITERION_SUGGESTIONS, start=1):
+        print(f"{index}. {label}")
+    custom_index = len(_CRITERION_SUGGESTIONS) + 1
+    print(f"{custom_index}. Custom criterion")
+    print("B. Back")
+    print()
+    selection = input("Select suggestion or choose Custom: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(_CRITERION_SUGGESTIONS):
+        label, description = _CRITERION_SUGGESTIONS[int(selection) - 1]
+    elif selection == str(custom_index):
+        label = _required_input("Criterion label:\nExample: Reasoning / Explanation\n")
+        description = input(
+            "Description:\n"
+            "Example: Score how clearly the response explains its thinking.\n"
+        ).strip()
+    else:
+        print("Invalid criterion selection.")
+        return None
+    suggestion = suggest_identifier(label)
+    print(f"Suggested criterion_id:\n{suggestion}")
+    criterion_id = input(
+        "Press Enter to accept, or type a different criterion_id: "
+    ).strip()
+    if not criterion_id:
+        criterion_id = suggestion
+    ensure_unique_identifier(criterion_id, existing_ids, "criterion_id")
+    max_score = _parse_required_number(input("Max score:\nExample: 4\n"))
+    scale = _required_input("Scale:\nExample: 4_point\n")
+    standard_ids = parse_comma_separated_values(
+        input("Optional standard_ids, comma-separated (leave blank to omit): ")
+    )
+    sort_order = _parse_optional_nonnegative_int(
+        input("Sort order (leave blank to auto-assign): ")
+    )
+    if sort_order is None:
+        sort_order = (criterion_count + 1) * 10
+    print()
+    print("Add Score Level")
+    level = _prompt_new_level(max_score=max_score, existing_scores=set(), level_count=0)
+    if level is None:
+        return None
+    return build_rubric_criterion(
+        criterion_id=criterion_id,
+        label=label,
+        max_score=max_score,
+        scale=scale,
+        levels=[level],
+        description=description,
+        standard_ids=standard_ids,
+        sort_order=sort_order,
+    )
+
+
+def _prompt_new_level(
+    *,
+    max_score: int | float,
+    existing_scores: set[int | float],
+    level_count: int,
+) -> dict[str, Any] | None:
+    score = _parse_required_number(input("Score:\nExample: 3\n"))
+    if score in existing_scores:
+        raise RubricError(f"Duplicate level score '{score}'.")
+    label = _required_input("Level label:\nExample: Clear explanation\n")
+    description = input(
+        "Description:\n"
+        "Example: The response explains its reasoning clearly with support.\n"
+    ).strip()
+    student_feedback = input(
+        "Student-facing feedback (optional):\n"
+        "Example: Your explanation is clear. Add one more specific detail.\n"
+    ).strip()
+    teacher_note = input("Teacher note (optional, leave blank to omit): ").strip()
+    sort_order = _parse_optional_nonnegative_int(
+        input("Sort order (leave blank to auto-assign): ")
+    )
+    if sort_order is None:
+        sort_order = (level_count + 1) * 10
+    level = build_rubric_level(
+        score=score,
+        label=label,
+        description=description,
+        student_facing_feedback=student_feedback,
+        teacher_note=teacher_note,
+        sort_order=sort_order,
+    )
+    probe = build_rubric_criterion(
+        criterion_id="temporary_probe",
+        label="Temporary Probe",
+        max_score=max_score,
+        scale="temporary",
+        levels=[level],
+    )
+    # Reuse full criterion validation through a synthetic rubric-shaped build.
+    build_rubric(
+        rubric_id="temporary_probe",
+        title="Temporary Probe",
+        description="",
+        writing_types=["temporary"],
+        criteria=[probe],
+    )
+    return level
+
+
+def _prompt_valid_rubric() -> tuple[Path, dict[str, Any]] | None:
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return None
+    files = list_valid_rubrics(workspace_root)
+    if not files:
+        print("No valid shared rubrics found.")
+        print(
+            "Create one from Review Materials -> Rubrics / Scoring Profiles -> "
+            "Create rubric / scoring profile."
+        )
+        return None
+    print("Available rubrics / scoring profiles:")
+    for index, item in enumerate(files, start=1):
+        assert item.rubric is not None
+        print(f"{index}. {item.rubric['rubric_id']} - {item.rubric['title']}")
+    print("B. Back")
+    print()
+    selection = input("Select rubric: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Rubric selection canceled.")
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(files):
+        item = files[int(selection) - 1]
+        assert item.rubric is not None
+        return item.path, item.rubric
+    for item in files:
+        assert item.rubric is not None
+        if item.rubric["rubric_id"] == selection:
+            return item.path, item.rubric
+    print("Invalid rubric selection. Please choose a listed rubric or Back.")
+    return None
+
+
+def _prompt_criterion(rubric: dict[str, Any]) -> dict[str, Any] | None:
+    criteria = _sorted_records(rubric["criteria"])
+    print("Criteria:")
+    for index, criterion in enumerate(criteria, start=1):
+        print(f"{index}. {criterion['label']}")
+    print("B. Back")
+    print()
+    selection = input("Select criterion: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Criterion selection canceled.")
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(criteria):
+        criterion = criteria[int(selection) - 1]
+        print()
+        print(f"{criterion['label']} levels:")
+        for level in _sorted_records(criterion["levels"]):
+            print(f"- {level['score']}: {level['label']}")
+        return criterion
+    print("Invalid criterion selection. Please choose a listed criterion or Back.")
+    return None
+
+
+def _print_criteria(rubric: dict[str, Any]) -> None:
+    print("Existing criteria:")
+    for index, criterion in enumerate(_sorted_records(rubric["criteria"]), start=1):
+        print(f"{index}. {criterion['criterion_id']} - {criterion['label']}")
+
+
+def _print_invalid_files(invalid: list[Any]) -> None:
+    if not invalid:
+        return
+    print()
+    print("Invalid rubric files:")
+    print()
+    for item in invalid:
+        print(f"- {item.path}")
+        print(f"  Error: {item.error}")
+
+
+def _sorted_records(records: list[Any]) -> list[dict[str, Any]]:
+    valid = [record for record in records if isinstance(record, dict)]
+    return sorted(
+        valid,
+        key=lambda item: (
+            item.get("sort_order")
+            if isinstance(item.get("sort_order"), int)
+            else 999999,
+            str(item.get("label", "")).casefold(),
+        ),
+    )
+
+
+def _parse_required_number(value: str) -> int | float:
+    text = value.strip()
+    if not text:
+        raise ValueError("Score value is required.")
+    try:
+        if "." in text or "e" in text.lower():
+            return float(text)
+        return int(text)
+    except ValueError as error:
+        raise ValueError("Score value must be a number.") from error
+
+
+def _parse_optional_nonnegative_int(value: str) -> int | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = int(text)
+    except ValueError as error:
+        raise ValueError("Value must be a non-negative integer.") from error
+    if parsed < 0:
+        raise ValueError("Value must be a non-negative integer.")
+    return parsed

--- a/quillan/rubric_writing.py
+++ b/quillan/rubric_writing.py
@@ -1,0 +1,212 @@
+"""Construction, listing, and safe writes for Quillan rubrics."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import unicodedata
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.rubrics import (
+    RubricError,
+    RubricFile,
+    rubric_path,
+    validate_rubric,
+)
+
+
+def current_timestamp() -> str:
+    """Return a timezone-aware ISO 8601 timestamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def suggest_identifier(label: str) -> str:
+    """Suggest a shared identifier from teacher-facing text."""
+    normalized = unicodedata.normalize("NFKD", label)
+    ascii_label = normalized.encode("ascii", "ignore").decode("ascii")
+    suggestion = re.sub(r"[^A-Za-z0-9_-]+", "_", ascii_label.strip())
+    suggestion = suggestion.strip("_-").lower()
+    return suggestion or "rubric"
+
+
+def parse_comma_separated_values(value: str) -> list[str]:
+    """Return trimmed nonblank values from comma-separated input."""
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def build_rubric_level(
+    *,
+    score: int | float,
+    label: str,
+    description: str = "",
+    student_facing_feedback: str = "",
+    teacher_note: str = "",
+    sort_order: int | None = None,
+) -> dict[str, Any]:
+    """Build one rubric level record."""
+    if not label.strip():
+        raise RubricError("Level label is required.")
+    level: dict[str, Any] = {
+        "score": score,
+        "label": label.strip(),
+        "module_details": {},
+    }
+    if description.strip():
+        level["description"] = description.strip()
+    if student_facing_feedback.strip():
+        level["student_facing_feedback"] = student_facing_feedback.strip()
+    if teacher_note.strip():
+        level["teacher_note"] = teacher_note.strip()
+    if sort_order is not None:
+        level["sort_order"] = sort_order
+    return level
+
+
+def build_rubric_criterion(
+    *,
+    criterion_id: str,
+    label: str,
+    max_score: int | float,
+    scale: str,
+    levels: Sequence[Mapping[str, Any]],
+    description: str = "",
+    standard_ids: Sequence[str] | None = None,
+    sort_order: int | None = None,
+) -> dict[str, Any]:
+    """Build one rubric criterion record."""
+    validate_identifier(criterion_id, "criterion_id")
+    if not label.strip():
+        raise RubricError("Criterion label is required.")
+    criterion: dict[str, Any] = {
+        "criterion_id": criterion_id,
+        "label": label.strip(),
+        "max_score": max_score,
+        "scale": scale.strip(),
+        "levels": [dict(level) for level in levels],
+        "module_details": {},
+    }
+    if description.strip():
+        criterion["description"] = description.strip()
+    if standard_ids:
+        criterion["standard_ids"] = list(standard_ids)
+    if sort_order is not None:
+        criterion["sort_order"] = sort_order
+    return criterion
+
+
+def build_rubric(
+    *,
+    rubric_id: str,
+    title: str,
+    description: str,
+    writing_types: Sequence[str],
+    criteria: Sequence[Mapping[str, Any]],
+    created_at: str | None = None,
+    updated_at: str | None = None,
+    module_details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build and validate a version 1 Quillan shared rubric."""
+    timestamp = current_timestamp()
+    rubric: dict[str, Any] = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "rubric",
+        "rubric_id": rubric_id,
+        "title": title.strip(),
+        "description": description.strip(),
+        "scope": "shared",
+        "writing_types": list(writing_types),
+        "criteria": [dict(criterion) for criterion in criteria],
+        "created_at": created_at or timestamp,
+        "updated_at": updated_at or timestamp,
+        "module_details": dict(module_details or {}),
+    }
+    validate_rubric(rubric)
+    return rubric
+
+
+def list_rubric_files(workspace_root: str | Path) -> tuple[RubricFile, ...]:
+    """List shared rubric files without raising on invalid files."""
+    from quillan.rubrics import list_rubric_files as _list_rubric_files
+
+    return _list_rubric_files(workspace_root)
+
+
+def list_valid_rubrics(workspace_root: str | Path) -> tuple[RubricFile, ...]:
+    """Return valid shared rubric files only."""
+    from quillan.rubrics import list_valid_rubrics as _list_valid_rubrics
+
+    return _list_valid_rubrics(workspace_root)
+
+
+def summarize_rubric(rubric: Mapping[str, Any], path: str | Path) -> str:
+    """Return a concise teacher-facing summary for one rubric."""
+    criteria = rubric["criteria"]
+    level_count = sum(len(item["levels"]) for item in criteria)
+    writing_types = ", ".join(str(item) for item in rubric["writing_types"])
+    return "\n".join(
+        [
+            f"Rubric ID: {rubric['rubric_id']}",
+            f"Title: {rubric['title']}",
+            f"Description: {rubric['description']}",
+            f"Scope: {rubric['scope']}",
+            f"Writing types: {writing_types}",
+            f"Criteria: {len(criteria)}",
+            f"Levels: {level_count}",
+            f"Path: {Path(path)}",
+        ]
+    )
+
+
+def write_rubric(
+    workspace_root: str | Path,
+    rubric: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Validate and atomically write a shared rubric."""
+    rubric_data = dict(rubric)
+    validate_rubric(rubric_data)
+    rubric_id = str(rubric_data["rubric_id"])
+    path = rubric_path(workspace_root, rubric_id)
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"Rubric already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            json.dump(rubric_data, file, indent=2, ensure_ascii=False)
+            file.write("\n")
+        os.replace(temporary_path, path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def touch_updated_at(rubric: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a mutable copy with a refreshed updated_at value."""
+    updated = dict(rubric)
+    updated["updated_at"] = current_timestamp()
+    return updated
+
+
+def ensure_unique_identifier(identifier: str, existing: set[str], field: str) -> None:
+    """Validate an identifier and reject duplicates."""
+    try:
+        validate_identifier(identifier, field)
+    except IdentifierValidationError as error:
+        raise RubricError(str(error)) from error
+    if identifier in existing:
+        raise RubricError(f"Duplicate {field} '{identifier}'.")

--- a/quillan/rubrics.py
+++ b/quillan/rubrics.py
@@ -1,0 +1,334 @@
+"""Loading, canonical paths, and validation for shared rubrics."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+REQUIRED_RUBRIC_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "module",
+        "record_type",
+        "rubric_id",
+        "title",
+        "description",
+        "scope",
+        "writing_types",
+        "criteria",
+        "created_at",
+        "updated_at",
+        "module_details",
+    }
+)
+REQUIRED_CRITERION_FIELDS: Final[frozenset[str]] = frozenset(
+    {"criterion_id", "label", "max_score", "scale", "levels", "module_details"}
+)
+OPTIONAL_CRITERION_FIELDS: Final[frozenset[str]] = frozenset(
+    {"description", "standard_ids", "sort_order"}
+)
+REQUIRED_LEVEL_FIELDS: Final[frozenset[str]] = frozenset(
+    {"score", "label", "module_details"}
+)
+OPTIONAL_LEVEL_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "description",
+        "student_facing_feedback",
+        "teacher_note",
+        "sort_order",
+    }
+)
+ALLOWED_SCOPES: Final[frozenset[str]] = frozenset({"shared"})
+
+
+class RubricError(ValueError):
+    """Raised when a shared rubric is missing or invalid."""
+
+
+@dataclass(frozen=True)
+class RubricFile:
+    """One discovered rubric file and its validation state."""
+
+    path: Path
+    rubric: dict[str, Any] | None
+    error: str | None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.rubric is not None and self.error is None
+
+
+def rubric_path(workspace_root: str | Path, rubric_id: str) -> Path:
+    """Return the canonical path for one shared rubric."""
+    _validate_identifier(rubric_id, "rubric_id")
+    return Path(workspace_root) / "shared" / "rubrics" / f"{rubric_id}.json"
+
+
+def load_rubric(path: str | Path) -> dict[str, Any]:
+    """Load and validate a version 1 shared rubric."""
+    path_obj = Path(path)
+    try:
+        with path_obj.open("r", encoding="utf-8") as file:
+            value = json.load(file)
+    except FileNotFoundError as error:
+        raise RubricError(f"Rubric not found: {path_obj}") from error
+    except json.JSONDecodeError as error:
+        raise RubricError(f"Rubric is not valid JSON: {path_obj}") from error
+    except OSError as error:
+        raise RubricError(f"Could not read rubric {path_obj}: {error}") from error
+
+    if not isinstance(value, dict):
+        raise RubricError(f"Rubric must be a JSON object: {path_obj}")
+    rubric = cast(dict[str, Any], value)
+    validate_rubric(rubric)
+    if rubric["rubric_id"] != path_obj.stem:
+        raise RubricError(
+            f"Rubric rubric_id is {rubric['rubric_id']!r}, expected "
+            f"{path_obj.stem!r} from its filename."
+        )
+    return rubric
+
+
+def list_rubric_files(workspace_root: str | Path) -> tuple[RubricFile, ...]:
+    """List shared rubric files without raising on invalid files."""
+    directory = Path(workspace_root) / "shared" / "rubrics"
+    if not directory.is_dir():
+        return ()
+    files: list[RubricFile] = []
+    for path in sorted(directory.glob("*.json"), key=lambda item: item.name.casefold()):
+        try:
+            files.append(RubricFile(path, load_rubric(path), None))
+        except (OSError, RubricError) as error:
+            files.append(RubricFile(path, None, str(error)))
+    return tuple(files)
+
+
+def list_valid_rubrics(workspace_root: str | Path) -> tuple[RubricFile, ...]:
+    """Return valid shared rubric files only."""
+    return tuple(item for item in list_rubric_files(workspace_root) if item.is_valid)
+
+
+def validate_rubric(rubric: dict[str, Any]) -> None:
+    """Validate the intrinsic version 1 shared-rubric contract."""
+    if not isinstance(rubric, dict):
+        raise RubricError("Rubric must be an object.")
+    _validate_fields(rubric, REQUIRED_RUBRIC_FIELDS, frozenset(), "rubric")
+    _validate_exact(rubric["schema_version"], "schema_version", "1")
+    _validate_exact(rubric["module"], "module", "quillan")
+    _validate_exact(rubric["record_type"], "record_type", "rubric")
+    _validate_identifier(rubric["rubric_id"], "rubric_id")
+    _validate_non_empty_string(rubric["title"], "title")
+    _validate_string(rubric["description"], "description")
+    _validate_allowed(rubric["scope"], "scope", ALLOWED_SCOPES)
+    _validate_unique_strings(
+        rubric["writing_types"], "writing_types", require_non_empty=True
+    )
+    _validate_criteria(rubric["criteria"])
+    created_at = _validate_timestamp(rubric["created_at"], "created_at")
+    updated_at = _validate_timestamp(rubric["updated_at"], "updated_at")
+    if updated_at < created_at:
+        raise RubricError("Field 'updated_at' must not precede field 'created_at'.")
+    _validate_object(rubric["module_details"], "module_details")
+
+
+def _validate_criteria(value: Any) -> None:
+    criteria = _validate_list(value, "criteria")
+    if not criteria:
+        raise RubricError("Field 'criteria' must be a non-empty list.")
+    seen: set[str] = set()
+    for index, value_item in enumerate(criteria):
+        context = f"criteria[{index}]"
+        item = _validate_record(value_item, context)
+        _validate_fields(
+            item,
+            REQUIRED_CRITERION_FIELDS,
+            OPTIONAL_CRITERION_FIELDS,
+            context,
+        )
+        criterion_id = _validate_identifier(
+            item["criterion_id"], f"{context}.criterion_id"
+        )
+        if criterion_id in seen:
+            raise RubricError(f"Duplicate criterion_id '{criterion_id}'.")
+        seen.add(criterion_id)
+        _validate_non_empty_string(item["label"], f"{context}.label")
+        max_score = _validate_number(
+            item["max_score"],
+            f"{context}.max_score",
+            minimum=0,
+            exclusive_minimum=True,
+        )
+        _validate_non_empty_string(item["scale"], f"{context}.scale")
+        _validate_levels(item["levels"], max_score, context)
+        _validate_object(item["module_details"], f"{context}.module_details")
+        if "description" in item:
+            _validate_string(item["description"], f"{context}.description")
+        if "standard_ids" in item:
+            _validate_unique_strings(item["standard_ids"], f"{context}.standard_ids")
+        if "sort_order" in item:
+            _validate_integer(item["sort_order"], f"{context}.sort_order")
+
+
+def _validate_levels(value: Any, max_score: int | float, context: str) -> None:
+    levels = _validate_list(value, f"{context}.levels")
+    if not levels:
+        raise RubricError(f"Field '{context}.levels' must be a non-empty list.")
+    seen_scores: set[int | float] = set()
+    for index, value_item in enumerate(levels):
+        level_context = f"{context}.levels[{index}]"
+        item = _validate_record(value_item, level_context)
+        _validate_fields(
+            item,
+            REQUIRED_LEVEL_FIELDS,
+            OPTIONAL_LEVEL_FIELDS,
+            level_context,
+        )
+        score = _validate_number(item["score"], f"{level_context}.score", minimum=0)
+        if score > max_score:
+            raise RubricError(
+                f"Field '{level_context}.score' must not exceed criterion max_score."
+            )
+        if score in seen_scores:
+            raise RubricError(f"Duplicate level score '{score}' in {context}.")
+        seen_scores.add(score)
+        _validate_non_empty_string(item["label"], f"{level_context}.label")
+        _validate_object(item["module_details"], f"{level_context}.module_details")
+        for field in ("description", "student_facing_feedback", "teacher_note"):
+            if field in item:
+                _validate_string(item[field], f"{level_context}.{field}")
+        if "sort_order" in item:
+            _validate_integer(item["sort_order"], f"{level_context}.sort_order")
+
+
+def _validate_fields(
+    data: dict[str, Any],
+    required: frozenset[str],
+    optional: frozenset[str],
+    context: str,
+) -> None:
+    missing = required - data.keys()
+    if missing:
+        raise RubricError(
+            f"Missing required field '{sorted(missing)[0]}' in {context}."
+        )
+    unknown = data.keys() - required - optional
+    if unknown:
+        raise RubricError(f"Unknown field '{sorted(unknown)[0]}' in {context}.")
+
+
+def _validate_record(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RubricError(f"{context} must be an object.")
+    return cast(dict[str, Any], value)
+
+
+def _validate_list(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise RubricError(f"Field '{field}' must be a list.")
+    return value
+
+
+def _validate_unique_strings(
+    value: Any, field: str, *, require_non_empty: bool = False
+) -> list[str]:
+    values = _validate_list(value, field)
+    if require_non_empty and not values:
+        raise RubricError(f"Field '{field}' must be a non-empty list.")
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in values:
+        text = _validate_non_empty_string(item, field)
+        if text in seen:
+            raise RubricError(f"Field '{field}' contains duplicate {text!r}.")
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _validate_identifier(value: Any, field: str) -> str:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise RubricError(str(error)) from error
+    return cast(str, value)
+
+
+def _validate_non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RubricError(f"Field '{field}' must be a non-empty string.")
+    return value
+
+
+def _validate_string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise RubricError(f"Field '{field}' must be a string.")
+    return value
+
+
+def _validate_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RubricError(f"Field '{field}' must be an integer.")
+    return value
+
+
+def _validate_number(
+    value: Any,
+    field: str,
+    *,
+    minimum: int,
+    exclusive_minimum: bool = False,
+) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RubricError(f"Field '{field}' must be a finite number.")
+    if not math.isfinite(value):
+        raise RubricError(f"Field '{field}' must be a finite number.")
+    if exclusive_minimum and value <= minimum:
+        raise RubricError(f"Field '{field}' must be greater than {minimum}.")
+    if not exclusive_minimum and value < minimum:
+        raise RubricError(
+            f"Field '{field}' must be greater than or equal to {minimum}."
+        )
+    return value
+
+
+def _validate_object(value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        raise RubricError(f"Field '{field}' must be an object.")
+
+
+def _validate_exact(value: Any, field: str, expected: str) -> None:
+    if value != expected:
+        raise RubricError(f"Field '{field}' must be the string '{expected}'.")
+
+
+def _validate_allowed(
+    value: Any, field: str, allowed_values: frozenset[str]
+) -> str:
+    if not isinstance(value, str) or value not in allowed_values:
+        allowed = ", ".join(sorted(allowed_values))
+        raise RubricError(f"Invalid {field} {value!r}. Allowed values: {allowed}.")
+    return value
+
+
+def _validate_timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise RubricError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise RubricError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise RubricError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    return parsed

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -22,6 +22,12 @@ from quillan.assignments import (
     load_assignment_config,
     validate_assignment_config,
 )
+from quillan.rubric_writing import (
+    build_rubric,
+    build_rubric_criterion,
+    build_rubric_level,
+    write_rubric,
+)
 
 
 def _assignment(
@@ -107,6 +113,25 @@ def _write_standards_library(workspace_root: Path) -> None:
             ),
         ),
     )
+
+
+def _write_rubric(workspace_root: Path) -> None:
+    level = build_rubric_level(score=3, label="Clear explanation")
+    criterion = build_rubric_criterion(
+        criterion_id="reasoning",
+        label="Reasoning / Explanation",
+        max_score=4,
+        scale="4_point",
+        levels=[level],
+    )
+    rubric = build_rubric(
+        rubric_id="general_response",
+        title="General Response Rubric",
+        description="Synthetic scoring profile.",
+        writing_types=["general"],
+        criteria=[criterion],
+    )
+    write_rubric(workspace_root, rubric)
 
 
 def _inputs(
@@ -258,6 +283,31 @@ def test_prompt_create_assignment_selects_roster_class_and_writes_config(
         "required_elements": ["claim", "textual evidence"],
     }
     assert "Saved assignment config:" in capsys.readouterr().out
+
+
+def test_prompt_create_assignment_can_select_shared_rubric(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_roster(tmp_path)
+    _write_standards_library(tmp_path)
+    _write_rubric(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    responses = _creation_responses()
+    responses[-1] = "1"
+    _inputs(monkeypatch, responses)
+
+    assert workflows.prompt_create_assignment() == 0
+
+    assignment = load_assignment_config(
+        tmp_path
+        / "classes"
+        / "english_12_p3"
+        / "assignments"
+        / "literary_analysis_essay"
+        / "assignment.json"
+    )
+    assert assignment["rubric_id"] == "general_response"
 
 
 def test_prompt_create_assignment_accepts_exact_class_id_and_blank_options(

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -13,6 +13,12 @@ from quillan.cli import main
 import quillan.comment_bank_workflows as comment_bank_workflows
 import quillan.review_menu as review_menu
 from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.rubric_writing import (
+    build_rubric,
+    build_rubric_criterion,
+    build_rubric_level,
+    write_rubric,
+)
 from quillan.tag_bank_writing import (
     build_tag_bank,
     build_tag_category,
@@ -189,6 +195,25 @@ def _write_tag_bank(root: Path) -> None:
         tags=[tag],
     )
     write_tag_bank(root, bank)
+
+
+def _write_rubric(root: Path) -> None:
+    level = build_rubric_level(score=3, label="Clear explanation")
+    criterion = build_rubric_criterion(
+        criterion_id="reasoning",
+        label="Reasoning / Explanation",
+        max_score=4,
+        scale="4_point",
+        levels=[level],
+    )
+    rubric = build_rubric(
+        rubric_id="synthetic_rubric",
+        title="Synthetic Rubric",
+        description="Synthetic scoring profile.",
+        writing_types=["argument"],
+        criteria=[criterion],
+    )
+    write_rubric(root, rubric)
 
 
 def _write_review_record(root: Path, review: dict[str, Any]) -> Path:
@@ -512,6 +537,63 @@ def test_review_menu_sets_criterion_score(
     assert review["scores"][0]["max_score"] == 4
     assert review["review_state"] == "in_progress"
     assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_scores_from_assignment_rubric(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_rubric(workspace)
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["5", "1", "1", "1", "Private score note"]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    score = review["scores"][0]
+    assert score["criterion_id"] == "reasoning"
+    assert score["label"] == "Reasoning / Explanation"
+    assert score["score"] == 3
+    assert score["max_score"] == 4
+    assert score["scale"] == "4_point"
+    assert score["teacher_note"] == "Private score note"
+    assert manifest_path.read_bytes() == manifest_before
+    capsys.readouterr()
+
+
+def test_review_menu_missing_rubric_keeps_custom_score_available(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["5", "1", "1", "evidence", "Evidence", "2", "4", "", ""]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert review["scores"][0]["criterion_id"] == "evidence"
+    assert "does not resolve" in capsys.readouterr().out
 
 
 def test_review_menu_blank_score_cancels_without_review_record(

--- a/tests/test_review_materials_menu.py
+++ b/tests/test_review_materials_menu.py
@@ -94,7 +94,6 @@ def test_review_materials_menu_navigation_returns_to_main_menu(
     ("choice", "header", "future_issue", "path_text"),
     [
         ("2", "Tag Banks", "#166", "shared/tag_banks/"),
-        ("3", "Rubrics / Scoring Profiles", "#167", "shared/rubrics/"),
         ("4", "Starter Materials", "#169", ""),
     ],
 )
@@ -116,6 +115,21 @@ def test_review_materials_informational_screens_return_safely(
     assert "No files were changed." in output
     if path_text:
         assert path_text in output
+
+
+def test_review_materials_rubrics_opens_submenu(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["3", "7", "5"])
+
+    assert launch_review_materials_menu() == 0
+
+    output = capsys.readouterr().out
+    assert "Rubrics / Scoring Profiles" in output
+    assert "1. Create rubric / scoring profile" in output
+    assert "6. Validate rubric / scoring profile" in output
+    assert "7. Back" in output
 
 
 def test_review_materials_comment_banks_opens_submenu(

--- a/tests/test_rubric_workflows.py
+++ b/tests/test_rubric_workflows.py
@@ -1,0 +1,189 @@
+"""Tests for teacher-facing rubric workflows."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.rubric_workflows as workflows
+from quillan.rubrics import load_rubric
+from quillan.rubric_writing import (
+    build_rubric,
+    build_rubric_criterion,
+    build_rubric_level,
+    write_rubric,
+)
+
+
+def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError("Menu requested unexpected input.") from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _patch_workspace(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: root)
+
+
+def _sample_rubric(rubric_id: str = "general_response") -> dict[str, Any]:
+    level = build_rubric_level(score=3, label="Clear")
+    criterion = build_rubric_criterion(
+        criterion_id="reasoning",
+        label="Reasoning / Explanation",
+        max_score=4,
+        scale="4_point",
+        levels=[level],
+    )
+    return build_rubric(
+        rubric_id=rubric_id,
+        title="General Response",
+        description="Synthetic rubric.",
+        writing_types=["general"],
+        criteria=[criterion],
+    )
+
+
+def test_create_rubric_writes_valid_minimal_rubric(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "General Constructed Response 4-Point Rubric",
+            "",
+            "Reusable scoring profile.",
+            "general, constructed_response",
+            "3",
+            "",
+            "4",
+            "4_point",
+            "",
+            "",
+            "3",
+            "Clear explanation",
+            "Clear reasoning.",
+            "Your explanation is clear.",
+            "",
+            "",
+            "1",
+        ],
+    )
+
+    assert workflows.prompt_create_rubric() == 0
+
+    path = (
+        tmp_path
+        / "shared"
+        / "rubrics"
+        / "general_constructed_response_4-point_rubric.json"
+    )
+    rubric = load_rubric(path)
+    assert rubric["rubric_id"] == path.stem
+    assert rubric["criteria"]
+    assert rubric["criteria"][0]["levels"]
+    assert "Saved rubric" in capsys.readouterr().out
+
+
+def test_create_cancel_before_save_writes_no_partial_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(
+        monkeypatch,
+        [
+            "General Rubric",
+            "",
+            "Reusable scoring profile.",
+            "general",
+            "1",
+            "",
+            "4",
+            "4_point",
+            "",
+            "",
+            "3",
+            "Accurate",
+            "",
+            "",
+            "",
+            "",
+            "2",
+        ],
+    )
+
+    assert workflows.prompt_create_rubric() == 1
+
+    capsys.readouterr()
+    assert not (tmp_path / "shared" / "rubrics").exists()
+
+
+def test_view_rubrics_lists_valid_and_invalid_files(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_rubric(tmp_path, _sample_rubric())
+    invalid = tmp_path / "shared" / "rubrics" / "draft.json"
+    invalid.write_text(json.dumps({"rubric_id": "draft"}), encoding="utf-8")
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1"])
+
+    assert workflows.prompt_view_rubrics() == 0
+
+    output = capsys.readouterr().out
+    assert "general_response - General Response" in output
+    assert "Invalid rubric files" in output
+    assert "draft.json" in output
+    assert "Levels: 1" in output
+
+
+def test_add_level_rejects_duplicate_without_modifying_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = write_rubric(tmp_path, _sample_rubric())
+    before = path.read_bytes()
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1", "1", "3"])
+
+    assert workflows.prompt_add_level() == 1
+
+    assert "Duplicate level score" in capsys.readouterr().out
+    assert path.read_bytes() == before
+
+
+def test_validate_rubric_reports_invalid_without_modifying_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "shared" / "rubrics"
+    directory.mkdir(parents=True)
+    invalid = directory / "draft.json"
+    invalid.write_text("{", encoding="utf-8")
+    before = invalid.read_bytes()
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1"])
+
+    assert workflows.prompt_validate_rubric() == 1
+
+    output = capsys.readouterr().out
+    assert "Rubric is invalid." in output
+    assert "not valid JSON" in output
+    assert invalid.read_bytes() == before

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -1,0 +1,160 @@
+"""Tests for shared rubric loading, validation, and writing."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.rubrics import RubricError, load_rubric, rubric_path, validate_rubric
+from quillan.rubric_writing import (
+    build_rubric,
+    build_rubric_criterion,
+    build_rubric_level,
+    write_rubric,
+)
+
+TIMESTAMP = "2026-06-26T00:00:00+00:00"
+
+
+def _rubric(rubric_id: str = "general_response_4pt") -> dict[str, Any]:
+    level = build_rubric_level(
+        score=3,
+        label="Clear explanation",
+        description="The response explains its reasoning clearly.",
+        student_facing_feedback="Your explanation is clear.",
+        teacher_note="Use when reasoning is clear.",
+        sort_order=30,
+    )
+    criterion = build_rubric_criterion(
+        criterion_id="reasoning_explanation",
+        label="Reasoning / Explanation",
+        max_score=4,
+        scale="4_point",
+        standard_ids=["synthetic-standard"],
+        sort_order=20,
+        levels=[level],
+    )
+    return build_rubric(
+        rubric_id=rubric_id,
+        title="General Response 4-Point Rubric",
+        description="Reusable synthetic scoring profile.",
+        writing_types=["general", "constructed_response"],
+        criteria=[criterion],
+        created_at=TIMESTAMP,
+        updated_at=TIMESTAMP,
+    )
+
+
+def test_valid_rubric_writes_and_loads_from_shared_path(tmp_path: Path) -> None:
+    path = write_rubric(tmp_path, _rubric())
+
+    assert path == tmp_path / "shared" / "rubrics" / "general_response_4pt.json"
+    loaded = load_rubric(path)
+    assert loaded["rubric_id"] == path.stem
+    assert loaded["criteria"][0]["criterion_id"] == "reasoning_explanation"
+    assert loaded["criteria"][0]["levels"][0]["score"] == 3
+
+
+def test_canonical_path_validates_identifier(tmp_path: Path) -> None:
+    assert rubric_path(tmp_path, "general_rubric") == (
+        tmp_path / "shared" / "rubrics" / "general_rubric.json"
+    )
+    with pytest.raises(RubricError, match="rubric_id"):
+        rubric_path(tmp_path, "../unsafe")
+
+
+def test_filename_rubric_id_mismatch_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "different.json"
+    path.write_text(json.dumps(_rubric()), encoding="utf-8")
+    with pytest.raises(RubricError, match="filename"):
+        load_rubric(path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("schema_version", "2", "schema_version"),
+        ("module", "other", "module"),
+        ("record_type", "other", "record_type"),
+        ("rubric_id", "../unsafe", "rubric_id"),
+        ("title", " ", "title"),
+        ("scope", "private", "scope"),
+        ("writing_types", [], "non-empty"),
+        ("criteria", [], "non-empty"),
+        ("created_at", "2026-06-26T00:00:00", "timezone-aware"),
+    ],
+)
+def test_invalid_top_level_values_are_rejected(
+    field: str,
+    value: Any,
+    message: str,
+) -> None:
+    rubric = _rubric()
+    rubric[field] = value
+    with pytest.raises(RubricError, match=message):
+        validate_rubric(rubric)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("duplicate_criterion", "Duplicate criterion_id"),
+        ("criterion_missing_levels", "non-empty"),
+        ("invalid_max_score", "max_score"),
+        ("invalid_scale", "scale"),
+        ("invalid_standard_ids", "standard_ids"),
+        ("duplicate_level_score", "Duplicate level score"),
+        ("negative_level_score", "greater than or equal"),
+        ("level_above_max", "must not exceed"),
+    ],
+)
+def test_nested_contract_failures_are_rejected(
+    mutation: str,
+    message: str,
+) -> None:
+    rubric = copy.deepcopy(_rubric())
+    criterion = rubric["criteria"][0]
+    level = criterion["levels"][0]
+    if mutation == "duplicate_criterion":
+        rubric["criteria"].append(copy.deepcopy(criterion))
+    elif mutation == "criterion_missing_levels":
+        criterion["levels"] = []
+    elif mutation == "invalid_max_score":
+        criterion["max_score"] = 0
+    elif mutation == "invalid_scale":
+        criterion["scale"] = ""
+    elif mutation == "invalid_standard_ids":
+        criterion["standard_ids"] = "synthetic-standard"
+    elif mutation == "duplicate_level_score":
+        criterion["levels"].append(copy.deepcopy(level))
+    elif mutation == "negative_level_score":
+        level["score"] = -1
+    else:
+        level["score"] = 5
+
+    with pytest.raises(RubricError, match=message):
+        validate_rubric(rubric)
+
+
+def test_write_refuses_overwrite_without_confirmation(tmp_path: Path) -> None:
+    path = write_rubric(tmp_path, _rubric())
+    before = path.read_bytes()
+
+    with pytest.raises(FileExistsError):
+        write_rubric(tmp_path, _rubric(), overwrite=False)
+
+    assert path.read_bytes() == before
+
+
+def test_write_validates_before_creating_directory(tmp_path: Path) -> None:
+    rubric = _rubric()
+    rubric["criteria"] = []
+
+    with pytest.raises(RubricError):
+        write_rubric(tmp_path, rubric)
+
+    assert not (tmp_path / "shared" / "rubrics").exists()


### PR DESCRIPTION
## Summary

Adds reusable rubric / scoring-profile workflows and review-time rubric scoring.

Closes #167

## Changes

* Added rubric runtime support:

  * `quillan/rubrics.py`
  * `quillan/rubric_writing.py`
  * `quillan/rubric_workflows.py`
* Wired `Review Materials -> Rubrics / Scoring Profiles` to a real teacher-facing submenu.
* Added rubric workflows to:

  * create rubrics;
  * view rubrics;
  * edit rubric title, description, and writing types;
  * add criteria;
  * add score levels;
  * validate rubric files.
* Updated assignment creation so teachers can select valid shared rubrics.
* Preserved custom `rubric_id` entry for backward compatibility.
* Updated assignment view/validate to report resolved vs. not-found rubric profile status.
* Updated review-time `Set criterion score` to support:

  * rubric criterion -> level selection;
  * missing-rubric fallback;
  * custom/manual score entry.
* Added `docs/rubric_contract.md`.
* Updated README and existing CLI/data/review-record documentation.
* Added rubric validation, workflow, assignment-linkage, and review-scoring tests.

## Behavior

Rubrics are stored at:

```text id="m7lsk3"
shared/rubrics/<rubric_id>.json
```

Rubrics validate against schema version `1`.

Creation and editing workflows:

* build complete records in memory;
* validate before writing;
* write atomically;
* refuse overwrite unless the teacher types exact `OVERWRITE`;
* avoid writing invalid partial files;
* keep rubrics subject-agnostic and writing-type-aware.

Assignment creation now lists valid shared rubrics when available and stores the selected `rubric_id`.

Assignments with custom or unresolved `rubric_id` values remain structurally valid.

Review mode can now score from a rubric by selecting:

```text id="hsc3m8"
criterion -> level
```

Selected rubric scores write the existing `review.json.scores` shape:

* `criterion_id`
* `label`
* `score`
* `max_score`
* `scale`
* optional `teacher_note`

Custom/manual score entry remains available.

Direct CLI `set-score` remains compatible and unchanged.

## Safety

* Rubric authoring writes only confirmed, valid files under `shared/rubrics/`.
* Optional `standard_ids` remain pds-core reference-only metadata.
* No pds-core standards files are created, edited, retired, reactivated, imported, or mutated.
* No pds-core route/workspace ownership is duplicated.
* Rubric authoring does not modify scans, rosters, submissions, exports, comment banks, tag banks, or sibling repositories.
* Review records are modified only during explicit review-time scoring.
* Selected rubric scores snapshot score values into review records; they do not store live rubric references.
* Rubric level feedback does not automatically create comments or student feedback exports.

## Validation

Ran:

```powershell id="i26le6"
.\run_tests.ps1
```

Result:

* pytest: `1004 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
