### PR TITLE
Improve review navigation and requirement checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A **retained source scan** is the canonical active source copy Quillan keeps dur
 
 A **student submission manifest** is the structured record connecting one student and assignment to pages, page states, selected evidence, alternate evidence, and provenance.
 
-A **review record** is the teacher-controlled `review.json` containing notes, tags, selected comments, and criterion scores.
+A **review record** is the teacher-controlled `review.json` containing notes, tags, selected comments, criterion scores, and teacher-entered requirement checks.
 
 An **export** is a derived artifact produced from canonical records.
 
@@ -119,7 +119,7 @@ The supported sequence is:
 10. Quillan assembles submission manifests from routed evidence.
 11. The teacher lists submission status.
 12. The teacher opens selected evidence locally.
-13. The teacher adds notes, structured tags, reusable comments, and scores.
+13. The teacher records minimum requirement checks and adds notes, structured tags, reusable comments, and scores.
 14. The teacher updates lightweight submission review state when appropriate.
 15. The teacher exports student feedback, class review summary, and standards summary.
 
@@ -265,20 +265,21 @@ The selected-student review menu is:
 
 ```text
 1. Open submission evidence
-2. Manage submission pages
-3. Add teacher note
-4. Add structured tag
-5. Select reusable comment
-6. Set criterion score
-7. Update submission review state
-8. Export student feedback
-9. Refresh summary
-10. Back
+2. Record minimum requirement checks
+3. Manage submission pages
+4. Add teacher note
+5. Add structured tag
+6. Select reusable comment
+7. Set criterion score
+8. Update submission review state
+9. Export student feedback
+10. Refresh summary
+11. Back
 ```
 
 These guided actions reuse the same underlying services and data contracts as the direct CLI commands. The menu does not implement separate export logic, scoring logic, routing logic, or AI logic.
 
-Review mode is selection-first. Teacher notes open with private-note guidance and safe Back behavior. Reusable comments are selected by comment bank, category, and comment, with label and feedback preview shown before writing. Reusable tags are selected by tag bank, category, and tag template, with a custom one-off fallback. Rubric scoring uses the assignment's resolved shared rubric when available, then asks the teacher to choose a criterion and level before confirming the saved score; custom scoring remains available when the rubric is missing or does not contain the needed criterion.
+Review mode is selection-first. Selection screens clear between major levels so the current student, assignment, bank, category, or criterion context is visible without old summaries above it. `B. Back` returns to the immediate previous selection screen. Teacher notes open with private-note guidance and safe Back behavior. Minimum requirement checks are generated from assignment `basic_requirements` and stored as teacher-entered booleans in `review.json.requirement_checks`; Quillan does not count words or paragraphs, parse writing, run OCR, use AI, infer requirement completion, or change scores from those checks. Reusable comments are selected by comment bank, category, and comment, with label and feedback preview shown before writing. Reusable tags are selected by tag bank, category, and tag template, with a custom one-off fallback. Rubric scoring uses the assignment's resolved shared rubric when available, then asks the teacher to choose a criterion and level before confirming the saved score; custom scoring remains available when the rubric is missing or does not contain the needed criterion.
 
 Review-time standards metadata is display-only. When reusable comments or tags reference durable pds-core `standard_id` values, Quillan may resolve readable code/name metadata through pds-core read-only helpers for display. It still stores durable IDs in review records and does not create, import, edit, retire, reactivate, or authoritatively validate standards.
 
@@ -909,7 +910,7 @@ Quillan does not currently provide:
 * automatic mastery calculation;
 * automatic evidence selection among duplicates;
 * automatic review-state decisions;
-* complete requirements-checking workflows;
+* automatic requirements evaluation;
 * recursive raw scan folder intake;
 * production inbox draining;
 * source cleanup/archive automation;

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -388,19 +388,26 @@ assignment, student, submission/evidence status, review state, and existing
 `review.json` counts when a valid review record is already present. Long file
 paths are reserved for detail/output actions.
 
+Assignment-level student selection clears the prior assignment-status summary
+before showing the student list. Nested review selections such as reusable
+tags, reusable comments, and rubric scoring also clear between levels so each
+screen stands on its own. `B. Back` returns to the immediate previous
+selection screen.
+
 The selected-student review menu provides:
 
 ```text
 1. Open submission evidence
-2. Manage submission pages
-3. Add teacher note
-4. Add structured tag
-5. Select reusable comment
-6. Set criterion score
-7. Update submission review state
-8. Export student feedback
-9. Refresh summary
-10. Back
+2. Record minimum requirement checks
+3. Manage submission pages
+4. Add teacher note
+5. Add structured tag
+6. Select reusable comment
+7. Set criterion score
+8. Update submission review state
+9. Export student feedback
+10. Refresh summary
+11. Back
 ```
 
 Opening submission evidence delegates to the same existing safe selected
@@ -411,6 +418,14 @@ quillan open-submission <class_id> <assignment_id> <student_id>
 ```
 
 Missing manifests or missing selected evidence are reported clearly.
+
+`Record minimum requirement checks` lists checks generated from the selected
+assignment's `basic_requirements`: minimum/maximum paragraph count,
+minimum/maximum word count, and each configured required element. The teacher
+records each check as `1` for met/yes or `2` for not met/no. Quillan stores
+the teacher-entered boolean in `review.json.requirement_checks`; it does not
+count words or paragraphs, parse writing, run OCR, use AI, infer a result, or
+change rubric scores.
 
 Guided review-entry actions reuse the same underlying review services as the
 direct commands:

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -15,7 +15,8 @@ manifest:
 * `submission.json` answers what evidence exists, where it came from, which
   evidence is selected, and what evidence-management state it is in.
 * `review.json` answers what the teacher recorded about that evidence,
-  including notes, tags, scores, selected comments, and review/export state.
+  including notes, tags, scores, selected comments, requirement checks, and
+  review/export state.
 
 Teacher review must not rewrite or duplicate the evidence manifest. In
 particular, `review.json` references evidence by `evidence_id` and optional
@@ -45,14 +46,17 @@ Every version `1` review record contains:
   "tags": [],
   "scores": [],
   "comments": [],
+  "requirement_checks": [],
   "created_at": "2026-06-22T00:00:00+00:00",
   "updated_at": "2026-06-22T00:00:00+00:00",
   "module_details": {}
 }
 ```
 
-All fields shown above are required, including arrays that are initially
-empty.
+All fields shown above except `requirement_checks` are required, including
+arrays that are initially empty. `requirement_checks` is optional for older
+schema version `1` records; new records written by current review workflows
+include it as an empty array until the teacher records checks.
 
 Field requirements are:
 
@@ -66,6 +70,8 @@ Field requirements are:
 * `review_state`: one of the controlled values below;
 * `notes`, `tags`, `scores`, and `comments`: arrays of the records defined
   below;
+* `requirement_checks`: optional array of teacher-entered assignment
+  requirement checks;
 * `created_at`: the review-record creation timestamp;
 * `updated_at`: the timestamp of the most recent change anywhere in the
   review record; and
