### PR TITLE
Add review targets and detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,21 +265,24 @@ The selected-student review menu is:
 
 ```text
 1. Open submission evidence
-2. Record minimum requirement checks
-3. Manage submission pages
-4. Add teacher note
-5. Add structured tag
-6. Select reusable comment
-7. Set criterion score
-8. Update submission review state
-9. Export student feedback
-10. Refresh summary
-11. Back
+2. View current review details
+3. Record minimum requirement checks
+4. Manage submission pages
+5. Add teacher note
+6. Add structured tag
+7. Select reusable comment
+8. Set criterion score
+9. Update submission review state
+10. Export student feedback
+11. Refresh summary
+12. Back
 ```
 
 These guided actions reuse the same underlying services and data contracts as the direct CLI commands. The menu does not implement separate export logic, scoring logic, routing logic, or AI logic.
 
-Review mode is selection-first. Selection screens clear between major levels so the current student, assignment, bank, category, or criterion context is visible without old summaries above it. `B. Back` returns to the immediate previous selection screen. Teacher notes open with private-note guidance and safe Back behavior. Minimum requirement checks are generated from assignment `basic_requirements` and stored as teacher-entered booleans in `review.json.requirement_checks`; Quillan does not count words or paragraphs, parse writing, run OCR, use AI, infer requirement completion, or change scores from those checks. Reusable comments are selected by comment bank, category, and comment, with label and feedback preview shown before writing. Reusable tags are selected by tag bank, category, and tag template, with a custom one-off fallback. Rubric scoring uses the assignment's resolved shared rubric when available, then asks the teacher to choose a criterion and level before confirming the saved score; custom scoring remains available when the rubric is missing or does not contain the needed criterion.
+Review mode is selection-first. Selection screens clear between major levels so the current student, assignment, bank, category, or criterion context is visible without old summaries above it. `B. Back` returns to the immediate previous selection screen. Teacher notes open with private-note guidance and safe Back behavior. Minimum requirement checks are generated from assignment `basic_requirements` and stored as teacher-entered booleans in `review.json.requirement_checks`; Quillan does not count words or paragraphs, parse writing, run OCR, use AI, infer requirement completion, or change scores from those checks. Reusable comments are selected by comment bank, category, and comment, with label, feedback preview, target, and include-in-feedback setting shown before writing. Reusable tags are selected by tag bank, category, and tag template, with a custom one-off fallback. Tags and comments can optionally be attached to whole submission, page, paragraph, multiple paragraphs, or page plus paragraphs. Paragraph targets are teacher-entered metadata; Quillan does not parse the student's writing to determine paragraph numbers or infer where feedback belongs. Rubric scoring uses the assignment's resolved shared rubric when available, then asks the teacher to choose a criterion and level before confirming the saved score; custom scoring remains available when the rubric is missing or does not contain the needed criterion.
+
+Selected Student Review includes a read-only `View current review details` option near the top of the menu. It displays the current student's saved requirement checks, notes, tags, comments, scores, feedback-inclusion choices, and tag/comment targets in the terminal. It does not generate an export file and is separate from full reporting and student feedback export, so Quillan remains useful as a standalone review tool with only pds-core.
 
 Review-time standards metadata is display-only. When reusable comments or tags reference durable pds-core `standard_id` values, Quillan may resolve readable code/name metadata through pds-core read-only helpers for display. It still stores durable IDs in review records and does not create, import, edit, retire, reactivate, or authoritatively validate standards.
 
@@ -574,7 +577,8 @@ Optional flags can reference:
 * teacher note;
 * page;
 * evidence ID;
-* controlled location metadata.
+* controlled location metadata, including optional teacher-entered paragraph
+  or page targets.
 
 A missing review record is created only for a valid matching `submission.json`.
 
@@ -593,6 +597,11 @@ shared/comment_banks/<bank_id>.json
 ```
 
 The direct `add-comment` workflow validates a bank and copies selected teacher-authored language into the canonical review record.
+
+Reusable comments selected from the guided review menu can also store optional
+teacher-entered page and paragraph targets in `review.json.comments`. Existing
+comments without targets remain valid, and exports continue to use the
+snapshotted comment text and include-in-feedback setting.
 
 The selected review comment stores `bank_id + comment_id` provenance and copies label and text, so later bank edits do not change an existing review.
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -595,6 +595,29 @@ JSON files only into `shared/comment_banks/`, `shared/tag_banks/`, and
 `shared/rubrics/`. Existing files are skipped by default, and bulk overwrite
 requires the exact confirmation text `OVERWRITE`.
 
+Selected Student Review presents the assembled student's review workspace as:
+
+```text
+1. Open submission evidence
+2. View current review details
+3. Record minimum requirement checks
+4. Manage submission pages
+5. Add teacher note
+6. Add structured tag
+7. Select reusable comment
+8. Set criterion score
+9. Update submission review state
+10. Export student feedback
+11. Refresh summary
+12. Back
+```
+
+View current review details is terminal-only and read-only. It displays the
+current `review.json` contents for the selected student, including requirement
+checks, notes, tags, comments, scores, comment feedback-inclusion settings,
+and tag/comment targets. It does not generate an export file and does not
+modify `review.json`, `submission.json`, or evidence files.
+
 Selected Student Review includes Manage Submission Pages. Teachers can exclude
 a page from active review, restore an excluded page, or mark a page as needing
 rescan after confirmation. These actions update only the selected student's
@@ -919,6 +942,13 @@ polarity, review state, and workspace-relative review-record path.
 The command never mutates the submission manifest, routed evidence, or
 retained source scans, and it does not score, analyze, or generate feedback.
 
+The guided Selected Student Review tag flow uses teacher-facing target prompts
+instead of raw JSON. Teachers may choose whole submission, specific
+paragraph(s), a specific page, page plus paragraph(s), skip location, or Back.
+Paragraph input accepts values such as `2`, `2-4`, `2,4,6`, and `2, 4-6`.
+Targets are teacher-entered metadata; Quillan does not parse writing, run OCR,
+use AI, count paragraphs, or infer where a tag belongs.
+
 ## Reusable Comment Selection
 
 ```powershell
@@ -927,6 +957,13 @@ quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --c
 
 This direct command validates a shared comment bank and appends one
 teacher-selected student-facing comment to canonical `review.json`.
+
+In the guided Selected Student Review reusable-comment flow, the teacher is
+also prompted for the same optional target choices used by tags. The
+confirmation screen shows the selected comment text, target, and
+include-in-feedback setting before writing. Comment targets are stored in
+`review.json.comments` as optional `page_number`, `evidence_id`, and
+`location` fields.
 
 Optional flags are:
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -272,10 +272,24 @@ Allowed location types are:
 * `custom`.
 
 For `whole_submission`, `value` must be `null`. For `page`, `paragraph`,
-`sentence`, and `line`, `value` must be a positive integer. For `section`,
-`scene`, `stanza`, and `custom`, `value` must be either a positive integer or
-a non-empty string. A `page` location must agree with `page_number` when both
-are present.
+`sentence`, and `line`, a single-value `value` must be a positive integer.
+For `paragraph`, `value` may also be a non-empty list of unique positive
+integers:
+
+```json
+{
+  "type": "paragraph",
+  "value": [2, 3, 4]
+}
+```
+
+The preferred convention is to store one paragraph as an integer and multiple
+paragraphs as a list. Existing single-integer paragraph locations remain
+valid. For `section`, `scene`, `stanza`, and `custom`, `value` must be either
+a positive integer or a non-empty string. A `page` location must agree with
+`page_number` when both are present. Paragraph targets are teacher-entered
+metadata; Quillan does not parse writing, count paragraphs, run OCR, or infer
+where a tag applies.
 
 ### Reusable Tag Snapshots
 
@@ -450,6 +464,11 @@ Each comment contains:
   "text": "The evidence is relevant, but the explanation needs to show more clearly how it supports the claim.",
   "source": "comment_bank",
   "include_in_feedback": true,
+  "page_number": 1,
+  "location": {
+    "type": "paragraph",
+    "value": [2, 3]
+  },
   "created_at": "2026-06-22T00:00:00+00:00",
   "module_details": {}
 }
@@ -468,8 +487,11 @@ Required comment fields are:
 Optional comment fields are:
 
 * `bank_id`;
-* `comment_id`; and
-* `standard_id`.
+* `comment_id`;
+* `standard_id`;
+* `page_number`;
+* `evidence_id`; and
+* `location`.
 
 Comment field rules are:
 
@@ -480,6 +502,13 @@ Comment field rules are:
   globally unique across comment banks.
 * `standard_id`, when present, is durable pds-core provenance for the
   associated standard.
+* `page_number`, when present, is a positive integer.
+* `evidence_id`, when present, is a non-empty reference to the submission
+  manifest as described above.
+* `location`, when present, uses the same controlled shape and paragraph
+  rules as tag locations. Comments may target a paragraph, multiple
+  paragraphs, a page, page plus paragraphs, evidence, or the whole
+  submission.
 * `label` and `text` are non-empty strings.
 * `source` is one of `comment_bank` or `custom`.
 * `include_in_feedback` is a boolean expressing the teacher's export choice.
