### PR TITLE
Add synthetic starter review materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Guided export actions preserve overwrite protection. Student feedback export exp
 
 ### Review Materials
 
-The Review Materials menu is the preparation area for reusable teacher-authored review aids. It includes Comment Banks, Tag Banks, and Rubrics / Scoring Profiles submenus for creating, viewing, editing, extending, and validating shared reusable review materials. Optional synthetic starter materials remain a future workflow.
+The Review Materials menu is the preparation area for reusable teacher-authored review aids. It includes Comment Banks, Tag Banks, and Rubrics / Scoring Profiles submenus for creating, viewing, editing, extending, and validating shared reusable review materials. It also includes optional synthetic starter materials for onboarding and local testing.
 
 These materials help teachers review written student work more quickly by selecting prepared comments, tags, and scoring criteria instead of typing everything during review.
 
@@ -286,6 +286,8 @@ Comment banks store reusable teacher-authored feedback language. They do not gra
 Tag banks created through the menu are stored at `shared/tag_banks/<tag_bank_id>.json` and validate against the version `1` tag-bank contract. Tag banks store reusable teacher-authored observations for quick review tagging. They are not grades, scores, mastery determinations, generated feedback, or automatic judgments. During Review Student Work -> Add structured tag, teachers can select a reusable tag by bank, category, and tag template, or choose a custom one-off tag. Selected reusable tags snapshot label, polarity, optional severity, optional standard/criterion metadata, teacher notes, and `source: "tag_bank"` provenance into `review.json.tags`.
 
 Rubrics / scoring profiles created through the menu are stored at `shared/rubrics/<rubric_id>.json` and validate against the version `1` rubric contract. Assignment creation can select a valid shared rubric by number, while custom or unresolved rubric IDs remain allowed for compatibility. During Review Student Work -> Set criterion score, teachers can score from the assignment rubric by selecting a criterion and level, or choose Custom criterion score. Selected rubric scores snapshot the criterion ID, label, selected score, max score, scale, and optional teacher note into the existing `review.json.scores` shape. Rubric level feedback metadata does not automatically create comments or feedback entries.
+
+Starter Materials can preview, validate, and install clearly synthetic example comment banks, tag banks, and rubrics for general written responses, lab reports, research responses, reflection journals, and creative work. Installation copies only validated JSON files into `shared/comment_banks/`, `shared/tag_banks/`, and `shared/rubrics/`. Existing workspace files are skipped by default; overwriting requires exact `OVERWRITE` confirmation. Starter materials do not create assignments, rosters, scans, submissions, review records, exports, pds-core standards, pds-core route helpers, or pds-core standards profiles. See [`docs/starter_materials.md`](docs/starter_materials.md).
 
 Optional `standard_ids` in comment metadata are durable pds-core references only. Quillan comment-bank authoring does not create, import, edit, retire, reactivate, or validate standards as authoritative.
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -542,10 +542,31 @@ Tag banks are teacher-authored reusable observations for quick tagging. They do
 not grade work, imply mastery, generate automatic feedback, or mutate student
 records by themselves.
 
-Rubrics / Scoring Profiles and Starter Materials remain guidance-only. They do
-not create directories, edit files, install starter data, mutate student
-submissions, route scans, change rosters or assignments, write exports, or
-update review records.
+Rubrics / Scoring Profiles opens a submenu for teacher-authored reusable
+scoring profiles. It writes confirmed, valid version `1` rubrics only under
+`shared/rubrics/<rubric_id>.json`; assignment creation and review-time rubric
+scoring can immediately resolve valid shared rubrics.
+
+Starter Materials opens a submenu:
+
+```text
+1. Preview starter materials
+2. Validate starter materials
+3. Install all starter materials
+4. Install selected starter materials
+5. Back
+```
+
+Starter materials are optional synthetic examples for onboarding and local
+testing. The workflow validates source JSON files with the same comment-bank,
+tag-bank, and rubric validators used at runtime. Installation copies validated
+JSON files only into `shared/comment_banks/`, `shared/tag_banks/`, and
+`shared/rubrics/`. Existing files are skipped by default, and bulk overwrite
+requires the exact confirmation text `OVERWRITE`.
+
+Starter installation does not create assignments, rosters, scans, submissions,
+review records, exports, pds-core standards, pds-core standards profiles, or
+pds-core route helpers.
 
 Review materials are Quillan-owned teaching and review aids. They may later
 reference durable pds-core `profile_id` and `standard_id` values. Optional

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -398,3 +398,9 @@ The repository example at
 [`../examples/comment_banks/general_writing_synthetic.json`](../examples/comment_banks/general_writing_synthetic.json)
 contains synthetic teacher language only and demonstrates the version `1`
 shape.
+
+Additional optional synthetic starter comment banks live under
+[`../examples/comment_banks/`](../examples/comment_banks/). They can be
+installed from Review Materials -> Starter Materials into
+`shared/comment_banks/`; existing files are skipped unless exact overwrite
+confirmation is provided. See [`starter_materials.md`](starter_materials.md).

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -42,6 +42,13 @@ For reusable teacher-authored rubric / scoring profile records stored at
 assignment linkage, and review-time score snapshots, see
 [`rubric_contract.md`](rubric_contract.md).
 
+For optional synthetic starter review materials that can be previewed,
+validated, and installed into `shared/comment_banks/`, `shared/tag_banks/`, and
+`shared/rubrics/`, see [`starter_materials.md`](starter_materials.md). Starter
+installation is limited to those review-material folders and does not create
+assignments, rosters, scans, submissions, review records, exports, or pds-core
+standards.
+
 For the required structure and human-readable elements of a printable
 writing-response page, see
 [`printable_response_template.md`](printable_response_template.md).

--- a/docs/rubric_contract.md
+++ b/docs/rubric_contract.md
@@ -15,6 +15,13 @@ They may contain optional `standard_ids` as durable pds-core references, but
 Quillan does not create, import, edit, retire, reactivate, or otherwise manage
 pds-core standards through rubric workflows.
 
+Optional synthetic starter rubrics live under
+[`../examples/rubrics/`](../examples/rubrics/). They can be installed from
+Review Materials -> Starter Materials into `shared/rubrics/`; existing files are
+skipped unless exact overwrite confirmation is provided. Starter rubrics are
+examples only and are not official curriculum or recommended grading policy.
+See [`starter_materials.md`](starter_materials.md).
+
 ## Version 1
 
 Required top-level fields:

--- a/docs/starter_materials.md
+++ b/docs/starter_materials.md
@@ -1,0 +1,70 @@
+# Synthetic Starter Review Materials
+
+Quillan includes optional synthetic starter review materials for onboarding,
+testing, and local development.
+
+Starter materials are examples only. They are not official curriculum, not a
+recommended grading policy, and not a substitute for teacher-created local
+review materials.
+
+## What Is Included
+
+The starter set includes synthetic examples for varied written-work contexts:
+
+* general written responses;
+* lab reports;
+* research responses;
+* reflection journals;
+* creative writing and creative project reflections.
+
+The source files live under:
+
+```text
+examples/comment_banks/
+examples/tag_banks/
+examples/rubrics/
+```
+
+Each file is validated with the same runtime validators used for teacher-created
+comment banks, tag banks, and rubrics.
+
+## Installation
+
+Use:
+
+```text
+Quillan -> Review Materials -> Starter Materials
+```
+
+The submenu can preview, validate, install all, or install selected starter
+materials.
+
+Installed files are copied into the active workspace:
+
+```text
+shared/comment_banks/
+shared/tag_banks/
+shared/rubrics/
+```
+
+Existing workspace files are skipped by default. Bulk overwrite requires the
+exact confirmation text `OVERWRITE`; lowercase `overwrite`, `yes`, and `y` do
+not replace existing files.
+
+## Safety Boundaries
+
+Starter material installation creates or edits only:
+
+```text
+shared/comment_banks/
+shared/tag_banks/
+shared/rubrics/
+```
+
+It does not create assignments, rosters, scans, submissions, review records,
+exports, pds-core standards files, pds-core standards profiles, or pds-core route
+helpers. The starter files do not include pds-core `standard_ids`, so they stay
+portable across workspaces with different standards libraries.
+
+The examples are synthetic and subject-agnostic. Teachers should customize or
+replace them before local classroom use.

