### PR TITLE
Polish review material authoring UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,14 +251,15 @@ The selected-student review menu is:
 
 ```text
 1. Open submission evidence
-2. Add teacher note
-3. Add structured tag
-4. Select reusable comment
-5. Set criterion score
-6. Update submission review state
-7. Export student feedback
-8. Refresh summary
-9. Back
+2. Manage submission pages
+3. Add teacher note
+4. Add structured tag
+5. Select reusable comment
+6. Set criterion score
+7. Update submission review state
+8. Export student feedback
+9. Refresh summary
+10. Back
 ```
 
 These guided actions reuse the same underlying services and data contracts as the direct CLI commands. The menu does not implement separate export logic, scoring logic, routing logic, or AI logic.
@@ -279,11 +280,15 @@ These materials help teachers review written student work more quickly by select
 
 Review materials are subject-agnostic. They may support essays, constructed responses, lab reports, journals, reflections, creative writing, research papers, mathematical explanations, technical writing, and other local writing tasks.
 
+Authoring prompts distinguish teacher-facing labels from stored system IDs. Labels may use spaces and capitalization. IDs such as `bank_id`, `tag_bank_id`, `rubric_id`, `category_id`, `comment_id`, `tag_template_id`, and `criterion_id` are short JSON names; the menus suggest IDs from labels and ask for lowercase letters, numbers, underscores, or hyphens. Multi-word ID-style values and `writing_types` values should use underscores instead of spaces. The teacher-facing term for `writing_types` is "writing assignment types."
+
 Comment banks created through the menu are stored at `shared/comment_banks/<bank_id>.json` and validate against the same version `1` contract used by review-time selection. Banks are subject-agnostic and writing-type-aware, so they can support essays, constructed responses, lab reports, reflections, research papers, mathematical explanations, technical documentation, design rationale, portfolio reflection, and other local written-work contexts.
 
 Comment banks store reusable teacher-authored feedback language. They do not grade work, imply mastery, generate comments automatically, or change student records by themselves. When a teacher selects a reusable comment during Review Student Work, Quillan snapshots the selected label and text into the review record with `source: "comment_bank"`, `bank_id`, and `comment_id`; later bank edits do not silently rewrite prior student review records.
 
 Tag banks created through the menu are stored at `shared/tag_banks/<tag_bank_id>.json` and validate against the version `1` tag-bank contract. Tag banks store reusable teacher-authored observations for quick review tagging. They are not grades, scores, mastery determinations, generated feedback, or automatic judgments. During Review Student Work -> Add structured tag, teachers can select a reusable tag by bank, category, and tag template, or choose a custom one-off tag. Selected reusable tags snapshot label, polarity, optional severity, optional standard/criterion metadata, teacher notes, and `source: "tag_bank"` provenance into `review.json.tags`.
+
+Tag-bank authoring asks for optional tag details in teacher-facing language. Optional details can include a description, writing assignment type limits, linked standards, linked rubric criteria, priority/severity, a private note question, and display order. `severity_default` is optional priority/severity for concerns only; it is not a grade and does not affect scoring. `teacher_note_prompt` is shown during review and stores the teacher's answer as a private tag note. `student_facing_default` remains a schema field, but the teacher menu does not prompt for it because it does not yet send anything to students by itself. `sort_order` is displayed as optional display order.
 
 Rubrics / scoring profiles created through the menu are stored at `shared/rubrics/<rubric_id>.json` and validate against the version `1` rubric contract. Assignment creation can select a valid shared rubric by number, while custom or unresolved rubric IDs remain allowed for compatibility. During Review Student Work -> Set criterion score, teachers can score from the assignment rubric by selecting a criterion and level, or choose Custom criterion score. Selected rubric scores snapshot the criterion ID, label, selected score, max score, scale, and optional teacher note into the existing `review.json.scores` shape. Rubric level feedback metadata does not automatically create comments or feedback entries.
 
@@ -481,6 +486,8 @@ The status includes:
 * duplicate pages;
 * needs-rescan pages;
 * excluded pages.
+
+Selected Student Review includes Manage Submission Pages. Teachers can exclude a page from active review, restore an excluded page, or mark a page as needing rescan. These actions update only that student's `submission.json`, preserve evidence records and files, and do not change review notes, tags, comments, scores, feedback exports, rosters, assignments, review materials, pds-core standards, or pds-core routes. Excluded pages are preserved, not deleted.
 
 Existing manifests are loaded and validated. An invalid manifest is an error.
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -389,14 +389,15 @@ The selected-student review menu provides:
 
 ```text
 1. Open submission evidence
-2. Add teacher note
-3. Add structured tag
-4. Select reusable comment
-5. Set criterion score
-6. Update submission review state
-7. Export student feedback
-8. Refresh summary
-9. Back
+2. Manage submission pages
+3. Add teacher note
+4. Add structured tag
+5. Select reusable comment
+6. Set criterion score
+7. Update submission review state
+8. Export student feedback
+9. Refresh summary
+10. Back
 ```
 
 Opening submission evidence delegates to the same existing safe selected
@@ -528,7 +529,7 @@ Tag Banks opens a submenu:
 2. View tag banks
 3. Edit tag bank
 4. Add category
-5. Add tag template
+5. Add reusable tag
 6. Validate tag bank
 7. Back
 ```
@@ -541,6 +542,17 @@ exactly `OVERWRITE`, and does not write invalid partial files.
 Tag banks are teacher-authored reusable observations for quick tagging. They do
 not grade work, imply mastery, generate automatic feedback, or mutate student
 records by themselves.
+
+Review-material authoring prompts use teacher-facing labels while preserving
+the JSON contracts. The UI calls `writing_types` "writing assignment types,"
+explains comma-separated values and underscores for multi-word values, suggests
+stored IDs from labels, and distinguishes labels from system IDs such as
+`bank_id`, `tag_bank_id`, `rubric_id`, `category_id`, `comment_id`,
+`tag_template_id`, and `criterion_id`. Optional tag details are explained as
+description, writing assignment type limits, linked standards, linked rubric
+criteria, priority/severity, private note question, and display order.
+`student_facing_default` is not prompted for until it has visible runtime
+behavior.
 
 Rubrics / Scoring Profiles opens a submenu for teacher-authored reusable
 scoring profiles. It writes confirmed, valid version `1` rubrics only under
@@ -563,6 +575,14 @@ tag-bank, and rubric validators used at runtime. Installation copies validated
 JSON files only into `shared/comment_banks/`, `shared/tag_banks/`, and
 `shared/rubrics/`. Existing files are skipped by default, and bulk overwrite
 requires the exact confirmation text `OVERWRITE`.
+
+Selected Student Review includes Manage Submission Pages. Teachers can exclude
+a page from active review, restore an excluded page, or mark a page as needing
+rescan after confirmation. These actions update only the selected student's
+`submission.json`, validate before writing, preserve evidence records and
+routed files, and do not modify review notes, tags, comments, scores, feedback
+exports, rosters, assignments, review materials, pds-core standards, or
+pds-core routes.
 
 Starter installation does not create assignments, rosters, scans, submissions,
 review records, exports, pds-core standards, pds-core standards profiles, or

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -155,6 +155,12 @@ be a subset of the bank-level values. When the comment field is absent, the
 comment inherits all bank-level writing types. The value `general` is an
 ordinary writing-type label, not a wildcard.
 
+Teacher-facing authoring menus call these values "writing assignment types."
+Prompts explain comma-separated entry, lowercase values, and underscores
+instead of spaces for multi-word values. The UI asks for labels first, suggests
+stored IDs such as `bank_id`, `category_id`, and `comment_id`, and explains
+that labels can use spaces while IDs are short JSON names.
+
 ## Category Records
 
 Categories divide a bank into teacher-scannable sections and avoid one large
@@ -274,6 +280,8 @@ Comment field rules are:
   `neutral`.
 * `severity_default`, when present, must be a non-negative integer. It is a
   triage and organization default, not a score.
+  Teacher-facing authoring describes this as optional priority/severity for
+  concerns; positive or neutral comments usually leave it blank.
 * `include_in_feedback_default` must be a boolean. It is the initial
   preference used by the direct selection workflow, not an instruction to
   export the source comment automatically.
@@ -285,6 +293,7 @@ Comment field rules are:
 * `sort_order`, when present, must be an integer. Consumers should sort by
   category order, then comment `sort_order`, and then preserve file order as
   a stable tie-breaker.
+  Teacher-facing authoring describes this as display order.
 * `created_at` and `updated_at`, when present, must be timezone-aware ISO 8601
   strings. When both are present, `updated_at` must not precede `created_at`.
 * `module_details` must be an object.

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -330,6 +330,20 @@ Initial `page_state` values are:
 Page state records evidence-management status only. Known pages may be listed
 with an empty `evidence` array, including missing pages.
 
+Teacher-facing page management may change a selected student's page state to
+`excluded`, restore an excluded page to `present`, `missing`, or `duplicate`
+based on preserved evidence, or mark a page `needs_rescan`. These updates are
+manifest-only: routed evidence files and review records are preserved. Restore
+selects a single evidence candidate only when there is exactly one candidate;
+multiple candidates remain duplicate/unselected to avoid choosing the wrong
+evidence.
+
+When excluding a page, Quillan records each evidence candidate's prior
+`evidence_role` and `evidence_state` in that candidate's `module_details`
+before setting the active fields to `excluded`. Restoring an excluded page uses
+that preserved state when available, so prior candidate, replacement, damaged,
+or needs-rescan evidence-management information is not silently erased.
+
 ### Evidence Candidates
 
 A page may have zero, one, or many evidence candidates. Every candidate

--- a/docs/rubric_contract.md
+++ b/docs/rubric_contract.md
@@ -39,6 +39,12 @@ Required top-level fields:
 * `updated_at`: timezone-aware ISO 8601 timestamp;
 * `module_details`: object.
 
+Teacher-facing authoring menus call `writing_types` "writing assignment
+types." Prompts explain comma-separated entry, lowercase values, and
+underscores instead of spaces for multi-word values. The UI asks for labels
+first, suggests stored IDs such as `rubric_id` and `criterion_id`, and explains
+that labels can use spaces while IDs are short JSON names.
+
 Example:
 
 ```json
