### PR TITLE
Simplify Quillan menu navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Quillan currently supports:
 * teacher-facing class roster creation, viewing, staged editing, and validation through the Roster Management menu;
 * teacher-facing writing assignment config creation and validation through the Assignment Management menu;
 * teacher-facing generation of one combined printable response class packet from an existing canonical roster and assignment config;
-* teacher-facing Review Materials guidance for reusable review aids;
+* teacher-facing Manage Review Materials guidance for reusable review aids;
 * shared Paper Data Suite workspace status reporting;
 * assignment-local storage paths based on shared `pds-core` route helpers;
 * decoded response-page route planning that validates class, assignment, roster, and student relationships before writing routed evidence;
@@ -143,14 +143,11 @@ The current top-level menu is:
 
 ```text
 1. Assignment Management
-2. Roster Management
-3. Printable Response Pages
-4. Scan Intake / Route Paper Responses
-5. Review Student Work
-6. Review Materials
-7. Workspace Settings
-8. Help
-9. Exit
+2. Review Student Work
+3. Roster Management
+4. Workspace Settings
+5. Help
+6. Exit
 ```
 
 ### Assignment Management
@@ -160,7 +157,8 @@ The Assignment Management menu supports:
 ```text
 1. Create writing assignment
 2. View/validate assignment
-3. Back
+3. Printable Response Pages
+4. Back
 ```
 
 Assignment creation requires an existing canonical class roster and writes to:
@@ -209,7 +207,10 @@ Existing optional columns are displayed and preserved when students are added, e
 
 ### Printable Response Pages
 
-The Printable Response Pages menu selects an existing canonical class roster and assignment config, prompts for a positive number of pages per student, and generates one combined class packet at:
+Printable Response Pages is available from Assignment Management. It selects
+an existing canonical class roster and assignment config, prompts for a
+positive number of pages per student, and generates one combined class packet
+at:
 
 ```text
 <PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
@@ -223,7 +224,9 @@ Generation does not alter the roster or assignment config. Generated PDFs are lo
 
 ### Scan Intake / Route Paper Responses
 
-The Scan Intake / Route Paper Responses menu asks for an image, PDF, or non-recursive folder path and uses the same QR-aware behavior as:
+Scan Intake / Route Paper Responses is available from Review Student Work. It
+asks for an image, PDF, or non-recursive folder path and uses the same
+QR-aware behavior as:
 
 ```powershell
 quillan route-scan <source> --decode-qr
@@ -235,16 +238,27 @@ It does not expose direct payload mode. It does not move or archive original sou
 
 ### Review Student Work
 
-The Review Student Work menu supports class, assignment, and student/submission navigation plus guided review actions.
+The Review Student Work menu supports scan intake, review-material management,
+class/assignment/student navigation, and guided review actions.
+
+The top Review Student Work menu is:
+
+```text
+1. Assignment Review Actions
+2. Scan Intake / Route Paper Responses
+3. Manage Review Materials
+4. Back
+```
 
 The assignment-level review actions menu is:
 
 ```text
 1. Select student/submission
-2. Export class review summary
-3. Export standards summary
-4. Refresh submission status
-5. Back
+2. Assemble routed submissions
+3. Export class review summary
+4. Export standards summary
+5. Refresh submission status
+6. Back
 ```
 
 The selected-student review menu is:
@@ -272,9 +286,14 @@ Review state updates are explicit and teacher-controlled. The state screen expla
 
 Guided export actions preserve overwrite protection. Student feedback export explains that it formats the current review record, does not rescore work, and does not generate AI feedback. Existing export files are not replaced unless the teacher explicitly confirms overwrite behavior.
 
-### Review Materials
+### Manage Review Materials
 
-The Review Materials menu is the preparation area for reusable teacher-authored review aids. It includes Comment Banks, Tag Banks, and Rubrics / Scoring Profiles submenus for creating, viewing, editing, extending, and validating shared reusable review materials. It also includes optional synthetic starter materials for onboarding and local testing.
+Manage Review Materials is available from Review Student Work. It is the
+preparation area for reusable teacher-authored review aids. It includes
+Comment Banks, Tag Banks, and Rubrics / Scoring Profiles submenus for
+creating, viewing, editing, extending, and validating shared reusable review
+materials. It also includes optional synthetic starter materials for
+onboarding and local testing.
 
 These materials help teachers review written student work more quickly by selecting prepared comments, tags, and scoring criteria instead of typing everything during review.
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -14,7 +14,7 @@ development. It records:
 The CLI includes a developer-oriented, scriptable command layer and a
 teacher-facing terminal menu. The menu now covers assignment management, roster
 management, printable response pages, QR-aware scan intake, review navigation,
-guided review-entry actions, guided export actions, Review Materials guidance,
+guided review-entry actions, guided export actions, Manage Review Materials guidance,
 workspace settings, help, and exit.
 
 This contract describes implemented behavior separately from future design. A