--- a/docs/tag_bank_contract.md
+++ b/docs/tag_bank_contract.md
@@ -80,6 +80,12 @@ writing, writes only valid files, atomically replaces existing files, and
 requires exact `OVERWRITE` confirmation before replacing an existing bank.
 Canceling creation does not create `shared/tag_banks/` or partial files.
 
+Optional synthetic starter tag banks live under
+[`../examples/tag_banks/`](../examples/tag_banks/). They can be installed from
+Review Materials -> Starter Materials into `shared/tag_banks/`; existing files
+are skipped unless exact overwrite confirmation is provided. See
+[`starter_materials.md`](starter_materials.md).
+
 Review mode can select reusable tags by bank, category, and template. Selected
 values are snapshotted into `review.json.tags` with `source: "tag_bank"`,
 `tag_bank_id`, and `tag_template_id`. Later edits to the source tag bank do not

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -214,6 +214,12 @@ as secondary detail. Missing comment banks point teachers to Review Materials
 The source contract and future assignment-activation design are defined in
 [`comment_bank_contract.md`](comment_bank_contract.md).
 
+Optional synthetic starter comment banks, tag banks, and rubrics can be
+installed from Review Materials -> Starter Materials for onboarding and
+testing. They are subject-agnostic examples only, install into shared
+review-material folders, and do not create assignments, rosters, submissions,
+review records, exports, or pds-core standards.
+
 Reusable tag banks are also selected in a bank, category, and tag-template
 flow. Custom tags are framed as one-off/manual observations with enumerated
 polarity and optional details grouped behind an explicit prompt. Missing tag