@@ -94,6 +100,8 @@ Required criterion fields:
 Optional criterion fields are `description`, `standard_ids`, and `sort_order`.
 `standard_ids` are metadata references only; rubric workflows never mutate
 pds-core standards files.
+Teacher-facing authoring explains linked standards as optional pds-core
+references and describes `sort_order` as display order.
 
 ## Levels
 

--- a/docs/tag_bank_contract.md
+++ b/docs/tag_bank_contract.md
@@ -62,6 +62,19 @@ Optional fields are `description`, `writing_types`, `standard_ids`,
 `criterion_ids`, `severity_default`, `teacher_note_prompt`,
 `student_facing_default`, `sort_order`, `created_at`, and `updated_at`.
 
+Teacher-facing authoring menus describe these as optional tag details rather
+than metadata. The UI asks for a tag label first, suggests `tag_template_id`
+from that label, and explains that stored IDs use lowercase letters, numbers,
+underscores, or hyphens with underscores for multi-word values. The UI uses
+"writing assignment types" for `writing_types`.
+
+`severity_default` is presented as optional priority/severity for concerns; it
+is not a grade and does not affect scoring. `teacher_note_prompt` is presented
+as a private note question shown during review, and the teacher's response is
+stored as a private tag note. `student_facing_default` remains valid schema but
+is not prompted for in teacher authoring until a visible student-facing runtime
+workflow exists. `sort_order` is presented as optional display order.
+
 `polarity` is one of `positive`, `developing`, `negative`, or `neutral`.
 `category_id` must reference a category in the same bank. Template
 `writing_types`, when present, must be a subset of the bank-level

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -36,6 +36,15 @@ feedback exports, or reports.
 Keeping source evidence separate allows a teacher to compare later review
 artifacts with the writing that was actually submitted.
 
+Teachers can manage page state from Selected Student Review without changing
+teacher-review artifacts. Excluding a page removes it from active review while
+preserving the manifest entry and routed evidence file. Restoring an excluded
+page returns it to the active evidence set when safe; duplicate evidence is not
+silently selected. Marking a page as needing rescan records evidence-management
+status only. These actions update only the selected student's `submission.json`
+and do not alter `review.json`, exports, rosters, assignments, review
+materials, pds-core standards, or pds-core routes.
+
 ## Teacher-Review Artifacts
 
 Teacher-review artifacts are records created by the teacher or confirmed