@@ -194,14 +194,11 @@ The top-level menu provides:
 
 ```text
 1. Assignment Management
-2. Roster Management
-3. Printable Response Pages
-4. Scan Intake / Route Paper Responses
-5. Review Student Work
-6. Review Materials
-7. Workspace Settings
-8. Help
-9. Exit
+2. Review Student Work
+3. Roster Management
+4. Workspace Settings
+5. Help
+6. Exit
 ```
 
 Menu workflows should orchestrate reusable application functions. They should
@@ -215,7 +212,8 @@ Assignment Management provides:
 ```text
 1. Create writing assignment
 2. View/validate assignment
-3. Back
+3. Printable Response Pages
+4. Back
 ```
 
 Creation selects one class with an existing canonical roster, prompts for the
@@ -250,7 +248,7 @@ loader and validator, prints a concise summary, and does not rewrite the file.
 
 These workflows do not add assignment editing, deletion, import, scoring,
 feedback, tagging execution, requirements checking, reports, scan routing,
-OCR, AI, or printable packet generation.
+OCR, or AI.
 
 #### Roster Management
 
@@ -283,7 +281,7 @@ scans, reports, tags, scores, feedback, or historical evidence.
 
 #### Printable Response Pages
 
-Printable Response Pages provides:
+Printable Response Pages is reached through Assignment Management and provides:
 
 ```text
 1. Generate class packet
@@ -313,7 +311,8 @@ CLI command.
 
 #### Scan Intake / Route Paper Responses
 
-Scan Intake / Route Paper Responses prompts for a local scan source path:
+Scan Intake / Route Paper Responses is reached through Review Student Work and
+prompts for a local scan source path:
 
 ```text
 Scan file or folder path (leave blank to cancel):
@@ -351,14 +350,17 @@ run OCR, score, tag, generate feedback, or perform AI work.
 
 #### Review Student Work
 
-Review Student Work provides guided class, assignment, and student/submission
-navigation plus review-entry and export actions.
+Review Student Work provides guided scan intake, review-material management,
+class, assignment, and student/submission navigation plus review-entry and
+export actions.
 
 The first Review Student Work menu provides:
 
 ```text
-1. Select class and assignment
-2. Back
+1. Assignment Review Actions
+2. Scan Intake / Route Paper Responses
+3. Manage Review Materials
+4. Back
 ```
 
 The workflow lists available classes from the active workspace, lists
@@ -373,10 +375,11 @@ menu provides:
 
 ```text
 1. Select student/submission
-2. Export class review summary
-3. Export standards summary
-4. Refresh submission status
-5. Back
+2. Assemble routed submissions
+3. Export class review summary
+4. Export standards summary
+5. Refresh submission status
+6. Back
 ```
 
 Selecting a student/submission lets the teacher pick a student by number. The
@@ -435,7 +438,8 @@ direct `add-tag` command remain compatible.
 bank, category, and student-facing comment, sees a feedback preview, then
 confirms the write or changes the include-in-feedback setting. Comment labels
 are primary; bank and comment IDs are displayed as secondary durable details.
-Missing comment banks point teachers to Review Materials -> Comment Banks.
+Missing comment banks point teachers to Review Student Work ->
+Manage Review Materials -> Comment Banks.
 
 `Set criterion score` opens a score chooser. Teachers can score from a valid
 shared rubric resolved through `assignment.rubric_id`, or choose Custom
@@ -481,10 +485,10 @@ The Review Student Work menu does not automatically assemble submissions,
 route scans, run OCR, parse evidence contents, score work automatically, infer
 mastery, generate AI feedback, or perform AI work.
 
-#### Review Materials
+#### Manage Review Materials
 
-Review Materials provides a preparation area for reusable teacher-authored
-review aids:
+Manage Review Materials is reached through Review Student Work and provides a
+preparation area for reusable teacher-authored review aids:
 
 ```text
 1. Comment Banks

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -25,13 +25,14 @@ student's review by itself.
 
 This document defines comment bank schema version `1`. Runtime loading,
 validation, direct student-facing selection, and teacher-facing creation and
-editing through Review Materials -> Comment Banks are implemented. Assignment
+editing through Review Student Work -> Manage Review Materials -> Comment
+Banks are implemented. Assignment
 activation, automatic suggestions, and AI-generated comments are not.
 
 Teachers can create, view, edit, extend, and validate shared banks from:
 
 ```text