--- a/examples/comment_banks/creative_writing.json
+++ b/examples/comment_banks/creative_writing.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "comment_bank",
+  "bank_id": "creative_writing",
+  "title": "Creative Writing Comments",
+  "description": "Synthetic starter comment bank for testing creative-writing and creative-project review workflows.",
+  "scope": "shared",
+  "writing_types": ["creative_writing", "narrative", "creative_project"],
+  "categories": [
+    {"category_id": "voice", "label": "Voice", "sort_order": 10},
+    {"category_id": "detail_imagery", "label": "Detail / Imagery", "sort_order": 20},
+    {"category_id": "revision_craft", "label": "Revision / Craft", "sort_order": 30}
+  ],
+  "comments": [
+    {"comment_id": "voice_is_distinct", "label": "Voice is distinct", "text": "The piece has a clear voice that fits the creative purpose.", "category_id": "voice", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "voice_needs_focus", "label": "Voice needs focus", "text": "Strengthen the voice by making the tone more consistent.", "category_id": "voice", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "vivid_detail", "label": "Vivid detail", "text": "The specific detail helps the reader picture the moment or idea.", "category_id": "detail_imagery", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "add_sensory_detail", "label": "Add sensory detail", "text": "Add one sensory or concrete detail to make this part more vivid.", "category_id": "detail_imagery", "polarity": "neutral", "include_in_feedback_default": false, "student_facing": true, "module_details": {}},
+    {"comment_id": "revision_choice_visible", "label": "Revision choice visible", "text": "A craft or revision choice is visible and supports the purpose.", "category_id": "revision_craft", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "craft_target_needed", "label": "Craft target needed", "text": "Choose one craft target to revise, such as pacing, structure, or description.", "category_id": "revision_craft", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/comment_banks/general_written_response.json
+++ b/examples/comment_banks/general_written_response.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "comment_bank",
+  "bank_id": "general_written_response",
+  "title": "General Written Response Comments",
+  "description": "Synthetic starter comment bank for testing general written-response review workflows.",
+  "scope": "shared",
+  "writing_types": ["general", "constructed_response", "open_response"],
+  "categories": [
+    {"category_id": "content_accuracy", "label": "Content Accuracy", "sort_order": 10},
+    {"category_id": "reasoning_explanation", "label": "Reasoning / Explanation", "sort_order": 20},
+    {"category_id": "organization", "label": "Organization", "sort_order": 30}
+  ],
+  "comments": [
+    {"comment_id": "accurate_main_idea", "label": "Accurate main idea", "text": "Your main idea is clear and matches the task.", "category_id": "content_accuracy", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "check_key_detail", "label": "Check a key detail", "text": "Recheck one important detail so the response is fully accurate.", "category_id": "content_accuracy", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "strong_supporting_example", "label": "Strong supporting example", "text": "The supporting example helps explain the answer.", "category_id": "reasoning_explanation", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "explanation_needs_detail", "label": "Explanation needs detail", "text": "Add more explanation so the reader can follow your thinking.", "category_id": "reasoning_explanation", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "clear_sequence", "label": "Clear sequence", "text": "The response is organized in a sequence that is easy to follow.", "category_id": "organization", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "conclusion_unclear", "label": "Conclusion unclear", "text": "Clarify the final sentence so it connects back to the main idea.", "category_id": "organization", "polarity": "neutral", "include_in_feedback_default": false, "student_facing": true, "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/comment_banks/lab_report.json
+++ b/examples/comment_banks/lab_report.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "comment_bank",
+  "bank_id": "lab_report",
+  "title": "Lab Report Comments",
+  "description": "Synthetic starter comment bank for testing lab-report review workflows.",
+  "scope": "shared",
+  "writing_types": ["lab_report", "scientific_explanation", "process_method"],
+  "categories": [
+    {"category_id": "observation_data", "label": "Observation / Data", "sort_order": 10},
+    {"category_id": "procedure_method", "label": "Procedure / Method", "sort_order": 20},
+    {"category_id": "analysis_conclusion", "label": "Analysis / Conclusion", "sort_order": 30}
+  ],
+  "comments": [
+    {"comment_id": "data_recorded_clearly", "label": "Data recorded clearly", "text": "The observations are recorded clearly enough to support the conclusion.", "category_id": "observation_data", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "data_table_incomplete", "label": "Data table incomplete", "text": "Add missing values or labels so the data table can be interpreted.", "category_id": "observation_data", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "procedure_repeatable", "label": "Procedure repeatable", "text": "The method is described in a way another reader could repeat.", "category_id": "procedure_method", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "variables_need_clarity", "label": "Variables need clarity", "text": "Identify the variables or controls more clearly in the method.", "category_id": "procedure_method", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "conclusion_uses_evidence", "label": "Conclusion uses evidence", "text": "The conclusion connects back to evidence from the investigation.", "category_id": "analysis_conclusion", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "analysis_connection_missing", "label": "Analysis connection missing", "text": "Explain how the evidence supports the conclusion.", "category_id": "analysis_conclusion", "polarity": "neutral", "include_in_feedback_default": false, "student_facing": true, "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/comment_banks/reflection_journal.json
+++ b/examples/comment_banks/reflection_journal.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "comment_bank",
+  "bank_id": "reflection_journal",
+  "title": "Reflection Journal Comments",
+  "description": "Synthetic starter comment bank for testing reflection-journal review workflows.",
+  "scope": "shared",
+  "writing_types": ["reflection", "journal", "portfolio_reflection"],
+  "categories": [
+    {"category_id": "insight", "label": "Insight", "sort_order": 10},
+    {"category_id": "specificity", "label": "Specificity", "sort_order": 20},
+    {"category_id": "growth_next_steps", "label": "Growth / Next Steps", "sort_order": 30}
+  ],
+  "comments": [
+    {"comment_id": "thoughtful_insight", "label": "Thoughtful insight", "text": "The reflection shows thoughtful insight about the work or process.", "category_id": "insight", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "reflection_too_general", "label": "Reflection too general", "text": "Make the reflection more specific so it shows what was learned.", "category_id": "insight", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "specific_example_used", "label": "Specific example used", "text": "A specific example helps explain the reflection.", "category_id": "specificity", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "add_process_detail", "label": "Add process detail", "text": "Add a detail from the process to make the reflection more concrete.", "category_id": "specificity", "polarity": "neutral", "include_in_feedback_default": false, "student_facing": true, "module_details": {}},
+    {"comment_id": "clear_next_step", "label": "Clear next step", "text": "The next step is clear and connected to the reflection.", "category_id": "growth_next_steps", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "next_step_needed", "label": "Next step needed", "text": "Name one specific next step for future work.", "category_id": "growth_next_steps", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/comment_banks/research_response.json
+++ b/examples/comment_banks/research_response.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "comment_bank",
+  "bank_id": "research_response",
+  "title": "Research Response Comments",
+  "description": "Synthetic starter comment bank for testing research-response review workflows.",
+  "scope": "shared",
+  "writing_types": ["research", "source_use", "informational"],
+  "categories": [
+    {"category_id": "source_use", "label": "Source Use", "sort_order": 10},
+    {"category_id": "evidence_support", "label": "Evidence / Support", "sort_order": 20},
+    {"category_id": "organization", "label": "Organization", "sort_order": 30}
+  ],
+  "comments": [
+    {"comment_id": "relevant_source", "label": "Relevant source", "text": "The selected source is relevant to the research question.", "category_id": "source_use", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "citation_support_needed", "label": "Citation support needed", "text": "Add citation information so the reader can identify the source.", "category_id": "source_use", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "specific_evidence", "label": "Specific evidence", "text": "The response uses specific evidence instead of only a general claim.", "category_id": "evidence_support", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "explain_evidence", "label": "Explain evidence", "text": "Explain how the evidence supports the point being made.", "category_id": "evidence_support", "polarity": "developing", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "logical_grouping", "label": "Logical grouping", "text": "Related ideas are grouped in a logical way.", "category_id": "organization", "polarity": "positive", "include_in_feedback_default": true, "student_facing": true, "module_details": {}},
+    {"comment_id": "transition_needed", "label": "Transition needed", "text": "Add a transition to show how this idea connects to the next one.", "category_id": "organization", "polarity": "neutral", "include_in_feedback_default": false, "student_facing": true, "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/rubrics/creative_project_reflection.json
+++ b/examples/rubrics/creative_project_reflection.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "rubric",
+  "rubric_id": "creative_project_reflection",
+  "title": "Creative Project Reflection Rubric",
+  "description": "Synthetic starter rubric for testing creative-project reflection scoring workflows. It is not official curriculum or grading policy.",
+  "scope": "shared",
+  "writing_types": ["creative_writing", "narrative", "creative_project"],
+  "criteria": [
+    {"criterion_id": "creative_choice", "label": "Creative Choice", "max_score": 4, "scale": "4_point", "sort_order": 10, "levels": [{"score": 4, "label": "Choice explained", "module_details": {}}, {"score": 2, "label": "Choice named", "module_details": {}}, {"score": 0, "label": "Choice unclear", "module_details": {}}], "module_details": {}},
+    {"criterion_id": "process_reflection", "label": "Process Reflection", "max_score": 4, "scale": "4_point", "sort_order": 20, "levels": [{"score": 4, "label": "Process clearly described", "module_details": {}}, {"score": 2, "label": "Some process detail", "module_details": {}}, {"score": 0, "label": "Process unclear", "module_details": {}}], "module_details": {}},
+    {"criterion_id": "audience_purpose", "label": "Audience / Purpose", "max_score": 4, "scale": "4_point", "sort_order": 30, "levels": [{"score": 4, "label": "Audience impact clear", "module_details": {}}, {"score": 2, "label": "Audience partly addressed", "module_details": {}}, {"score": 0, "label": "Audience unclear", "module_details": {}}], "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/rubrics/general_constructed_response.json
+++ b/examples/rubrics/general_constructed_response.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "rubric",
+  "rubric_id": "general_constructed_response",
+  "title": "General Constructed Response Rubric",
+  "description": "Synthetic starter rubric for testing general constructed-response scoring workflows. It is not official curriculum or grading policy.",
+  "scope": "shared",
+  "writing_types": ["general", "constructed_response", "open_response"],
+  "criteria": [
+    {"criterion_id": "content_accuracy", "label": "Content Accuracy", "max_score": 4, "scale": "4_point", "sort_order": 10, "levels": [{"score": 4, "label": "Accurate and complete", "module_details": {}}, {"score": 2, "label": "Partly accurate", "module_details": {}}, {"score": 0, "label": "Not yet accurate", "module_details": {}}], "module_details": {}},
+    {"criterion_id": "reasoning_explanation", "label": "Reasoning / Explanation", "max_score": 4, "scale": "4_point", "sort_order": 20, "levels": [{"score": 4, "label": "Clear and supported", "module_details": {}}, {"score": 2, "label": "Some explanation", "module_details": {}}, {"score": 0, "label": "Little explanation", "module_details": {}}], "module_details": {}},
+    {"criterion_id": "organization", "label": "Organization", "max_score": 4, "scale": "4_point", "sort_order": 30, "levels": [{"score": 4, "label": "Easy to follow", "module_details": {}}, {"score": 2, "label": "Mostly followable", "module_details": {}}, {"score": 0, "label": "Hard to follow", "module_details": {}}], "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/rubrics/lab_report.json
+++ b/examples/rubrics/lab_report.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "rubric",
+  "rubric_id": "lab_report",
+  "title": "Lab Report Rubric",
+  "description": "Synthetic starter rubric for testing lab-report scoring workflows. It is not official curriculum or grading policy.",
+  "scope": "shared",
+  "writing_types": ["lab_report", "scientific_explanation", "process_method"],
+  "criteria": [
+    {"criterion_id": "procedure_method", "label": "Procedure / Method", "max_score": 4, "scale": "4_point", "sort_order": 10, "levels": [{"score": 4, "label": "Repeatable method", "module_details": {}}, {"score": 2, "label": "Partly clear method", "module_details": {}}, {"score": 0, "label": "Method unclear", "module_details": {}}], "module_details": {}},
+    {"criterion_id": "data_observation", "label": "Data / Observation", "max_score": 4, "scale": "4_point", "sort_order": 20, "levels": [{"score": 4, "label": "Complete and clear", "module_details": {}}, {"score": 2, "label": "Some data present", "module_details": {}}, {"score": 0, "label": "Data missing", "module_details": {}}], "module_details": {}},
+    {"criterion_id": "analysis_conclusion", "label": "Analysis / Conclusion", "max_score": 4, "scale": "4_point", "sort_order": 30, "levels": [{"score": 4, "label": "Conclusion uses evidence", "module_details": {}}, {"score": 2, "label": "Conclusion partly supported", "module_details": {}}, {"score": 0, "label": "Conclusion unsupported", "module_details": {}}], "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/rubrics/reflection_journal.json
+++ b/examples/rubrics/reflection_journal.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "rubric",
+  "rubric_id": "reflection_journal",
+  "title": "Reflection Journal Rubric",
+  "description": "Synthetic starter rubric for testing reflection-journal scoring workflows. It is not official curriculum or grading policy.",
+  "scope": "shared",
+  "writing_types": ["reflection", "journal", "portfolio_reflection"],
+  "criteria": [
+    {"criterion_id": "insight", "label": "Insight", "max_score": 4, "scale": "4_point", "sort_order": 10, "levels": [{"score": 4, "label": "Thoughtful insight", "module_details": {}}, {"score": 2, "label": "Some reflection", "module_details": {}}, {"score": 0, "label": "Minimal reflection", "module_details": {}}], "module_details": {}},
+    {"criterion_id": "specificity", "label": "Specificity", "max_score": 4, "scale": "4_point", "sort_order": 20, "levels": [{"score": 4, "label": "Specific evidence", "module_details": {}}, {"score": 2, "label": "Some detail", "module_details": {}}, {"score": 0, "label": "Too general", "module_details": {}}], "module_details": {}},
+    {"criterion_id": "growth_next_steps", "label": "Growth / Next Steps", "max_score": 4, "scale": "4_point", "sort_order": 30, "levels": [{"score": 4, "label": "Clear next step", "module_details": {}}, {"score": 2, "label": "General next step", "module_details": {}}, {"score": 0, "label": "Next step missing", "module_details": {}}], "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/rubrics/research_project.json
+++ b/examples/rubrics/research_project.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "rubric",
+  "rubric_id": "research_project",
+  "title": "Research Project Rubric",
+  "description": "Synthetic starter rubric for testing research-project scoring workflows. It is not official curriculum or grading policy.",
+  "scope": "shared",
+  "writing_types": [
+    "research",
+    "source_use",
+    "informational"
+  ],
+  "criteria": [
+    {
+      "criterion_id": "source_use",
+      "label": "Source Use",
+      "max_score": 4,
+      "scale": "4_point",
+      "sort_order": 10,
+      "levels": [
+        {
+          "score": 4,
+          "label": "Relevant sources",
+          "module_details": {}
+        },
+        {
+          "score": 2,
+          "label": "Some source support",
+          "module_details": {}
+        },
+        {
+          "score": 0,
+          "label": "Source support missing",
+          "module_details": {}
+        }
+      ],
+      "module_details": {}
+    },
+    {
+      "criterion_id": "evidence_support",
+      "label": "Evidence / Support",
+      "max_score": 4,
+      "scale": "4_point",
+      "sort_order": 20,
+      "levels": [
+        {
+          "score": 4,
+          "label": "Specific evidence",
+          "module_details": {}
+        },
+        {
+          "score": 2,
+          "label": "General evidence",
+          "module_details": {}
+        },
+        {
+          "score": 0,
+          "label": "Evidence unclear",
+          "module_details": {}
+        }
+      ],
+      "module_details": {}
+    },
+    {
+      "criterion_id": "synthesis_explanation",
+      "label": "Synthesis / Explanation",
+      "max_score": 4,
+      "scale": "4_point",
+      "sort_order": 30,
+      "levels": [
+        {
+          "score": 4,
+          "label": "Ideas connected",
+          "module_details": {}
+        },
+        {
+          "score": 2,
+          "label": "Some connection",
+          "module_details": {}
+        },
+        {
+          "score": 0,
+          "label": "Connection missing",
+          "module_details": {}
+        }
+      ],
+      "module_details": {}
+    }
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/tag_banks/creative_process_tags.json
+++ b/examples/tag_banks/creative_process_tags.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "tag_bank",
+  "tag_bank_id": "creative_process_tags",
+  "title": "Creative Process Tags",
+  "description": "Synthetic starter tag bank for testing creative-process review workflows.",
+  "scope": "shared",
+  "writing_types": ["creative_writing", "narrative", "creative_project"],
+  "categories": [
+    {"category_id": "creative_choice", "label": "Creative Choice", "module_details": {}, "sort_order": 10},
+    {"category_id": "craft_revision", "label": "Craft / Revision", "module_details": {}, "sort_order": 20},
+    {"category_id": "audience_purpose", "label": "Audience / Purpose", "module_details": {}, "sort_order": 30}
+  ],
+  "tags": [
+    {"tag_template_id": "strong_design_choice", "label": "Strong design choice", "category_id": "creative_choice", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "choice_needs_explanation", "label": "Choice needs explanation", "category_id": "creative_choice", "polarity": "developing", "severity_default": 1, "module_details": {}},
+    {"tag_template_id": "vivid_detail", "label": "Vivid detail", "category_id": "craft_revision", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "revision_target_identified", "label": "Revision target identified", "category_id": "craft_revision", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "audience_impact_clear", "label": "Audience impact clear", "category_id": "audience_purpose", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "audience_impact_unclear", "label": "Audience impact unclear", "category_id": "audience_purpose", "polarity": "neutral", "teacher_note_prompt": "What audience response should be clarified?", "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/tag_banks/general_written_response_tags.json
+++ b/examples/tag_banks/general_written_response_tags.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "tag_bank",
+  "tag_bank_id": "general_written_response_tags",
+  "title": "General Written Response Tags",
+  "description": "Synthetic starter tag bank for testing general written-response review workflows.",
+  "scope": "shared",
+  "writing_types": ["general", "constructed_response", "open_response"],
+  "categories": [
+    {"category_id": "content_accuracy", "label": "Content Accuracy", "module_details": {}, "sort_order": 10},
+    {"category_id": "reasoning_explanation", "label": "Reasoning / Explanation", "module_details": {}, "sort_order": 20},
+    {"category_id": "organization", "label": "Organization", "module_details": {}, "sort_order": 30}
+  ],
+  "tags": [
+    {"tag_template_id": "clear_main_idea", "label": "Clear main idea", "category_id": "content_accuracy", "polarity": "positive", "severity_default": 0, "student_facing_default": true, "module_details": {}},
+    {"tag_template_id": "accuracy_check_needed", "label": "Accuracy check needed", "category_id": "content_accuracy", "polarity": "developing", "severity_default": 1, "teacher_note_prompt": "What detail should be checked?", "module_details": {}},
+    {"tag_template_id": "strong_supporting_example", "label": "Strong supporting example", "category_id": "reasoning_explanation", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "explanation_needs_more_detail", "label": "Explanation needs more detail", "category_id": "reasoning_explanation", "polarity": "developing", "severity_default": 1, "module_details": {}},
+    {"tag_template_id": "organized_sequence", "label": "Organized sequence", "category_id": "organization", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "unclear_conclusion", "label": "Unclear conclusion", "category_id": "organization", "polarity": "neutral", "teacher_note_prompt": "What should the conclusion reconnect to?", "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/tag_banks/lab_report_tags.json
+++ b/examples/tag_banks/lab_report_tags.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "tag_bank",
+  "tag_bank_id": "lab_report_tags",
+  "title": "Lab Report Tags",
+  "description": "Synthetic starter tag bank for testing lab-report review workflows.",
+  "scope": "shared",
+  "writing_types": ["lab_report", "scientific_explanation", "process_method"],
+  "categories": [
+    {"category_id": "procedure_method", "label": "Procedure / Method", "module_details": {}, "sort_order": 10},
+    {"category_id": "observation_data", "label": "Observation / Data", "module_details": {}, "sort_order": 20},
+    {"category_id": "analysis_conclusion", "label": "Analysis / Conclusion", "module_details": {}, "sort_order": 30}
+  ],
+  "tags": [
+    {"tag_template_id": "procedure_is_repeatable", "label": "Procedure is repeatable", "category_id": "procedure_method", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "variables_unclear", "label": "Variables unclear", "category_id": "procedure_method", "polarity": "developing", "severity_default": 1, "teacher_note_prompt": "Which variable or control is unclear?", "module_details": {}},
+    {"tag_template_id": "data_table_complete", "label": "Data table complete", "category_id": "observation_data", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "data_table_incomplete", "label": "Data table incomplete", "category_id": "observation_data", "polarity": "negative", "severity_default": 2, "module_details": {}},
+    {"tag_template_id": "conclusion_connects_to_evidence", "label": "Conclusion connects to evidence", "category_id": "analysis_conclusion", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "analysis_needs_connection", "label": "Analysis needs connection", "category_id": "analysis_conclusion", "polarity": "neutral", "teacher_note_prompt": "What evidence should be explained?", "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/tag_banks/reflection_tags.json
+++ b/examples/tag_banks/reflection_tags.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "tag_bank",
+  "tag_bank_id": "reflection_tags",
+  "title": "Reflection Tags",
+  "description": "Synthetic starter tag bank for testing reflection and journal review workflows.",
+  "scope": "shared",
+  "writing_types": ["reflection", "journal", "portfolio_reflection"],
+  "categories": [
+    {"category_id": "insight", "label": "Insight", "module_details": {}, "sort_order": 10},
+    {"category_id": "specificity", "label": "Specificity", "module_details": {}, "sort_order": 20},
+    {"category_id": "growth_next_steps", "label": "Growth / Next Steps", "module_details": {}, "sort_order": 30}
+  ],
+  "tags": [
+    {"tag_template_id": "specific_self_assessment", "label": "Specific self-assessment", "category_id": "insight", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "reflection_too_general", "label": "Reflection too general", "category_id": "insight", "polarity": "developing", "severity_default": 1, "module_details": {}},
+    {"tag_template_id": "example_from_process", "label": "Example from process", "category_id": "specificity", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "needs_specific_detail", "label": "Needs specific detail", "category_id": "specificity", "polarity": "neutral", "teacher_note_prompt": "What kind of detail would help?", "module_details": {}},
+    {"tag_template_id": "clear_next_step", "label": "Clear next step", "category_id": "growth_next_steps", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "growth_with_evidence_needed", "label": "Growth needs evidence", "category_id": "growth_next_steps", "polarity": "developing", "severity_default": 1, "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/examples/tag_banks/research_tags.json
+++ b/examples/tag_banks/research_tags.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "module": "quillan",
+  "record_type": "tag_bank",
+  "tag_bank_id": "research_tags",
+  "title": "Research Tags",
+  "description": "Synthetic starter tag bank for testing research and source-use review workflows.",
+  "scope": "shared",
+  "writing_types": ["research", "source_use", "informational"],
+  "categories": [
+    {"category_id": "source_use", "label": "Source Use", "module_details": {}, "sort_order": 10},
+    {"category_id": "evidence_support", "label": "Evidence / Support", "module_details": {}, "sort_order": 20},
+    {"category_id": "synthesis", "label": "Synthesis", "module_details": {}, "sort_order": 30}
+  ],
+  "tags": [
+    {"tag_template_id": "source_is_relevant", "label": "Source is relevant", "category_id": "source_use", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "needs_citation_support", "label": "Needs citation support", "category_id": "source_use", "polarity": "developing", "severity_default": 1, "module_details": {}},
+    {"tag_template_id": "specific_evidence", "label": "Specific evidence", "category_id": "evidence_support", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "evidence_not_explained", "label": "Evidence is summarized but not explained", "category_id": "evidence_support", "polarity": "neutral", "teacher_note_prompt": "Which evidence needs explanation?", "module_details": {}},
+    {"tag_template_id": "multiple_sources_synthesized", "label": "Multiple sources are synthesized", "category_id": "synthesis", "polarity": "positive", "module_details": {}},
+    {"tag_template_id": "single_source_only", "label": "Single source only", "category_id": "synthesis", "polarity": "negative", "severity_default": 2, "module_details": {}}
+  ],
+  "created_at": "2026-01-01T00:00:00+00:00",
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "module_details": {}
+}

--- a/quillan/review_materials_menu.py
+++ b/quillan/review_materials_menu.py
@@ -41,7 +41,11 @@ def launch_review_materials_menu() -> int:
 
                 launch_rubrics_menu()
             elif choice == "4":
-                _show_starter_materials_info()
+                from quillan.starter_material_workflows import (
+                    launch_starter_materials_menu,
+                )
+
+                launch_starter_materials_menu()
             else:
                 print("Invalid selection. Please enter a number from 1 to 5.")
                 print()
@@ -72,23 +76,6 @@ def _show_tag_banks_info() -> None:
     print()
     print("Expected future workspace location:")
     print("shared/tag_banks/")
-    print()
-    print("No files were changed.")
-    print()
-    pause_for_user()
-
-
-def _show_starter_materials_info() -> None:
-    from quillan.menu import clear_screen, pause_for_user, print_menu_header
-
-    clear_screen()
-    print_menu_header("Starter Materials")
-    print(
-        "Starter materials will provide optional synthetic examples for "
-        "local testing and setup."
-    )
-    print()
-    print("Starter material installation will be implemented in #169.")
     print()
     print("No files were changed.")
     print()

--- a/quillan/starter_material_workflows.py
+++ b/quillan/starter_material_workflows.py
@@ -1,0 +1,312 @@
+"""Teacher-facing workflows for synthetic starter review materials."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.starter_materials import (
+    StarterInstallSummary,
+    StarterMaterial,
+    StarterMaterialError,
+    StarterValidationResult,
+    discover_starter_materials,
+    install_starter_materials,
+    summarize_install_impact,
+    target_path_for_material,
+    validate_all_starter_materials,
+)
+
+
+def launch_starter_materials_menu() -> int:
+    """Launch the synthetic starter-materials submenu."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Starter Materials")
+            print(
+                "Synthetic starter materials help teachers and developers test "
+                "Quillan without manually creating JSON files."
+            )
+            print()
+            print(
+                "They include sample comment banks, tag banks, and rubrics for "
+                "varied written-work contexts."
+            )
+            print()
+            print("1. Preview starter materials")
+            print("2. Validate starter materials")
+            print("3. Install all starter materials")
+            print("4. Install selected starter materials")
+            print("5. Back")
+            print()
+
+            choice = input("Select an option: ").strip()
+            print()
+            if choice in {"", "5"}:
+                return 0
+            workflows = {
+                "1": prompt_preview_starter_materials,
+                "2": prompt_validate_starter_materials,
+                "3": prompt_install_all_starter_materials,
+                "4": prompt_install_selected_starter_materials,
+            }
+            workflow = workflows.get(choice)
+            if workflow is None:
+                print("Invalid selection. Please enter a number from 1 to 5.")
+            else:
+                clear_screen()
+                workflow()
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting starter materials menu.")
+        return 0
+
+
+def prompt_preview_starter_materials() -> int:
+    """Preview starter materials grouped by material type."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Preview Starter Materials")
+    materials = discover_starter_materials()
+    _print_material_groups(materials, workspace_root=_workspace_root_or_cwd())
+    return 0
+
+
+def prompt_validate_starter_materials() -> int:
+    """Validate every starter-material source file."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Validate Starter Materials")
+    materials = discover_starter_materials()
+    results = validate_all_starter_materials(materials)
+    _print_validation_results(results)
+    return 0 if all(result.is_valid for result in results) else 1
+
+
+def prompt_install_all_starter_materials() -> int:
+    """Prompt for and install all valid starter materials."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Install Synthetic Starter Materials")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    materials = discover_starter_materials()
+    print(
+        "This will copy synthetic comment banks, tag banks, and rubrics into "
+        "the active workspace."
+    )
+    print()
+    _print_target_folders()
+    print(
+        "These files are examples only. They do not create assignments, "
+        "rosters, scans, submissions, review records, exports, or "
+        "pds-core standards."
+    )
+    print()
+    print("1. Install")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Starter material installation canceled. No files were changed.")
+        return 1
+    return _confirm_and_install(workspace_root, materials)
+
+
+def prompt_install_selected_starter_materials() -> int:
+    """Prompt for and install selected starter materials."""
+    from quillan.menu import print_menu_header
+
+    print_menu_header("Install Selected Starter Materials")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    materials = discover_starter_materials()
+    for index, material in enumerate(materials, start=1):
+        print(f"{index}. {material.display_name}")
+    print()
+    selection = input("Enter numbers, comma-separated, or B to go back: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print(
+            "Selected starter material installation canceled. "
+            "No files were changed."
+        )
+        return 1
+    selected = _parse_selection(selection, materials)
+    if selected is None:
+        print("Invalid selection. Please enter listed numbers separated by commas.")
+        return 1
+    return _confirm_and_install(workspace_root, selected)
+
+
+def _confirm_and_install(
+    workspace_root: Path,
+    materials: tuple[StarterMaterial, ...],
+) -> int:
+    validation = validate_all_starter_materials(materials)
+    invalid = [result for result in validation if not result.is_valid]
+    if invalid:
+        _print_validation_results(validation)
+        print()
+        print("Installation aborted because one or more starter files are invalid.")
+        return 1
+
+    summary = summarize_install_impact(workspace_root, materials)
+    _print_install_summary(summary)
+    choice = input("Select an option: ").strip()
+    if choice == "1":
+        overwrite = False
+    elif choice == "2":
+        confirmation = input(
+            "Type OVERWRITE to replace existing starter-material files: "
+        ).strip()
+        if confirmation != "OVERWRITE":
+            print("Overwrite canceled. Existing files were not changed.")
+            return 1
+        overwrite = True
+    else:
+        print("Starter material installation canceled. No files were changed.")
+        return 1
+
+    try:
+        result = install_starter_materials(
+            workspace_root,
+            materials,
+            overwrite=overwrite,
+        )
+    except StarterMaterialError as error:
+        print(f"Error: {error}")
+        return 1
+
+    print()
+    print(f"Installed files: {len(result.installed)}")
+    print(f"Skipped existing files: {len(result.skipped_existing)}")
+    for path in result.installed:
+        print(f"- {path.relative_to(workspace_root).as_posix()}")
+    return 0
+
+
+def _print_material_groups(
+    materials: tuple[StarterMaterial, ...],
+    *,
+    workspace_root: Path,
+) -> None:
+    groups = (
+        ("Comment Banks", "comment_bank"),
+        ("Tag Banks", "tag_bank"),
+        ("Rubrics / Scoring Profiles", "rubric"),
+    )
+    index = 1
+    for heading, kind in groups:
+        print(heading)
+        for material in [item for item in materials if item.kind == kind]:
+            print(f"{index}. {material.display_name}")
+            print(f"   ID: {material.material_id}")
+            print(f"   Writing types: {', '.join(material.writing_types)}")
+            if material.kind == "rubric":
+                print(f"   Criteria: {material.item_count}")
+            elif material.kind == "tag_bank":
+                print(
+                    f"   Categories: {material.categories_count}; "
+                    f"Tags: {material.item_count}"
+                )
+            else:
+                print(
+                    f"   Categories: {material.categories_count}; "
+                    f"Comments: {material.item_count}"
+                )
+            print(f"   Source: {material.source_path}")
+            print(f"   Target: {_workspace_relative_target(workspace_root, material)}")
+            index += 1
+        print()
+
+
+def _print_validation_results(
+    results: tuple[StarterValidationResult, ...],
+) -> None:
+    print("Starter material validation")
+    print()
+    groups = (
+        ("Comment Banks:", "comment_bank"),
+        ("Tag Banks:", "tag_bank"),
+        ("Rubrics:", "rubric"),
+    )
+    for heading, kind in groups:
+        print(heading)
+        for result in results:
+            if result.material.kind != kind:
+                continue
+            status = "OK" if result.is_valid else "INVALID"
+            print(f"{status} {result.material.source_path.name}")
+            if result.error:
+                print(f"  Error: {result.error}")
+        print()
+
+
+def _print_target_folders() -> None:
+    print("Target folders:")
+    print("shared/comment_banks/")
+    print("shared/tag_banks/")
+    print("shared/rubrics/")
+    print()
+
+
+def _print_install_summary(summary: StarterInstallSummary) -> None:
+    print("Install summary:")
+    print()
+    print(f"New files: {summary.new_files}")
+    print(f"Existing files that would be skipped: {summary.existing_files}")
+    print(f"Existing files that would require overwrite: {summary.overwrite_files}")
+    print()
+    print("1. Install new files only")
+    print("2. Install and overwrite existing files")
+    print("3. Back")
+    print()
+
+
+def _parse_selection(
+    selection: str,
+    materials: tuple[StarterMaterial, ...],
+) -> tuple[StarterMaterial, ...] | None:
+    selected: list[StarterMaterial] = []
+    seen: set[int] = set()
+    for raw_item in selection.split(","):
+        item = raw_item.strip()
+        if not item.isdigit():
+            return None
+        index = int(item)
+        if not 1 <= index <= len(materials):
+            return None
+        if index not in seen:
+            selected.append(materials[index - 1])
+            seen.add(index)
+    return tuple(selected) if selected else None
+
+
+def _workspace_relative_target(
+    workspace_root: Path,
+    material: StarterMaterial,
+) -> str:
+    return target_path_for_material(workspace_root, material).relative_to(
+        workspace_root
+    ).as_posix()
+
+
+def _workspace_root() -> Path | None:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError as error:
+        print(f"Error: {error}")
+        return None
+
+
+def _workspace_root_or_cwd() -> Path:
+    try:
+        return resolve_workspace_root()
+    except WorkspaceRootError:
+        return Path.cwd()

--- a/quillan/starter_materials.py
+++ b/quillan/starter_materials.py
@@ -1,0 +1,248 @@
+"""Discovery, validation, and safe installation of synthetic starter materials."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from quillan.comment_banks import CommentBankError, load_comment_bank
+from quillan.rubrics import RubricError, load_rubric
+from quillan.tag_banks import TagBankError, load_tag_bank
+
+MaterialKind = Literal["comment_bank", "tag_bank", "rubric"]
+
+_SOURCE_ROOT = Path(__file__).resolve().parents[1] / "examples"
+_KINDS: tuple[MaterialKind, ...] = ("comment_bank", "tag_bank", "rubric")
+_SOURCE_DIRS: dict[MaterialKind, str] = {
+    "comment_bank": "comment_banks",
+    "tag_bank": "tag_banks",
+    "rubric": "rubrics",
+}
+_TARGET_DIRS: dict[MaterialKind, str] = {
+    "comment_bank": "shared/comment_banks",
+    "tag_bank": "shared/tag_banks",
+    "rubric": "shared/rubrics",
+}
+_STARTER_FILES: dict[MaterialKind, tuple[str, ...]] = {
+    "comment_bank": (
+        "general_written_response.json",
+        "lab_report.json",
+        "research_response.json",
+        "reflection_journal.json",
+        "creative_writing.json",
+    ),
+    "tag_bank": (
+        "general_written_response_tags.json",
+        "lab_report_tags.json",
+        "research_tags.json",
+        "reflection_tags.json",
+        "creative_process_tags.json",
+    ),
+    "rubric": (
+        "general_constructed_response.json",
+        "lab_report.json",
+        "research_project.json",
+        "reflection_journal.json",
+        "creative_project_reflection.json",
+    ),
+}
+class StarterMaterialError(ValueError):
+    """Raised when starter materials cannot be discovered or installed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class StarterMaterial:
+    """One synthetic starter-material source file."""
+
+    kind: MaterialKind
+    source_path: Path
+    title: str
+    material_id: str
+    writing_types: tuple[str, ...]
+    categories_count: int
+    item_count: int
+
+    @property
+    def display_name(self) -> str:
+        return self.title
+
+
+@dataclass(frozen=True, slots=True)
+class StarterValidationResult:
+    """Validation result for one starter-material source file."""
+
+    material: StarterMaterial
+    error: str | None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.error is None
+
+
+@dataclass(frozen=True, slots=True)
+class StarterInstallSummary:
+    """Overwrite impact for a pending starter-material install."""
+
+    new_files: int
+    existing_files: int
+    overwrite_files: int
+
+
+@dataclass(frozen=True, slots=True)
+class StarterInstallResult:
+    """Result of copying selected starter materials into a workspace."""
+
+    installed: tuple[Path, ...]
+    skipped_existing: tuple[Path, ...]
+
+
+def starter_examples_root() -> Path:
+    """Return the repository/package-relative starter examples directory."""
+    return _SOURCE_ROOT
+
+
+def discover_starter_materials() -> tuple[StarterMaterial, ...]:
+    """Discover and validate starter-material metadata from source JSON files."""
+    materials: list[StarterMaterial] = []
+    for kind in _KINDS:
+        directory = _SOURCE_ROOT / _SOURCE_DIRS[kind]
+        for file_name in _STARTER_FILES[kind]:
+            source_path = directory / file_name
+            if not source_path.is_file():
+                raise StarterMaterialError(
+                    f"Starter material source file not found: {source_path}"
+                )
+            data = _load_material_data(kind, source_path)
+            material_id = _material_id(kind, data)
+            if material_id != source_path.stem:
+                raise StarterMaterialError(
+                    f"{source_path} has id {material_id!r}; expected "
+                    f"{source_path.stem!r} from its filename."
+                )
+            materials.append(
+                StarterMaterial(
+                    kind=kind,
+                    source_path=source_path,
+                    title=str(data["title"]),
+                    material_id=material_id,
+                    writing_types=tuple(str(item) for item in data["writing_types"]),
+                    categories_count=_categories_count(kind, data),
+                    item_count=_item_count(kind, data),
+                )
+            )
+    return tuple(materials)
+
+
+def target_path_for_material(
+    workspace_root: str | Path,
+    material: StarterMaterial,
+) -> Path:
+    """Return the safe shared review-material target path for one material."""
+    return Path(workspace_root) / _TARGET_DIRS[material.kind] / material.source_path.name
+
+
+def validate_starter_material(material: StarterMaterial) -> StarterValidationResult:
+    """Validate one starter-material source file with its runtime validator."""
+    try:
+        _load_material_data(material.kind, material.source_path)
+    except (CommentBankError, TagBankError, RubricError, OSError) as error:
+        return StarterValidationResult(material, str(error))
+    return StarterValidationResult(material, None)
+
+
+def validate_all_starter_materials(
+    materials: tuple[StarterMaterial, ...] | None = None,
+) -> tuple[StarterValidationResult, ...]:
+    """Validate all discovered starter materials."""
+    selected = discover_starter_materials() if materials is None else materials
+    return tuple(validate_starter_material(material) for material in selected)
+
+
+def summarize_install_impact(
+    workspace_root: str | Path,
+    materials: tuple[StarterMaterial, ...],
+) -> StarterInstallSummary:
+    """Summarize how many selected targets are new or already exist."""
+    existing = sum(1 for material in materials if _target_exists(workspace_root, material))
+    new = len(materials) - existing
+    return StarterInstallSummary(
+        new_files=new,
+        existing_files=existing,
+        overwrite_files=existing,
+    )
+
+
+def install_starter_materials(
+    workspace_root: str | Path,
+    materials: tuple[StarterMaterial, ...],
+    *,
+    overwrite: bool = False,
+) -> StarterInstallResult:
+    """Validate and copy selected starter materials into a workspace.
+
+    Only shared comment-bank, tag-bank, and rubric folders are ever created.
+    Existing files are skipped unless ``overwrite`` is true.
+    """
+    if not materials:
+        return StarterInstallResult(installed=(), skipped_existing=())
+    validation = validate_all_starter_materials(materials)
+    invalid = [result for result in validation if not result.is_valid]
+    if invalid:
+        first = invalid[0]
+        raise StarterMaterialError(
+            f"Starter material is invalid: {first.material.source_path}: "
+            f"{first.error}"
+        )
+
+    installed: list[Path] = []
+    skipped: list[Path] = []
+    for material in materials:
+        target_path = target_path_for_material(workspace_root, material)
+        if target_path.exists() and not overwrite:
+            skipped.append(target_path)
+            continue
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(material.source_path, target_path)
+        installed.append(target_path)
+    return StarterInstallResult(
+        installed=tuple(installed),
+        skipped_existing=tuple(skipped),
+    )
+
+
+def _load_material_data(kind: MaterialKind, source_path: Path) -> dict[str, Any]:
+    if kind == "comment_bank":
+        return load_comment_bank(source_path)
+    if kind == "tag_bank":
+        return load_tag_bank(source_path)
+    return load_rubric(source_path)
+
+
+def _material_id(kind: MaterialKind, data: dict[str, Any]) -> str:
+    field = {
+        "comment_bank": "bank_id",
+        "tag_bank": "tag_bank_id",
+        "rubric": "rubric_id",
+    }[kind]
+    return str(data[field])
+
+
+def _categories_count(kind: MaterialKind, data: dict[str, Any]) -> int:
+    if kind == "rubric":
+        return 0
+    return len(data["categories"])
+
+
+def _item_count(kind: MaterialKind, data: dict[str, Any]) -> int:
+    field = {
+        "comment_bank": "comments",
+        "tag_bank": "tags",
+        "rubric": "criteria",
+    }[kind]
+    return len(data[field])
+
+
+def _target_exists(workspace_root: str | Path, material: StarterMaterial) -> bool:
+    return target_path_for_material(workspace_root, material).exists()

--- a/tests/test_review_materials_menu.py
+++ b/tests/test_review_materials_menu.py
@@ -94,7 +94,6 @@ def test_review_materials_menu_navigation_returns_to_main_menu(
     ("choice", "header", "future_issue", "path_text"),
     [
         ("2", "Tag Banks", "#166", "shared/tag_banks/"),
-        ("4", "Starter Materials", "#169", ""),
     ],
 )
 def test_review_materials_informational_screens_return_safely(
@@ -115,6 +114,22 @@ def test_review_materials_informational_screens_return_safely(
     assert "No files were changed." in output
     if path_text:
         assert path_text in output
+
+
+def test_review_materials_starter_materials_opens_real_submenu(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["4", "5", "5"])
+
+    assert launch_review_materials_menu() == 0
+
+    output = capsys.readouterr().out
+    assert "Starter Materials" in output
+    assert "1. Preview starter materials" in output
+    assert "2. Validate starter materials" in output
+    assert "3. Install all starter materials" in output
+    assert "4. Install selected starter materials" in output
 
 
 def test_review_materials_rubrics_opens_submenu(

--- a/tests/test_starter_materials.py
+++ b/tests/test_starter_materials.py
@@ -1,0 +1,296 @@
+"""Tests for synthetic starter review materials."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import quillan.starter_material_workflows as workflows
+from quillan.assignment_workflows import resolve_assignment_rubric
+from quillan.comment_bank_writing import list_valid_comment_banks
+from quillan.comment_banks import load_comment_bank
+from quillan.rubric_writing import list_valid_rubrics
+from quillan.rubrics import load_rubric
+from quillan.starter_materials import (
+    discover_starter_materials,
+    install_starter_materials,
+    summarize_install_impact,
+    target_path_for_material,
+    validate_all_starter_materials,
+)
+from quillan.tag_bank_writing import list_valid_tag_banks
+from quillan.tag_banks import load_tag_bank
+
+
+def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
+    response_iterator: Iterator[str] = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(response_iterator)
+        except StopIteration as error:
+            raise AssertionError("Menu requested unexpected input.") from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _patch_workspace(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: root)
+
+
+def _file_tree(root: Path) -> tuple[tuple[str, str, bytes | None], ...]:
+    entries: list[tuple[str, str, bytes | None]] = []
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        if path.is_file():
+            entries.append(("file", relative, path.read_bytes()))
+        elif path.is_dir():
+            entries.append(("dir", relative, None))
+    return tuple(entries)
+
+
+def test_every_starter_material_validates_and_id_matches_filename() -> None:
+    materials = discover_starter_materials()
+
+    assert len(materials) == 15
+    assert all(result.is_valid for result in validate_all_starter_materials(materials))
+    for material in materials:
+        if material.kind == "comment_bank":
+            data = load_comment_bank(material.source_path)
+            assert data["bank_id"] == material.source_path.stem
+        elif material.kind == "tag_bank":
+            data = load_tag_bank(material.source_path)
+            assert data["tag_bank_id"] == material.source_path.stem
+        else:
+            data = load_rubric(material.source_path)
+            assert data["rubric_id"] == material.source_path.stem
+        assert "Synthetic starter" in data["description"]
+        assert not any("standard_ids" in item for item in data.get("comments", []))
+        assert not any("standard_ids" in item for item in data.get("tags", []))
+        assert not any("standard_ids" in item for item in data.get("criteria", []))
+
+
+def test_starter_materials_avoid_obvious_real_or_placeholder_content() -> None:
+    forbidden_fragments = (
+        "@",
+        "TODO",
+        "real student",
+        "real teacher",
+        "class roster",
+        "student name",
+        "school district",
+        "english12_p3",
+        "villainy",
+    )
+
+    for material in discover_starter_materials():
+        text = material.source_path.read_text(encoding="utf-8")
+        folded = text.casefold()
+        assert all(fragment.casefold() not in folded for fragment in forbidden_fragments)
+
+
+def test_install_all_copies_only_review_material_files(tmp_path: Path) -> None:
+    materials = discover_starter_materials()
+
+    result = install_starter_materials(tmp_path, materials)
+
+    assert len(result.installed) == 15
+    assert not result.skipped_existing
+    assert len(list_valid_comment_banks(tmp_path)) == 5
+    assert len(list_valid_tag_banks(tmp_path)) == 5
+    assert len(list_valid_rubrics(tmp_path)) == 5
+    assert sorted(path.relative_to(tmp_path).parts[:2] for path in result.installed) == [
+        ("shared", "comment_banks"),
+        ("shared", "comment_banks"),
+        ("shared", "comment_banks"),
+        ("shared", "comment_banks"),
+        ("shared", "comment_banks"),
+        ("shared", "rubrics"),
+        ("shared", "rubrics"),
+        ("shared", "rubrics"),
+        ("shared", "rubrics"),
+        ("shared", "rubrics"),
+        ("shared", "tag_banks"),
+        ("shared", "tag_banks"),
+        ("shared", "tag_banks"),
+        ("shared", "tag_banks"),
+        ("shared", "tag_banks"),
+    ]
+    assert not (tmp_path / "classes").exists()
+    assert not (tmp_path / "assignments").exists()
+    assert not (tmp_path / "scans").exists()
+    assert not (tmp_path / "exports").exists()
+    assert not (tmp_path / "shared" / "standards").exists()
+    assert not list(tmp_path.rglob("submission.json"))
+    assert not list(tmp_path.rglob("review.json"))
+
+
+def test_install_skips_existing_by_default_and_exact_overwrite_replaces(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    material = discover_starter_materials()[0]
+    target = target_path_for_material(tmp_path, material)
+    target.parent.mkdir(parents=True)
+    target.write_text('{"existing": true}\n', encoding="utf-8")
+    before = target.read_bytes()
+
+    result = install_starter_materials(tmp_path, (material,))
+
+    assert result.installed == ()
+    assert result.skipped_existing == (target,)
+    assert target.read_bytes() == before
+
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1", "2", "overwrite"])
+
+    assert workflows.prompt_install_selected_starter_materials() == 1
+    assert target.read_bytes() == before
+    assert "Overwrite canceled" in capsys.readouterr().out
+
+    _menu_input(monkeypatch, ["1", "2", "OVERWRITE"])
+
+    assert workflows.prompt_install_selected_starter_materials() == 0
+    assert target.read_bytes() != before
+    assert load_comment_bank(target)["bank_id"] == material.material_id
+
+
+def test_install_summary_counts_existing_files(tmp_path: Path) -> None:
+    materials = discover_starter_materials()[:3]
+    target_path_for_material(tmp_path, materials[0]).parent.mkdir(parents=True)
+    target_path_for_material(tmp_path, materials[0]).write_text("{}", encoding="utf-8")
+
+    summary = summarize_install_impact(tmp_path, materials)
+
+    assert summary.new_files == 2
+    assert summary.existing_files == 1
+    assert summary.overwrite_files == 1
+
+
+def test_install_selected_one_of_each_type(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1,6,11", "1"])
+
+    assert workflows.prompt_install_selected_starter_materials() == 0
+
+    assert len(list((tmp_path / "shared" / "comment_banks").glob("*.json"))) == 1
+    assert len(list((tmp_path / "shared" / "tag_banks").glob("*.json"))) == 1
+    assert len(list((tmp_path / "shared" / "rubrics").glob("*.json"))) == 1
+
+
+def test_invalid_selected_install_is_rejected_without_writes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    before = _file_tree(tmp_path)
+    _menu_input(monkeypatch, ["1,99"])
+
+    assert workflows.prompt_install_selected_starter_materials() == 1
+
+    assert _file_tree(tmp_path) == before
+    assert "Invalid selection" in capsys.readouterr().out
+
+
+def test_cancel_paths_create_no_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    before = _file_tree(tmp_path)
+    _menu_input(monkeypatch, ["2"])
+
+    assert workflows.prompt_install_all_starter_materials() == 1
+
+    _menu_input(monkeypatch, ["b"])
+
+    assert workflows.prompt_install_selected_starter_materials() == 1
+    assert _file_tree(tmp_path) == before
+
+
+def test_preview_and_validate_workflows_report_material_groups(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+
+    assert workflows.prompt_preview_starter_materials() == 0
+    assert workflows.prompt_validate_starter_materials() == 0
+
+    output = capsys.readouterr().out
+    assert "Comment Banks" in output
+    assert "Tag Banks" in output
+    assert "Rubrics / Scoring Profiles" in output
+    assert "OK general_written_response.json" in output
+    assert "OK general_written_response_tags.json" in output
+    assert "OK general_constructed_response.json" in output
+
+
+def test_starter_materials_submenu_preview_and_back(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_workspace(monkeypatch, tmp_path)
+    _menu_input(monkeypatch, ["1", "", "5"])
+
+    assert workflows.launch_starter_materials_menu() == 0
+
+    output = capsys.readouterr().out
+    assert "Preview starter materials" in output
+    assert "General Written Response Comments" in output
+
+
+def test_installed_materials_are_discoverable_by_review_helpers(
+    tmp_path: Path,
+) -> None:
+    install_starter_materials(tmp_path, discover_starter_materials())
+
+    comment_bank_ids = {
+        item.bank["bank_id"]
+        for item in list_valid_comment_banks(tmp_path)
+        if item.bank is not None
+    }
+    tag_bank_ids = {
+        item.bank["tag_bank_id"]
+        for item in list_valid_tag_banks(tmp_path)
+        if item.bank is not None
+    }
+    rubric_ids = {
+        item.rubric["rubric_id"]
+        for item in list_valid_rubrics(tmp_path)
+        if item.rubric is not None
+    }
+
+    assert "general_written_response" in comment_bank_ids
+    assert "general_written_response_tags" in tag_bank_ids
+    assert "general_constructed_response" in rubric_ids
+    assignment = {
+        "rubric_id": "general_constructed_response",
+        "assignment_id": "synthetic_assignment",
+        "class_ids": ["synthetic_class"],
+        "standards_profile_id": "synthetic_profile",
+    }
+    resolved = resolve_assignment_rubric(tmp_path, assignment)
+    assert resolved is not None
+    assert resolved["rubric_id"] == "general_constructed_response"
+
+
+def test_installed_json_matches_sources_exactly(tmp_path: Path) -> None:
+    materials = discover_starter_materials()
+    install_starter_materials(tmp_path, materials)
+
+    for material in materials:
+        target = target_path_for_material(tmp_path, material)
+        assert json.loads(target.read_text(encoding="utf-8")) == json.loads(
+            material.source_path.read_text(encoding="utf-8")
+        )


### PR DESCRIPTION
## Summary

Adds synthetic starter review materials and a safe Review Materials installation workflow.

Closes #169

## Changes

* Added starter-material runtime/workflow support:

  * `quillan/starter_materials.py`
  * `quillan/starter_material_workflows.py`
* Wired `Review Materials -> Starter Materials` to a real submenu.
* Added 15 synthetic starter JSON files:

  * 5 comment banks under `examples/comment_banks/`
  * 5 tag banks under `examples/tag_banks/`
  * 5 rubrics under `examples/rubrics/`
* Added starter workflows to:

  * preview starter materials;
  * validate all starter materials;
  * install all starter materials;
  * install selected starter materials;
  * skip existing workspace files by default;
  * overwrite only after exact `OVERWRITE` confirmation.
* Added `docs/starter_materials.md`.
* Updated README and existing review-material/data-contract documentation.
* Added starter-material tests and updated Review Materials menu tests.

## Behavior

Starter materials are optional synthetic examples for testing and onboarding.

They cover varied written-work contexts, including:

* general written responses;
* lab reports;
* research responses;
* reflection journals;
* creative writing / creative project reflection.

Installed starter materials are copied into:

```text
shared/comment_banks/
shared/tag_banks/
shared/rubrics/
```

The workflow supports:

* preview grouped by material type;
* validation through existing runtime validators;
* install all;
* selected install by comma-separated number;
* safe cancel paths;
* default skip behavior for existing files;
* exact `OVERWRITE` confirmation for replacement.

## Safety

* Starter installation creates only review-material files.
* No assignments are created.
* No rosters are created.
* No scans are created or modified.
* No submissions are created or modified.
* No review records are created or modified.
* No exports are created or modified.
* No pds-core standards files are created or modified.
* No pds-core route helpers are modified.
* No sibling repositories were modified.
* Existing workspace review-material files are skipped by default and overwritten only after explicit confirmation.

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `1016 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed

Only Git CRLF warnings were reported.