--- a/quillan/authoring_prompt_helpers.py
+++ b/quillan/authoring_prompt_helpers.py
@@ -1,0 +1,110 @@
+"""Shared teacher-facing prompts for review-material authoring."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+def print_identifier_guidance(field_name: str, suggestion: str) -> None:
+    """Explain teacher-facing labels versus stored system IDs."""
+    print(f"Suggested {field_name}:")
+    print(suggestion)
+    print()
+    print("This is the short system name Quillan stores in JSON.")
+    print("Labels can use spaces and capitalization.")
+    print("Use lowercase letters, numbers, underscores, or hyphens. No spaces.")
+    print("For multi-word values, use underscores instead of spaces.")
+    print()
+
+
+def prompt_identifier_with_guidance(
+    field_name: str,
+    suggestion: str,
+    *,
+    input_func: Callable[[str], str] | None = None,
+) -> str:
+    """Prompt for an identifier, accepting the suggested value on Enter."""
+    reader = input if input_func is None else input_func
+    print_identifier_guidance(field_name, suggestion)
+    value = reader(
+        f"Press Enter to accept, or type a different {field_name}: "
+    ).strip()
+    return value or suggestion
+
+
+def prompt_writing_assignment_types(
+    *,
+    input_func: Callable[[str], str] | None = None,
+) -> str:
+    """Prompt text for comma-separated writing assignment types."""
+    reader = input if input_func is None else input_func
+    return reader(
+        "Writing assignment types this material applies to, comma-separated.\n"
+        "\n"
+        "Use lowercase words. For multi-word types, use underscores instead "
+        "of spaces.\n"
+        "\n"
+        "Examples:\n"
+        "general, persuasive_writing, persuasive_speech, argumentative\n"
+    )
+
+
+def prompt_display_order(
+    *,
+    within: str = "menus",
+    input_func: Callable[[str], str] | None = None,
+) -> str:
+    """Prompt for optional display order in teacher-facing language."""
+    reader = input if input_func is None else input_func
+    return reader(
+        "Display order (optional)\n"
+        "\n"
+        f"This controls where this item appears in {within}.\n"
+        "Leave blank to place it next.\n"
+        "\n"
+        "Example:\n"
+        "1\n"
+    )
+
+
+def print_standard_ids_help() -> None:
+    """Explain optional standards references."""
+    print("Linked standards, comma-separated (optional)")
+    print()
+    print("Use this only if you want this item connected to specific standards.")
+    print("Leave blank if this item is not tied to a specific standard.")
+    print()
+    print("Example:")
+    print("njsls-ela:W.AW.11-12.1")
+    print()
+
+
+def print_criterion_ids_help() -> None:
+    """Explain optional rubric criterion references."""
+    print("Linked rubric criteria, comma-separated (optional)")
+    print()
+    print(
+        "Use this only if this item connects to criteria from a rubric/scoring "
+        "profile."
+    )
+    print("Leave blank if you are not sure.")
+    print()
+    print("Example:")
+    print("rhetorical_technique")
+    print()
+
+
+def print_priority_severity_help() -> None:
+    """Explain severity without implying grading."""
+    print("Default priority/severity (optional)")
+    print()
+    print("Use this only for concerns or issues you may want to spot quickly later.")
+    print("This is not a grade and does not affect scoring.")
+    print()
+    print("Suggested scale:")
+    print("1 = minor note")
+    print("2 = moderate concern")
+    print("3 = important issue")
+    print()
+    print("Leave blank for positive or neutral items.")
+    print()

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -164,6 +164,13 @@ def print_assignment_submission_status(
         "reviewed",
     )
     page_states = ("present", "missing", "duplicate", "needs_rescan", "excluded")
+    page_state_labels = {
+        "present": "present",
+        "missing": "missing",
+        "duplicate": "duplicate",
+        "needs_rescan": "needs rescan",
+        "excluded": "excluded from active review",
+    }
     submission_counts = {
         state: sum(
             status.submission_state == state
@@ -206,7 +213,7 @@ def print_assignment_submission_status(
     print()
     print("Page states:")
     for state in page_states:
-        print(f"- {state}: {page_counts[state]}")
+        print(f"- {page_state_labels[state]}: {page_counts[state]}")
     print(f"- present but unselected: {unselected_count}")
 
     if result.student_statuses:
@@ -228,7 +235,7 @@ def print_assignment_submission_status(
                 for state in page_states
             }
             detail_parts = [
-                f"{state}={counts[state]}"
+                f"{page_state_labels[state]}={counts[state]}"
                 for state in page_states
                 if counts[state]
             ]

--- a/quillan/comment_bank_workflows.py
+++ b/quillan/comment_bank_workflows.py
@@ -7,6 +7,15 @@ from typing import Any
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
+from quillan.authoring_prompt_helpers import (
+    print_criterion_ids_help,
+    print_identifier_guidance,
+    print_priority_severity_help,
+    print_standard_ids_help,
+    prompt_display_order,
+    prompt_identifier_with_guidance,
+    prompt_writing_assignment_types,
+)
 from quillan.comment_banks import (
     ALLOWED_POLARITIES,
     CommentBankError,
@@ -101,10 +110,7 @@ def prompt_create_comment_bank() -> int:
             "Bank title:\nExample: General Written Response Comments\n"
         )
         suggestion = suggest_identifier(title)
-        print(f"Suggested bank_id:\n{suggestion}")
-        bank_id = input("Press Enter to accept, or type a different bank_id: ").strip()
-        if not bank_id:
-            bank_id = suggestion
+        bank_id = prompt_identifier_with_guidance("bank_id", suggestion)
         description = input(
             "Description:\n"
             "Example: Reusable comments for written responses across subjects.\n"
@@ -144,7 +150,7 @@ def prompt_create_comment_bank() -> int:
     print()
     print(f"Bank ID: {bank['bank_id']}")
     print(f"Title: {bank['title']}")
-    print(f"Writing types: {', '.join(bank['writing_types'])}")
+    print(f"Writing assignment types: {', '.join(bank['writing_types'])}")
     print(f"Categories: {len(bank['categories'])}")
     print(f"Comments: {len(bank['comments'])}")
     print(f"Path: {path}")
@@ -202,7 +208,7 @@ def prompt_view_comment_banks() -> int:
             bank = item.bank
             assert bank is not None
             print(f"{index}. {bank['bank_id']} - {bank['title']}")
-            print(f"   Writing types: {', '.join(bank['writing_types'])}")
+            print(f"   Writing assignment types: {', '.join(bank['writing_types'])}")
             print(f"   Categories: {len(bank['categories'])}")
             print(f"   Comments: {len(bank['comments'])}")
             print()
@@ -233,7 +239,7 @@ def prompt_edit_comment_bank() -> int:
     print()
     print("1. Edit title")
     print("2. Edit description")
-    print("3. Edit writing types")
+    print("3. Edit writing assignment types")
     print("4. Back")
     print()
     choice = input("Select an option: ").strip()
@@ -410,13 +416,10 @@ def _required_input(prompt: str) -> str:
 
 
 def _prompt_writing_types() -> list[str]:
-    value = input(
-        "Writing types, comma-separated:\n"
-        "Examples: general, lab_report, reflection, research, constructed_response\n"
-    )
+    value = prompt_writing_assignment_types()
     writing_types = parse_comma_separated_values(value)
     if not writing_types:
-        raise ValueError("At least one writing type is required.")
+        raise ValueError("At least one writing assignment type is required.")
     return writing_types
 
 
@@ -447,14 +450,14 @@ def _prompt_new_category(existing_ids: set[str]) -> dict[str, Any] | None:
         print("Invalid category selection.")
         return None
     suggestion = suggest_identifier(label)
-    print(f"Suggested category_id:\n{suggestion}")
+    print_identifier_guidance("category_id", suggestion)
     category_id = input(
         "Press Enter to accept, or type a different category_id: "
     ).strip()
     if not category_id:
         category_id = suggestion
     sort_order = _parse_optional_nonnegative_int(
-        input("Sort order (leave blank to auto-assign): ")
+        prompt_display_order()
     )
     if sort_order is None:
         sort_order = len(existing_ids) + 1
@@ -478,7 +481,7 @@ def _prompt_new_comment(
     print()
     label = _required_input("Comment label:\nExample: Explanation needs more detail\n")
     suggestion = suggest_identifier(label)
-    print(f"Suggested comment_id:\n{suggestion}")
+    print_identifier_guidance("comment_id", suggestion)
     comment_id = input(
         "Press Enter to accept, or type a different comment_id: "
     ).strip()
@@ -578,11 +581,23 @@ def _prompt_yes_no(label: str, *, default: bool) -> bool | None:
 
 def _prompt_optional_metadata(bank_writing_types: list[str]) -> dict[str, Any] | None:
     print()
-    response = input("Add optional metadata? (y/N): ").strip().lower()
-    if response in {"", "n", "no"}:
+    print("Add optional details for this comment?")
+    print()
+    print(
+        "Optional details can help Quillan sort the comment, link it to "
+        "standards or rubric criteria, and filter it by writing assignment type."
+    )
+    print()
+    print("You can skip these now.")
+    print()
+    print("1. Add optional details")
+    print("2. Skip optional details")
+    print("B. Back")
+    response = input("Select an option: ").strip().lower()
+    if response in {"", "2", "n", "no"}:
         return {}
-    if response not in {"y", "yes"}:
-        print("Invalid selection. Optional metadata skipped by canceling.")
+    if response not in {"1", "y", "yes"}:
+        print("Invalid selection. Optional details canceled.")
         return None
     metadata: dict[str, Any] = {}
     for field in (
@@ -595,31 +610,49 @@ def _prompt_optional_metadata(bank_writing_types: list[str]) -> dict[str, Any] |
         value = input(f"{field} (leave blank to omit): ").strip()
         if value:
             metadata[field] = value
+    print()
+    print("Limit this comment to specific writing assignment types from this bank.")
+    print("Leave blank if this comment applies to the whole bank.")
+    print("Use lowercase words. For multi-word types, use underscores instead of spaces.")
+    print(f"Available writing assignment types: {', '.join(bank_writing_types)}")
     writing_types = parse_comma_separated_values(
-        input("Comment writing types, comma-separated (leave blank to omit): ")
+        input("Comment writing assignment types, comma-separated (leave blank to omit): ")
     )
     if writing_types:
         outside = set(writing_types) - set(bank_writing_types)
         if outside:
             print(
                 "Invalid comment writing types. They must be part of the bank "
-                f"writing types: {', '.join(bank_writing_types)}."
+                f"writing assignment types: {', '.join(bank_writing_types)}."
             )
             return None
         metadata["writing_types"] = writing_types
-    for field in ("standard_ids", "criterion_ids", "tags", "hotwords"):
+    print_standard_ids_help()
+    standard_ids = parse_comma_separated_values(
+        input("Linked standards (leave blank to omit): ")
+    )
+    if standard_ids:
+        metadata["standard_ids"] = standard_ids
+    print_criterion_ids_help()
+    criterion_ids = parse_comma_separated_values(
+        input("Linked rubric criteria (leave blank to omit): ")
+    )
+    if criterion_ids:
+        metadata["criterion_ids"] = criterion_ids
+    for field in ("tags", "hotwords"):
         values = parse_comma_separated_values(
             input(f"{field}, comma-separated (leave blank to omit): ")
         )
         if values:
             metadata[field] = values
+    print_priority_severity_help()
     severity = _parse_optional_nonnegative_int(
-        input("severity_default (leave blank to omit): ")
+        input("Default priority/severity (leave blank to omit): ")
     )
     if severity is not None:
         metadata["severity_default"] = severity
     sort_order = _parse_optional_nonnegative_int(
-        input("sort_order (leave blank to omit): ")
+        prompt_display_order(within="this category")
     )
     if sort_order is not None:
         metadata["sort_order"] = sort_order

--- a/quillan/comment_bank_writing.py
+++ b/quillan/comment_bank_writing.py
@@ -176,7 +176,7 @@ def summarize_comment_bank(bank: Mapping[str, Any], path: str | Path) -> str:
             f"Title: {bank['title']}",
             f"Description: {bank['description']}",
             f"Scope: {bank['scope']}",
-            f"Writing types: {writing_types}",
+            f"Writing assignment types: {writing_types}",
             f"Categories: {len(bank['categories'])}",
             f"Comments: {len(bank['comments'])}",
             f"Path: {Path(path)}",

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -66,6 +66,12 @@ from quillan.submission_review_opening import (
     open_student_submission_for_review,
 )
 from quillan.submission_manifest import ALLOWED_SUBMISSION_STATES
+from quillan.submission_page_management import (
+    SubmissionPageManagementError,
+    exclude_submission_page,
+    mark_submission_page_needs_rescan,
+    restore_excluded_submission_page,
+)
 from quillan.submission_review_state import (
     SubmissionReviewStateError,
     update_submission_review_state,
@@ -372,20 +378,21 @@ def _launch_selected_student_review(
                 input("Press Enter to continue...")
             continue
         print("1. Open submission evidence")
-        print("2. Add teacher note")
-        print("3. Add structured tag")
-        print("4. Select reusable comment")
-        print("5. Set criterion score")
-        print("6. Update submission review state")
-        print("7. Export student feedback")
-        print("8. Refresh summary")
-        print("9. Back")
+        print("2. Manage submission pages")
+        print("3. Add teacher note")
+        print("4. Add structured tag")
+        print("5. Select reusable comment")
+        print("6. Set criterion score")
+        print("7. Update submission review state")
+        print("8. Export student feedback")
+        print("9. Refresh summary")
+        print("10. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "9"}:
+        if choice in {"", "10"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -396,7 +403,7 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "2":
-            _menu_add_review_note(
+            _menu_manage_submission_pages(
                 workspace_root,
                 class_id,
                 assignment_id,
@@ -404,7 +411,7 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "3":
-            _menu_add_review_tag(
+            _menu_add_review_note(
                 workspace_root,
                 class_id,
                 assignment_id,
@@ -412,7 +419,7 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "4":
-            _menu_add_review_comment(
+            _menu_add_review_tag(
                 workspace_root,
                 class_id,
                 assignment_id,
@@ -420,7 +427,7 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "5":
-            _menu_set_review_score(
+            _menu_add_review_comment(
                 workspace_root,
                 class_id,
                 assignment_id,
@@ -428,7 +435,7 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "6":
-            _menu_update_submission_review_state(
+            _menu_set_review_score(
                 workspace_root,
                 class_id,
                 assignment_id,
@@ -436,7 +443,7 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "7":
-            _menu_export_student_feedback(
+            _menu_update_submission_review_state(
                 workspace_root,
                 class_id,
                 assignment_id,
@@ -444,9 +451,17 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "8":
+            _menu_export_student_feedback(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "9":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 9.")
+            print("Invalid selection. Please enter a number from 1 to 10.")
             input("Press Enter to continue...")
 
 
@@ -848,7 +863,10 @@ def _prompt_tag_bank(files: tuple[Any, ...]) -> dict[str, Any] | None:
         print(f"   {_format_secondary_id(bank['tag_bank_id'])}")
         writing_types = bank.get("writing_types")
         if isinstance(writing_types, list) and writing_types:
-            print(f"   Writing types: {', '.join(str(item) for item in writing_types)}")
+            print(
+                "   Writing assignment types: "
+                f"{', '.join(str(item) for item in writing_types)}"
+            )
     print("B. Back")
     print()
     selection = input("Select tag bank: ").strip()
@@ -1038,7 +1056,10 @@ def _prompt_comment_bank(
         print(f"   {_format_secondary_id(bank['bank_id'])}")
         writing_types = bank.get("writing_types")
         if isinstance(writing_types, list) and writing_types:
-            print(f"   Writing types: {', '.join(str(item) for item in writing_types)}")
+            print(
+                "   Writing assignment types: "
+                f"{', '.join(str(item) for item in writing_types)}"
+            )
         comments = bank.get("comments")
         if isinstance(comments, list):
             print(f"   Comments: {len(comments)}")
@@ -1452,7 +1473,10 @@ def _prompt_score_criterion(rubric: dict[str, Any]) -> dict[str, Any] | None:
     print(f"{_format_secondary_id(rubric['rubric_id'])}")
     writing_types = rubric.get("writing_types")
     if isinstance(writing_types, list) and writing_types:
-        print(f"Writing types: {', '.join(str(item) for item in writing_types)}")
+        print(
+            "Writing assignment types: "
+            f"{', '.join(str(item) for item in writing_types)}"
+        )
     print()
     print("Criteria:")
     print()
@@ -1891,6 +1915,180 @@ def _open_submission_evidence(
         return
 
     print_opened_submission_review(opened)
+
+
+def _menu_manage_submission_pages(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    _print_review_action_header(
+        "Manage Submission Pages", class_id, assignment_id, student_id
+    )
+    print(
+        "Excluded pages are preserved in the submission record but left out "
+        "of active review."
+    )
+    print("Excluding a page does not delete the file.")
+    print()
+    status = _load_submission_status(workspace_root, class_id, assignment_id)
+    student_status = _student_submission_status(status, student_id)
+    if student_status is None or student_status.manifest_path is None:
+        print("No assembled submission record was found for this student.")
+        return
+
+    _print_manageable_pages(student_status.pages)
+    print()
+    print("Actions:")
+    print("1. Exclude page from review")
+    print("2. Restore excluded page")
+    print("3. Mark page as needs rescan")
+    print("4. Back")
+    print()
+    choice = input("Select an option: ").strip()
+    if choice in {"", "4"}:
+        print("Manage submission pages canceled.")
+        return
+    if choice == "1":
+        _menu_change_submission_page(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            student_status.pages,
+            action="exclude",
+        )
+    elif choice == "2":
+        _menu_change_submission_page(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            student_status.pages,
+            action="restore",
+        )
+    elif choice == "3":
+        _menu_change_submission_page(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            student_status.pages,
+            action="needs_rescan",
+        )
+    else:
+        print("Invalid selection. Please enter a number from 1 to 4.")
+
+
+def _print_manageable_pages(pages: tuple[Any, ...]) -> None:
+    print("Pages:")
+    for page in pages:
+        state = _teacher_page_state_label(page.page_state)
+        selected = page.selected_evidence_id or "no selected evidence"
+        print(
+            f"{page.page_number}. Page {page.page_number} - {state} - "
+            f"selected evidence: {selected}"
+        )
+
+
+def _teacher_page_state_label(page_state: str) -> str:
+    labels = {
+        "excluded": "excluded from active review",
+        "needs_rescan": "needs rescan",
+    }
+    return labels.get(page_state, page_state)
+
+
+def _menu_change_submission_page(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    pages: tuple[Any, ...],
+    *,
+    action: str,
+) -> None:
+    titles = {
+        "exclude": "Exclude Page From Review",
+        "restore": "Restore Excluded Page",
+        "needs_rescan": "Mark Page as Needing Rescan",
+    }
+    _print_review_action_header(titles[action], class_id, assignment_id, student_id)
+    if action == "exclude":
+        print("This keeps the evidence file but removes the page from active review.")
+        print(
+            "Use this for blank pages, wrong pages, accidental scans, or pages "
+            "that should not be scored."
+        )
+    elif action == "restore":
+        print("This returns an excluded page to active review.")
+        print("It does not change scores, tags, comments, or feedback.")
+    else:
+        print(
+            "Use this when a page is missing, damaged, unreadable, incomplete, "
+            "or the wrong page."
+        )
+    print()
+    _print_manageable_pages(pages)
+    print("B. Back")
+    print()
+    page_number = _prompt_page_number("Select page: ")
+    if page_number is None:
+        print("Page action canceled.")
+        return
+    if page_number not in {page.page_number for page in pages}:
+        print("Page action canceled. Please choose a listed page.")
+        return
+
+    confirm_labels = {
+        "exclude": f"Exclude page {page_number} from active review?",
+        "restore": f"Restore page {page_number} to active review?",
+        "needs_rescan": f"Mark page {page_number} as needing rescan?",
+    }
+    print()
+    print(confirm_labels[action])
+    print()
+    print("1. Save page change")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Page action canceled. No file was changed.")
+        return
+
+    try:
+        if action == "exclude":
+            result = exclude_submission_page(
+                workspace_root, class_id, assignment_id, student_id, page_number
+            )
+        elif action == "restore":
+            result = restore_excluded_submission_page(
+                workspace_root, class_id, assignment_id, student_id, page_number
+            )
+        else:
+            result = mark_submission_page_needs_rescan(
+                workspace_root, class_id, assignment_id, student_id, page_number
+            )
+    except SubmissionPageManagementError as error:
+        print(f"Error: page change was not saved: {error}")
+        return
+
+    print("Page change saved.")
+    print(f"Page: {result.page_number}")
+    print(f"State: {_teacher_page_state_label(result.page_state)}")
+    print(f"Evidence records preserved: {result.evidence_count}")
+    print("Review notes, tags, comments, scores, and feedback were not changed.")
+
+
+def _prompt_page_number(prompt: str) -> int | None:
+    selection = input(prompt).strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    try:
+        page_number = int(selection)
+    except ValueError:
+        return None
+    return page_number if page_number > 0 else None
 
 
 def _prompt_overwrite_export() -> bool | object:

--- a/quillan/rubric_workflows.py
+++ b/quillan/rubric_workflows.py
@@ -7,6 +7,13 @@ from typing import Any
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
+from quillan.authoring_prompt_helpers import (
+    print_identifier_guidance,
+    print_standard_ids_help,
+    prompt_display_order,
+    prompt_identifier_with_guidance,
+    prompt_writing_assignment_types,
+)
 from quillan.rubrics import RubricError, load_rubric
 from quillan.rubric_writing import (
     build_rubric,
@@ -93,12 +100,7 @@ def prompt_create_rubric() -> int:
             "Rubric title:\nExample: General Constructed Response 4-Point Rubric\n"
         )
         suggestion = suggest_identifier(title)
-        print(f"Suggested rubric_id:\n{suggestion}")
-        rubric_id = input(
-            "Press Enter to accept, or type a different rubric_id: "
-        ).strip()
-        if not rubric_id:
-            rubric_id = suggestion
+        rubric_id = prompt_identifier_with_guidance("rubric_id", suggestion)
         description = input(
             "Description:\n"
             "Example: Reusable scoring profile for written responses.\n"
@@ -129,7 +131,7 @@ def prompt_create_rubric() -> int:
     print()
     print(f"Rubric ID: {rubric['rubric_id']}")
     print(f"Title: {rubric['title']}")
-    print(f"Writing types: {', '.join(rubric['writing_types'])}")
+    print(f"Writing assignment types: {', '.join(rubric['writing_types'])}")
     print(f"Criteria: {len(rubric['criteria'])}")
     print(f"Levels: {sum(len(item['levels']) for item in rubric['criteria'])}")
     print(f"Path: {path}")
@@ -187,7 +189,7 @@ def prompt_view_rubrics() -> int:
             criteria = rubric["criteria"]
             levels = sum(len(criterion["levels"]) for criterion in criteria)
             print(f"{index}. {rubric['rubric_id']} - {rubric['title']}")
-            print(f"   Writing types: {', '.join(rubric['writing_types'])}")
+            print(f"   Writing assignment types: {', '.join(rubric['writing_types'])}")
             print(f"   Criteria: {len(criteria)}")
             print(f"   Levels: {levels}")
             print()
@@ -217,7 +219,7 @@ def prompt_edit_rubric() -> int:
     print()
     print("1. Edit title")
     print("2. Edit description")
-    print("3. Edit writing types")
+    print("3. Edit writing assignment types")
     print("4. Back")
     print()
     choice = input("Select an option: ").strip()
@@ -400,13 +402,10 @@ def _required_input(prompt: str) -> str:
 
 
 def _prompt_writing_types() -> list[str]:
-    value = input(
-        "Writing types, comma-separated:\n"
-        "Examples: general, lab_report, reflection, research, constructed_response\n"
-    )
+    value = prompt_writing_assignment_types()
     writing_types = parse_comma_separated_values(value)
     if not writing_types:
-        raise ValueError("At least one writing type is required.")
+        raise ValueError("At least one writing assignment type is required.")
     return writing_types
 
 
@@ -441,7 +440,7 @@ def _prompt_new_criterion(
         print("Invalid criterion selection.")
         return None
     suggestion = suggest_identifier(label)
-    print(f"Suggested criterion_id:\n{suggestion}")
+    print_identifier_guidance("criterion_id", suggestion)
     criterion_id = input(
         "Press Enter to accept, or type a different criterion_id: "
     ).strip()
@@ -450,11 +449,12 @@ def _prompt_new_criterion(
     ensure_unique_identifier(criterion_id, existing_ids, "criterion_id")
     max_score = _parse_required_number(input("Max score:\nExample: 4\n"))
     scale = _required_input("Scale:\nExample: 4_point\n")
+    print_standard_ids_help()
     standard_ids = parse_comma_separated_values(
-        input("Optional standard_ids, comma-separated (leave blank to omit): ")
+        input("Linked standards (leave blank to omit): ")
     )
     sort_order = _parse_optional_nonnegative_int(
-        input("Sort order (leave blank to auto-assign): ")
+        prompt_display_order()
     )
     if sort_order is None:
         sort_order = (criterion_count + 1) * 10
@@ -495,7 +495,7 @@ def _prompt_new_level(
     ).strip()
     teacher_note = input("Teacher note (optional, leave blank to omit): ").strip()
     sort_order = _parse_optional_nonnegative_int(
-        input("Sort order (leave blank to auto-assign): ")
+        prompt_display_order(within="this criterion")
     )
     if sort_order is None:
         sort_order = (level_count + 1) * 10

--- a/quillan/rubric_writing.py
+++ b/quillan/rubric_writing.py
@@ -157,7 +157,7 @@ def summarize_rubric(rubric: Mapping[str, Any], path: str | Path) -> str:
             f"Title: {rubric['title']}",
             f"Description: {rubric['description']}",
             f"Scope: {rubric['scope']}",
-            f"Writing types: {writing_types}",
+            f"Writing assignment types: {writing_types}",
             f"Criteria: {len(criteria)}",
             f"Levels: {level_count}",
             f"Path: {Path(path)}",

--- a/quillan/starter_material_workflows.py
+++ b/quillan/starter_material_workflows.py
@@ -207,7 +207,10 @@ def _print_material_groups(
         for material in [item for item in materials if item.kind == kind]:
             print(f"{index}. {material.display_name}")
             print(f"   ID: {material.material_id}")
-            print(f"   Writing types: {', '.join(material.writing_types)}")
+            print(
+                "   Writing assignment types: "
+                f"{', '.join(material.writing_types)}"
+            )
             if material.kind == "rubric":
                 print(f"   Criteria: {material.item_count}")
             elif material.kind == "tag_bank":

--- a/quillan/submission_page_management.py
+++ b/quillan/submission_page_management.py
@@ -1,0 +1,269 @@
+"""Teacher-controlled submission page/evidence management."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+    validate_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+_PRESERVED_EXCLUSION_KEY = "quillan_before_page_exclusion"
+
+
+class SubmissionPageManagementError(ValueError):
+    """Raised when a page-management action cannot be applied safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedSubmissionPage:
+    """A concise result for one managed submission page."""
+
+    manifest_path: Path
+    class_id: str
+    assignment_id: str
+    student_id: str
+    page_number: int
+    page_state: str
+    selected_evidence_id: str | None
+    evidence_count: int
+
+
+def exclude_submission_page(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    page_number: int,
+) -> ManagedSubmissionPage:
+    """Exclude one page from active review without deleting evidence."""
+    manifest_path, manifest, page = _load_page(
+        workspace_root, class_id, assignment_id, student_id, page_number
+    )
+    if page["page_state"] == "excluded":
+        raise SubmissionPageManagementError(
+            f"Page {page_number} is already excluded from active review."
+        )
+
+    updated = deepcopy(manifest)
+    updated_page = _page_by_number(updated, page_number)
+    updated_page["page_state"] = "excluded"
+    updated_page["selected_evidence_id"] = None
+    for evidence in _evidence_items(updated_page):
+        _preserve_evidence_state_before_exclusion(evidence)
+    return _write_result(manifest_path, updated, updated_page)
+
+
+def restore_excluded_submission_page(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    page_number: int,
+) -> ManagedSubmissionPage:
+    """Return one excluded page to the active review set when unambiguous."""
+    manifest_path, manifest, page = _load_page(
+        workspace_root, class_id, assignment_id, student_id, page_number
+    )
+    if page["page_state"] != "excluded":
+        raise SubmissionPageManagementError(
+            f"Page {page_number} is not currently excluded from active review."
+        )
+
+    updated = deepcopy(manifest)
+    updated_page = _page_by_number(updated, page_number)
+    evidence = _evidence_items(updated_page)
+    updated_page["selected_evidence_id"] = None
+    if not evidence:
+        updated_page["page_state"] = "missing"
+    else:
+        for item in evidence:
+            _restore_evidence_state_after_exclusion(
+                item,
+                default_role="selected" if len(evidence) == 1 else "candidate",
+                default_state="active",
+            )
+        selected_ids = [
+            str(item["evidence_id"])
+            for item in evidence
+            if item["evidence_role"] == "selected"
+        ]
+        if len(selected_ids) > 1:
+            raise SubmissionPageManagementError(
+                "Restore canceled because multiple evidence records would be selected."
+            )
+        updated_page["selected_evidence_id"] = (
+            selected_ids[0] if selected_ids else None
+        )
+        updated_page["page_state"] = _restored_page_state(evidence)
+    return _write_result(manifest_path, updated, updated_page)
+
+
+def mark_submission_page_needs_rescan(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    page_number: int,
+) -> ManagedSubmissionPage:
+    """Mark one page as needing a corrected scan without deleting evidence."""
+    manifest_path, manifest, page = _load_page(
+        workspace_root, class_id, assignment_id, student_id, page_number
+    )
+    if page["page_state"] == "needs_rescan":
+        raise SubmissionPageManagementError(
+            f"Page {page_number} is already marked as needing rescan."
+        )
+
+    updated = deepcopy(manifest)
+    updated_page = _page_by_number(updated, page_number)
+    updated_page["page_state"] = "needs_rescan"
+    updated_page["selected_evidence_id"] = None
+    for evidence in _evidence_items(updated_page):
+        evidence["evidence_role"] = "candidate"
+        evidence["evidence_state"] = "needs_rescan"
+    return _write_result(manifest_path, updated, updated_page)
+
+
+def _load_page(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    page_number: int,
+) -> tuple[Path, dict[str, Any], dict[str, Any]]:
+    _validate_identity(class_id, assignment_id, student_id)
+    if (
+        isinstance(page_number, bool)
+        or not isinstance(page_number, int)
+        or page_number < 1
+    ):
+        raise SubmissionPageManagementError("Page number must be a positive integer.")
+    path = submission_manifest_path(
+        workspace_root, class_id, assignment_id, student_id
+    )
+    try:
+        manifest = load_submission_manifest(path)
+    except (SubmissionManifestError, OSError) as error:
+        raise SubmissionPageManagementError(
+            f"Could not load submission record: {error}"
+        ) from error
+    if (
+        manifest["class_id"] != class_id
+        or manifest["assignment_id"] != assignment_id
+        or manifest["student_id"] != student_id
+    ):
+        raise SubmissionPageManagementError(
+            "Submission record identity does not match the selected student."
+        )
+    return path, manifest, _page_by_number(manifest, page_number)
+
+
+def _page_by_number(manifest: dict[str, Any], page_number: int) -> dict[str, Any]:
+    pages = cast(list[dict[str, Any]], manifest["pages"])
+    for page in pages:
+        if page["page_number"] == page_number:
+            return page
+    raise SubmissionPageManagementError(
+        f"Page {page_number} is not in this submission record."
+    )
+
+
+def _evidence_items(page: dict[str, Any]) -> list[dict[str, Any]]:
+    return cast(list[dict[str, Any]], page["evidence"])
+
+
+def _preserve_evidence_state_before_exclusion(evidence: dict[str, Any]) -> None:
+    module_details = _module_details(evidence)
+    module_details.setdefault(
+        _PRESERVED_EXCLUSION_KEY,
+        {
+            "evidence_role": evidence["evidence_role"],
+            "evidence_state": evidence["evidence_state"],
+        },
+    )
+    evidence["evidence_role"] = "excluded"
+    evidence["evidence_state"] = "excluded"
+
+
+def _restore_evidence_state_after_exclusion(
+    evidence: dict[str, Any],
+    *,
+    default_role: str,
+    default_state: str,
+) -> None:
+    preserved = _module_details(evidence).pop(_PRESERVED_EXCLUSION_KEY, None)
+    if isinstance(preserved, dict):
+        role = preserved.get("evidence_role")
+        state = preserved.get("evidence_state")
+        evidence["evidence_role"] = role if isinstance(role, str) else default_role
+        evidence["evidence_state"] = state if isinstance(state, str) else default_state
+    else:
+        evidence["evidence_role"] = default_role
+        evidence["evidence_state"] = default_state
+
+
+def _module_details(evidence: dict[str, Any]) -> dict[str, Any]:
+    module_details = evidence.get("module_details")
+    if not isinstance(module_details, dict):
+        module_details = {}
+        evidence["module_details"] = module_details
+    return module_details
+
+
+def _restored_page_state(evidence: list[dict[str, Any]]) -> str:
+    evidence_states = {item["evidence_state"] for item in evidence}
+    if evidence_states & {"needs_rescan", "damaged"}:
+        return "needs_rescan"
+    if len(evidence) > 1:
+        return "duplicate"
+    return "present"
+
+
+def _write_result(
+    manifest_path: Path, manifest: dict[str, Any], page: dict[str, Any]
+) -> ManagedSubmissionPage:
+    manifest["updated_at"] = datetime.now(UTC).isoformat()
+    try:
+        validate_submission_manifest(manifest)
+        write_submission_manifest(manifest_path, manifest, overwrite=True)
+    except (SubmissionManifestError, SubmissionManifestPathError, OSError) as error:
+        raise SubmissionPageManagementError(
+            f"Page change was not saved: {error}"
+        ) from error
+    return ManagedSubmissionPage(
+        manifest_path=manifest_path,
+        class_id=str(manifest["class_id"]),
+        assignment_id=str(manifest["assignment_id"]),
+        student_id=str(manifest["student_id"]),
+        page_number=int(page["page_number"]),
+        page_state=str(page["page_state"]),
+        selected_evidence_id=(
+            str(page["selected_evidence_id"])
+            if page["selected_evidence_id"] is not None
+            else None
+        ),
+        evidence_count=len(page["evidence"]),
+    )
+
+
+def _validate_identity(class_id: str, assignment_id: str, student_id: str) -> None:
+    try:
+        validate_identifier(class_id, "class_id")
+        validate_identifier(assignment_id, "assignment_id")
+        validate_identifier(student_id, "student_id")
+    except IdentifierValidationError as error:
+        raise SubmissionPageManagementError(str(error)) from error

--- a/quillan/tag_bank_workflows.py
+++ b/quillan/tag_bank_workflows.py
@@ -7,6 +7,15 @@ from typing import Any
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
+from quillan.authoring_prompt_helpers import (
+    print_criterion_ids_help,
+    print_identifier_guidance,
+    print_priority_severity_help,
+    print_standard_ids_help,
+    prompt_display_order,
+    prompt_identifier_with_guidance,
+    prompt_writing_assignment_types,
+)
 from quillan.tag_banks import ALLOWED_POLARITIES, TagBankError, load_tag_bank
 from quillan.tag_bank_writing import (
     build_tag_bank,
@@ -45,14 +54,12 @@ def launch_tag_banks_menu() -> int:
             print_menu_header("Tag Banks")
             print("Tag banks store reusable teacher observations for quick review tagging.")
             print("Tags are review aids; they are not grades or automatic mastery judgments.")
-            print("Implemented in #166. Shared storage: shared/tag_banks/")
-            print("Opening this screen: No files were changed.")
             print()
             print("1. Create tag bank")
             print("2. View tag banks")
             print("3. Edit tag bank")
             print("4. Add category")
-            print("5. Add tag template")
+            print("5. Add reusable tag")
             print("6. Validate tag bank")
             print("7. Back")
             print()
@@ -92,19 +99,14 @@ def prompt_create_tag_bank() -> int:
     try:
         title = _required_input("Tag bank title:\nExample: General Written Response Tags\n")
         suggestion = suggest_identifier(title)
-        print(f"Suggested tag_bank_id:\n{suggestion}")
-        tag_bank_id = input(
-            "Press Enter to accept, or type a different tag_bank_id: "
-        ).strip()
-        if not tag_bank_id:
-            tag_bank_id = suggestion
+        tag_bank_id = prompt_identifier_with_guidance("tag_bank_id", suggestion)
         description = input(
             "Description:\n"
             "Example: Reusable teacher observations for written responses across subjects.\n"
         ).strip()
         writing_types = _prompt_writing_types()
         print()
-        print("Now add at least one category and one tag template before saving.")
+        print("Now add at least one category and one reusable tag before saving.")
         print()
         category = _prompt_new_category(existing_ids=set())
         if category is None:
@@ -137,7 +139,7 @@ def prompt_create_tag_bank() -> int:
     print()
     print(f"Tag Bank ID: {bank['tag_bank_id']}")
     print(f"Title: {bank['title']}")
-    print(f"Writing types: {', '.join(bank['writing_types'])}")
+    print(f"Writing assignment types: {', '.join(bank['writing_types'])}")
     print(f"Categories: {len(bank['categories'])}")
     print(f"Tags: {len(bank['tags'])}")
     print(f"Path: {path}")
@@ -162,6 +164,7 @@ def prompt_create_tag_bank() -> int:
         print(f"Error: {error}")
         return 1
     print(f"Saved tag bank: {saved_path}")
+    _prompt_after_tag_bank_saved(bank["title"])
     return 0
 
 
@@ -190,7 +193,7 @@ def prompt_view_tag_banks() -> int:
             bank = item.bank
             assert bank is not None
             print(f"{index}. {bank['tag_bank_id']} - {bank['title']}")
-            print(f"   Writing types: {', '.join(bank['writing_types'])}")
+            print(f"   Writing assignment types: {', '.join(bank['writing_types'])}")
             print(f"   Categories: {len(bank['categories'])}")
             print(f"   Tags: {len(bank['tags'])}")
             print()
@@ -220,7 +223,7 @@ def prompt_edit_tag_bank() -> int:
     print()
     print("1. Edit title")
     print("2. Edit description")
-    print("3. Edit writing types")
+    print("3. Edit writing assignment types")
     print("4. Back")
     print()
     choice = input("Select an option: ").strip()
@@ -288,14 +291,15 @@ def prompt_add_category() -> int:
         print("Existing tag bank was not changed.")
         return 1
     print(f"Saved tag bank: {path}")
+    _prompt_after_category_saved(bank, category)
     return 0
 
 
 def prompt_add_tag_template() -> int:
-    """Add a tag template to an existing valid bank."""
+    """Add a reusable tag to an existing valid bank."""
     from quillan.menu import print_menu_header
 
-    print_menu_header("Add Tag Template")
+    print_menu_header("Add Reusable Tag")
     selected = _prompt_valid_bank()
     if selected is None:
         return 1
@@ -313,19 +317,19 @@ def prompt_add_tag_template() -> int:
         )
     except (TagBankError, ValueError) as error:
         print(f"Error: {error}")
-        print("Add tag template canceled. No file was changed.")
+        print("Add reusable tag canceled. No file was changed.")
         return 1
     if tag is None:
-        print("Add tag template canceled. No file was changed.")
+        print("Add reusable tag canceled. No file was changed.")
         return 1
     updated = touch_updated_at(bank)
     updated["tags"] = [dict(item) for item in bank["tags"]] + [tag]
     print()
-    print(f"Add tag template '{tag['label']}' to {bank['tag_bank_id']}?")
+    print(f"Add reusable tag '{tag['label']}' to {bank['tag_bank_id']}?")
     print("1. Save")
     print("2. Cancel")
     if input("Select an option: ").strip() != "1":
-        print("Add tag template canceled. No file was changed.")
+        print("Add reusable tag canceled. No file was changed.")
         return 1
     try:
         write_tag_bank(path.parents[2], updated, overwrite=True)
@@ -334,6 +338,7 @@ def prompt_add_tag_template() -> int:
         print("Existing tag bank was not changed.")
         return 1
     print(f"Saved tag bank: {path}")
+    _prompt_after_tag_saved(bank, tag)
     return 0
 
 
@@ -396,13 +401,10 @@ def _required_input(prompt: str) -> str:
 
 
 def _prompt_writing_types() -> list[str]:
-    value = input(
-        "Writing types, comma-separated:\n"
-        "Examples: general, lab_report, reflection, research, constructed_response\n"
-    )
+    value = prompt_writing_assignment_types()
     writing_types = parse_comma_separated_values(value)
     if not writing_types:
-        raise ValueError("At least one writing type is required.")
+        raise ValueError("At least one writing assignment type is required.")
     return writing_types
 
 
@@ -433,14 +435,14 @@ def _prompt_new_category(existing_ids: set[str]) -> dict[str, Any] | None:
         print("Invalid category selection.")
         return None
     suggestion = suggest_identifier(label)
-    print(f"Suggested category_id:\n{suggestion}")
+    print_identifier_guidance("category_id", suggestion)
     category_id = input(
         "Press Enter to accept, or type a different category_id: "
     ).strip()
     if not category_id:
         category_id = suggestion
     sort_order = _parse_optional_nonnegative_int(
-        input("Sort order (leave blank to auto-assign): ")
+        prompt_display_order()
     )
     if sort_order is None:
         sort_order = len(existing_ids) + 1
@@ -460,11 +462,11 @@ def _prompt_new_tag_template(
     existing_ids: set[str],
 ) -> dict[str, Any] | None:
     print()
-    print("Add Tag Template")
+    print("Add Reusable Tag")
     print()
     label = _required_input("Tag label:\nExample: Explanation needs more detail\n")
     suggestion = suggest_identifier(label)
-    print(f"Suggested tag_template_id:\n{suggestion}")
+    print_identifier_guidance("tag_template_id", suggestion)
     tag_template_id = input(
         "Press Enter to accept, or type a different tag_template_id: "
     ).strip()
@@ -527,51 +529,92 @@ def _prompt_polarity() -> str | None:
 
 def _prompt_optional_metadata(bank_writing_types: list[str]) -> dict[str, Any] | None:
     print()
-    response = input("Add optional metadata? (y/N): ").strip().lower()
-    if response in {"", "n", "no"}:
+    print("Add optional details for this tag?")
+    print()
+    print(
+        "Optional details can help Quillan sort the tag, link it to standards "
+        "or rubric criteria, ask a private note question during review, or "
+        "reserve future feedback behavior."
+    )
+    print()
+    print("You can skip these now.")
+    print()
+    print("1. Add optional details")
+    print("2. Skip optional details")
+    print("B. Back")
+    print()
+    response = input("Select an option: ").strip().lower()
+    if response in {"", "2", "n", "no"}:
         return {}
-    if response not in {"y", "yes"}:
-        print("Invalid selection. Optional metadata skipped by canceling.")
+    if response not in {"1", "y", "yes"}:
+        print("Invalid selection. Optional details canceled.")
         return None
     metadata: dict[str, Any] = {}
-    description = input("description (leave blank to omit): ").strip()
+    print()
+    print("Description helps you remember when to use this tag.")
+    print("It is not automatically shown to students.")
+    print()
+    print("Example:")
+    print(
+        "Use when the speaker builds credibility through expertise, fairness, "
+        "or trustworthiness."
+    )
+    description = input("Description (leave blank to omit): ").strip()
     if description:
         metadata["description"] = description
+    print()
+    print("Limit this tag to specific writing assignment types from this tag bank.")
+    print("Leave blank if this tag applies to the whole bank.")
+    print()
+    print("Use lowercase words. For multi-word types, use underscores instead of spaces.")
+    print(f"Available writing assignment types: {', '.join(bank_writing_types)}")
+    print()
+    print("Examples:")
+    print("persuasive_speech, argumentative")
     writing_types = parse_comma_separated_values(
-        input("Tag writing types, comma-separated (leave blank to omit): ")
+        input("Tag writing assignment types, comma-separated (leave blank to omit): ")
     )
     if writing_types:
         outside = set(writing_types) - set(bank_writing_types)
         if outside:
             print(
                 "Invalid tag writing types. They must be part of the bank "
-                f"writing types: {', '.join(bank_writing_types)}."
+                f"writing assignment types: {', '.join(bank_writing_types)}."
             )
             return None
         metadata["writing_types"] = writing_types
-    for field in ("standard_ids", "criterion_ids"):
-        values = parse_comma_separated_values(
-            input(f"{field}, comma-separated (leave blank to omit): ")
-        )
-        if values:
-            metadata[field] = values
+    print_standard_ids_help()
+    standard_ids = parse_comma_separated_values(
+        input("Linked standards (leave blank to omit): ")
+    )
+    if standard_ids:
+        metadata["standard_ids"] = standard_ids
+    print_criterion_ids_help()
+    criterion_ids = parse_comma_separated_values(
+        input("Linked rubric criteria (leave blank to omit): ")
+    )
+    if criterion_ids:
+        metadata["criterion_ids"] = criterion_ids
+    print_priority_severity_help()
     severity = _parse_optional_nonnegative_int(
-        input("severity_default (leave blank to omit): ")
+        input("Default priority/severity (leave blank to omit): ")
     )
     if severity is not None:
         metadata["severity_default"] = severity
-    teacher_note_prompt = input(
-        "teacher_note_prompt (leave blank to omit): "
-    ).strip()
+    print()
+    print("Private note question to ask during review (optional)")
+    print()
+    print("If you enter a question here, Quillan will ask it when you select this tag.")
+    print("The teacher's answer is stored as a private note on that tag.")
+    print()
+    print("Example:")
+    print("What makes the speaker seem credible or trustworthy?")
+    print()
+    teacher_note_prompt = input("Private note question (leave blank to omit): ").strip()
     if teacher_note_prompt:
         metadata["teacher_note_prompt"] = teacher_note_prompt
-    student_facing = _parse_optional_boolean(
-        input("student_facing_default (y/n, leave blank to omit): ")
-    )
-    if student_facing is not None:
-        metadata["student_facing_default"] = student_facing
     sort_order = _parse_optional_nonnegative_int(
-        input("sort_order (leave blank to omit): ")
+        prompt_display_order(within="this category")
     )
     if sort_order is not None:
         metadata["sort_order"] = sort_order
@@ -579,6 +622,26 @@ def _prompt_optional_metadata(bank_writing_types: list[str]) -> dict[str, Any] |
     metadata["created_at"] = timestamp
     metadata["updated_at"] = timestamp
     return metadata
+
+
+def _prompt_after_tag_bank_saved(title: object) -> None:
+    print()
+    print(f"Tag bank saved: {title}")
+    print("Return to the Tag Banks menu to add more categories or reusable tags.")
+
+
+def _prompt_after_category_saved(
+    bank: dict[str, Any], category: dict[str, Any]
+) -> None:
+    print()
+    print(f"Category saved: {category['label']}")
+    print("Return to the Tag Banks menu to add more categories or reusable tags.")
+
+
+def _prompt_after_tag_saved(bank: dict[str, Any], tag: dict[str, Any]) -> None:
+    print()
+    print(f"Tag saved: {tag['label']}")
+    print("Return to the Tag Banks menu to add more categories or reusable tags.")
 
 
 def _prompt_valid_bank() -> tuple[Path, dict[str, Any]] | None:

--- a/quillan/tag_bank_writing.py
+++ b/quillan/tag_bank_writing.py
@@ -165,7 +165,7 @@ def summarize_tag_bank(bank: Mapping[str, Any], path: str | Path) -> str:
             f"Title: {bank['title']}",
             f"Description: {bank['description']}",
             f"Scope: {bank['scope']}",
-            f"Writing types: {writing_types}",
+            f"Writing assignment types: {writing_types}",
             f"Categories: {len(bank['categories'])}",
             f"Tags: {len(bank['tags'])}",
             f"Path: {Path(path)}",

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -56,11 +56,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["9"] + _exit_assignment_review_actions_to_main()
+    return ["10"] + _exit_assignment_review_actions_to_main()
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "9"] + _exit_assignment_review_actions_to_main()
+    return ["", "10"] + _exit_assignment_review_actions_to_main()
 
 
 def _write_workspace(root: Path) -> None:
@@ -285,7 +285,7 @@ def test_selected_student_review_menu_includes_feedback_export(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
-    assert "7. Export student feedback" in output
+    assert "8. Export student feedback" in output
 
 
 def test_menu_export_student_feedback_creates_feedback_file(
@@ -325,7 +325,7 @@ def test_menu_export_student_feedback_creates_feedback_file(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1"]
+        + ["8", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -427,7 +427,7 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "2"]
+        + ["8", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -458,7 +458,7 @@ def test_menu_export_feedback_reports_missing_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1"]
+        + ["8", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -492,7 +492,7 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1", "1"]
+        + ["8", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -526,7 +526,7 @@ def test_menu_export_feedback_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1", "2"]
+        + ["8", "1", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -628,7 +628,6 @@ def test_menu_export_class_summary_invalid_overwrite_cancels_without_writing(
     output = capsys.readouterr().out
     assert "Export canceled. Please enter y or n." in output
     assert not summary_path.exists()
-
 
 def test_menu_export_standards_summary_overwrites_existing_export(
     workspace: Path,

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -226,11 +226,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["9", "6", "", "2", "9"]
+    return ["10", "6", "", "2", "9"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "9", "6", "", "2", "9"]
+    return ["", "10", "6", "", "2", "9"]
 
 
 @pytest.fixture
@@ -252,11 +252,12 @@ def test_review_menu_selected_student_shows_review_entry_actions(
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
     assert "1. Open submission evidence" in output
-    assert "2. Add teacher note" in output
-    assert "3. Add structured tag" in output
-    assert "4. Select reusable comment" in output
-    assert "5. Set criterion score" in output
-    assert "6. Update submission review state" in output
+    assert "2. Manage submission pages" in output
+    assert "3. Add teacher note" in output
+    assert "4. Add structured tag" in output
+    assert "5. Select reusable comment" in output
+    assert "6. Set criterion score" in output
+    assert "7. Update submission review state" in output
     assert "Review record: not started" in output
     assert not review_record_path(
         workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
@@ -276,7 +277,7 @@ def test_review_menu_blank_note_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["2", ""]
+        + ["3", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -296,7 +297,7 @@ def test_review_menu_adds_structured_tag_to_review_record(
         monkeypatch,
         _enter_selected_student()
         + [
-            "3",
+            "4",
             "2",
             "claim",
             "1",
@@ -330,7 +331,7 @@ def test_review_menu_selects_reusable_tag_by_bank_and_category(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["3", "1", "1", "1", "1", "The explanation names the idea only."]
+        + ["4", "1", "1", "1", "1", "The explanation names the idea only."]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -373,7 +374,7 @@ def test_review_menu_blank_tag_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["3", ""]
+        + ["4", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -397,7 +398,7 @@ def test_review_menu_no_comment_banks_returns_safely(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["4", "1"]
+        + ["5", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -423,7 +424,7 @@ def test_review_menu_selects_reusable_comment_by_number(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["4", "1", "1", "1", "1", "1"]
+        + ["5", "1", "1", "1", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -478,7 +479,7 @@ def test_comment_bank_created_by_workflow_is_selectable_in_review(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["4", "1", "1", "1", "1", "1"]
+        + ["5", "1", "1", "1", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -518,7 +519,7 @@ def test_review_menu_sets_criterion_score(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "evidence", "Evidence", "3", "4", "", ""]
+        + ["6", "evidence", "Evidence", "3", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -549,7 +550,7 @@ def test_review_menu_scores_from_assignment_rubric(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "1", "1", "1", "2", "Private score note"]
+        + ["6", "1", "1", "1", "2", "Private score note"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -578,7 +579,7 @@ def test_review_menu_missing_rubric_keeps_custom_score_available(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "1", "1", "Evidence", "", "2", "4", "", ""]
+        + ["6", "1", "1", "Evidence", "", "2", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -605,7 +606,7 @@ def test_review_menu_blank_score_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", ""]
+        + ["6", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -657,7 +658,7 @@ def test_review_menu_invalid_score_does_not_corrupt_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "evidence", "Evidence", "5", "4", "", ""]
+        + ["6", "evidence", "Evidence", "5", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -679,7 +680,7 @@ def test_review_menu_invalid_state_does_not_corrupt_manifest(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "not_a_state"]
+        + ["7", "not_a_state"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -220,7 +220,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "1", "9", "6", "", "2", "9"])
+    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "1", "10", "6", "", "2", "9"])
 
     assert main(["menu"]) == 0
 
@@ -265,7 +265,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "9", "6", "", "2", "9"],
+        ["5", "1", "1", "1", "1", "1", "10", "6", "", "2", "9"],
     )
 
     assert main(["menu"]) == 0
@@ -313,7 +313,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "1", "", "9", "6", "", "2", "9"],
+        ["5", "1", "1", "1", "1", "1", "1", "", "10", "6", "", "2", "9"],
     )
 
     assert main(["menu"]) == 0
@@ -359,10 +359,10 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "1",
             "1",
             "1",
-            "2",
+            "3",
             "This is a test note.",
             "",
-            "9",
+            "10",
             "6",
             "",
             "2",
@@ -402,11 +402,11 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "1",
-            "6",
+            "7",
             "in_progress",
             "1",
             "",
-            "9",
+            "10",
             "6",
             "",
             "2",
@@ -424,6 +424,69 @@ def test_review_menu_updates_submission_review_state(
     )
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["submission_state"] == "in_progress"
+
+
+def test_review_menu_excludes_submission_page_without_touching_review_record(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "review.json"
+    )
+    review_path.write_text(json.dumps(_review_record()), encoding="utf-8")
+    review_before = review_path.read_bytes()
+    evidence_path = workspace / EVIDENCE_RELATIVE_PATH
+    evidence_before = evidence_path.read_bytes()
+    _menu_input(
+        monkeypatch,
+        [
+            "5",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "2",
+            "1",
+            "1",
+            "1",
+            "",
+            "10",
+            "6",
+            "",
+            "2",
+            "9",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Manage Submission Pages" in output
+    assert "Excluding a page does not delete the file." in output
+    assert "Page change saved." in output
+    manifest_path = submission_manifest_path(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    page = manifest["pages"][0]
+    assert page["page_state"] == "excluded"
+    assert page["selected_evidence_id"] is None
+    assert page["evidence"][0]["evidence_role"] == "excluded"
+    assert page["evidence"][0]["evidence_state"] == "excluded"
+    assert evidence_path.read_bytes() == evidence_before
+    assert review_path.read_bytes() == review_before
 
 
 def test_review_menu_no_classes_and_invalid_selection_back_out_safely(

--- a/tests/test_review_materials_menu.py
+++ b/tests/test_review_materials_menu.py
@@ -91,15 +91,14 @@ def test_review_materials_menu_navigation_returns_to_main_menu(
 
 
 @pytest.mark.parametrize(
-    ("choice", "header", "future_issue", "path_text"),
+    ("choice", "header", "path_text"),
     [
-        ("2", "Tag Banks", "#166", "shared/tag_banks/"),
+        ("2", "Tag Banks", "shared/tag_banks/"),
     ],
 )
 def test_review_materials_informational_screens_return_safely(
     choice: str,
     header: str,
-    future_issue: str,
     path_text: str,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -110,10 +109,11 @@ def test_review_materials_informational_screens_return_safely(
 
     output = capsys.readouterr().out
     assert header in output
-    assert future_issue in output
-    assert "No files were changed." in output
+    assert "Add reusable tag" in output
+    assert "Implemented in #166" not in output
+    assert "Opening this screen" not in output
     if path_text:
-        assert path_text in output
+        assert path_text not in output
 
 
 def test_review_materials_starter_materials_opens_real_submenu(

--- a/tests/test_submission_page_management.py
+++ b/tests/test_submission_page_management.py
@@ -1,0 +1,255 @@
+"""Tests for teacher-controlled submission page management."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import quillan.submission_page_management as page_management
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+from quillan.submission_page_management import (
+    SubmissionPageManagementError,
+    exclude_submission_page,
+    mark_submission_page_needs_rescan,
+    restore_excluded_submission_page,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+TIMESTAMP = "2026-06-22T12:00:00+00:00"
+
+
+def _evidence(evidence_id: str, page_number: int, *, role: str = "selected") -> dict[str, Any]:
+    return {
+        "evidence_id": evidence_id,
+        "routed_evidence_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+            f"response_{STUDENT_ID}_pg_{page_number:03d}_{evidence_id}.pdf"
+        ),
+        "evidence_role": role,
+        "evidence_state": "active",
+        "duplicate_number": None,
+        "created_at": TIMESTAMP,
+        "retained_source": None,
+        "module_details": {},
+    }
+
+
+def _write_manifest(root: Path) -> Path:
+    manifest = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 3,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [_evidence("evidence_001", 1)],
+            },
+            {
+                "page_number": 2,
+                "page_state": "duplicate",
+                "selected_evidence_id": None,
+                "evidence": [
+                    _evidence("evidence_002a", 2, role="candidate"),
+                    _evidence("evidence_002b", 2, role="candidate"),
+                ],
+            },
+            {
+                "page_number": 3,
+                "page_state": "excluded",
+                "selected_evidence_id": None,
+                "evidence": [
+                    {
+                        **_evidence("evidence_003", 3, role="excluded"),
+                        "evidence_state": "excluded",
+                    }
+                ],
+            },
+        ],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+    path = submission_manifest_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    written = write_submission_manifest(path, manifest)
+    for page in cast(list[dict[str, Any]], manifest["pages"]):
+        for evidence in page["evidence"]:
+            evidence_path = root / evidence["routed_evidence_path"]
+            evidence_path.parent.mkdir(parents=True, exist_ok=True)
+            evidence_path.write_bytes(b"evidence")
+    return written
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def test_exclude_page_preserves_evidence_files_and_excludes_manifest_records(
+    tmp_path: Path,
+) -> None:
+    path = _write_manifest(tmp_path)
+    evidence_before = {
+        item: item.read_bytes()
+        for item in tmp_path.rglob("*.pdf")
+    }
+
+    result = exclude_submission_page(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 1
+    )
+
+    manifest = _read(path)
+    page = manifest["pages"][0]
+    assert result.page_state == "excluded"
+    assert page["selected_evidence_id"] is None
+    assert page["evidence"][0]["evidence_role"] == "excluded"
+    assert page["evidence"][0]["evidence_state"] == "excluded"
+    assert page["evidence"][0]["module_details"][
+        "quillan_before_page_exclusion"
+    ] == {"evidence_role": "selected", "evidence_state": "active"}
+    assert evidence_before == {
+        item: item.read_bytes()
+        for item in tmp_path.rglob("*.pdf")
+    }
+
+
+def test_restore_single_excluded_page_selects_only_unambiguous_evidence(
+    tmp_path: Path,
+) -> None:
+    path = _write_manifest(tmp_path)
+
+    result = restore_excluded_submission_page(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 3
+    )
+
+    manifest = _read(path)
+    page = manifest["pages"][2]
+    assert result.page_state == "present"
+    assert page["selected_evidence_id"] == "evidence_003"
+    assert page["evidence"][0]["evidence_role"] == "selected"
+    assert page["evidence"][0]["evidence_state"] == "active"
+
+
+def test_restore_recovers_preserved_duplicate_evidence_roles(
+    tmp_path: Path,
+) -> None:
+    path = _write_manifest(tmp_path)
+
+    exclude_submission_page(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 2)
+    result = restore_excluded_submission_page(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 2
+    )
+
+    manifest = _read(path)
+    page = manifest["pages"][1]
+    assert result.page_state == "duplicate"
+    assert page["selected_evidence_id"] is None
+    assert [item["evidence_role"] for item in page["evidence"]] == [
+        "candidate",
+        "candidate",
+    ]
+    assert [item["evidence_state"] for item in page["evidence"]] == [
+        "active",
+        "active",
+    ]
+    assert all(
+        "quillan_before_page_exclusion" not in item["module_details"]
+        for item in page["evidence"]
+    )
+
+
+def test_restore_preserves_prior_damaged_evidence_state(
+    tmp_path: Path,
+) -> None:
+    path = _write_manifest(tmp_path)
+    manifest = _read(path)
+    manifest["pages"][0]["evidence"][0]["evidence_state"] = "damaged"
+    write_submission_manifest(path, manifest, overwrite=True)
+
+    exclude_submission_page(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 1)
+    result = restore_excluded_submission_page(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 1
+    )
+
+    manifest = _read(path)
+    page = manifest["pages"][0]
+    assert result.page_state == "needs_rescan"
+    assert page["selected_evidence_id"] == "evidence_001"
+    assert page["evidence"][0]["evidence_role"] == "selected"
+    assert page["evidence"][0]["evidence_state"] == "damaged"
+
+
+def test_mark_page_needs_rescan_preserves_review_record(
+    tmp_path: Path,
+) -> None:
+    path = _write_manifest(tmp_path)
+    review_path = path.with_name("review.json")
+    review_path.write_text('{"review_state": "in_progress"}', encoding="utf-8")
+    before = review_path.read_bytes()
+
+    result = mark_submission_page_needs_rescan(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 1
+    )
+
+    manifest = _read(path)
+    page = manifest["pages"][0]
+    assert result.page_state == "needs_rescan"
+    assert page["selected_evidence_id"] is None
+    assert page["evidence"][0]["evidence_role"] == "candidate"
+    assert page["evidence"][0]["evidence_state"] == "needs_rescan"
+    assert review_path.read_bytes() == before
+
+
+def test_invalid_page_number_fails_without_writing(
+    tmp_path: Path,
+) -> None:
+    path = _write_manifest(tmp_path)
+    before = path.read_bytes()
+
+    with pytest.raises(SubmissionPageManagementError, match="Page 99"):
+        exclude_submission_page(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 99)
+
+    assert path.read_bytes() == before
+
+
+def test_non_integer_page_number_fails_without_type_error(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path)
+    before = path.read_bytes()
+
+    with pytest.raises(SubmissionPageManagementError, match="positive integer"):
+        exclude_submission_page(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "1"  # type: ignore[arg-type]
+        )
+
+    assert path.read_bytes() == before
+
+
+def test_write_os_error_is_wrapped_without_partial_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_manifest(tmp_path)
+    before = path.read_bytes()
+
+    def fail_write(*_args: object, **_kwargs: object) -> Path:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(page_management, "write_submission_manifest", fail_write)
+
+    with pytest.raises(SubmissionPageManagementError, match="disk full"):
+        exclude_submission_page(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 1)
+
+    assert path.read_bytes() == before