@@ -492,9 +521,12 @@ Source-specific rules are:
 * `custom` comments must omit `bank_id`, `comment_id`, and `standard_id`.
 
 Comments are teacher-selected or teacher-entered; they are not generated from
-student writing or supplied as AI judgments. Comments are append-only for the
-MVP. Editing, deletion, and toggling export inclusion are reserved for future
-explicit workflows, which must not silently erase other comment records.
+student writing or supplied as AI judgments. Comment targets are optional,
+teacher-entered context; Quillan does not parse student writing to determine
+paragraph numbers or infer which paragraph a comment applies to. Comments are
+append-only for the MVP. Editing, deletion, and toggling export inclusion are
+reserved for future explicit workflows, which must not silently erase other
+comment records.
 
 For a shared-bank selection, `source` must be `"comment_bank"`. `bank_id` is
 provenance metadata only: validation does not load or look up the bank file.
@@ -618,8 +650,10 @@ quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity
 
 It appends one teacher-entered tag to `tags`, using sequential IDs such as
 `tag_0001`. Optional references to pages and evidence IDs are validated
-against the adjacent submission manifest. Optional standard references use
-shared `pds-core` `standard_id` values from the workspace standards library.
+against the adjacent submission manifest. Optional paragraph targets may name
+one paragraph or multiple paragraphs, but they are not checked against parsed
+student writing. Optional standard references use shared `pds-core`
+`standard_id` values from the workspace standards library.
 Reusable comment references remain Quillan-owned module data; their labels and
 polarities must match the stored Quillan comment/profile values.
 
@@ -674,6 +708,11 @@ missing review record using the same state and preservation rules as notes and
 tags, and does not mutate the source bank, submission manifest, evidence, or
 retained scans. It does not export feedback, select comments automatically,
 analyze writing, score work, or infer mastery.
+
+Selected comments may also store optional `page_number`, `evidence_id`, and
+`location` fields using the same target model as tags. Page and evidence
+references are validated against the adjacent submission manifest when
+supplied. Paragraph numbers are teacher-entered metadata only.
 
 ## Derived Artifacts and Historical Names
 

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -60,6 +60,12 @@ remains separate so teacher judgment does not alter the student's original
 work. Current requirement checks are stored in
 `review.json.requirement_checks`, not in a sibling `requirements.json`.
 
+Tags and selected comments may include optional teacher-entered target
+metadata such as page number, evidence ID, paragraph, multiple paragraphs, or
+whole submission. Paragraph targets are not discovered from the student work:
+Quillan does not parse writing, run OCR, use AI, count paragraphs, or infer
+where a tag or comment applies.
+
 Earlier designs named separate `tags.json` and `scores.json` files. Those are
 historical concepts, not alternate active v0.7 records. Their content belongs
 in `review.json`.
@@ -77,6 +83,13 @@ assignment-level CSV reports are
 aggregations. These outputs are not independent evidence or substitutes for
 `review.json`; they should remain traceable to the teacher-confirmed records
 from which they were derived.
+
+Selected Student Review also includes a terminal-only `View current review
+details` view. It reads the current student's `review.json` and displays saved
+requirement checks, tags, comments, scores, notes, target labels, and
+include-in-feedback settings so a teacher can resume an interrupted review
+without exporting a report. It is read-only and is not a replacement for full
+reporting or student feedback export.
 
 ## Tag Philosophy
 

--- a/quillan/review_comments.py
+++ b/quillan/review_comments.py
@@ -26,6 +26,7 @@ from quillan.review_record_paths import (
     review_record_path,
     write_review_record,
 )