@@ -94,9 +100,10 @@ classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submissi
 ```
 
 Review-local identifiers such as `note_id`, `tag_id`, `score_id`, and
-`comment_record_id` are opaque, non-empty strings. Each identifier must be
-unique within its own array. Consumers must not derive ordering, timestamps,
-or meaning from an identifier's spelling.
+`comment_record_id` are opaque, non-empty strings. Requirement checks use
+`requirement_check_id`. Each identifier must be unique within its own array.
+Consumers must not derive ordering, timestamps, or meaning from an
+identifier's spelling.
 
 When present:
 
@@ -370,6 +377,60 @@ reference that changes when the rubric is later edited, and rubric level
 `student_facing_feedback` does not automatically create a comment or feedback
 export entry.
 
+## Requirement Checks
+
+`requirement_checks` records teacher-entered boolean checks against the
+assignment's `basic_requirements`. Quillan prompts from configured
+`paragraphs_min`, `paragraphs_max`, `word_count_min`, `word_count_max`, and
+individual `required_elements`, but it does not count paragraphs, count words,
+parse writing, run OCR, or use AI. The teacher records whether each
+requirement is met.
+
+Example:
+
+```json
+{
+  "requirement_check_id": "requirement_check_0001",
+  "requirement_key": "paragraphs_min",
+  "label": "Minimum paragraphs",
+  "expected": 5,
+  "met": true,
+  "updated_at": "2026-06-29T00:00:00+00:00",
+  "module_details": {}
+}
+```
+
+Required elements use a key that includes the element value:
+
+```json
+{
+  "requirement_check_id": "requirement_check_0002",
+  "requirement_key": "required_elements:thesis_statement",
+  "label": "Required element: thesis_statement",
+  "expected": "thesis_statement",
+  "met": false,
+  "updated_at": "2026-06-29T00:00:00+00:00",
+  "module_details": {},
+  "teacher_note": "Missing a clear thesis statement."
+}
+```
+
+Field requirements:
+
+* `requirement_check_id` is unique within `requirement_checks`;
+* `requirement_key` is non-empty and unique within `requirement_checks`;
+* `label` is a non-empty teacher-facing label;
+* `expected` is a finite number or non-empty string copied from assignment
+  configuration;
+* `met` is a boolean;
+* `updated_at` is the last teacher update timestamp; and
+* `module_details` is an object.
+
+Requirement checks are mutable by `requirement_key`. Updating a check
+preserves its `requirement_check_id`, replaces the recorded boolean and
+optional note, updates top-level `updated_at`, and preserves notes, tags,
+scores, comments, review state semantics, and evidence references.
+
 ## Comments
 
 `comments` contains teacher-selected reusable language or teacher-entered
@@ -616,8 +677,8 @@ analyze writing, score work, or infer mastery.
 
 ## Derived Artifacts and Historical Names
 
-`review.json` is the canonical active v0.7 teacher-review record for notes,
-tags, criterion scores, and selected comments.
+`review.json` is the canonical active teacher-review record for notes, tags,
+criterion scores, selected comments, and teacher-entered requirement checks.
 
 Earlier design documents used separate `tags.json` and `scores.json` files.
 Those names are historical design background, not alternate active v0.7
@@ -630,9 +691,10 @@ across those files.
 artifacts. They may be
 generated from teacher-controlled review records, but they do
 not replace `review.json` and are not authoritative independent evidence.
-`requirements.json` remains a separate reserved structural-check record
-because requirements checks are not teacher evaluation artifacts in this
-schema.
+Earlier design documents reserved `requirements.json` for structural checks.
+Current teacher-entered assignment requirement checks are stored in
+`review.json.requirement_checks`; implementations must not write a sibling
+`requirements.json` for this workflow.
 
 The Markdown feedback export requires valid matching canonical
 `submission.json` and `review.json` records and uses only snapshotted review

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -16,9 +16,10 @@ This document defines the review model and data boundaries. Quillan currently
 validates relevant data contracts, can prepare printable writing-response
 pages, supports direct teacher-entered notes, tags, comments, and criterion
 scores, provides guided selected-student review actions in the terminal menu,
-and can export student feedback and assignment summaries. It does not yet
-implement complete requirements-checking. AI tagging, AI scoring, AI feedback,
-and automatic grading are not implemented.
+supports teacher-entered minimum requirement checks from assignment
+configuration, and can export student feedback and assignment summaries. AI
+tagging, AI scoring, AI feedback, automatic requirements evaluation, and
+automatic grading are not implemented.
 
 ## Source Evidence
 
@@ -50,14 +51,14 @@ materials, pds-core standards, or pds-core routes.
 Teacher-review artifacts are records created by the teacher or confirmed
 through teacher review:
 
-* `requirements.json`
 * `review.json`
 
 `review.json` is the canonical active v0.7 record for teacher-entered notes,
-tags, criterion scores, and teacher-selected comments. It is adjacent to and
-references `submission.json`, but remains separate so teacher judgment does
-not alter the student's original work. `requirements.json` remains a
-separate, reserved structural-check support artifact.
+tags, criterion scores, teacher-selected comments, and teacher-entered
+requirement checks. It is adjacent to and references `submission.json`, but
+remains separate so teacher judgment does not alter the student's original
+work. Current requirement checks are stored in
+`review.json.requirement_checks`, not in a sibling `requirements.json`.
 
 Earlier designs named separate `tags.json` and `scores.json` files. Those are
 historical concepts, not alternate active v0.7 records. Their content belongs
@@ -138,10 +139,12 @@ These checks help a teacher see whether basic assignment conditions were met.
 They do not measure writing quality and must not be treated as a
 writing-quality score.
 
-Requirements results may be entered manually, confirmed by the teacher, or
-eventually computed for low-risk structural facts. A computed result remains
-distinct from scoring and feedback, and the teacher retains responsibility
-for interpreting it in context.
+Current Quillan requirement checks are manual teacher-entered booleans
+generated from assignment `basic_requirements`. Quillan does not infer
+paragraph counts, word counts, or required-element presence, and it does not
+use OCR, AI, or automatic text parsing. Requirement checks remain distinct
+from scoring and feedback, and the teacher retains responsibility for
+interpreting them in context.
 
 ## Score Philosophy
 

--- a/quillan/review_comments.py
+++ b/quillan/review_comments.py
@@ -179,6 +179,7 @@ def add_review_comment(
             "tags": [],
             "scores": [],
             "comments": [],
+            "requirement_checks": [],
             "created_at": normalized_created_at,
             "updated_at": normalized_created_at,
             "module_details": {},

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -57,6 +57,10 @@ from quillan.review_record import (
     load_review_record,
 )
 from quillan.review_record_paths import review_record_path
+from quillan.review_requirements import (
+    ReviewRequirementError,
+    set_requirement_check,
+)
 from quillan.review_scores import ReviewScoreError, set_review_score
 from quillan.rubrics import RubricError, load_rubric, rubric_path
 from quillan.review_tags import ReviewTagError, add_review_tag
@@ -81,6 +85,8 @@ from quillan.submission_status import (
     StudentSubmissionStatus,
     list_assignment_submission_status,
 )
+
+_BACK = object()
 
 
 def launch_review_student_work_menu() -> int:
@@ -246,12 +252,21 @@ def _load_submission_status(
 def _prompt_student_id(
     workspace_root: Path,
     class_id: str,
+    assignment_id: str,
     status: AssignmentSubmissionStatus,
 ) -> str | None:
+    from quillan.menu import clear_screen, print_menu_header
+
     student_ids = _student_choices(workspace_root, class_id, status)
     if not student_ids:
         print("No students or submissions found for this class assignment.")
         return None
+
+    clear_screen()
+    print_menu_header("Select Student/Submission")
+    print(f"Class: {class_id}")
+    print(f"Assignment: {assignment_id}")
+    print()
 
     status_by_student = {
         student_status.student_id: student_status
@@ -387,21 +402,22 @@ def _launch_selected_student_review(
                 input("Press Enter to continue...")
             continue
         print("1. Open submission evidence")
-        print("2. Manage submission pages")
-        print("3. Add teacher note")
-        print("4. Add structured tag")
-        print("5. Select reusable comment")
-        print("6. Set criterion score")
-        print("7. Update submission review state")
-        print("8. Export student feedback")
-        print("9. Refresh summary")
-        print("10. Back")
+        print("2. Record minimum requirement checks")
+        print("3. Manage submission pages")
+        print("4. Add teacher note")
+        print("5. Add structured tag")
+        print("6. Select reusable comment")
+        print("7. Set criterion score")
+        print("8. Update submission review state")
+        print("9. Export student feedback")
+        print("10. Refresh summary")
+        print("11. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "10"}:
+        if choice in {"", "11"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -412,6 +428,13 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "2":
+            _menu_record_requirement_checks(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+        elif choice == "3":
             _menu_manage_submission_pages(
                 workspace_root,
                 class_id,
@@ -419,7 +442,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "3":
+        elif choice == "4":
             _menu_add_review_note(
                 workspace_root,
                 class_id,
@@ -427,7 +450,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "4":
+        elif choice == "5":
             _menu_add_review_tag(
                 workspace_root,
                 class_id,
@@ -435,7 +458,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "5":
+        elif choice == "6":
             _menu_add_review_comment(
                 workspace_root,
                 class_id,
@@ -443,7 +466,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "6":
+        elif choice == "7":
             _menu_set_review_score(
                 workspace_root,
                 class_id,
@@ -451,7 +474,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "7":
+        elif choice == "8":
             _menu_update_submission_review_state(
                 workspace_root,
                 class_id,
@@ -459,7 +482,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "8":
+        elif choice == "9":
             _menu_export_student_feedback(
                 workspace_root,
                 class_id,
@@ -467,10 +490,10 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "9":
+        elif choice == "10":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 10.")
+            print("Invalid selection. Please enter a number from 1 to 11.")
             input("Press Enter to continue...")
 
 
@@ -759,9 +782,11 @@ def _menu_add_reusable_review_tag(
     assignment_id: str,
     student_id: str,
 ) -> None:
-    _print_review_action_header("Select Reusable Tag", class_id, assignment_id, student_id)
     files = list_valid_tag_banks(workspace_root)
     if not files:
+        _print_review_action_header(
+            "Select Reusable Tag", class_id, assignment_id, student_id
+        )
         print("No valid shared tag banks found.")
         print()
         print("Create one from:")
@@ -784,30 +809,94 @@ def _menu_add_reusable_review_tag(
             print("Add tag canceled.")
         return
 
-    bank = _prompt_tag_bank(files)
-    if bank is None:
-        return
-    category = _prompt_tag_category(bank)
-    if category is None:
-        return
-    tag = _prompt_tag_template(bank, category)
-    if tag is None:
-        return
-    if tag is _CUSTOM_TAG:
-        _menu_add_custom_review_tag(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
+    while True:
+        _print_review_action_header(
+            "Select Reusable Tag", class_id, assignment_id, student_id
         )
-        return
+        bank = _prompt_tag_bank(files)
+        if bank is _BACK:
+            return
+        if bank is None:
+            input("Press Enter to continue...")
+            continue
+        assert isinstance(bank, dict)
 
-    assert isinstance(tag, dict)
+        while True:
+            _print_tag_context_header(
+                "Select Tag Category",
+                class_id,
+                assignment_id,
+                student_id,
+                bank=bank,
+            )
+            category = _prompt_tag_category(bank)
+            if category is _BACK:
+                break
+            if category is None:
+                input("Press Enter to continue...")
+                continue
+            assert isinstance(category, dict)
+
+            while True:
+                _print_tag_context_header(
+                    "Select Tag",
+                    class_id,
+                    assignment_id,
+                    student_id,
+                    bank=bank,
+                    category=category,
+                )
+                tag = _prompt_tag_template(bank, category)
+                if tag is _BACK:
+                    break
+                if tag is None:
+                    input("Press Enter to continue...")
+                    continue
+                if tag is _CUSTOM_TAG:
+                    _menu_add_custom_review_tag(
+                        workspace_root,
+                        class_id,
+                        assignment_id,
+                        student_id,
+                    )
+                    return
+
+                assert isinstance(tag, dict)
+                _print_tag_context_header(
+                    "Reusable Tag Details",
+                    class_id,
+                    assignment_id,
+                    student_id,
+                    bank=bank,
+                    category=category,
+                )
+                if _add_selected_reusable_tag(
+                    workspace_root,
+                    class_id,
+                    assignment_id,
+                    student_id,
+                    bank,
+                    tag,
+                ):
+                    return
+                input("Press Enter to continue...")
+
+
+def _add_selected_reusable_tag(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    bank: dict[str, Any],
+    tag: dict[str, Any],
+) -> bool:
     standard_id = _prompt_tag_standard_id(tag)
     criterion_id = _prompt_tag_criterion_id(tag)
     teacher_note = _prompt_template_teacher_note(tag)
     severity = tag.get("severity_default")
-    severity_value = severity if isinstance(severity, int) and not isinstance(severity, bool) else None
+    severity_value = (
+        severity if isinstance(severity, int) and not isinstance(severity, bool) else None
+    )
 
     try:
         added = add_review_tag(
@@ -850,18 +939,47 @@ def _menu_add_reusable_review_tag(
                     )
                 except (ReviewTagError, OSError) as retry_error:
                     print(f"Error: could not add structured tag: {retry_error}")
-                    return
+                    return False
             else:
                 print("Add tag canceled.")
-                return
+                return False
         else:
             print(f"Error: could not add structured tag: {error}")
-            return
+            return False
 
     print_added_review_tag(added)
+    return True
 
 
-def _prompt_tag_bank(files: tuple[Any, ...]) -> dict[str, Any] | None:
+def _print_tag_context_header(
+    title: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    bank: dict[str, Any],
+    category: dict[str, Any] | None = None,
+) -> None:
+    from quillan.menu import clear_screen, print_menu_header
+
+    clear_screen()
+    print_menu_header(title)
+    bank_title = bank.get("title")
+    bank_label = (
+        bank_title.strip()
+        if isinstance(bank_title, str) and bank_title.strip()
+        else str(bank["tag_bank_id"])
+    )
+    print(f"Tag Bank: {bank_label}")
+    if category is not None:
+        print(f"Category: {category['label']}")
+    print(f"Class: {class_id}")
+    print(f"Assignment: {assignment_id}")
+    print(f"Student: {student_id}")
+    print()
+
+
+def _prompt_tag_bank(files: tuple[Any, ...]) -> dict[str, Any] | object | None:
     print("Available tag banks:")
     print()
     banks: list[dict[str, Any]] = []
@@ -883,8 +1001,7 @@ def _prompt_tag_bank(files: tuple[Any, ...]) -> dict[str, Any] | None:
     print()
     selection = input("Select tag bank: ").strip()
     if selection == "" or selection.casefold() == "b":
-        print("Select tag canceled.")
-        return None
+        return _BACK
     if selection.isdigit() and 1 <= int(selection) <= len(banks):
         return banks[int(selection) - 1]
     for bank in banks:
@@ -894,7 +1011,7 @@ def _prompt_tag_bank(files: tuple[Any, ...]) -> dict[str, Any] | None:
     return None
 
 
-def _prompt_tag_category(bank: dict[str, Any]) -> dict[str, Any] | None:
+def _prompt_tag_category(bank: dict[str, Any]) -> dict[str, Any] | object | None:
     categories = _sorted_records(bank["categories"])
     print("Categories:")
     for index, category in enumerate(categories, start=1):
@@ -903,8 +1020,7 @@ def _prompt_tag_category(bank: dict[str, Any]) -> dict[str, Any] | None:
     print()
     selection = input("Select category: ").strip()
     if selection == "" or selection.casefold() == "b":
-        print("Select tag canceled.")
-        return None
+        return _BACK
     if selection.isdigit() and 1 <= int(selection) <= len(categories):
         return categories[int(selection) - 1]
     print("Invalid category selection. Please choose a listed category or Back.")
@@ -940,8 +1056,7 @@ def _prompt_tag_template(bank: dict[str, Any], category: dict[str, Any]) -> dict
     print()
     selection = input("Select tag: ").strip()
     if selection == "" or selection.casefold() == "b":
-        print("Select tag canceled.")
-        return None
+        return _BACK
     if selection.isdigit():
         selected = int(selection)
         if 1 <= selected <= len(tags):
@@ -1058,7 +1173,7 @@ def _load_available_comment_banks(
 
 def _prompt_comment_bank(
     banks: tuple[dict[str, Any], ...],
-) -> dict[str, Any] | None:
+) -> dict[str, Any] | object | None:
     print("Available comment banks:")
     print()
     for index, bank in enumerate(banks, start=1):
@@ -1081,8 +1196,7 @@ def _prompt_comment_bank(
     while True:
         selection = input("Select comment bank: ").strip()
         if selection == "" or selection.casefold() == "b":
-            print("Select comment canceled.")
-            return None
+            return _BACK
         if selection.isdigit():
             index = int(selection) - 1
             if 0 <= index < len(banks):
@@ -1096,7 +1210,7 @@ def _prompt_comment_bank(
         )
 
 
-def _prompt_comment_category(bank: dict[str, Any]) -> dict[str, Any] | None:
+def _prompt_comment_category(bank: dict[str, Any]) -> dict[str, Any] | object | None:
     categories = _sorted_records(bank["categories"])
     print("Categories:")
     print()
@@ -1106,8 +1220,7 @@ def _prompt_comment_category(bank: dict[str, Any]) -> dict[str, Any] | None:
     print()
     selection = input("Select category: ").strip()
     if selection == "" or selection.casefold() == "b":
-        print("Select comment canceled.")
-        return None
+        return _BACK
     if selection.isdigit() and 1 <= int(selection) <= len(categories):
         return categories[int(selection) - 1]
     print("Invalid category selection. Please choose a listed category or Back.")
@@ -1117,7 +1230,7 @@ def _prompt_comment_category(bank: dict[str, Any]) -> dict[str, Any] | None:
 def _prompt_comment_from_bank(
     bank: dict[str, Any],
     category: dict[str, Any],
-) -> dict[str, Any] | None:
+) -> dict[str, Any] | object | None:
     raw_comments = bank.get("comments")
     if not isinstance(raw_comments, list):
         return None
@@ -1159,8 +1272,7 @@ def _prompt_comment_from_bank(
     while True:
         selection = input("Select comment: ").strip()
         if selection == "" or selection.casefold() == "b":
-            print("Select comment canceled.")
-            return None
+            return _BACK
         if selection.isdigit():
             index = int(selection) - 1
             if 0 <= index < len(comments):
@@ -1286,6 +1398,9 @@ def _menu_add_review_comment(
 
     banks = _load_available_comment_banks(workspace_root)
     if not banks:
+        _print_review_action_header(
+            "Select Comment Bank", class_id, assignment_id, student_id
+        )
         print("No valid shared comment banks found.")
         print()
         print("Create one from:")
@@ -1295,25 +1410,86 @@ def _menu_add_review_comment(
         )
         return
 
-    bank = _prompt_comment_bank(banks)
-    if bank is None:
-        return
+    while True:
+        _print_review_action_header(
+            "Select Comment Bank", class_id, assignment_id, student_id
+        )
+        bank = _prompt_comment_bank(banks)
+        if bank is _BACK:
+            return
+        if bank is None:
+            input("Press Enter to continue...")
+            continue
+        assert isinstance(bank, dict)
 
-    category = _prompt_comment_category(bank)
-    if category is None:
-        return
+        while True:
+            _print_comment_context_header(
+                "Select Comment Category",
+                class_id,
+                assignment_id,
+                student_id,
+                bank=bank,
+            )
+            category = _prompt_comment_category(bank)
+            if category is _BACK:
+                break
+            if category is None:
+                input("Press Enter to continue...")
+                continue
+            assert isinstance(category, dict)
 
-    comment = _prompt_comment_from_bank(bank, category)
-    if comment is None:
-        return
+            while True:
+                _print_comment_context_header(
+                    "Select Comment",
+                    class_id,
+                    assignment_id,
+                    student_id,
+                    bank=bank,
+                    category=category,
+                )
+                comment = _prompt_comment_from_bank(bank, category)
+                if comment is _BACK:
+                    break
+                if comment is None:
+                    input("Press Enter to continue...")
+                    continue
+                assert isinstance(comment, dict)
 
+                _print_comment_context_header(
+                    "Confirm Comment",
+                    class_id,
+                    assignment_id,
+                    student_id,
+                    bank=bank,
+                    category=category,
+                )
+                if _add_selected_reusable_comment(
+                    workspace_root,
+                    class_id,
+                    assignment_id,
+                    student_id,
+                    bank,
+                    comment,
+                ):
+                    return
+                input("Press Enter to continue...")
+
+
+def _add_selected_reusable_comment(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    bank: dict[str, Any],
+    comment: dict[str, Any],
+) -> bool:
     standard_id = _prompt_optional_standard_id(workspace_root, comment)
     include_in_feedback = _confirm_comment_selection(
         comment,
         bool(comment["include_in_feedback_default"]),
     )
     if include_in_feedback is _CANCEL:
-        return
+        return False
 
     val_include: bool | None = (
         include_in_feedback if isinstance(include_in_feedback, bool) else None
@@ -1332,9 +1508,38 @@ def _menu_add_review_comment(
         )
     except (ReviewCommentError, OSError) as error:
         print(f"Error: could not select review comment: {error}")
-        return
+        return False
 
     print_added_review_comment(added)
+    return True
+
+
+def _print_comment_context_header(
+    title: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    bank: dict[str, Any],
+    category: dict[str, Any] | None = None,
+) -> None:
+    from quillan.menu import clear_screen, print_menu_header
+
+    clear_screen()
+    print_menu_header(title)
+    bank_title = bank.get("title")
+    bank_label = (
+        bank_title.strip()
+        if isinstance(bank_title, str) and bank_title.strip()
+        else str(bank["bank_id"])
+    )
+    print(f"Comment Bank: {bank_label}")
+    if category is not None:
+        print(f"Category: {category['label']}")
+    print(f"Class: {class_id}")
+    print(f"Assignment: {assignment_id}")
+    print(f"Student: {student_id}")
+    print()
 
 
 def _menu_set_review_score(
@@ -1408,33 +1613,68 @@ def _menu_set_review_score_from_rubric(
         )
         return
 
-    criterion = _prompt_score_criterion(rubric)
-    if criterion is None:
-        return
-    level = _prompt_score_level(criterion)
-    if level is None:
-        return
-    teacher_note = _confirm_score_selection(criterion, level)
-    if teacher_note is _CANCEL:
-        return
-    score_teacher_note = teacher_note if isinstance(teacher_note, str) else None
-    try:
-        updated = set_review_score(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-            criterion_id=criterion["criterion_id"],
-            label=criterion["label"],
-            score=level["score"],
-            max_score=criterion["max_score"],
-            scale=criterion["scale"],
-            teacher_note=score_teacher_note,
+    while True:
+        _print_review_action_header(
+            "Select Score Criterion", class_id, assignment_id, student_id
         )
-    except (ReviewScoreError, OSError) as error:
-        print(f"Error: could not set review score: {error}")
-        return
-    print_updated_review_score(updated)
+        criterion = _prompt_score_criterion(rubric)
+        if criterion is _BACK:
+            return
+        if criterion is None:
+            input("Press Enter to continue...")
+            continue
+        assert isinstance(criterion, dict)
+
+        while True:
+            _print_score_context_header(
+                "Select Score Level",
+                class_id,
+                assignment_id,
+                student_id,
+                criterion=criterion,
+            )
+            level = _prompt_score_level(criterion)
+            if level is _BACK:
+                break
+            if level is None:
+                input("Press Enter to continue...")
+                continue
+            assert isinstance(level, dict)
+
+            _print_score_context_header(
+                "Confirm Score",
+                class_id,
+                assignment_id,
+                student_id,
+                criterion=criterion,
+            )
+            teacher_note = _confirm_score_selection(criterion, level)
+            if teacher_note is _BACK:
+                continue
+            if teacher_note is _CANCEL:
+                return
+            score_teacher_note = (
+                teacher_note if isinstance(teacher_note, str) else None
+            )
+            try:
+                updated = set_review_score(
+                    workspace_root,
+                    class_id,
+                    assignment_id,
+                    student_id,
+                    criterion_id=criterion["criterion_id"],
+                    label=criterion["label"],
+                    score=level["score"],
+                    max_score=criterion["max_score"],
+                    scale=criterion["scale"],
+                    teacher_note=score_teacher_note,
+                )
+            except (ReviewScoreError, OSError) as error:
+                print(f"Error: could not set review score: {error}")
+                input("Press Enter to continue...")
+                continue
+            print_updated_review_score(updated)
+            return
 
 
 def _menu_missing_rubric(
@@ -1486,7 +1726,7 @@ def _load_assignment_for_review(
         return None
 
 
-def _prompt_score_criterion(rubric: dict[str, Any]) -> dict[str, Any] | None:
+def _prompt_score_criterion(rubric: dict[str, Any]) -> dict[str, Any] | object | None:
     criteria = _sorted_records(rubric["criteria"])
     print(f"Rubric: {rubric['title']}")
     print(f"{_format_secondary_id(rubric['rubric_id'])}")
@@ -1511,15 +1751,14 @@ def _prompt_score_criterion(rubric: dict[str, Any]) -> dict[str, Any] | None:
     print()
     selection = input("Select criterion: ").strip()
     if selection == "" or selection.casefold() == "b":
-        print("Set score canceled.")
-        return None
+        return _BACK
     if selection.isdigit() and 1 <= int(selection) <= len(criteria):
         return criteria[int(selection) - 1]
     print("Invalid criterion selection. Please choose a listed criterion or Back.")
     return None
 
 
-def _prompt_score_level(criterion: dict[str, Any]) -> dict[str, Any] | None:
+def _prompt_score_level(criterion: dict[str, Any]) -> dict[str, Any] | object | None:
     levels = _sorted_records(criterion["levels"])
     print(criterion["label"])
     print()
@@ -1533,8 +1772,7 @@ def _prompt_score_level(criterion: dict[str, Any]) -> dict[str, Any] | None:
     print()
     selection = input("Select score: ").strip()
     if selection == "" or selection.casefold() == "b":
-        print("Set score canceled.")
-        return None
+        return _BACK
     if selection.isdigit() and 1 <= int(selection) <= len(levels):
         return levels[int(selection) - 1]
     for level in levels:
@@ -1566,13 +1804,30 @@ def _confirm_score_selection(
         if selection == "2":
             note = input("Teacher note, or B to go back: ").strip()
             if note.casefold() == "b":
-                print("Set score canceled.")
-                return _CANCEL
+                return _BACK
             return note or None
         if selection in {"", "3"} or selection.casefold() == "b":
-            print("Set score canceled.")
-            return _CANCEL
+            return _BACK
         print("Invalid selection. Please enter a number from 1 to 3.")
+
+
+def _print_score_context_header(
+    title: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    criterion: dict[str, Any],
+) -> None:
+    from quillan.menu import clear_screen, print_menu_header
+
+    clear_screen()
+    print_menu_header(title)
+    print(f"Criterion: {criterion['label']}")
+    print(f"Class: {class_id}")
+    print(f"Assignment: {assignment_id}")
+    print(f"Student: {student_id}")
+    print()
 
 
 def _menu_set_custom_review_score(
@@ -1894,6 +2149,12 @@ def _print_review_record_summary(
     if not path.exists():
         print("Review record: not started")
         print("Review record file: missing")
+        _print_requirement_check_summary(
+            workspace_root,
+            class_id,
+            assignment_id,
+            {},
+        )
         return
 
     try:
@@ -1909,11 +2170,59 @@ def _print_review_record_summary(
     print(f"Tags: {_count_record_items(record, 'tags')}")
     print(f"Comments: {_count_record_items(record, 'comments')}")
     print(f"Scores: {_count_record_items(record, 'scores')}")
+    _print_requirement_check_summary(
+        workspace_root,
+        class_id,
+        assignment_id,
+        _current_requirement_checks(workspace_root, class_id, assignment_id, student_id),
+    )
 
 
 def _count_record_items(record: dict[str, Any], field: str) -> int:
     value = record.get(field)
     return len(value) if isinstance(value, list) else 0
+
+
+def _print_requirement_check_summary(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    checks: dict[str, dict[str, Any]],
+) -> None:
+    assignment = _load_assignment_for_summary(workspace_root, class_id, assignment_id)
+    requirements = (
+        _requirement_items_from_assignment(assignment)
+        if assignment is not None
+        else []
+    )
+    if not requirements:
+        print("Minimum requirements: none configured")
+        return
+    requirement_keys = {str(requirement["key"]) for requirement in requirements}
+    relevant_checks = [
+        check
+        for key, check in checks.items()
+        if key in requirement_keys and isinstance(check, dict)
+    ]
+    unmet_count = sum(1 for check in relevant_checks if check.get("met") is False)
+    print(
+        "Requirement checks: "
+        f"{len(relevant_checks)}/{len(requirements)} complete; "
+        f"{unmet_count} unmet"
+    )
+
+
+def _load_assignment_for_summary(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> dict[str, Any] | None:
+    try:
+        return load_assignment_config(
+            assignment_config_path(workspace_root, class_id, assignment_id)
+        )
+    except (AssignmentConfigError, OSError):
+        return None
 
 
 def _open_submission_evidence(
@@ -1934,6 +2243,218 @@ def _open_submission_evidence(
         return
 
     print_opened_submission_review(opened)
+
+
+def _menu_record_requirement_checks(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    while True:
+        _print_review_action_header(
+            "Requirement Checks", class_id, assignment_id, student_id
+        )
+        assignment = _load_assignment_for_review(
+            workspace_root, class_id, assignment_id
+        )
+        if assignment is None:
+            input("Press Enter to continue...")
+            return
+        requirements = _requirement_items_from_assignment(assignment)
+        if not requirements:
+            print("Minimum requirements: none configured")
+            print()
+            print("No review record was changed.")
+            input("Press Enter to continue...")
+            return
+
+        existing = _current_requirement_checks(
+            workspace_root, class_id, assignment_id, student_id
+        )
+        print("Requirement Checks")
+        print()
+        for index, requirement in enumerate(requirements, start=1):
+            print(
+                f"{index}. {requirement['label']}: "
+                f"{_requirement_status(existing.get(requirement['key']))}"
+            )
+        print("B. Back")
+        print()
+        selection = input("Select requirement: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            return
+        if not selection.isdigit() or not (1 <= int(selection) <= len(requirements)):
+            print("Invalid requirement selection. Please choose a listed item or Back.")
+            input("Press Enter to continue...")
+            continue
+
+        requirement = requirements[int(selection) - 1]
+        result = _prompt_and_set_requirement_check(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            requirement,
+            existing.get(requirement["key"]),
+        )
+        if result is _BACK:
+            continue
+        input("Press Enter to continue...")
+
+
+def _prompt_and_set_requirement_check(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    requirement: dict[str, Any],
+    current_check: dict[str, Any] | None,
+) -> object | None:
+    _print_review_action_header(
+        "Record Requirement Check", class_id, assignment_id, student_id
+    )
+    print(requirement["question"])
+    print()
+    print(requirement["detail"])
+    print(f"Current value: {_requirement_status(current_check)}")
+    print()
+    print("1. True / Yes / Met")
+    print("2. False / No / Not met")
+    print("B. Back")
+    print()
+    selection = input("Select status: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return _BACK
+    if selection == "1":
+        met = True
+    elif selection == "2":
+        met = False
+    else:
+        print("Invalid status. Enter 1 for met or 2 for not met.")
+        return None
+
+    teacher_note = input(
+        "Teacher note (leave blank if not applicable): "
+    ).strip() or None
+    try:
+        updated = set_requirement_check(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            requirement_key=str(requirement["key"]),
+            label=str(requirement["label"]),
+            expected=requirement["expected"],
+            met=met,
+            teacher_note=teacher_note,
+        )
+    except (ReviewRequirementError, OSError) as error:
+        print(f"Error: could not record requirement check: {error}")
+        return None
+
+    print()
+    print("Recorded requirement check:")
+    print(f"Requirement: {updated.requirement_key}")
+    print(f"Met: {_format_yes_no(updated.met)}")
+    print(f"Action: {'created' if updated.was_created else 'updated'}")
+    print(f"Review state: {updated.review_state}")
+    print(f"Review record: {updated.review_record_relative_path}")
+    return None
+
+
+def _requirement_items_from_assignment(
+    assignment: dict[str, Any],
+) -> list[dict[str, Any]]:
+    basic_requirements = assignment.get("basic_requirements")
+    if not isinstance(basic_requirements, dict):
+        return []
+
+    items: list[dict[str, Any]] = []
+    numeric_specs = (
+        (
+            "paragraphs_min",
+            "Minimum paragraphs",
+            "Does the submission meet the minimum paragraph requirement?",
+            "Minimum: {value} paragraphs",
+        ),
+        (
+            "paragraphs_max",
+            "Maximum paragraphs",
+            "Does the submission stay within the maximum paragraph requirement?",
+            "Maximum: {value} paragraphs",
+        ),
+        (
+            "word_count_min",
+            "Minimum word count",
+            "Does the submission meet the minimum word count?",
+            "Minimum: {value} words",
+        ),
+        (
+            "word_count_max",
+            "Maximum word count",
+            "Does the submission stay within the maximum word count?",
+            "Maximum: {value} words",
+        ),
+    )
+    for key, label, question, detail_template in numeric_specs:
+        value = basic_requirements.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            items.append(
+                {
+                    "key": key,
+                    "label": label,
+                    "expected": value,
+                    "question": question,
+                    "detail": detail_template.format(value=value),
+                }
+            )
+
+    required_elements = basic_requirements.get("required_elements")
+    if isinstance(required_elements, list):
+        for element in required_elements:
+            if not isinstance(element, str) or not element.strip():
+                continue
+            normalized = element.strip()
+            items.append(
+                {
+                    "key": f"required_elements:{normalized}",
+                    "label": f"Required element: {normalized}",
+                    "expected": normalized,
+                    "question": "Does the submission include this required element?",
+                    "detail": f"Required element: {normalized}",
+                }
+            )
+    return items
+
+
+def _current_requirement_checks(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> dict[str, dict[str, Any]]:
+    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
+    if not path.exists():
+        return {}
+    try:
+        record = load_review_record(path)
+    except (OSError, ReviewRecordError):
+        return {}
+    checks = record.get("requirement_checks")
+    if not isinstance(checks, list):
+        return {}
+    return {
+        str(check["requirement_key"]): check
+        for check in checks
+        if isinstance(check, dict) and isinstance(check.get("requirement_key"), str)
+    }
+
+
+def _requirement_status(check: dict[str, Any] | None) -> str:
+    if check is None:
+        return "not checked"
+    return "met" if check.get("met") is True else "not met"
 
 
 def _menu_manage_submission_pages(
@@ -2260,7 +2781,9 @@ def _launch_assignment_review_actions(
         if choice in {"", "6"}:
             return 0
         elif choice == "1":
-            student_id = _prompt_student_id(workspace_root, class_id, status)
+            student_id = _prompt_student_id(
+                workspace_root, class_id, assignment_id, status
+            )
             if student_id is not None:
                 _launch_selected_student_review(
                     workspace_root,

--- a/quillan/review_notes.py
+++ b/quillan/review_notes.py
@@ -136,6 +136,7 @@ def add_review_note(
             "tags": [],
             "scores": [],
             "comments": [],
+            "requirement_checks": [],
             "created_at": normalized_created_at,
             "updated_at": normalized_created_at,
             "module_details": {},

--- a/quillan/review_record.py
+++ b/quillan/review_record.py
@@ -30,6 +30,9 @@ REQUIRED_REVIEW_FIELDS: Final[frozenset[str]] = frozenset(
         "module_details",
     }
 )
+OPTIONAL_REVIEW_FIELDS: Final[frozenset[str]] = frozenset(
+    {"requirement_checks"}
+)
 REQUIRED_NOTE_FIELDS: Final[frozenset[str]] = frozenset(
     {"note_id", "text", "created_at", "updated_at", "module_details"}
 )
@@ -78,6 +81,20 @@ REQUIRED_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
 )
 OPTIONAL_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
     {"bank_id", "comment_id", "standard_id"}
+)
+REQUIRED_REQUIREMENT_CHECK_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "requirement_check_id",
+        "requirement_key",
+        "label",
+        "expected",
+        "met",
+        "updated_at",
+        "module_details",
+    }
+)
+OPTIONAL_REQUIREMENT_CHECK_FIELDS: Final[frozenset[str]] = frozenset(
+    {"teacher_note"}
 )
 
 ALLOWED_REVIEW_STATES: Final[frozenset[str]] = frozenset(
@@ -147,7 +164,9 @@ def validate_review_record(record: dict[str, Any]) -> None:
     """Validate the intrinsic version 1 submission review record contract."""
     if not isinstance(record, dict):
         raise ReviewRecordError("Review record must be an object.")
-    _validate_fields(record, REQUIRED_REVIEW_FIELDS, frozenset(), "review record")
+    _validate_fields(
+        record, REQUIRED_REVIEW_FIELDS, OPTIONAL_REVIEW_FIELDS, "review record"
+    )
     _validate_exact_value(record["schema_version"], "schema_version", "1")
     _validate_exact_value(record["module"], "module", "quillan")
     _validate_exact_value(
@@ -172,6 +191,8 @@ def validate_review_record(record: dict[str, Any]) -> None:
     _validate_tags(record["tags"])
     _validate_scores(record["scores"])
     _validate_comments(record["comments"])
+    if "requirement_checks" in record:
+        _validate_requirement_checks(record["requirement_checks"])
 
 
 def _validate_submission_manifest_path(record: dict[str, Any]) -> None:
@@ -402,6 +423,41 @@ def _validate_comments(value: Any) -> None:
         _validate_json_object(item["module_details"], f"{context}.module_details")
 
 
+def _validate_requirement_checks(value: Any) -> None:
+    checks = _validate_array(value, "requirement_checks")
+    seen_ids: set[str] = set()
+    seen_keys: set[str] = set()
+    for index, check in enumerate(checks):
+        context = f"requirement_checks[{index}]"
+        item = _validate_record(check, context)
+        _validate_fields(
+            item,
+            REQUIRED_REQUIREMENT_CHECK_FIELDS,
+            OPTIONAL_REQUIREMENT_CHECK_FIELDS,
+            context,
+        )
+        _validate_unique_local_id(
+            item["requirement_check_id"],
+            f"{context}.requirement_check_id",
+            seen_ids,
+        )
+        _validate_unique_local_id(
+            item["requirement_key"],
+            f"{context}.requirement_key",
+            seen_keys,
+        )
+        _validate_non_empty_string(item["label"], f"{context}.label")
+        _validate_requirement_expected(item["expected"], f"{context}.expected")
+        if not isinstance(item["met"], bool):
+            raise ReviewRecordError(f"Field '{context}.met' must be a boolean.")
+        if "teacher_note" in item:
+            _validate_non_empty_string(
+                item["teacher_note"], f"{context}.teacher_note"
+            )
+        _validate_timestamp(item["updated_at"], f"{context}.updated_at")
+        _validate_json_object(item["module_details"], f"{context}.module_details")
+
+
 def _validate_comment_provenance(
     item: dict[str, Any], source: str, context: str
 ) -> None:
@@ -523,6 +579,20 @@ def _validate_finite_number(value: Any, field: str) -> float:
     ):
         raise ReviewRecordError(f"Field '{field}' must be a finite number.")
     return float(value)
+
+
+def _validate_requirement_expected(value: Any, field: str) -> None:
+    if isinstance(value, str) and value.strip():
+        return
+    if (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+    ):
+        return
+    raise ReviewRecordError(
+        f"Field '{field}' must be a non-empty string or finite number."
+    )
 
 
 def _validate_allowed_value(

--- a/quillan/review_requirements.py
+++ b/quillan/review_requirements.py
@@ -1,4 +1,4 @@
-"""Teacher-entered criterion scores for submission review records."""
+"""Teacher-entered assignment requirement checks for review records."""
 
 from __future__ import annotations
 
@@ -20,6 +20,7 @@ from quillan.review_record_paths import (
     review_record_path,
     write_review_record,
 )
+from quillan.submission_guidance import missing_submission_guidance
 from quillan.submission_manifest import (
     SubmissionManifestError,
     load_submission_manifest,
@@ -28,74 +29,65 @@ from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
 )
-from quillan.submission_guidance import missing_submission_guidance
 
-_SEQUENTIAL_SCORE_ID = re.compile(r"^score_(\d{4})$")
+_SEQUENTIAL_REQUIREMENT_CHECK_ID = re.compile(r"^requirement_check_(\d{4})$")
 
 
-class ReviewScoreError(Exception):
-    """Raised when a teacher score cannot be set safely."""
+class ReviewRequirementError(Exception):
+    """Raised when a requirement check cannot be set safely."""
 
 
 @dataclass(frozen=True, slots=True)
-class UpdatedReviewScore:
-    """Information about a criterion score set in a review record."""
+class UpdatedRequirementCheck:
+    """Information about a requirement check set in a review record."""
 
     class_id: str
     assignment_id: str
     student_id: str
     review_record_path: Path
     review_record_relative_path: str
-    score_id: str
-    criterion_id: str
-    score: int | float
-    max_score: int | float
+    requirement_check_id: str
+    requirement_key: str
+    met: bool
     review_state: str
     updated_at: str
     was_created: bool
 
 
-def set_review_score(
+def set_requirement_check(
     workspace_root: str | Path,
     class_id: str,
     assignment_id: str,
     student_id: str,
     *,
-    criterion_id: str,
+    requirement_key: str,
     label: str,
-    score: int | float,
-    max_score: int | float,
-    scale: str | None = None,
+    expected: str | int | float,
+    met: bool,
     teacher_note: str | None = None,
     updated_at: datetime | str | None = None,
-) -> UpdatedReviewScore:
-    """Set or update one teacher-entered criterion score."""
-    normalized_criterion_id = _normalize_required_string(
-        criterion_id, "criterion_id"
+) -> UpdatedRequirementCheck:
+    """Set or update one teacher-entered assignment requirement check."""
+    normalized_key = _normalize_required_string(
+        requirement_key, "requirement_key"
     )
     normalized_label = _normalize_required_string(label, "label")
-    normalized_score = _normalize_number(score, "score", minimum=0)
-    normalized_max_score = _normalize_number(
-        max_score, "max_score", minimum=0, exclusive_minimum=True
-    )
-    if normalized_score > normalized_max_score:
-        raise ReviewScoreError("score must be less than or equal to max_score.")
-    normalized_scale = _normalize_optional_string(scale, "scale")
-    normalized_teacher_note = _normalize_optional_string(
-        teacher_note, "teacher_note"
-    )
+    normalized_expected = _normalize_expected(expected)
+    if not isinstance(met, bool):
+        raise ReviewRequirementError("met must be a boolean.")
+    normalized_note = _normalize_optional_string(teacher_note, "teacher_note")
     normalized_updated_at = _normalize_timestamp(updated_at)
 
     try:
-        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
+        resolved_root = Path(workspace_root).resolve(strict=False)
         manifest_path = submission_manifest_path(
-            resolved_workspace_root,
+            resolved_root,
             class_id,
             assignment_id,
             student_id,
         )
         record_path = review_record_path(
-            resolved_workspace_root,
+            resolved_root,
             class_id,
             assignment_id,
             student_id,
@@ -106,15 +98,15 @@ def set_review_score(
         SubmissionManifestPathError,
         ReviewRecordPathError,
     ) as error:
-        raise ReviewScoreError(str(error)) from error
+        raise ReviewRequirementError(str(error)) from error
 
     if not manifest_path.exists():
-        raise ReviewScoreError(missing_submission_guidance())
+        raise ReviewRequirementError(missing_submission_guidance())
 
     try:
         manifest = load_submission_manifest(manifest_path)
     except (OSError, SubmissionManifestError) as error:
-        raise ReviewScoreError(
+        raise ReviewRequirementError(
             f"Could not load submission manifest: {error}"
         ) from error
     _validate_identity(
@@ -129,7 +121,7 @@ def set_review_score(
         try:
             review = load_review_record(record_path)
         except (OSError, ReviewRecordError) as error:
-            raise ReviewScoreError(
+            raise ReviewRequirementError(
                 f"Could not load review record: {error}"
             ) from error
         _validate_identity(
@@ -140,12 +132,10 @@ def set_review_score(
             student_id=student_id,
         )
         updated_review = copy.deepcopy(review)
+        updated_review.setdefault("requirement_checks", [])
         if updated_review["review_state"] == "not_started":
             updated_review["review_state"] = "in_progress"
     else:
-        manifest_relative_path = _workspace_relative_path(
-            manifest_path, resolved_workspace_root, "submission manifest"
-        )
         updated_review = {
             "schema_version": "1",
             "module": "quillan",
@@ -153,7 +143,9 @@ def set_review_score(
             "class_id": class_id,
             "assignment_id": assignment_id,
             "student_id": student_id,
-            "submission_manifest_path": manifest_relative_path,
+            "submission_manifest_path": _workspace_relative_path(
+                manifest_path, resolved_root, "submission manifest"
+            ),
             "review_state": "in_progress",
             "notes": [],
             "tags": [],
@@ -165,38 +157,37 @@ def set_review_score(
             "module_details": {},
         }
 
-    existing_score = next(
+    checks = updated_review["requirement_checks"]
+    existing_check = next(
         (
             candidate
-            for candidate in updated_review["scores"]
-            if candidate["criterion_id"] == normalized_criterion_id
+            for candidate in checks
+            if candidate["requirement_key"] == normalized_key
         ),
         None,
     )
-    was_created = existing_score is None
-    if existing_score is None:
-        score_id = _next_score_id(updated_review["scores"])
-        existing_score = {"score_id": score_id}
-        updated_review["scores"].append(existing_score)
+    was_created = existing_check is None
+    if existing_check is None:
+        check_id = _next_requirement_check_id(checks)
+        existing_check = {"requirement_check_id": check_id}
+        checks.append(existing_check)
     else:
-        score_id = existing_score["score_id"]
+        check_id = existing_check["requirement_check_id"]
 
-    existing_score.clear()
-    existing_score.update(
+    existing_check.clear()
+    existing_check.update(
         {
-            "score_id": score_id,
-            "criterion_id": normalized_criterion_id,
+            "requirement_check_id": check_id,
+            "requirement_key": normalized_key,
             "label": normalized_label,
-            "score": normalized_score,
-            "max_score": normalized_max_score,
+            "expected": normalized_expected,
+            "met": met,
             "updated_at": normalized_updated_at,
             "module_details": {},
         }
     )
-    if normalized_scale is not None:
-        existing_score["scale"] = normalized_scale
-    if normalized_teacher_note is not None:
-        existing_score["teacher_note"] = normalized_teacher_note
+    if normalized_note is not None:
+        existing_check["teacher_note"] = normalized_note
     updated_review["updated_at"] = normalized_updated_at
 
     try:
@@ -206,8 +197,8 @@ def set_review_score(
             updated_review,
             overwrite=record_path.exists(),
         )
-        record_relative_path = _workspace_relative_path(
-            record_path, resolved_workspace_root, "review record"
+        relative_path = _workspace_relative_path(
+            record_path, resolved_root, "review record"
         )
     except (
         OSError,
@@ -216,18 +207,19 @@ def set_review_score(
         ReviewRecordError,
         ReviewRecordPathError,
     ) as error:
-        raise ReviewScoreError(f"Could not write review record: {error}") from error
+        raise ReviewRequirementError(
+            f"Could not write review record: {error}"
+        ) from error
 
-    return UpdatedReviewScore(
+    return UpdatedRequirementCheck(
         class_id=class_id,
         assignment_id=assignment_id,
         student_id=student_id,
         review_record_path=record_path,
-        review_record_relative_path=record_relative_path,
-        score_id=score_id,
-        criterion_id=normalized_criterion_id,
-        score=normalized_score,
-        max_score=normalized_max_score,
+        review_record_relative_path=relative_path,
+        requirement_check_id=check_id,
+        requirement_key=normalized_key,
+        met=met,
         review_state=updated_review["review_state"],
         updated_at=normalized_updated_at,
         was_created=was_created,
@@ -236,7 +228,7 @@ def set_review_score(
 
 def _normalize_required_string(value: str, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
-        raise ReviewScoreError(f"{field} must be a non-empty string.")
+        raise ReviewRequirementError(f"{field} must be a non-empty string.")
     return value.strip()
 
 
@@ -246,24 +238,20 @@ def _normalize_optional_string(value: str | None, field: str) -> str | None:
     return _normalize_required_string(value, field)
 
 
-def _normalize_number(
-    value: int | float,
-    field: str,
-    *,
-    minimum: int,
-    exclusive_minimum: bool = False,
-) -> int | float:
+def _normalize_expected(value: str | int | float) -> str | int | float:
+    if isinstance(value, str):
+        if not value.strip():
+            raise ReviewRequirementError(
+                "expected must be a non-empty string or finite number."
+            )
+        return value.strip()
     if (
         isinstance(value, bool)
         or not isinstance(value, (int, float))
         or not math.isfinite(value)
     ):
-        raise ReviewScoreError(f"{field} must be a finite number.")
-    if exclusive_minimum and value <= minimum:
-        raise ReviewScoreError(f"{field} must be greater than {minimum}.")
-    if not exclusive_minimum and value < minimum:
-        raise ReviewScoreError(
-            f"{field} must be greater than or equal to {minimum}."
+        raise ReviewRequirementError(
+            "expected must be a non-empty string or finite number."
         )
     return value
 
@@ -273,20 +261,22 @@ def _normalize_timestamp(value: datetime | str | None) -> str:
         return datetime.now(timezone.utc).isoformat()
     if isinstance(value, datetime):
         if value.tzinfo is None or value.utcoffset() is None:
-            raise ReviewScoreError("updated_at datetime must be timezone-aware.")
+            raise ReviewRequirementError(
+                "updated_at datetime must be timezone-aware."
+            )
         return value.isoformat()
     if not isinstance(value, str):
-        raise ReviewScoreError(
+        raise ReviewRequirementError(
             "updated_at must be a timezone-aware datetime or ISO 8601 string."
         )
     try:
         parsed = datetime.fromisoformat(value)
     except ValueError as error:
-        raise ReviewScoreError(
+        raise ReviewRequirementError(
             "updated_at must be a timezone-aware ISO 8601 string."
         ) from error
     if parsed.tzinfo is None or parsed.utcoffset() is None:
-        raise ReviewScoreError(
+        raise ReviewRequirementError(
             "updated_at must be a timezone-aware ISO 8601 string."
         )
     return value
@@ -300,32 +290,31 @@ def _validate_identity(
     assignment_id: str,
     student_id: str,
 ) -> None:
-    requested = {
+    for field, expected in {
         "class_id": class_id,
         "assignment_id": assignment_id,
         "student_id": student_id,
-    }
-    for field, expected in requested.items():
+    }.items():
         actual = record[field]
         if actual != expected:
-            raise ReviewScoreError(
+            raise ReviewRequirementError(
                 f"{record_name} {field} is {actual!r}, expected {expected!r}."
             )
 
 
-def _next_score_id(scores: list[dict[str, Any]]) -> str:
-    existing_ids = {score["score_id"] for score in scores}
+def _next_requirement_check_id(checks: list[dict[str, Any]]) -> str:
+    existing_ids = {check["requirement_check_id"] for check in checks}
     highest = max(
         (
             int(match.group(1))
-            for score_id in existing_ids
-            if (match := _SEQUENTIAL_SCORE_ID.fullmatch(score_id))
+            for check_id in existing_ids
+            if (match := _SEQUENTIAL_REQUIREMENT_CHECK_ID.fullmatch(check_id))
         ),
         default=0,
     )
     candidate_number = highest + 1
     while True:
-        candidate = f"score_{candidate_number:04d}"
+        candidate = f"requirement_check_{candidate_number:04d}"
         if candidate not in existing_ids:
             return candidate
         candidate_number += 1
@@ -339,6 +328,6 @@ def _workspace_relative_path(
     try:
         return path.resolve(strict=False).relative_to(workspace_root).as_posix()
     except (OSError, RuntimeError, ValueError) as error:
-        raise ReviewScoreError(
+        raise ReviewRequirementError(
             f"Could not resolve workspace-relative {description} path: {error}"
         ) from error

--- a/quillan/review_tags.py
+++ b/quillan/review_tags.py
@@ -218,6 +218,7 @@ def add_review_tag(
             "tags": [],
             "scores": [],
             "comments": [],
+            "requirement_checks": [],
             "created_at": normalized_created_at,
             "updated_at": normalized_created_at,
             "module_details": {},

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -56,11 +56,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["10"] + _exit_assignment_review_actions_to_main()
+    return ["11"] + _exit_assignment_review_actions_to_main()
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "10"] + _exit_assignment_review_actions_to_main()
+    return ["", "11"] + _exit_assignment_review_actions_to_main()
 
 
 def _write_workspace(root: Path) -> None:
@@ -285,7 +285,7 @@ def test_selected_student_review_menu_includes_feedback_export(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
-    assert "8. Export student feedback" in output
+    assert "9. Export student feedback" in output
 
 
 def test_menu_export_student_feedback_creates_feedback_file(
@@ -325,7 +325,7 @@ def test_menu_export_student_feedback_creates_feedback_file(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "1"]
+        + ["9", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -427,7 +427,7 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "2"]
+        + ["9", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -458,7 +458,7 @@ def test_menu_export_feedback_reports_missing_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "1"]
+        + ["9", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -492,7 +492,7 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "1", "1"]
+        + ["9", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -526,7 +526,7 @@ def test_menu_export_feedback_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "1", "2"]
+        + ["9", "1", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -226,11 +226,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["10", "6", "", "4", "6"]
+    return ["11", "6", "", "4", "6"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "10", "6", "", "4", "6"]
+    return ["", "11", "6", "", "4", "6"]
 
 
 @pytest.fixture
@@ -252,12 +252,13 @@ def test_review_menu_selected_student_shows_review_entry_actions(
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
     assert "1. Open submission evidence" in output
-    assert "2. Manage submission pages" in output
-    assert "3. Add teacher note" in output
-    assert "4. Add structured tag" in output
-    assert "5. Select reusable comment" in output
-    assert "6. Set criterion score" in output
-    assert "7. Update submission review state" in output
+    assert "2. Record minimum requirement checks" in output
+    assert "3. Manage submission pages" in output
+    assert "4. Add teacher note" in output
+    assert "5. Add structured tag" in output
+    assert "6. Select reusable comment" in output
+    assert "7. Set criterion score" in output
+    assert "8. Update submission review state" in output
     assert "Review record: not started" in output
     assert not review_record_path(
         workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
@@ -277,7 +278,7 @@ def test_review_menu_blank_note_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["3", ""]
+        + ["4", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -286,6 +287,78 @@ def test_review_menu_blank_note_cancels_without_review_record(
         workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
     ).exists()
     assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_records_minimum_requirement_check(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["2", "1", "1", "", "", "b"]
+        + _exit_selected_student_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Requirement Checks" in output
+    assert "Minimum paragraphs: not checked" in output
+    assert "Recorded requirement check:" in output
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert review["requirement_checks"] == [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "paragraphs_min",
+            "label": "Minimum paragraphs",
+            "expected": 1,
+            "met": True,
+            "updated_at": review["requirement_checks"][0]["updated_at"],
+            "module_details": {},
+        }
+    ]
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_reports_no_minimum_requirements_without_writing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assignment_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment = json.loads(assignment_path.read_text(encoding="utf-8"))
+    assignment["basic_requirements"] = {}
+    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["2", ""]
+        + _exit_selected_student_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    assert "Minimum requirements: none configured" in capsys.readouterr().out
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
 
 
 def test_review_menu_adds_structured_tag_to_review_record(
@@ -297,7 +370,7 @@ def test_review_menu_adds_structured_tag_to_review_record(
         monkeypatch,
         _enter_selected_student()
         + [
-            "4",
+            "5",
             "2",
             "claim",
             "1",
@@ -331,7 +404,7 @@ def test_review_menu_selects_reusable_tag_by_bank_and_category(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["4", "1", "1", "1", "1", "The explanation names the idea only."]
+        + ["5", "1", "1", "1", "1", "The explanation names the idea only."]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -361,6 +434,29 @@ def test_review_menu_selects_reusable_tag_by_bank_and_category(
     assert manifest_path.read_bytes() == manifest_before
 
 
+def test_reusable_tag_back_returns_one_level_at_a_time(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_tag_bank(workspace)
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["5", "1", "1", "1", "b", "b", "b"]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert output.count("Select Tag Category") >= 2
+    assert output.count("Select Reusable Tag") >= 2
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+
+
 def test_review_menu_blank_tag_cancels_without_review_record(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -374,7 +470,7 @@ def test_review_menu_blank_tag_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["4", ""]
+        + ["5", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -398,7 +494,7 @@ def test_review_menu_no_comment_banks_returns_safely(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "1"]
+        + ["6", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -424,7 +520,7 @@ def test_review_menu_selects_reusable_comment_by_number(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "1", "1", "1", "1", "1"]
+        + ["6", "1", "1", "1", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -479,7 +575,7 @@ def test_comment_bank_created_by_workflow_is_selectable_in_review(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "1", "1", "1", "1", "1"]
+        + ["6", "1", "1", "1", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -519,7 +615,7 @@ def test_review_menu_sets_criterion_score(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "evidence", "Evidence", "3", "4", "", ""]
+        + ["7", "evidence", "Evidence", "3", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -550,7 +646,7 @@ def test_review_menu_scores_from_assignment_rubric(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "1", "1", "1", "2", "Private score note"]
+        + ["7", "1", "1", "1", "2", "Private score note"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -579,7 +675,7 @@ def test_review_menu_missing_rubric_keeps_custom_score_available(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "1", "1", "Evidence", "", "2", "4", "", ""]
+        + ["7", "1", "1", "Evidence", "", "2", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -606,7 +702,7 @@ def test_review_menu_blank_score_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", ""]
+        + ["7", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -658,7 +754,7 @@ def test_review_menu_invalid_score_does_not_corrupt_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "evidence", "Evidence", "5", "4", "", ""]
+        + ["7", "evidence", "Evidence", "5", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -680,7 +776,7 @@ def test_review_menu_invalid_state_does_not_corrupt_manifest(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "not_a_state"]
+        + ["8", "not_a_state"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -222,7 +222,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "10", "6", "", "4", "6"])
+    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "11", "6", "", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -267,7 +267,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "10", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "11", "6", "", "4", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -315,7 +315,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "", "10", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "", "11", "6", "", "4", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -361,10 +361,10 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "1",
             "1",
             "1",
-            "3",
+            "4",
             "This is a test note.",
             "",
-            "10",
+            "11",
             "6",
             "",
             "4",
@@ -404,11 +404,11 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "1",
-            "7",
+            "8",
             "in_progress",
             "1",
             "",
-            "10",
+            "11",
             "6",
             "",
             "4",
@@ -456,12 +456,12 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
             "1",
             "1",
             "1",
-            "2",
+            "3",
             "1",
             "1",
             "1",
             "",
-            "10",
+            "11",
             "6",
             "",
             "4",

--- a/tests/test_review_requirements.py
+++ b/tests/test_review_requirements.py
@@ -1,0 +1,301 @@
+"""Tests for teacher-entered assignment requirement checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.review_record import ReviewRecordError, validate_review_record
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.review_requirements import (
+    ReviewRequirementError,
+    set_requirement_check,
+)
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
+FIRST_TIMESTAMP = "2026-06-29T12:00:00+00:00"
+SECOND_TIMESTAMP = "2026-06-29T13:00:00+00:00"
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [
+                    {
+                        "evidence_id": "evidence_001",
+                        "routed_evidence_path": (
+                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            "scans/response_00107_pg_001.pdf"
+                        ),
+                        "evidence_role": "selected",
+                        "evidence_state": "active",
+                        "duplicate_number": None,
+                        "created_at": ORIGINAL_TIMESTAMP,
+                        "retained_source": None,
+                        "module_details": {},
+                    }
+                ],
+            }
+        ],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def _review(state: str = "not_started") -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": state,
+        "notes": [
+            {
+                "note_id": "note_0001",
+                "text": "Existing note.",
+                "created_at": ORIGINAL_TIMESTAMP,
+                "updated_at": ORIGINAL_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "tags": [],
+        "scores": [
+            {
+                "score_id": "score_0001",
+                "criterion_id": "evidence",
+                "label": "Evidence",
+                "score": 3,
+                "max_score": 4,
+                "updated_at": ORIGINAL_TIMESTAMP,
+                "module_details": {"preserve": True},
+            }
+        ],
+        "comments": [],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {"preserve": True},
+    }
+
+
+def _write_manifest(workspace: Path) -> Path:
+    return write_submission_manifest(
+        submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        _manifest(),
+    )
+
+
+def test_creates_review_record_with_requirement_check(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    manifest_before = manifest_path.read_bytes()
+
+    result = set_requirement_check(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        requirement_key="paragraphs_min",
+        label="Minimum paragraphs",
+        expected=5,
+        met=True,
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    review = json.loads(
+        review_record_path(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert result.requirement_check_id == "requirement_check_0001"
+    assert result.was_created is True
+    assert review["review_state"] == "in_progress"
+    assert review["requirement_checks"] == [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "paragraphs_min",
+            "label": "Minimum paragraphs",
+            "expected": 5,
+            "met": True,
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_updates_existing_check_by_key_and_preserves_other_data(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    review = _review("ready_for_export")
+    review["requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "required_elements:thesis_statement",
+            "label": "Required element: thesis_statement",
+            "expected": "thesis_statement",
+            "met": True,
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {"preserve": True},
+        }
+    ]
+    path = write_review_record(
+        review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        review,
+    )
+
+    result = set_requirement_check(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        requirement_key="required_elements:thesis_statement",
+        label="Required element: thesis_statement",
+        expected="thesis_statement",
+        met=False,
+        teacher_note="Missing a clear thesis statement.",
+        updated_at=SECOND_TIMESTAMP,
+    )
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert result.requirement_check_id == "requirement_check_0001"
+    assert result.was_created is False
+    assert written["review_state"] == "ready_for_export"
+    assert written["notes"] == review["notes"]
+    assert written["scores"] == review["scores"]
+    assert written["module_details"] == review["module_details"]
+    assert written["requirement_checks"] == [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "required_elements:thesis_statement",
+            "label": "Required element: thesis_statement",
+            "expected": "thesis_statement",
+            "met": False,
+            "updated_at": SECOND_TIMESTAMP,
+            "module_details": {},
+            "teacher_note": "Missing a clear thesis statement.",
+        }
+    ]
+
+
+def test_existing_review_without_requirement_checks_remains_valid() -> None:
+    validate_review_record(_review())
+
+
+def test_requirement_check_validation_accepts_new_shape() -> None:
+    review = _review()
+    review["requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "word_count_max",
+            "label": "Maximum word count",
+            "expected": 800,
+            "met": False,
+            "teacher_note": "The submission is too long.",
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+
+    validate_review_record(review)
+
+
+def test_rejects_non_boolean_met(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+
+    with pytest.raises(ReviewRequirementError, match="met must be a boolean"):
+        set_requirement_check(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            requirement_key="paragraphs_min",
+            label="Minimum paragraphs",
+            expected=5,
+            met="true",  # type: ignore[arg-type]
+            updated_at=FIRST_TIMESTAMP,
+        )
+
+
+def test_rejects_blank_requirement_key(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+
+    with pytest.raises(ReviewRequirementError, match="requirement_key"):
+        set_requirement_check(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            requirement_key=" ",
+            label="Minimum paragraphs",
+            expected=5,
+            met=True,
+            updated_at=FIRST_TIMESTAMP,
+        )
+
+
+def test_validation_rejects_invalid_requirement_checks() -> None:
+    review = _review()
+    review["requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "paragraphs_min",
+            "label": "Minimum paragraphs",
+            "expected": 5,
+            "met": "yes",
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+
+    with pytest.raises(ReviewRecordError, match="met.*boolean"):
+        validate_review_record(review)
+
+
+def test_missing_submission_manifest_errors_without_review_write(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ReviewRequirementError):
+        set_requirement_check(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            requirement_key="paragraphs_min",
+            label="Minimum paragraphs",
+            expected=5,
+            met=True,
+            updated_at=FIRST_TIMESTAMP,
+        )
+
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()


### PR DESCRIPTION
## Summary

Improves Review Student Work screen flow and adds teacher-entered minimum requirement checks.

Closes #181

## Changes

* Clears the assignment-status screen before showing student/submission selection.
* Adds standalone context headers for nested review-selection screens.
* Clears between nested reusable tag screens:

  * tag bank
  * category
  * tag
  * reusable tag details
* Clears between nested reusable comment screens:

  * comment bank
  * category
  * comment
  * confirmation
* Clears between rubric scoring screens:

  * criterion
  * score level
  * confirmation
* Fixes `B. Back` behavior so it returns one level up instead of exiting the whole workflow.
* Adds `Record minimum requirement checks` near the top of Selected Student Review.
* Generates requirement-check prompts from assignment `basic_requirements`.
* Stores teacher-entered requirement checks in `review.json.requirement_checks`.
* Adds `quillan/review_requirements.py`.
* Updates review-record validation to allow optional `requirement_checks` for older schema version `1` records.
* Updates review-record creation paths so new review records include `requirement_checks: []`.
* Updates selected-student review summary with compact requirement-check status.

## Final Selected Student Review Menu

```text
1. Open submission evidence
2. Record minimum requirement checks
3. Manage submission pages
4. Add teacher note
5. Add structured tag
6. Select reusable comment
7. Set criterion score
8. Update submission review state
9. Export student feedback
10. Refresh summary
11. Back
```

## Requirement Check Behavior

Requirement checks are generated from the selected assignment’s `basic_requirements`, including:

* `paragraphs_min`
* `paragraphs_max`
* `word_count_min`
* `word_count_max`
* `required_elements`

Teachers record each check manually:

```text
1 = True / Yes / Met
2 = False / No / Not met
```

Requirement checks are stored as teacher-entered booleans in:

```text
review.json.requirement_checks
```

Existing checks are updated by `requirement_key`, preserving stable `requirement_check_id` values.

## Safety

This PR does not:

* run OCR
* use AI
* parse student writing
* count paragraphs automatically
* count words automatically
* infer required-element presence
* calculate scores
* change rubric scores
* change tags
* change comments
* modify feedback exports automatically
* modify `submission.json`
* delete evidence files
* modify rosters
* modify assignments
* modify review materials
* modify pds-core standards
* modify pds-core routes
* modify sibling repositories

Requirement checks update only the selected student’s `review.json`.

Existing notes, tags, comments, scores, metadata, and review-state semantics are preserved.

## Back / Navigation Behavior

`B. Back` now returns to the immediate previous selection screen in nested review workflows.

Examples:

* tag → category
* category → tag bank
* comment → category
* category → comment bank
* score level → criterion
* score confirmation → score level

The selected-student review summary is no longer the default destination for every nested Back action.

## Documentation

Updated:

* `README.md`
* `docs/cli_contract.md`
* `docs/teacher_review_model.md`
* `docs/review_record_contract.md`

Docs now explain:

* review screens clear between major selection levels
* Back returns to the immediate previous screen
* requirement checks are teacher-entered booleans
* requirement checks are generated from assignment `basic_requirements`
* requirement checks are stored in `review.json`
* requirement checks are not scoring, OCR, AI, parsing, automatic counting, or automatic evaluation

## Tests

Added:

* `tests/test_review_requirements.py`

Updated tests for:

* selected-student review menu numbering
* requirement-check storage
* requirement-check menu behavior
* Back behavior
* reusable tag navigation
* reusable comment navigation
* rubric scoring navigation
* review-record validation
* existing menu/export/review workflows

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `1037 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