--- a/tests/test_tag_bank_workflows.py
+++ b/tests/test_tag_bank_workflows.py
@@ -205,7 +205,6 @@ def test_add_tag_template_stores_optional_metadata(
             "criterion_1",
             "2",
             "What evidence needs clarification?",
-            "n",
             "10",
             "1",
         ],
@@ -220,8 +219,23 @@ def test_add_tag_template_stores_optional_metadata(
     assert added["criterion_ids"] == ["criterion_1"]
     assert added["severity_default"] == 2
     assert added["teacher_note_prompt"] == "What evidence needs clarification?"
-    assert added["student_facing_default"] is False
+    assert "student_facing_default" not in added
     capsys.readouterr()
+
+
+def test_tag_bank_menu_uses_teacher_facing_language(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["7"])
+
+    assert workflows.launch_tag_banks_menu() == 0
+
+    output = capsys.readouterr().out
+    assert "Add reusable tag" in output
+    assert "Add tag template" not in output
+    assert "Implemented in #166" not in output
+    assert "Opening this screen" not in output
 
 
 def test_validate_tag_bank_reports_invalid_without_modifying_file(


### PR DESCRIPTION
## Summary

Polishes teacher-facing review-material authoring workflows and adds teacher-controlled submission page management.

Closes #177

## Changes

* Added shared authoring prompt helpers in `quillan/authoring_prompt_helpers.py`.
* Polished Review Materials authoring language across:

  * Tag Banks
  * Comment Banks
  * Rubrics / Scoring Profiles
  * Starter Materials
  * review-time material display
* Replaced developer-facing wording with teacher-facing language:

  * `metadata` → optional details
  * `Writing types` → writing assignment types
  * `Add tag template` → Add reusable tag
  * `sort_order` → display order
* Added label-vs-system-ID guidance.
* Added lowercase / underscore / no-spaces guidance for ID-style values.
* Added clearer explanations for:

  * linked standards
  * linked rubric criteria
  * priority/severity
  * private note questions
  * display order
* Hid `student_facing_default` from teacher authoring because it has no active runtime behavior yet.
* Removed implementation-history language such as `Implemented in #166`.
* Removed menu text such as `Opening this screen: No files were changed`.
* Replaced ignored post-save next-step choices with honest post-save guidance.
* Added teacher-facing page/evidence management:

  * exclude page from active review
  * restore excluded page
  * mark page as needing rescan
* Wired page management into `Selected Student Review -> Manage submission pages`.

## Page Management Behavior

Teachers can now manage submission pages without deleting evidence.

Supported actions:

* Exclude a page from active review.
* Restore an excluded page.
* Mark a page as needing rescan.

These actions update only the selected student’s `submission.json`.

Evidence records and routed evidence files are preserved.

Exclusion behavior:

* The page is marked `excluded`.
* Active evidence role/state fields are set to `excluded`.
* Each evidence item’s prior `evidence_role` and `evidence_state` are preserved under `module_details["quillan_before_page_exclusion"]`.

Restore behavior:

* If preserved pre-exclusion role/state metadata exists, it is restored.
* If no preserved metadata exists, legacy fallback behavior is used:

  * no evidence restores to `missing`;
  * exactly one evidence candidate restores to `present` and selects that evidence;
  * multiple evidence candidates restore to `duplicate` and remain unselected.

Needs-rescan behavior:

* The page is marked `needs_rescan`.
* Evidence is preserved.
* The action does not alter review notes, tags, comments, scores, or exports.

## Safety

Page/evidence management does not modify:

* routed evidence files
* retained source scans
* review records
* notes
* tags
* comments
* scores
* feedback exports
* rosters
* assignment configs
* comment banks
* tag banks
* rubrics
* pds-core standards
* pds-core routes
* sibling repositories

Invalid page selections and canceled confirmations write no changes.

Submission manifests are validated before write.

Filesystem write errors are wrapped in `SubmissionPageManagementError`.

## Documentation

Updated:

* `README.md`
* `docs/cli_contract.md`
* `docs/teacher_review_model.md`
* `docs/tag_bank_contract.md`
* `docs/comment_bank_contract.md`
* `docs/rubric_contract.md`
* `docs/data_contracts.md`

Docs now cover:

* teacher-facing labels vs system IDs
* lowercase/underscore guidance
* writing assignment types
* optional tag details
* private note questions
* priority/severity
* page exclusion/restoration
* needs-rescan page management
* preservation/safety boundaries

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `1026 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed

Note: validation was run with `.venv\Scripts` on `PATH` because plain `python` was not available in that shell.