+from quillan.review_targets import ReviewTargetError, build_location
 from quillan.submission_manifest import (
     SubmissionManifestError,
     load_submission_manifest,
@@ -71,12 +72,22 @@ def add_review_comment(
     comment_id: str,
     standard_id: str | None = None,
     include_in_feedback: bool | None = None,
+    page_number: int | None = None,
+    evidence_id: str | None = None,
+    location_type: str | None = None,
+    location_value: int | list[int] | str | None = None,
     created_at: datetime | str | None = None,
 ) -> AddedReviewComment:
     """Append one snapshotted shared-bank comment to a review record."""
     normalized_bank_id = _normalize_identifier(bank_id, "bank_id")
     normalized_comment_id = _normalize_identifier(comment_id, "comment_id")
     normalized_standard = _normalize_optional_string(standard_id, "standard_id")
+    normalized_evidence = _normalize_optional_string(evidence_id, "evidence_id")
+    _validate_page_number(page_number)
+    try:
+        location = build_location(location_type, location_value, page_number)
+    except ReviewTargetError as error:
+        raise ReviewCommentError(str(error)) from error
     if include_in_feedback is not None and not isinstance(
         include_in_feedback, bool
     ):
@@ -149,6 +160,19 @@ def add_review_comment(
     _validate_identity(
         manifest, "Submission manifest", class_id, assignment_id, student_id
     )
+    _validate_manifest_references(
+        manifest,
+        page_number=(
+            page_number
+            if page_number is not None
+            else (
+                location["value"]
+                if location is not None and location["type"] == "page"
+                else None
+            )
+        ),
+        evidence_id=normalized_evidence,
+    )
 
     if record_path.exists():
         try:
@@ -197,6 +221,18 @@ def add_review_comment(
         "created_at": normalized_created_at,
         "module_details": {},
     }
+    optional_target_fields = {
+        "page_number": page_number,
+        "evidence_id": normalized_evidence,
+        "location": location,
+    }
+    selected_comment.update(
+        {
+            field: value
+            for field, value in optional_target_fields.items()
+            if value is not None
+        }
+    )
     if selected_standard is not None:
         selected_comment["standard_id"] = selected_standard
     updated_review["comments"].append(selected_comment)
@@ -270,6 +306,42 @@ def _normalize_optional_string(value: str | None, field: str) -> str | None:
     if not isinstance(value, str) or not value.strip():
         raise ReviewCommentError(f"{field} must be a non-empty string.")
     return value.strip()
+
+
+def _validate_page_number(value: int | None) -> None:
+    if value is not None and (
+        isinstance(value, bool) or not isinstance(value, int) or value < 1
+    ):
+        raise ReviewCommentError("page_number must be a positive integer.")
+
+
+def _validate_manifest_references(
+    manifest: dict[str, Any],
+    *,
+    page_number: int | None,
+    evidence_id: str | None,
+) -> None:
+    pages = {page["page_number"]: page for page in manifest["pages"]}
+    if page_number is not None and page_number not in pages:
+        raise ReviewCommentError(
+            f"page_number {page_number} does not exist in the submission manifest."
+        )
+    if evidence_id is None:
+        return
+    evidence_pages = {
+        candidate["evidence_id"]: page["page_number"]
+        for page in manifest["pages"]
+        for candidate in page["evidence"]
+    }
+    if evidence_id not in evidence_pages:
+        raise ReviewCommentError(
+            f"evidence_id {evidence_id!r} does not exist in the submission manifest."
+        )
+    if page_number is not None and evidence_pages[evidence_id] != page_number:
+        raise ReviewCommentError(
+            f"evidence_id {evidence_id!r} occurs on page "
+            f"{evidence_pages[evidence_id]}, not page {page_number}."
+        )
 
 
 def _normalize_timestamp(value: datetime | str | None) -> str:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -51,12 +51,17 @@ from quillan.tag_bank_writing import list_valid_tag_banks
 from quillan.review_comments import ReviewCommentError, add_review_comment
 from quillan.review_notes import ReviewNoteError, add_review_note
 from quillan.review_record import (
-    ALLOWED_LOCATION_TYPES,
     ALLOWED_TAG_POLARITIES,
     ReviewRecordError,
     load_review_record,
 )
 from quillan.review_record_paths import review_record_path
+from quillan.review_snapshot import current_review_details_text
+from quillan.review_targets import (
+    ReviewTargetError,
+    format_review_target,
+    parse_paragraph_selection,
+)
 from quillan.review_requirements import (
     ReviewRequirementError,
     set_requirement_check,
@@ -402,22 +407,23 @@ def _launch_selected_student_review(
                 input("Press Enter to continue...")
             continue
         print("1. Open submission evidence")
-        print("2. Record minimum requirement checks")
-        print("3. Manage submission pages")
-        print("4. Add teacher note")
-        print("5. Add structured tag")
-        print("6. Select reusable comment")
-        print("7. Set criterion score")
-        print("8. Update submission review state")
-        print("9. Export student feedback")
-        print("10. Refresh summary")
-        print("11. Back")
+        print("2. View current review details")
+        print("3. Record minimum requirement checks")
+        print("4. Manage submission pages")
+        print("5. Add teacher note")
+        print("6. Add structured tag")
+        print("7. Select reusable comment")
+        print("8. Set criterion score")
+        print("9. Update submission review state")
+        print("10. Export student feedback")
+        print("11. Refresh summary")
+        print("12. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "11"}:
+        if choice in {"", "12"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -428,13 +434,21 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "2":
+            _menu_view_current_review_details(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        elif choice == "3":
             _menu_record_requirement_checks(
                 workspace_root,
                 class_id,
                 assignment_id,
                 student_id,
             )
-        elif choice == "3":
+        elif choice == "4":
             _menu_manage_submission_pages(
                 workspace_root,
                 class_id,
@@ -442,7 +456,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "4":
+        elif choice == "5":
             _menu_add_review_note(
                 workspace_root,
                 class_id,
@@ -450,7 +464,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "5":
+        elif choice == "6":
             _menu_add_review_tag(
                 workspace_root,
                 class_id,
@@ -458,7 +472,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "6":
+        elif choice == "7":
             _menu_add_review_comment(
                 workspace_root,
                 class_id,
@@ -466,7 +480,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "7":
+        elif choice == "8":
             _menu_set_review_score(
                 workspace_root,
                 class_id,
@@ -474,7 +488,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "8":
+        elif choice == "9":
             _menu_update_submission_review_state(
                 workspace_root,
                 class_id,
@@ -482,7 +496,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "9":
+        elif choice == "10":
             _menu_export_student_feedback(
                 workspace_root,
                 class_id,
@@ -490,10 +504,10 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "10":
+        elif choice == "11":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 11.")
+            print("Invalid selection. Please enter a number from 1 to 12.")
             input("Press Enter to continue...")
 
 
@@ -538,6 +552,18 @@ def _print_review_action_header(
     print(f"Assignment: {assignment_id}")
     print(f"Student: {student_id}")
     print()
+
+
+def _menu_view_current_review_details(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    _print_review_action_header(
+        "Current Review Details", class_id, assignment_id, student_id
+    )
+    print(current_review_details_text(workspace_root, class_id, assignment_id, student_id))
 
 
 def _format_secondary_id(value: object) -> str:
@@ -698,7 +724,7 @@ def _menu_add_custom_review_tag(
     page_number = None
     evidence_id = None
     location_type = None
-    location_value: str | int | None = None
+    location_value: str | int | list[int] | None = None
     if initial_label is not None or _prompt_yes_no_default_no("Add optional details?"):
         standard_id = input(
             "Standard ID (leave blank if not applicable): "
@@ -714,42 +740,20 @@ def _menu_add_custom_review_tag(
         teacher_note = input(
             "Private teacher note (leave blank if not applicable): "
         ).strip() or None
-        page_number = _parse_optional_positive_int(
-            input("Page number (leave blank if not applicable): ")
+        target = _prompt_review_target(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
         )
-        evidence_id = input(
-            "Evidence ID (leave blank if not applicable): "
-        ).strip() or None
-        location_type = input(
-            "Location type (leave blank if not applicable): "
-        ).strip() or None
-        if location_type:
-            if location_type not in ALLOWED_LOCATION_TYPES:
-                print(
-                    "Add tag canceled. Invalid location type. "
-                    f"Allowed values: {', '.join(sorted(ALLOWED_LOCATION_TYPES))}."
-                )
-                return
-            raw_location = input(
-                "Location value (leave blank if not applicable): "
-            ).strip()
-            if raw_location:
-                if location_type in {
-                    "page",
-                    "paragraph",
-                    "sentence",
-                    "line",
-                }:
-                    try:
-                        location_value = int(raw_location)
-                    except ValueError:
-                        print(
-                            "Add tag canceled. Location value must be a positive "
-                            f"integer for {location_type}."
-                        )
-                        return
-                else:
-                    location_value = raw_location
+        if target is _BACK:
+            print("Add tag canceled.")
+            return
+        assert isinstance(target, dict)
+        page_number = target.get("page_number")
+        evidence_id = target.get("evidence_id")
+        location_type = target.get("location_type")
+        location_value = target.get("location_value")
 
     try:
         added = add_review_tag(
@@ -897,6 +901,16 @@ def _add_selected_reusable_tag(
     severity_value = (
         severity if isinstance(severity, int) and not isinstance(severity, bool) else None
     )
+    target = _prompt_review_target(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+    )
+    if target is _BACK:
+        print("Add tag canceled.")
+        return False
+    assert isinstance(target, dict)
 
     try:
         added = add_review_tag(
@@ -913,6 +927,7 @@ def _add_selected_reusable_tag(
             source="tag_bank",
             tag_bank_id=str(bank["tag_bank_id"]),
             tag_template_id=str(tag["tag_template_id"]),
+            **target,
         )
     except (ReviewTagError, OSError) as error:
         if standard_id is not None:
@@ -936,6 +951,7 @@ def _add_selected_reusable_tag(
                         source="tag_bank",
                         tag_bank_id=str(bank["tag_bank_id"]),
                         tag_template_id=str(tag["tag_template_id"]),
+                        **target,
                     )
                 except (ReviewTagError, OSError) as retry_error:
                     print(f"Error: could not add structured tag: {retry_error}")
@@ -1348,29 +1364,49 @@ def _prompt_optional_boolean(
 def _confirm_comment_selection(
     comment: dict[str, Any],
     include_default: bool,
-) -> bool | object:
+    target: dict[str, Any],
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> tuple[bool, dict[str, Any]] | object:
     include_in_feedback = include_default
+    selected_target = target
     while True:
         print("Add this comment?")
         print()
         print(f"Comment: {comment['label']}")
         print(f"Feedback: {comment['text']}")
+        print(f"Target: {_format_prompt_target(selected_target)}")
         print(f"Include in feedback: {_format_yes_no(include_in_feedback)}")
         print()
         print("1. Add comment")
         print("2. Change include-in-feedback setting")
-        print("3. Back")
+        print("3. Change target")
+        print("4. Back")
         print()
         selection = input("Select an option: ").strip()
         if selection == "1":
-            return include_in_feedback
+            return include_in_feedback, selected_target
         if selection == "2":
             include_in_feedback = not include_in_feedback
             continue
-        if selection in {"", "3"} or selection.casefold() == "b":
+        if selection == "3":
+            updated_target = _prompt_review_target(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            if updated_target is _BACK:
+                continue
+            assert isinstance(updated_target, dict)
+            selected_target = updated_target
+            continue
+        if selection in {"", "4"} or selection.casefold() == "b":
             print("Select comment canceled.")
             return _CANCEL
-        print("Invalid selection. Please enter a number from 1 to 3.")
+        print("Invalid selection. Please enter a number from 1 to 4.")
 
 
 def _menu_add_review_comment(
@@ -1484,12 +1520,29 @@ def _add_selected_reusable_comment(
     comment: dict[str, Any],
 ) -> bool:
     standard_id = _prompt_optional_standard_id(workspace_root, comment)
-    include_in_feedback = _confirm_comment_selection(
+    target = _prompt_review_target(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+    )
+    if target is _BACK:
+        print("Select comment canceled.")
+        return False
+    assert isinstance(target, dict)
+    selection = _confirm_comment_selection(
         comment,
         bool(comment["include_in_feedback_default"]),
+        target,
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
     )
-    if include_in_feedback is _CANCEL:
+    if selection is _CANCEL:
         return False
+    assert isinstance(selection, tuple)
+    include_in_feedback, selected_target = selection
 
     val_include: bool | None = (
         include_in_feedback if isinstance(include_in_feedback, bool) else None
@@ -1505,6 +1558,7 @@ def _add_selected_reusable_comment(
             comment_id=comment["comment_id"],
             standard_id=standard_id,
             include_in_feedback=val_include,
+            **selected_target,
         )
     except (ReviewCommentError, OSError) as error:
         print(f"Error: could not select review comment: {error}")
@@ -2629,6 +2683,86 @@ def _prompt_page_number(prompt: str) -> int | None:
     except ValueError:
         return None
     return page_number if page_number > 0 else None
+
+
+def _prompt_review_target(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> dict[str, Any] | object:
+    while True:
+        _print_review_action_header(
+            "Review Target", class_id, assignment_id, student_id
+        )
+        print("Where does this apply?")
+        print()
+        print("1. Whole submission")
+        print("2. Specific paragraph(s)")
+        print("3. Specific page")
+        print("4. Specific page and paragraph(s)")
+        print("5. Skip location")
+        print("B. Back")
+        print()
+        selection = input("Select target: ").strip()
+        if selection == "" or selection.casefold() == "b":
+            return _BACK
+        if selection == "1":
+            return {"location_type": "whole_submission", "location_value": None}
+        if selection == "2":
+            paragraphs = _prompt_paragraph_numbers()
+            if paragraphs is _BACK:
+                return _BACK
+            return {"location_type": "paragraph", "location_value": paragraphs}
+        if selection == "3":
+            page_number = _prompt_page_number("Page number: ")
+            if page_number is None:
+                return _BACK
+            return {"page_number": page_number}
+        if selection == "4":
+            page_number = _prompt_page_number("Page number: ")
+            if page_number is None:
+                return _BACK
+            paragraphs = _prompt_paragraph_numbers()
+            if paragraphs is _BACK:
+                return _BACK
+            return {
+                "page_number": page_number,
+                "location_type": "paragraph",
+                "location_value": paragraphs,
+            }
+        if selection == "5":
+            return {}
+
+        print("Invalid selection. Please enter a number from 1 to 5 or B.")
+
+
+def _prompt_paragraph_numbers() -> int | list[int] | object:
+    print()
+    print("Paragraph number(s):")
+    print("Examples: 2, 2-4, 2,4,6")
+    while True:
+        raw = input("Paragraph number(s): ").strip()
+        if raw == "" or raw.casefold() == "b":
+            return _BACK
+        try:
+            return parse_paragraph_selection(raw)
+        except ReviewTargetError as error:
+            print(f"Invalid paragraph target: {error}")
+
+
+def _format_prompt_target(target: dict[str, Any]) -> str:
+    item: dict[str, Any] = {}
+    if "page_number" in target:
+        item["page_number"] = target["page_number"]
+    if "evidence_id" in target:
+        item["evidence_id"] = target["evidence_id"]
+    if "location_type" in target:
+        item["location"] = {
+            "type": target["location_type"],
+            "value": target.get("location_value"),
+        }
+    return format_review_target(item)
 
 
 def _prompt_overwrite_export() -> bool | object:

--- a/quillan/review_record.py
+++ b/quillan/review_record.py
@@ -80,7 +80,14 @@ REQUIRED_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
     }
 )
 OPTIONAL_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
-    {"bank_id", "comment_id", "standard_id"}
+    {
+        "bank_id",
+        "comment_id",
+        "standard_id",
+        "page_number",
+        "evidence_id",
+        "location",
+    }
 )
 REQUIRED_REQUIREMENT_CHECK_FIELDS: Final[frozenset[str]] = frozenset(
     {
@@ -319,6 +326,10 @@ def _validate_location(
             raise ReviewRecordError(
                 f"Field '{context}.value' must be null for whole_submission."
             )
+    elif location_type == "paragraph":
+        location_value = _validate_paragraph_location_value(
+            location_value, f"{context}.value"
+        )
     elif location_type in INTEGER_LOCATION_TYPES:
         location_value = _validate_positive_integer(
             location_value, f"{context}.value"
@@ -344,8 +355,24 @@ def _validate_location(
         and location_value != page_number
     ):
         raise ReviewRecordError(
-            f"Field '{context}.value' must agree with the tag's page_number."
+            f"Field '{context}.value' must agree with the item's page_number."
         )
+
+
+def _validate_paragraph_location_value(value: Any, field: str) -> int | list[int]:
+    if isinstance(value, list):
+        if not value:
+            raise ReviewRecordError(f"Field '{field}' must not be an empty list.")
+        seen: set[int] = set()
+        for item in value:
+            paragraph = _validate_positive_integer(item, field)
+            if paragraph in seen:
+                raise ReviewRecordError(
+                    f"Field '{field}' must not contain duplicate paragraph numbers."
+                )
+            seen.add(paragraph)
+        return value
+    return _validate_positive_integer(value, field)
 
 
 def _validate_scores(value: Any) -> None:
@@ -406,11 +433,19 @@ def _validate_comments(value: Any) -> None:
         )
         for field in ("label", "text"):
             _validate_non_empty_string(item[field], f"{context}.{field}")
-        for field in ("comment_id", "standard_id"):
+        for field in ("comment_id", "standard_id", "evidence_id"):
             if field in item:
                 _validate_non_empty_string(item[field], f"{context}.{field}")
         if "bank_id" in item:
             _validate_identifier(item["bank_id"], f"{context}.bank_id")
+        if "page_number" in item:
+            _validate_positive_integer(
+                item["page_number"], f"{context}.page_number"
+            )
+        if "location" in item:
+            _validate_location(
+                item["location"], f"{context}.location", item.get("page_number")
+            )
         source = _validate_allowed_value(
             item["source"], f"{context}.source", ALLOWED_COMMENT_SOURCES
         )

--- a/quillan/review_snapshot.py
+++ b/quillan/review_snapshot.py
@@ -1,0 +1,163 @@
+"""Read-only terminal snapshot of a student's current review record."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.review_record_paths import review_record_path
+from quillan.review_targets import format_review_target
+
+
+def current_review_details_text(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> str:
+    """Return a compact, read-only terminal view of recorded review artifacts."""
+    path = review_record_path(Path(workspace_root), class_id, assignment_id, student_id)
+    lines: list[str] = []
+    if not path.exists():
+        lines.append("No review record exists yet for this student.")
+        return "\n".join(lines)
+
+    try:
+        record = load_review_record(path)
+    except (OSError, ReviewRecordError) as error:
+        lines.append("Review record: invalid")
+        lines.append(f"Review record error: {error}")
+        return "\n".join(lines)
+
+    identity_error = _identity_error(record, class_id, assignment_id, student_id)
+    if identity_error is not None:
+        lines.append("Review record: invalid")
+        lines.append(identity_error)
+        return "\n".join(lines)
+
+    lines.append("Review record: exists")
+    lines.append(f"Review state: {record['review_state']}")
+    lines.append("")
+    _append_requirement_checks(lines, record)
+    _append_tags(lines, record)
+    _append_comments(lines, record)
+    _append_scores(lines, record)
+    _append_notes(lines, record)
+    return "\n".join(lines).rstrip()
+
+
+def _identity_error(
+    record: dict[str, Any],
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> str | None:
+    for field, expected in {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }.items():
+        if record[field] != expected:
+            return f"Review record {field} is {record[field]!r}, expected {expected!r}."
+    return None
+
+
+def _append_requirement_checks(lines: list[str], record: dict[str, Any]) -> None:
+    lines.append("Requirement Checks")
+    checks = _record_list(record, "requirement_checks")
+    if not checks:
+        lines.append("No requirement checks recorded.")
+        lines.append("")
+        return
+    for check in checks:
+        status = "met" if check.get("met") is True else "not met"
+        lines.append(f"- {check['label']}: {status}")
+        if note := _non_empty(check.get("teacher_note")):
+            lines.append(f"  Note: {note}")
+    lines.append("")
+
+
+def _append_tags(lines: list[str], record: dict[str, Any]) -> None:
+    lines.append("Tags")
+    tags = _record_list(record, "tags")
+    if not tags:
+        lines.append("No tags recorded.")
+        lines.append("")
+        return
+    for index, tag in enumerate(tags, start=1):
+        lines.append(f"{index}. [{tag['polarity']}] {tag['label']}")
+        lines.append(f"   Target: {format_review_target(tag)}")
+        lines.append(f"   Source: {_format_tag_source(tag)}")
+        if note := _non_empty(tag.get("teacher_note")):
+            lines.append(f"   Note: {note}")
+        lines.append("")
+
+
+def _append_comments(lines: list[str], record: dict[str, Any]) -> None:
+    lines.append("Comments")
+    comments = _record_list(record, "comments")
+    if not comments:
+        lines.append("No comments recorded.")
+        lines.append("")
+        return
+    for index, comment in enumerate(comments, start=1):
+        lines.append(f"{index}. {comment['label']}")
+        lines.append(f"   Target: {format_review_target(comment)}")
+        include = "yes" if comment["include_in_feedback"] else "no"
+        lines.append(f"   Include in feedback: {include}")
+        lines.append(f"   Feedback: {comment['text']}")
+        if source := _format_comment_source(comment):
+            lines.append(f"   Source: {source}")
+        lines.append("")
+
+
+def _append_scores(lines: list[str], record: dict[str, Any]) -> None:
+    lines.append("Scores")
+    scores = _record_list(record, "scores")
+    if not scores:
+        lines.append("No scores recorded.")
+        lines.append("")
+        return
+    for index, score in enumerate(scores, start=1):
+        lines.append(
+            f"{index}. {score['label']}: {score['score']:g} / {score['max_score']:g}"
+        )
+        if note := _non_empty(score.get("teacher_note")):
+            lines.append(f"   Note: {note}")
+    lines.append("")
+
+
+def _append_notes(lines: list[str], record: dict[str, Any]) -> None:
+    lines.append("Notes")
+    notes = _record_list(record, "notes")
+    if not notes:
+        lines.append("No notes recorded.")
+        return
+    for index, note in enumerate(notes, start=1):
+        lines.append(f"{index}. {note['text']}")
+
+
+def _record_list(record: dict[str, Any], field: str) -> list[dict[str, Any]]:
+    value = record.get(field, [])
+    return [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+
+
+def _format_tag_source(tag: dict[str, Any]) -> str:
+    if tag.get("source") == "tag_bank":
+        return f"{tag.get('tag_bank_id')} / {tag.get('tag_template_id')}"
+    if tag.get("source") == "custom":
+        return "custom"
+    return "not specified"
+
+
+def _format_comment_source(comment: dict[str, Any]) -> str:
+    if comment.get("source") == "comment_bank":
+        return f"{comment.get('bank_id')} / {comment.get('comment_id')}"
+    if comment.get("source") == "custom":
+        return "custom"
+    return ""
+
+
+def _non_empty(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None

--- a/quillan/review_tags.py
+++ b/quillan/review_tags.py
@@ -17,10 +17,7 @@ from pds_core.standards import (
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.review_record import (
-    ALLOWED_LOCATION_TYPES,
     ALLOWED_TAG_POLARITIES,
-    FLEXIBLE_LOCATION_TYPES,
-    INTEGER_LOCATION_TYPES,
     ReviewRecordError,
     load_review_record,
     validate_review_record,
@@ -30,6 +27,7 @@ from quillan.review_record_paths import (
     review_record_path,
     write_review_record,
 )
+from quillan.review_targets import ReviewTargetError, build_location
 from quillan.storage import assignment_config_path
 from quillan.submission_manifest import (
     SubmissionManifestError,
@@ -82,7 +80,7 @@ def add_review_tag(
     page_number: int | None = None,
     evidence_id: str | None = None,
     location_type: str | None = None,
-    location_value: int | str | None = None,
+    location_value: int | list[int] | str | None = None,
     created_at: datetime | str | None = None,
 ) -> AddedReviewTag:
     """Append one teacher-entered structured tag to a review record."""
@@ -100,7 +98,10 @@ def add_review_tag(
     normalized_evidence = _normalize_optional_string(evidence_id, "evidence_id")
     _validate_severity(severity)
     _validate_page_number(page_number)
-    location = _build_location(location_type, location_value, page_number)
+    try:
+        location = build_location(location_type, location_value, page_number)
+    except ReviewTargetError as error:
+        raise ReviewTagError(str(error)) from error
     normalized_created_at = _normalize_timestamp(created_at)
 
     if normalized_comment is not None and normalized_standard is None:
@@ -337,66 +338,6 @@ def _validate_page_number(value: int | None) -> None:
         isinstance(value, bool) or not isinstance(value, int) or value < 1
     ):
         raise ReviewTagError("page_number must be a positive integer.")
-
-
-def _build_location(
-    location_type: str | None,
-    location_value: int | str | None,
-    page_number: int | None,
-) -> dict[str, Any] | None:
-    if location_type is None:
-        if location_value is not None:
-            raise ReviewTagError("location_value requires location_type.")
-        return None
-    if location_type not in ALLOWED_LOCATION_TYPES:
-        allowed = ", ".join(sorted(ALLOWED_LOCATION_TYPES))
-        raise ReviewTagError(
-            f"Invalid location_type {location_type!r}. Allowed values: {allowed}."
-        )
-    if location_type == "whole_submission":
-        if location_value is not None:
-            raise ReviewTagError(
-                "location_value must be omitted for whole_submission."
-            )
-        return {"type": location_type, "value": None}
-    if location_type in INTEGER_LOCATION_TYPES:
-        if (
-            isinstance(location_value, bool)
-            or not isinstance(location_value, int)
-            or location_value < 1
-        ):
-            raise ReviewTagError(
-                f"location_value must be a positive integer for {location_type}."
-            )
-    elif location_type in FLEXIBLE_LOCATION_TYPES and (
-        isinstance(location_value, bool)
-        or not (
-            isinstance(location_value, int)
-            and location_value >= 1
-            or isinstance(location_value, str)
-            and bool(location_value.strip())
-        )
-    ):
-        raise ReviewTagError(
-            f"location_value must be a positive integer or non-empty string "
-            f"for {location_type}."
-        )
-    if (
-        location_type == "page"
-        and page_number is not None
-        and location_value != page_number
-    ):
-        raise ReviewTagError(
-            "page location_value must agree with page_number."
-        )
-    return {
-        "type": location_type,
-        "value": (
-            location_value.strip()
-            if isinstance(location_value, str)
-            else location_value
-        ),
-    }
 
 
 def _normalize_timestamp(value: datetime | str | None) -> str:

--- a/quillan/review_targets.py
+++ b/quillan/review_targets.py
@@ -1,0 +1,222 @@
+"""Shared review target parsing, normalization, and display helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from quillan.review_record import (
+    ALLOWED_LOCATION_TYPES,
+    FLEXIBLE_LOCATION_TYPES,
+    INTEGER_LOCATION_TYPES,
+)
+
+_INTEGER = re.compile(r"\d+")
+_RANGE = re.compile(r"(\d+)-(\d+)")
+
+
+class ReviewTargetError(ValueError):
+    """Raised when teacher-entered review target metadata is invalid."""
+
+
+def parse_paragraph_selection(value: str) -> int | list[int]:
+    """Parse teacher-entered paragraph numbers and ranges."""
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewTargetError("Paragraph number(s) are required.")
+
+    paragraphs: list[int] = []
+    seen: set[int] = set()
+    for raw_part in value.split(","):
+        part = raw_part.strip()
+        if not part:
+            raise ReviewTargetError("Paragraph entries must not be empty.")
+        if range_match := _RANGE.fullmatch(part):
+            start = _parse_positive_integer(range_match.group(1), "paragraph")
+            end = _parse_positive_integer(range_match.group(2), "paragraph")
+            if end < start:
+                raise ReviewTargetError("Paragraph ranges must go from low to high.")
+            candidates: Iterable[int] = range(start, end + 1)
+        elif _INTEGER.fullmatch(part):
+            candidates = (_parse_positive_integer(part, "paragraph"),)
+        else:
+            raise ReviewTargetError(
+                "Use paragraph numbers and ranges such as 2, 2-4, or 2, 4-6."
+            )
+
+        for paragraph in candidates:
+            if paragraph in seen:
+                raise ReviewTargetError(
+                    f"Paragraph {paragraph} was entered more than once."
+                )
+            seen.add(paragraph)
+            paragraphs.append(paragraph)
+
+    return paragraphs[0] if len(paragraphs) == 1 else paragraphs
+
+
+def build_location(
+    location_type: str | None,
+    location_value: int | list[int] | str | None,
+    page_number: int | None = None,
+) -> dict[str, Any] | None:
+    """Build the review-record location object used by tags and comments."""
+    if location_type is None:
+        if location_value is not None:
+            raise ReviewTargetError("location_value requires location_type.")
+        return None
+    if location_type not in ALLOWED_LOCATION_TYPES:
+        allowed = ", ".join(sorted(ALLOWED_LOCATION_TYPES))
+        raise ReviewTargetError(
+            f"Invalid location_type {location_type!r}. Allowed values: {allowed}."
+        )
+    normalized_value: Any
+    if location_type == "whole_submission":
+        if location_value is not None:
+            raise ReviewTargetError(
+                "location_value must be omitted for whole_submission."
+            )
+        return {"type": location_type, "value": None}
+    if location_type == "paragraph":
+        normalized_value = normalize_paragraph_location_value(location_value)
+    elif location_type in INTEGER_LOCATION_TYPES:
+        normalized_value = _validate_positive_integer(
+            location_value, "location_value"
+        )
+    elif location_type in FLEXIBLE_LOCATION_TYPES:
+        normalized_value = _normalize_flexible_location_value(location_value)
+    else:
+        raise ReviewTargetError(f"Unsupported location_type {location_type!r}.")
+
+    if (
+        location_type == "page"
+        and page_number is not None
+        and normalized_value != page_number
+    ):
+        raise ReviewTargetError("page location_value must agree with page_number.")
+    return {"type": location_type, "value": normalized_value}
+
+
+def normalize_paragraph_location_value(value: Any) -> int | list[int]:
+    """Normalize paragraph locations to one int or a unique non-empty int list."""
+    if isinstance(value, list):
+        if not value:
+            raise ReviewTargetError("paragraph location_value must not be empty.")
+        seen: set[int] = set()
+        normalized: list[int] = []
+        for item in value:
+            paragraph = _validate_positive_integer(item, "paragraph")
+            if paragraph in seen:
+                raise ReviewTargetError(
+                    f"Paragraph {paragraph} was entered more than once."
+                )
+            seen.add(paragraph)
+            normalized.append(paragraph)
+        return normalized[0] if len(normalized) == 1 else normalized
+    return _validate_positive_integer(value, "paragraph")
+
+
+def target_fields(
+    *,
+    page_number: int | None = None,
+    evidence_id: str | None = None,
+    location_type: str | None = None,
+    location_value: int | list[int] | str | None = None,
+) -> dict[str, Any]:
+    """Return review-record fields for optional target metadata."""
+    _validate_optional_page_number(page_number)
+    normalized_evidence = _normalize_optional_string(evidence_id, "evidence_id")
+    location = build_location(location_type, location_value, page_number)
+    fields: dict[str, Any] = {}
+    if page_number is not None:
+        fields["page_number"] = page_number
+    if normalized_evidence is not None:
+        fields["evidence_id"] = normalized_evidence
+    if location is not None:
+        fields["location"] = location
+    return fields
+
+
+def format_review_target(item: dict[str, Any]) -> str:
+    """Format target metadata for terminal display."""
+    page_number = item.get("page_number")
+    location = item.get("location")
+    evidence_id = item.get("evidence_id")
+
+    location_type = location.get("type") if isinstance(location, dict) else None
+    location_value = location.get("value") if isinstance(location, dict) else None
+
+    if location_type == "whole_submission":
+        return "Whole submission"
+    parts: list[str] = []
+    if location_type == "paragraph":
+        paragraph_text = _format_paragraphs(location_value)
+        if isinstance(page_number, int) and not isinstance(page_number, bool):
+            parts.append(f"Page {page_number}")
+            paragraph_text = paragraph_text.casefold()
+        parts.append(paragraph_text)
+    elif location_type == "page":
+        if isinstance(location_value, int) and not isinstance(location_value, bool):
+            parts.append(f"Page {location_value}")
+    elif isinstance(page_number, int) and not isinstance(page_number, bool):
+        parts.append(f"Page {page_number}")
+    elif location_type is not None and location_value is not None:
+        parts.append(f"{location_type.replace('_', ' ').title()}: {location_value}")
+    if isinstance(evidence_id, str) and evidence_id.strip():
+        parts.append(f"Evidence {evidence_id.strip()}")
+    return ", ".join(parts) if parts else "Not specified"
+
+
+def _format_paragraphs(value: Any) -> str:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return f"Paragraph {value}"
+    if isinstance(value, list):
+        paragraphs = [
+            item for item in value if isinstance(item, int) and not isinstance(item, bool)
+        ]
+        if len(paragraphs) == 1:
+            return f"Paragraph {paragraphs[0]}"
+        return f"Paragraphs {_format_number_ranges(paragraphs)}"
+    return "Paragraphs"
+
+
+def _format_number_ranges(values: list[int]) -> str:
+    ranges: list[str] = []
+    start = previous = values[0]
+    for value in values[1:]:
+        if value == previous + 1:
+            previous = value
+            continue
+        ranges.append(f"{start}-{previous}" if start != previous else str(start))
+        start = previous = value
+    ranges.append(f"{start}-{previous}" if start != previous else str(start))
+    return ", ".join(ranges)
+
+
+def _normalize_flexible_location_value(value: Any) -> int | str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return _validate_positive_integer(value, "location_value")
+
+
+def _validate_optional_page_number(value: int | None) -> None:
+    if value is not None:
+        _validate_positive_integer(value, "page_number")
+
+
+def _parse_positive_integer(value: str, field: str) -> int:
+    return _validate_positive_integer(int(value), field)
+
+
+def _validate_positive_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ReviewTargetError(f"{field} must be a positive integer.")
+    return value
+
+
+def _normalize_optional_string(value: str | None, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewTargetError(f"{field} must be a non-empty string.")
+    return value.strip()

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -56,11 +56,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["11"] + _exit_assignment_review_actions_to_main()
+    return ["12"] + _exit_assignment_review_actions_to_main()
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "11"] + _exit_assignment_review_actions_to_main()
+    return ["", "12"] + _exit_assignment_review_actions_to_main()
 
 
 def _write_workspace(root: Path) -> None:
@@ -285,7 +285,7 @@ def test_selected_student_review_menu_includes_feedback_export(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
-    assert "9. Export student feedback" in output
+    assert "10. Export student feedback" in output
 
 
 def test_menu_export_student_feedback_creates_feedback_file(
@@ -325,7 +325,7 @@ def test_menu_export_student_feedback_creates_feedback_file(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "1"]
+        + ["10", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -427,7 +427,7 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "2"]
+        + ["10", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -458,7 +458,7 @@ def test_menu_export_feedback_reports_missing_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "1"]
+        + ["10", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -492,7 +492,7 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "1", "1"]
+        + ["10", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -526,7 +526,7 @@ def test_menu_export_feedback_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "1", "2"]
+        + ["10", "1", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -226,11 +226,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["11", "6", "", "4", "6"]
+    return ["12", "6", "", "4", "6"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "11", "6", "", "4", "6"]
+    return ["", "12", "6", "", "4", "6"]
 
 
 @pytest.fixture
@@ -252,13 +252,14 @@ def test_review_menu_selected_student_shows_review_entry_actions(
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
     assert "1. Open submission evidence" in output
-    assert "2. Record minimum requirement checks" in output
-    assert "3. Manage submission pages" in output
-    assert "4. Add teacher note" in output
-    assert "5. Add structured tag" in output
-    assert "6. Select reusable comment" in output
-    assert "7. Set criterion score" in output
-    assert "8. Update submission review state" in output
+    assert "2. View current review details" in output
+    assert "3. Record minimum requirement checks" in output
+    assert "4. Manage submission pages" in output
+    assert "5. Add teacher note" in output
+    assert "6. Add structured tag" in output
+    assert "7. Select reusable comment" in output
+    assert "8. Set criterion score" in output
+    assert "9. Update submission review state" in output
     assert "Review record: not started" in output
     assert not review_record_path(
         workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
@@ -278,7 +279,7 @@ def test_review_menu_blank_note_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["4", ""]
+        + ["5", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -302,7 +303,7 @@ def test_review_menu_records_minimum_requirement_check(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["2", "1", "1", "", "", "b"]
+        + ["3", "1", "1", "", "", "b"]
         + _exit_selected_student_to_main(),
     )
 
@@ -350,7 +351,7 @@ def test_review_menu_reports_no_minimum_requirements_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["2", ""]
+        + ["3", ""]
         + _exit_selected_student_to_main(),
     )
 
@@ -370,7 +371,7 @@ def test_review_menu_adds_structured_tag_to_review_record(
         monkeypatch,
         _enter_selected_student()
         + [
-            "5",
+            "6",
             "2",
             "claim",
             "1",
@@ -390,6 +391,154 @@ def test_review_menu_adds_structured_tag_to_review_record(
     assert review["review_state"] == "in_progress"
 
 
+def test_review_target_invalid_choice_reprompts_then_saves_valid_target(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + [
+            "6",
+            "2",
+            "claim",
+            "1",
+            "y",
+            "",
+            "",
+            "",
+            "",
+            "9",
+            "2",
+            "2",
+        ]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Invalid selection. Please enter a number from 1 to 5 or B." in output
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert review["tags"][0]["location"] == {"type": "paragraph", "value": 2}
+
+
+def test_review_target_invalid_paragraph_reprompts_then_saves_valid_target(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + [
+            "6",
+            "2",
+            "claim",
+            "1",
+            "y",
+            "",
+            "",
+            "",
+            "",
+            "2",
+            "2,,4",
+            "2-3",
+        ]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Invalid paragraph target: Paragraph entries must not be empty." in output
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert review["tags"][0]["location"] == {"type": "paragraph", "value": [2, 3]}
+
+
+@pytest.mark.parametrize("target_back", ["", "b"])
+def test_review_target_back_cancels_without_writing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    target_back: str,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + [
+            "6",
+            "2",
+            "claim",
+            "1",
+            "y",
+            "",
+            "",
+            "",
+            "",
+            target_back,
+        ]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    assert "Add tag canceled." in capsys.readouterr().out
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_invalid_review_target_then_back_does_not_write_or_modify_submission(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = submission_manifest_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    manifest_before = manifest_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + [
+            "6",
+            "2",
+            "claim",
+            "1",
+            "y",
+            "",
+            "",
+            "",
+            "",
+            "9",
+            "",
+        ]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Invalid selection. Please enter a number from 1 to 5 or B." in output
+    assert not review_record_path(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+    assert manifest_path.read_bytes() == manifest_before
+
+
 def test_review_menu_selects_reusable_tag_by_bank_and_category(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -404,7 +553,16 @@ def test_review_menu_selects_reusable_tag_by_bank_and_category(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "1", "1", "1", "1", "The explanation names the idea only."]
+        + [
+            "6",
+            "1",
+            "1",
+            "1",
+            "1",
+            "The explanation names the idea only.",
+            "2",
+            "2-4",
+        ]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -429,6 +587,7 @@ def test_review_menu_selects_reusable_tag_by_bank_and_category(
     assert tag["severity"] == 2
     assert tag["criterion_id"] == "explanation"
     assert tag["teacher_note"] == "The explanation names the idea only."
+    assert tag["location"] == {"type": "paragraph", "value": [2, 3, 4]}
     assert "standard_id" not in tag
     assert review["review_state"] == "in_progress"
     assert manifest_path.read_bytes() == manifest_before
@@ -444,7 +603,7 @@ def test_reusable_tag_back_returns_one_level_at_a_time(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", "1", "1", "1", "b", "b", "b"]
+        + ["6", "1", "1", "1", "b", "b", "b"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -470,7 +629,7 @@ def test_review_menu_blank_tag_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", ""]
+        + ["6", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -494,7 +653,7 @@ def test_review_menu_no_comment_banks_returns_safely(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "1"]
+        + ["7", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -520,7 +679,7 @@ def test_review_menu_selects_reusable_comment_by_number(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "1", "1", "1", "1", "1"]
+        + ["7", "1", "1", "1", "1", "2", "2", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -534,6 +693,7 @@ def test_review_menu_selects_reusable_comment_by_number(
     )
     assert review["comments"][0]["bank_id"] == BANK_ID
     assert review["comments"][0]["comment_id"] == "focus_is_clear"
+    assert review["comments"][0]["location"] == {"type": "paragraph", "value": 2}
     assert review["review_state"] == "in_progress"
     assert manifest_path.read_bytes() == manifest_before
 
@@ -575,7 +735,7 @@ def test_comment_bank_created_by_workflow_is_selectable_in_review(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "1", "1", "1", "1", "1"]
+        + ["7", "1", "1", "1", "1", "5", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -615,7 +775,7 @@ def test_review_menu_sets_criterion_score(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "evidence", "Evidence", "3", "4", "", ""]
+        + ["8", "evidence", "Evidence", "3", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -646,7 +806,7 @@ def test_review_menu_scores_from_assignment_rubric(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1", "1", "1", "2", "Private score note"]
+        + ["8", "1", "1", "1", "2", "Private score note"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -675,7 +835,7 @@ def test_review_menu_missing_rubric_keeps_custom_score_available(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1", "1", "Evidence", "", "2", "4", "", ""]
+        + ["8", "1", "1", "Evidence", "", "2", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -702,7 +862,7 @@ def test_review_menu_blank_score_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", ""]
+        + ["8", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -754,7 +914,7 @@ def test_review_menu_invalid_score_does_not_corrupt_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "evidence", "Evidence", "5", "4", "", ""]
+        + ["8", "evidence", "Evidence", "5", "4", "", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -776,7 +936,7 @@ def test_review_menu_invalid_state_does_not_corrupt_manifest(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "not_a_state"]
+        + ["9", "not_a_state"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -222,7 +222,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "11", "6", "", "4", "6"])
+    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "12", "6", "", "4", "6"])
 
     assert main(["menu"]) == 0
 
@@ -267,7 +267,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "11", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "12", "6", "", "4", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -277,6 +277,62 @@ def test_review_summary_includes_existing_review_record_counts(
     assert "Review record state: in_progress" in output
     assert "Notes: 1" in output
     assert "Tags: 0" in output
+    assert review_path.read_bytes() == review_before
+
+
+def test_review_menu_views_current_review_details_read_only(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review = _review_record()
+    review["tags"] = [
+        {
+            "tag_id": "tag_0001",
+            "label": "Clear evidence",
+            "polarity": "positive",
+            "location": {"type": "paragraph", "value": 2},
+            "created_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    review["comments"] = [
+        {
+            "comment_record_id": "comment_record_0001",
+            "label": "Explain evidence",
+            "text": "Explain how this evidence supports the claim.",
+            "source": "custom",
+            "include_in_feedback": True,
+            "location": {"type": "paragraph", "value": [3, 4]},
+            "created_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    review_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "review.json"
+    )
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    review_before = review_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        ["2", "1", "1", "1", "1", "1", "2", "", "12", "6", "", "4", "6"],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Current Review Details" in output
+    assert "[positive] Clear evidence" in output
+    assert "Target: Paragraph 2" in output
+    assert "Explain evidence" in output
+    assert "Target: Paragraphs 3-4" in output
     assert review_path.read_bytes() == review_before
 
 
@@ -315,7 +371,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "", "11", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "", "12", "6", "", "4", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -361,10 +417,10 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "1",
             "1",
             "1",
-            "4",
+            "5",
             "This is a test note.",
             "",
-            "11",
+            "12",
             "6",
             "",
             "4",
@@ -404,11 +460,11 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "1",
-            "8",
+            "9",
             "in_progress",
             "1",
             "",
-            "11",
+            "12",
             "6",
             "",
             "4",
@@ -456,12 +512,12 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
             "1",
             "1",
             "1",
-            "3",
+            "4",
             "1",
             "1",
             "1",
             "",
-            "11",
+            "12",
             "6",
             "",
             "4",

--- a/tests/test_review_comments.py
+++ b/tests/test_review_comments.py
@@ -90,6 +90,57 @@ def test_creates_snapshotted_comment_without_mutating_sources(tmp_path: Path) ->
     assert bank_path.read_bytes() == bank_before
 
 
+def test_add_review_comment_stores_paragraph_target_without_mutating_manifest(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+    manifest_before = manifest_path.read_bytes()
+
+    result = _add(
+        tmp_path,
+        page_number=1,
+        evidence_id="evidence_001",
+        location_type="paragraph",
+        location_value=[2, 3],
+    )
+
+    written = json.loads(result.review_record_path.read_text(encoding="utf-8"))
+    comment = written["comments"][0]
+    assert comment["page_number"] == 1
+    assert comment["evidence_id"] == "evidence_001"
+    assert comment["location"] == {"type": "paragraph", "value": [2, 3]}
+    assert manifest_path.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"page_number": 3}, "does not exist"),
+        ({"evidence_id": "missing"}, "does not exist"),
+        ({"page_number": 1, "evidence_id": "evidence_002"}, "occurs on page 2"),
+        (
+            {"location_type": "paragraph", "location_value": [2, 2]},
+            "more than once",
+        ),
+    ],
+)
+def test_invalid_comment_target_is_rejected(
+    tmp_path: Path,
+    overrides: dict[str, Any],
+    message: str,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_bank(tmp_path)
+
+    with pytest.raises(ReviewCommentError, match=message):
+        _add(tmp_path, **overrides)
+
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+
+
 @pytest.mark.parametrize(
     ("override", "expected"),
     [(True, True), (False, False), (None, True)],

--- a/tests/test_review_record.py
+++ b/tests/test_review_record.py
@@ -393,6 +393,42 @@ def test_page_location_must_agree_with_page_number() -> None:
         validate_review_record(record)
 
 
+@pytest.mark.parametrize("value", [2, [2, 3, 4]])
+def test_tag_paragraph_location_values_are_valid(value: int | list[int]) -> None:
+    record = _record()
+    tag = _tag()
+    tag["location"] = {"type": "paragraph", "value": value}
+    record["tags"] = [tag]
+
+    validate_review_record(record)
+
+
+@pytest.mark.parametrize("value", [2, [2, 3, 4]])
+def test_comment_paragraph_location_values_are_valid(value: int | list[int]) -> None:
+    record = _record()
+    comment = _comment()
+    comment["page_number"] = 1
+    comment["evidence_id"] = "evidence_001"
+    comment["location"] = {"type": "paragraph", "value": value}
+    record["comments"] = [comment]
+
+    validate_review_record(record)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0, -1, True, 2.5, "", [], [1, 1], [1, 0], [1, "two"]],
+)
+def test_invalid_paragraph_location_value_is_rejected(value: Any) -> None:
+    record = _record()
+    tag = _tag()
+    tag["location"] = {"type": "paragraph", "value": value}
+    record["tags"] = [tag]
+
+    with pytest.raises(ReviewRecordError, match="location"):
+        validate_review_record(record)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [

--- a/tests/test_review_snapshot.py
+++ b/tests/test_review_snapshot.py
@@ -1,0 +1,137 @@
+"""Tests for read-only current review detail snapshots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.review_snapshot import current_review_details_text
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID
+
+TIMESTAMP = "2026-06-22T12:00:00+00:00"
+
+
+def _review() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_review",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "submission_manifest_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/submission.json"
+        ),
+        "review_state": "in_progress",
+        "notes": [
+            {
+                "note_id": "note_0001",
+                "text": "Needs conference about missing counterargument.",
+                "created_at": TIMESTAMP,
+                "updated_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "tags": [
+            {
+                "tag_id": "tag_0001",
+                "label": "Evidence needs more explanation",
+                "polarity": "developing",
+                "source": "custom",
+                "page_number": 1,
+                "location": {"type": "paragraph", "value": [3, 4]},
+                "created_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "scores": [
+            {
+                "score_id": "score_0001",
+                "criterion_id": "evidence",
+                "label": "Evidence",
+                "score": 3,
+                "max_score": 4,
+                "teacher_note": "Relevant evidence, uneven explanation.",
+                "updated_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "comments": [
+            {
+                "comment_record_id": "comment_record_0001",
+                "source": "comment_bank",
+                "bank_id": "argument_writing",
+                "comment_id": "evidence_needs_explanation",
+                "label": "Evidence needs more explanation",
+                "text": "The evidence is relevant, but explain the connection.",
+                "include_in_feedback": True,
+                "location": {"type": "paragraph", "value": 2},
+                "created_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "requirement_checks": [
+            {
+                "requirement_check_id": "requirement_check_0001",
+                "requirement_key": "paragraphs_min",
+                "label": "Minimum paragraphs",
+                "expected": 4,
+                "met": False,
+                "updated_at": TIMESTAMP,
+                "module_details": {},
+            }
+        ],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def test_current_review_details_handles_missing_record(tmp_path: Path) -> None:
+    text = current_review_details_text(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+
+    assert text.startswith("No review record exists yet for this student.")
+    assert "Quillan" not in text
+    assert "Current Review Details" not in text
+    assert "No review record exists yet for this student." in text
+    assert not list(tmp_path.rglob("review.json"))
+
+
+def test_current_review_details_formats_saved_artifacts(tmp_path: Path) -> None:
+    path = review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    write_review_record(path, _review())
+    before = path.read_bytes()
+
+    text = current_review_details_text(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+
+    assert text.startswith("Review record: exists\nReview state: in_progress")
+    assert "Quillan" not in text
+    assert "Current Review Details" not in text
+    assert "Review record: exists" in text
+    assert "Minimum paragraphs: not met" in text
+    assert "[developing] Evidence needs more explanation" in text
+    assert "Target: Page 1, paragraphs 3-4" in text
+    assert "Target: Paragraph 2" in text
+    assert "Include in feedback: yes" in text
+    assert "Evidence: 3 / 4" in text
+    assert "Needs conference about missing counterargument." in text
+    assert path.read_bytes() == before
+
+
+def test_current_review_details_formats_empty_sections(tmp_path: Path) -> None:
+    review = _review()
+    for field in ("notes", "tags", "scores", "comments", "requirement_checks"):
+        review[field] = []
+    path = review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    write_review_record(path, review)
+
+    text = current_review_details_text(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+
+    assert "No tags recorded." in text
+    assert "No comments recorded." in text
+    assert "No scores recorded." in text
+    assert "No notes recorded." in text
+    assert json.loads(path.read_text(encoding="utf-8")) == review

--- a/tests/test_review_tags.py
+++ b/tests/test_review_tags.py
@@ -308,6 +308,30 @@ def test_creates_structured_tag_without_mutating_submission_or_evidence(
     assert retained_path.read_bytes() == b"retained source"
 
 
+def test_add_review_tag_stores_multiple_paragraph_target(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+
+    result = add_review_tag(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        label="Explain evidence",
+        polarity="developing",
+        page_number=1,
+        location_type="paragraph",
+        location_value=[2, 3, 4],
+        created_at=FIRST_TAG_TIMESTAMP,
+    )
+
+    written = json.loads(result.review_record_path.read_text(encoding="utf-8"))
+    assert written["tags"][0]["page_number"] == 1
+    assert written["tags"][0]["location"] == {
+        "type": "paragraph",
+        "value": [2, 3, 4],
+    }
+
+
 def test_appends_tag_and_preserves_existing_review_sections(tmp_path: Path) -> None:
     _write_manifest(tmp_path)
     original = _review()
@@ -414,6 +438,10 @@ def test_tag_id_uses_highest_conforming_sequence(tmp_path: Path) -> None:
         (
             {"location_type": "paragraph", "location_value": "two"},
             "positive integer",
+        ),
+        (
+            {"location_type": "paragraph", "location_value": [2, 2]},
+            "more than once",
         ),
         (
             {"location_type": "whole_submission", "location_value": 1},

--- a/tests/test_review_targets.py
+++ b/tests/test_review_targets.py
@@ -1,0 +1,74 @@
+"""Tests for shared review target helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from quillan.review_targets import (
+    ReviewTargetError,
+    format_review_target,
+    parse_paragraph_selection,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("2", 2),
+        ("2-4", [2, 3, 4]),
+        ("2,4,6", [2, 4, 6]),
+        ("2, 4-6", [2, 4, 5, 6]),
+    ],
+)
+def test_parse_paragraph_selection(raw: str, expected: int | list[int]) -> None:
+    assert parse_paragraph_selection(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "3-2", "2,,4", "two", "2.5", "2,2"])
+def test_parse_paragraph_selection_rejects_invalid_input(raw: str) -> None:
+    with pytest.raises(ReviewTargetError):
+        parse_paragraph_selection(raw)
+
+
+@pytest.mark.parametrize(
+    ("item", "expected"),
+    [
+        ({"location": {"type": "paragraph", "value": 2}}, "Paragraph 2"),
+        (
+            {"location": {"type": "paragraph", "value": [2, 3, 4]}},
+            "Paragraphs 2-4",
+        ),
+        ({"page_number": 1}, "Page 1"),
+        (
+            {"page_number": 1, "location": {"type": "paragraph", "value": [2, 3]}},
+            "Page 1, paragraphs 2-3",
+        ),
+        ({"evidence_id": "evidence_001"}, "Evidence evidence_001"),
+        (
+            {"page_number": 1, "evidence_id": "evidence_001"},
+            "Page 1, Evidence evidence_001",
+        ),
+        (
+            {
+                "page_number": 1,
+                "evidence_id": "evidence_001",
+                "location": {"type": "paragraph", "value": [2, 3]},
+            },
+            "Page 1, paragraphs 2-3, Evidence evidence_001",
+        ),
+        (
+            {
+                "evidence_id": "evidence_001",
+                "location": {"type": "paragraph", "value": [2, 3]},
+            },
+            "Paragraphs 2-3, Evidence evidence_001",
+        ),
+        (
+            {"location": {"type": "whole_submission", "value": None}},
+            "Whole submission",
+        ),
+        ({}, "Not specified"),
+    ],
+)
+def test_format_review_target(item: dict[str, object], expected: str) -> None:
+    assert format_review_target(item) == expected


### PR DESCRIPTION
## Summary

Adds paragraph/page/evidence targets for review artifacts and a read-only Current Review Details view for selected-student review.

Closes #183

## Changes

* Added shared review target helpers in `quillan/review_targets.py`.
* Added read-only current review snapshot support in `quillan/review_snapshot.py`.
* Added `View current review details` to Selected Student Review.
* Added paragraph and multi-paragraph target support for tags.
* Added optional `page_number`, `evidence_id`, and `location` support for selected comments.
* Reusable tags now prompt for a target before saving.
* Reusable comments now prompt for a target and show it on the confirmation screen.
* Current Review Details shows saved:

  * requirement checks
  * notes
  * tags
  * comments
  * scores
  * targets
  * source/provenance
  * include-in-feedback choices
* Invalid target input now reprompts instead of canceling the workflow.
* Current Review Details avoids duplicate menu headers.
* Evidence target formatting now preserves evidence IDs alongside page/paragraph targets.

## Selected Student Review Menu

```text
1. Open submission evidence
2. View current review details
3. Record minimum requirement checks
4. Manage submission pages
5. Add teacher note
6. Add structured tag
7. Select reusable comment
8. Set criterion score
9. Update submission review state
10. Export student feedback
11. Refresh summary
12. Back
```

## Target Storage

Single paragraph:

```json
"location": {
  "type": "paragraph",
  "value": 2
}
```

Multiple paragraphs:

```json
"location": {
  "type": "paragraph",
  "value": [2, 3, 4]
}
```

Page targets use:

```json
"page_number": 1
```

Page plus paragraphs stores both:

```json
"page_number": 1,
"location": {
  "type": "paragraph",
  "value": [2, 3]
}
```

Evidence targets use:

```json
"evidence_id": "evidence_001"
```

## Paragraph Parser

Accepted examples:

* `2`
* `2-4`
* `2,4,6`
* `2, 4-6`

Rejected examples:

* `0`
* `-1`
* `3-2`
* `2,,4`
* `two`
* `2.5`
* duplicate paragraph entries

Invalid menu input now reprompts rather than canceling the workflow. `B` or blank still backs out cleanly.

## Current Review Details

The new detail view is terminal-only and read-only.

It displays the current student’s saved review artifacts without generating an export file and without modifying `review.json`, `submission.json`, or evidence files.

It handles:

* missing review records;
* empty review sections;
* saved tags and comments;
* paragraph/page/evidence targets;
* feedback-inclusion settings;
* source/provenance;
* requirement checks;
* scores;
* notes.

## Safety

This PR does not:

* parse student writing
* run OCR
* use AI
* infer paragraph numbers
* infer where feedback belongs
* change scores
* change requirement checks
* modify `submission.json`
* delete evidence
* modify routed evidence files
* modify rosters
* modify assignments
* modify review materials
* modify pds-core standards
* modify pds-core routes
* modify sibling repositories

Targets are teacher-entered metadata stored in `review.json`.

Current Review Details is read-only.

## Documentation

Updated:

* `README.md`
* `docs/cli_contract.md`
* `docs/teacher_review_model.md`
* `docs/review_record_contract.md`

Docs now explain:

* tags and comments can have optional teacher-entered targets;
* comments support `page_number`, `evidence_id`, and `location`;
* paragraph targets may be single integers or lists of positive integers;
* Quillan does not infer targets from student writing;
* Current Review Details is terminal-only and read-only;
* Current Review Details is separate from full reporting and student feedback export.

## Tests

Added:

* `tests/test_review_targets.py`
* `tests/test_review_snapshot.py`

Updated tests for:

* selected-student review menu numbering;
* reusable tag target prompts;
* reusable comment target prompts;
* comment target storage;
* tag multi-paragraph targets;
* review-record validation;
* current review detail display;
* invalid target input reprompting;
* evidence target formatting;
* export/menu regressions.

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `1087 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