-Quillan -> Review Materials -> Comment Banks
+Quillan -> Review Student Work -> Manage Review Materials -> Comment Banks
 ```
 
 The authoring workflow writes only confirmed, valid banks under
@@ -410,6 +411,6 @@ shape.
 
 Additional optional synthetic starter comment banks live under
 [`../examples/comment_banks/`](../examples/comment_banks/). They can be
-installed from Review Materials -> Starter Materials into
+installed from Review Student Work -> Manage Review Materials -> Starter Materials into
 `shared/comment_banks/`; existing files are skipped unless exact overwrite
 confirmation is provided. See [`starter_materials.md`](starter_materials.md).

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -128,7 +128,7 @@ banks are not student records, grades, scores, mastery determinations,
 generated feedback, automatic judgments, or automatic suggestions.
 
 Teachers can create, view, edit, extend, and validate shared tag banks from
-Review Materials -> Tag Banks. The workflows write only confirmed, valid
+Review Student Work -> Manage Review Materials -> Tag Banks. The workflows write only confirmed, valid
 version `1` bank files under `shared/tag_banks/`, never invalid partial files.
 Existing banks are not overwritten unless the teacher explicitly confirms with
 `OVERWRITE`.

--- a/docs/rubric_contract.md
+++ b/docs/rubric_contract.md
@@ -17,7 +17,7 @@ pds-core standards through rubric workflows.
 
 Optional synthetic starter rubrics live under
 [`../examples/rubrics/`](../examples/rubrics/). They can be installed from
-Review Materials -> Starter Materials into `shared/rubrics/`; existing files are
+Review Student Work -> Manage Review Materials -> Starter Materials into `shared/rubrics/`; existing files are
 skipped unless exact overwrite confirmation is provided. Starter rubrics are
 examples only and are not official curriculum or recommended grading policy.
 See [`starter_materials.md`](starter_materials.md).

--- a/docs/starter_materials.md
+++ b/docs/starter_materials.md
@@ -33,7 +33,7 @@ comment banks, tag banks, and rubrics.
 Use:
 
 ```text
-Quillan -> Review Materials -> Starter Materials
+Quillan -> Review Student Work -> Manage Review Materials -> Starter Materials
 ```
 
 The submenu can preview, validate, install all, or install selected starter

--- a/docs/tag_bank_contract.md
+++ b/docs/tag_bank_contract.md
@@ -85,7 +85,7 @@ workflow exists. `sort_order` is presented as optional display order.
 Tag banks are created and edited from:
 
 ```text
-Quillan -> Review Materials -> Tag Banks
+Quillan -> Review Student Work -> Manage Review Materials -> Tag Banks
 ```
 
 The workflow builds banks in memory, validates the complete bank before
@@ -95,7 +95,7 @@ Canceling creation does not create `shared/tag_banks/` or partial files.
 
 Optional synthetic starter tag banks live under
 [`../examples/tag_banks/`](../examples/tag_banks/). They can be installed from
-Review Materials -> Starter Materials into `shared/tag_banks/`; existing files
+Review Student Work -> Manage Review Materials -> Starter Materials into `shared/tag_banks/`; existing files
 are skipped unless exact overwrite confirmation is provided. See
 [`starter_materials.md`](starter_materials.md).
 

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -218,22 +218,23 @@ Teacher-only bank comments are rejected, and selection does not itself export
 feedback.
 The guided Review Student Work menu presents comment banks by title, then
 category, then comment label and feedback preview. Source IDs remain visible
-as secondary detail. Missing comment banks point teachers to Review Materials
--> Comment Banks.
+as secondary detail. Missing comment banks point teachers to Review Student
+Work -> Manage Review Materials -> Comment Banks.
 The source contract and future assignment-activation design are defined in
 [`comment_bank_contract.md`](comment_bank_contract.md).
 
 Optional synthetic starter comment banks, tag banks, and rubrics can be
-installed from Review Materials -> Starter Materials for onboarding and
-testing. They are subject-agnostic examples only, install into shared
+installed from Review Student Work -> Manage Review Materials -> Starter
+Materials for onboarding and testing. They are subject-agnostic examples only,
+install into shared
 review-material folders, and do not create assignments, rosters, submissions,
 review records, exports, or pds-core standards.
 
 Reusable tag banks are also selected in a bank, category, and tag-template
 flow. Custom tags are framed as one-off/manual observations with enumerated
 polarity and optional details grouped behind an explicit prompt. Missing tag
-banks point teachers to Review Materials -> Tag Banks while preserving the
-custom fallback.
+banks point teachers to Review Student Work -> Manage Review Materials ->
+Tag Banks while preserving the custom fallback.
 
 When reusable comments or tags include pds-core `standard_id` references,
 Quillan may resolve display metadata through pds-core read-only helpers. This

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -229,7 +229,10 @@ def _prompt_rubric_id(workspace_root: Path) -> str:
     if not rubrics:
         print("No valid shared rubrics found.")
         print()
-        print("Create one from Review Materials -> Rubrics / Scoring Profiles.")
+        print(
+            "Create one from Review Student Work -> Manage Review Materials "
+            "-> Rubrics / Scoring Profiles."
+        )
         print("You may still enter a custom rubric_id for now.")
         print()
         return _required_input("Rubric ID: ", "Rubric ID")
@@ -461,20 +464,27 @@ def launch_assignment_menu() -> int:
             print_menu_header("Assignment Management")
             print("1. Create writing assignment")
             print("2. View/validate assignment")
-            print("3. Back")
+            print("3. Printable Response Pages")
+            print("4. Back")
             print()
             choice = input("Select an option: ").strip()
             print()
 
-            if choice == "3":
+            if choice == "4":
                 return 0
             workflows = {
                 "1": prompt_create_assignment,
                 "2": prompt_view_validate_assignment,
             }
             workflow = workflows.get(choice)
-            if workflow is None:
-                print("Invalid selection. Please enter a number from 1 to 3.")
+            if choice == "3":
+                from quillan.printable_response_workflows import (
+                    launch_printable_response_menu,
+                )
+
+                launch_printable_response_menu()
+            elif workflow is None:
+                print("Invalid selection. Please enter a number from 1 to 4.")
             else:
                 clear_screen()
                 workflow()

--- a/quillan/comment_bank_workflows.py
+++ b/quillan/comment_bank_workflows.py
@@ -195,7 +195,8 @@ def prompt_view_comment_banks() -> int:
         print("No valid shared comment banks found.")
         print()
         print(
-            "Create one from Review Materials -> Comment Banks -> "
+            "Create one from Review Student Work -> Manage Review Materials "
+            "-> Comment Banks -> "
             "Create comment bank."
         )
         print()
@@ -670,7 +671,8 @@ def _prompt_valid_bank() -> tuple[Path, dict[str, Any]] | None:
     if not files:
         print("No valid shared comment banks found.")
         print(
-            "Create one from Review Materials -> Comment Banks -> "
+            "Create one from Review Student Work -> Manage Review Materials "
+            "-> Comment Banks -> "
             "Create comment bank."
         )
         return None

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -32,7 +32,7 @@ def pause_for_user() -> None:
 
 def print_menu_header(title: str | None = None) -> None:
     """Print the Quillan identity and an optional section title."""
-    print("Quillan")
+    print("\033[32mQuillan\033[0m")
     if title:
         print(title)
     print()
@@ -334,14 +334,11 @@ def launch_menu(
             clear_screen()
             print_menu_header()
             print("1. Assignment Management")
-            print("2. Roster Management")
-            print("3. Printable Response Pages")
-            print("4. Scan Intake / Route Paper Responses")
-            print("5. Review Student Work")
-            print("6. Review Materials")
-            print("7. Workspace Settings")
-            print("8. Help")
-            print("9. Exit")
+            print("2. Review Student Work")
+            print("3. Roster Management")
+            print("4. Workspace Settings")
+            print("5. Help")
+            print("6. Exit")
             print()
 
             choice = input("Select an option: ").strip()
@@ -350,32 +347,26 @@ def launch_menu(
             if choice == "1":
                 launch_assignment_menu()
             elif choice == "2":
-                launch_roster_menu()
-            elif choice == "3":
-                launch_printable_response_menu()
-            elif choice == "4":
-                launch_scan_intake_workflow()
-            elif choice == "5":
                 launch_review_student_work_menu()
-            elif choice == "6":
-                launch_review_materials_menu()
-            elif choice == "7":
+            elif choice == "3":
+                launch_roster_menu()
+            elif choice == "4":
                 launch_workspace_menu(
                     workspace_show,
                     workspace_set,
                     workspace_validate,
                     workspace_reset,
                 )
-            elif choice == "8":
+            elif choice == "5":
                 clear_screen()
                 print_menu_help()
                 print()
                 pause_for_user()
-            elif choice == "9":
+            elif choice == "6":
                 print("Goodbye.")
                 return 0
             else:
-                print("Invalid selection. Please enter a number from 1 to 9.")
+                print("Invalid selection. Please enter a number from 1 to 6.")
                 print()
                 pause_for_user()
     except KeyboardInterrupt:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -91,24 +91,33 @@ def launch_review_student_work_menu() -> int:
         while True:
             clear_screen()
             print_menu_header("Review Student Work")
-            print("1. Select class and assignment")
-            print("2. Back")
+            print("1. Assignment Review Actions")
+            print("2. Scan Intake / Route Paper Responses")
+            print("3. Manage Review Materials")
+            print("4. Back")
             print()
             choice = input("Select an option: ").strip()
             print()
 
-            if choice in {"", "2"}:
+            if choice in {"", "4"}:
                 return 0
-            if choice != "1":
-                print("Invalid selection. Please enter a number from 1 to 2.")
+            if choice == "1":
+                clear_screen()
+                _run_review_selection_workflow()
                 print()
                 pause_for_user()
-                continue
+            elif choice == "2":
+                from quillan.menu import launch_scan_intake_workflow
 
-            clear_screen()
-            _run_review_selection_workflow()
-            print()
-            pause_for_user()
+                launch_scan_intake_workflow()
+            elif choice == "3":
+                from quillan.review_materials_menu import launch_review_materials_menu
+
+                launch_review_materials_menu()
+            else:
+                print("Invalid selection. Please enter a number from 1 to 4.")
+                print()
+                pause_for_user()
     except KeyboardInterrupt:
         print("\nExiting review menu.")
         return 0
@@ -756,7 +765,10 @@ def _menu_add_reusable_review_tag(
         print("No valid shared tag banks found.")
         print()
         print("Create one from:")
-        print("Review Materials -> Tag Banks -> Create tag bank")
+        print(
+            "Review Student Work -> Manage Review Materials -> "
+            "Tag Banks -> Create tag bank"
+        )
         print()
         print("1. Custom tag")
         print("2. Back")
@@ -1119,7 +1131,10 @@ def _prompt_comment_from_bank(
         print("This bank has no student-facing comments.")
         print()
         print("Add one from:")
-        print("Review Materials -> Comment Banks -> Add comment")
+        print(
+            "Review Student Work -> Manage Review Materials -> "
+            "Comment Banks -> Add comment"
+        )
         print()
         print("1. Choose another bank")
         print("2. Back")
@@ -1274,7 +1289,10 @@ def _menu_add_review_comment(
         print("No valid shared comment banks found.")
         print()
         print("Create one from:")
-        print("Review Materials -> Comment Banks -> Create comment bank")
+        print(
+            "Review Student Work -> Manage Review Materials -> "
+            "Comment Banks -> Create comment bank"
+        )
         return
 
     bank = _prompt_comment_bank(banks)
@@ -1434,7 +1452,8 @@ def _menu_missing_rubric(
     print(f"Rubric ID: {rubric_id}")
     print()
     print(
-        "Create or fix the rubric from Review Materials -> "
+        "Create or fix the rubric from Review Student Work -> "
+        "Manage Review Materials -> "
         "Rubrics / Scoring Profiles."
     )
     print()

--- a/quillan/rubric_workflows.py
+++ b/quillan/rubric_workflows.py
@@ -174,7 +174,8 @@ def prompt_view_rubrics() -> int:
         print("No valid shared rubrics found.")
         print()
         print(
-            "Create one from Review Materials -> Rubrics / Scoring Profiles -> "
+            "Create one from Review Student Work -> Manage Review Materials "
+            "-> Rubrics / Scoring Profiles -> "
             "Create rubric / scoring profile."
         )
         print()
@@ -533,7 +534,8 @@ def _prompt_valid_rubric() -> tuple[Path, dict[str, Any]] | None:
     if not files:
         print("No valid shared rubrics found.")
         print(
-            "Create one from Review Materials -> Rubrics / Scoring Profiles -> "
+            "Create one from Review Student Work -> Manage Review Materials "
+            "-> Rubrics / Scoring Profiles -> "
             "Create rubric / scoring profile."
         )
         return None

--- a/quillan/tag_bank_workflows.py
+++ b/quillan/tag_bank_workflows.py
@@ -182,7 +182,10 @@ def prompt_view_tag_banks() -> int:
     if not valid:
         print("No valid shared tag banks found.")
         print()
-        print("Create one from Review Materials -> Tag Banks -> Create tag bank.")
+        print(
+            "Create one from Review Student Work -> Manage Review Materials "
+            "-> Tag Banks -> Create tag bank."
+        )
         print()
         print("Expected location:")
         print("shared/tag_banks/")
@@ -651,7 +654,10 @@ def _prompt_valid_bank() -> tuple[Path, dict[str, Any]] | None:
     files = list_valid_tag_banks(workspace_root)
     if not files:
         print("No valid shared tag banks found.")
-        print("Create one from Review Materials -> Tag Banks -> Create tag bank.")
+        print(
+            "Create one from Review Student Work -> Manage Review Materials "
+            "-> Tag Banks -> Create tag bank."
+        )
         return None
     print("Available tag banks:")
     for index, item in enumerate(files, start=1):

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -519,13 +519,14 @@ def test_assignment_menu_displays_options_and_dispatches(
         "prompt_view_validate_assignment",
         lambda: record("view"),
     )
-    _inputs(monkeypatch, ["1", "", "2", "", "3"])
+    _inputs(monkeypatch, ["1", "", "2", "", "4"])
 
     assert workflows.launch_assignment_menu() == 0
     output = capsys.readouterr().out
     assert calls == ["create", "view"]
     assert "Create writing assignment" in output
     assert "View/validate assignment" in output
+    assert "Printable Response Pages" in output
     assert "Back" in output
 
 
@@ -533,7 +534,7 @@ def test_assignment_menu_invalid_selection_and_keyboard_interrupt(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    _inputs(monkeypatch, ["bad", "", "3"])
+    _inputs(monkeypatch, ["bad", "", "4"])
     assert workflows.launch_assignment_menu() == 0
     assert "Invalid selection" in capsys.readouterr().out
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,21 +62,22 @@ def test_cli_without_command_displays_menu_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["9"])
+    _menu_input(monkeypatch, ["6"])
 
     assert main([]) == 0
 
     output = capsys.readouterr().out
     assert "Quillan" in output
-    assert "Assignment Management" in output
-    assert "Roster Management" in output
-    assert "Printable Response Pages" in output
-    assert "Scan Intake / Route Paper Responses" in output
-    assert "Review Student Work" in output
-    assert "Review Materials" in output
-    assert "Workspace Settings" in output
-    assert "Help" in output
-    assert "Exit" in output
+    assert "\033[32mQuillan\033[0m" in output
+    assert "1. Assignment Management" in output
+    assert "2. Review Student Work" in output
+    assert "3. Roster Management" in output
+    assert "4. Workspace Settings" in output
+    assert "5. Help" in output
+    assert "6. Exit" in output
+    assert "Printable Response Pages" not in output
+    assert "Scan Intake / Route Paper Responses" not in output
+    assert "Review Materials" not in output
     assert "Goodbye." in output
 
 
@@ -354,21 +355,22 @@ def test_menu_dispatch_displays_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["9"])
+    _menu_input(monkeypatch, ["6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
 
     assert "Quillan" in output
-    assert "Assignment Management" in output
-    assert "Roster Management" in output
-    assert "Printable Response Pages" in output
-    assert "Scan Intake / Route Paper Responses" in output
-    assert "Review Student Work" in output
-    assert "Review Materials" in output
-    assert "Workspace Settings" in output
-    assert "Help" in output
-    assert "Exit" in output
+    assert "\033[32mQuillan\033[0m" in output
+    assert "1. Assignment Management" in output
+    assert "2. Review Student Work" in output
+    assert "3. Roster Management" in output
+    assert "4. Workspace Settings" in output
+    assert "5. Help" in output
+    assert "6. Exit" in output
+    assert "Printable Response Pages" not in output
+    assert "Scan Intake / Route Paper Responses" not in output
+    assert "Review Materials" not in output
     assert "Goodbye." in output
 
 
@@ -376,7 +378,7 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["8", "", "9"])
+    _menu_input(monkeypatch, ["5", "", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -390,11 +392,11 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     assert "quillan menu" in output
 
 
-def test_main_menu_opens_printable_response_submenu(
+def test_assignment_management_opens_printable_response_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["3", "2", "9"])
+    _menu_input(monkeypatch, ["1", "3", "2", "", "4", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -408,13 +410,15 @@ def test_main_menu_opens_assignment_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["1", "3", "9"])
+    _menu_input(monkeypatch, ["1", "4", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Assignment Management" in output
+    assert "\033[32mQuillan\033[0m" in output
     assert "Create writing assignment" in output
     assert "View/validate assignment" in output
+    assert "Printable Response Pages" in output
     assert "Back" in output
     assert "Goodbye." in output
 
@@ -423,7 +427,7 @@ def test_main_menu_opens_roster_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "5", "9"])
+    _menu_input(monkeypatch, ["3", "5", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -449,7 +453,7 @@ def test_workspace_menu_reuses_workspace_show_handler(
         return 0
 
     monkeypatch.setattr(cli_workspace, "show_workspace", handle_workspace_show)
-    _menu_input(monkeypatch, ["7", "1", "", "5", "9"])
+    _menu_input(monkeypatch, ["4", "1", "", "5", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -480,7 +484,7 @@ def test_workspace_menu_sets_workspace_folder(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["7", "2", str(workspace_root), "", "5", "9"])
+    _menu_input(monkeypatch, ["4", "2", str(workspace_root), "", "5", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -504,7 +508,7 @@ def test_workspace_menu_blank_set_cancels_without_change(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["7", "2", "  ", "", "5", "9"])
+    _menu_input(monkeypatch, ["4", "2", "  ", "", "5", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
@@ -531,7 +535,7 @@ def test_workspace_menu_validates_current_workspace(
         "validate_workspace",
         handle_workspace_validate,
     )
-    _menu_input(monkeypatch, ["7", "3", "", "5", "9"])
+    _menu_input(monkeypatch, ["4", "3", "", "5", "6"])
 
     assert main(["menu"]) == 0
     assert calls == 1
@@ -558,7 +562,7 @@ def test_workspace_menu_resets_saved_preference(
         "reset_workspace",
         handle_workspace_reset,
     )
-    _menu_input(monkeypatch, ["7", "4", "", "5", "9"])
+    _menu_input(monkeypatch, ["4", "4", "", "5", "6"])
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -40,15 +40,15 @@ def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
 
 
 def _enter_assignment_review_actions() -> list[str]:
-    return ["5", "1", "1", "1"]
+    return ["2", "1", "1", "1"]
 
 
 def _exit_assignment_review_actions_to_main() -> list[str]:
-    return ["6", "", "2", "9"]
+    return ["6", "", "4", "6"]
 
 
 def _exit_after_assignment_action_to_main() -> list[str]:
-    return ["", "6", "", "2", "9"]
+    return ["", "6", "", "4", "6"]
 
 
 def _enter_selected_student(student_choice: str = "1") -> list[str]:

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -222,15 +222,15 @@ def _write_review_record(root: Path, review: dict[str, Any]) -> Path:
 
 
 def _enter_selected_student(student_choice: str = "1") -> list[str]:
-    return ["5", "1", "1", "1", "1", student_choice]
+    return ["2", "1", "1", "1", "1", student_choice]
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["10", "6", "", "2", "9"]
+    return ["10", "6", "", "4", "6"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "10", "6", "", "2", "9"]
+    return ["", "10", "6", "", "4", "6"]
 
 
 @pytest.fixture

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -192,14 +192,16 @@ def test_main_menu_shows_and_opens_review_student_work(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["5", "2", "9"])
+    _menu_input(monkeypatch, ["2", "4", "6"])
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "5. Review Student Work" in output
+    assert "2. Review Student Work" in output
     assert "Review Student Work" in output
-    assert "1. Select class and assignment" in output
+    assert "1. Assignment Review Actions" in output
+    assert "2. Scan Intake / Route Paper Responses" in output
+    assert "3. Manage Review Materials" in output
     assert "Goodbye." in output
 
 
@@ -220,7 +222,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["5", "1", "1", "1", "1", "1", "10", "6", "", "2", "9"])
+    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "10", "6", "", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -265,7 +267,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "10", "6", "", "2", "9"],
+        ["2", "1", "1", "1", "1", "1", "10", "6", "", "4", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -313,7 +315,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "1", "1", "", "10", "6", "", "2", "9"],
+        ["2", "1", "1", "1", "1", "1", "1", "", "10", "6", "", "4", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -331,7 +333,7 @@ def test_review_menu_reports_missing_openable_evidence(
 ) -> None:
     _menu_input(
         monkeypatch,
-        ["5", "1", "1", "1", "1", "2", "1", "", "6", "", "2", "9"],
+        ["2", "1", "1", "1", "1", "2", "1", "", "6", "", "4", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -353,7 +355,7 @@ def test_review_menu_adds_teacher_note_to_review_record(
     _menu_input(
         monkeypatch,
         [
-            "5",
+            "2",
             "1",
             "1",
             "1",
@@ -365,8 +367,8 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "10",
             "6",
             "",
-            "2",
-            "9",
+            "4",
+            "6",
         ],
     )
 
@@ -396,7 +398,7 @@ def test_review_menu_updates_submission_review_state(
     _menu_input(
         monkeypatch,
         [
-            "5",
+            "2",
             "1",
             "1",
             "1",
@@ -409,8 +411,8 @@ def test_review_menu_updates_submission_review_state(
             "10",
             "6",
             "",
-            "2",
-            "9",
+            "4",
+            "6",
         ],
     )
 
@@ -448,7 +450,7 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
     _menu_input(
         monkeypatch,
         [
-            "5",
+            "2",
             "1",
             "1",
             "1",
@@ -462,8 +464,8 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
             "10",
             "6",
             "",
-            "2",
-            "9",
+            "4",
+            "6",
         ],
     )
 
@@ -495,11 +497,11 @@ def test_review_menu_no_classes_and_invalid_selection_back_out_safely(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
-    _menu_input(monkeypatch, ["5", "9", "", "1", "", "2", "9"])
+    _menu_input(monkeypatch, ["2", "9", "", "1", "", "4", "6"])
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "Invalid selection. Please enter a number from 1 to 2." in output
+    assert "Invalid selection. Please enter a number from 1 to 4." in output
     assert "No classes found in the current workspace." in output
     assert "Goodbye." in output

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -166,23 +166,23 @@ def _routed_pngs(workspace: Path) -> list[Path]:
     )
 
 
-def test_main_menu_exposes_scan_intake_option(
+def test_review_student_work_exposes_scan_intake_option(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["9"])
+    _menu_input(monkeypatch, ["2", "4", "6"])
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "4. Scan Intake / Route Paper Responses" in output
+    assert "2. Scan Intake / Route Paper Responses" in output
 
 
 def test_menu_scan_intake_empty_input_cancels(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["4", "  ", "", "9"])
+    _menu_input(monkeypatch, ["2", "2", "  ", "", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -198,7 +198,7 @@ def test_menu_scan_intake_invalid_path_does_not_create_review_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     missing_source = workspace / "missing-scan.pdf"
-    _menu_input(monkeypatch, ["4", str(missing_source), "", "b", "9"])
+    _menu_input(monkeypatch, ["2", "2", str(missing_source), "", "b", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -216,7 +216,7 @@ def test_menu_scan_intake_with_quoted_qr_image_routes_and_prints_next_step(
     source = tmp_path / "synthetic response.png"
     _write_qr_image(source, _valid_payload())
     original_bytes = source.read_bytes()
-    _menu_input(monkeypatch, ["4", f'  "{source}"  ', "", "b", "9"])
+    _menu_input(monkeypatch, ["2", "2", f'  "{source}"  ', "", "b", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -250,7 +250,7 @@ def test_menu_scan_intake_pdf_uses_existing_qr_page_intake(
             _make_qr_image(_valid_payload(student_id=SECOND_STUDENT_ID, page=2)),
         ),
     )
-    _menu_input(monkeypatch, ["4", str(source), "", "b", "9"])
+    _menu_input(monkeypatch, ["2", "2", str(source), "", "b", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -281,7 +281,7 @@ def test_menu_scan_intake_mixed_pdf_prints_review_warning(
             _blank_image(),
         ),
     )
-    _menu_input(monkeypatch, ["4", str(source), "", "b", "9"])
+    _menu_input(monkeypatch, ["2", "2", str(source), "", "b", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -307,7 +307,7 @@ def test_menu_scan_intake_folder_processes_supported_files_and_skips_unsupported
     folder.mkdir()
     _write_qr_image(folder / "response.png", _valid_payload())
     (folder / "notes.txt").write_text("ignore me", encoding="utf-8")
-    _menu_input(monkeypatch, ["4", str(folder), "", "b", "9"])
+    _menu_input(monkeypatch, ["2", "2", str(folder), "", "b", "4", "6"])
 
     assert main(["menu"]) == 0
 

--- a/tests/test_review_materials_menu.py
+++ b/tests/test_review_materials_menu.py
@@ -39,20 +39,20 @@ def _file_tree(root: Path) -> tuple[tuple[str, str, bytes | None], ...]:
     return tuple(entries)
 
 
-def test_main_menu_includes_review_materials_and_exits_cleanly(
+def test_main_menu_excludes_review_materials_and_exits_cleanly(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["9"])
+    _menu_input(monkeypatch, ["6"])
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "5. Review Student Work" in output
-    assert "6. Review Materials" in output
-    assert "7. Workspace Settings" in output
-    assert "8. Help" in output
-    assert "9. Exit" in output
+    assert "2. Review Student Work" in output
+    assert "4. Workspace Settings" in output
+    assert "5. Help" in output
+    assert "6. Exit" in output
+    assert "Review Materials" not in output
     assert "Goodbye." in output
 
 
@@ -60,19 +60,19 @@ def test_main_menu_invalid_selection_uses_new_range(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["bad", "", "9"])
+    _menu_input(monkeypatch, ["bad", "", "6"])
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "Invalid selection. Please enter a number from 1 to 9." in output
+    assert "Invalid selection. Please enter a number from 1 to 6." in output
 
 
 def test_review_materials_menu_navigation_returns_to_main_menu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["6", "5", "9"])
+    _menu_input(monkeypatch, ["2", "3", "5", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -190,7 +190,7 @@ def test_review_materials_menu_has_no_workspace_side_effects(
     before = _file_tree(tmp_path)
     _menu_input(
         monkeypatch,
-        ["6", "1", "7", "2", "", "3", "", "4", "", "5", "9"],
+        ["2", "3", "1", "7", "2", "", "3", "", "4", "", "5", "4", "6"],
     )
 
     assert main(["menu"]) == 0


### PR DESCRIPTION
## Summary

Simplifies Quillan’s top-level menu and standardizes the persistent green Quillan title across menu screens.

Closes #179

## Changes

* Simplified the top-level menu to six options:

  * Assignment Management
  * Review Student Work
  * Roster Management
  * Workspace Settings
  * Help
  * Exit
* Moved Printable Response Pages under Assignment Management.
* Moved Scan Intake / Route Paper Responses under Review Student Work.
* Moved Review Materials under Review Student Work and renamed it Manage Review Materials.
* Updated Review Student Work to expose:

  * Assignment Review Actions
  * Scan Intake / Route Paper Responses
  * Manage Review Materials
  * Back
* Updated Assignment Management to expose Printable Response Pages.
* Centralized the persistent green Quillan title through `print_menu_header()`.
* Reused the shared menu-header helper instead of adding scattered color logic.
* Updated menu numbering, invalid-selection ranges, docs, breadcrumbs, and tests.

## New Menu Paths

Printable Response Pages:

```text
Quillan -> Assignment Management -> Printable Response Pages
```

Scan Intake / Route Paper Responses:

```text
Quillan -> Review Student Work -> Scan Intake / Route Paper Responses
```

Review Materials:

```text
Quillan -> Review Student Work -> Manage Review Materials
```

## Final Top-Level Menu

```text
1. Assignment Management
2. Review Student Work
3. Roster Management
4. Workspace Settings
5. Help
6. Exit
```

## Safety

This PR reorganizes navigation only.

It does not change data contracts for:

* assignments
* rosters
* printable response pages
* scan intake / routing
* submission manifests
* review records
* exports
* comment banks
* tag banks
* rubrics
* pds-core standards
* pds-core routes

Existing workflows remain reachable through their new menu paths.

No sibling repositories or `pds-core` files were modified.

## Documentation

Updated docs and breadcrumbs, including:

* `README.md`
* `docs/cli_contract.md`
* `docs/teacher_review_model.md`
* review-material contract docs

Old paths now point to the new menu locations.

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `1026 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
