### PR TITLE
Document prepared review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # Quillan
 
-Quillan is a local-first standards-based writing evidence capture system for teachers.
+Quillan is a local-first, subject-agnostic prepared-review system for
+teachers reviewing written student work.
 
-It helps teachers organize, review, tag, score, and respond to student writing by connecting specific written work to standards, comments, rubric scores, review states, and structured instructional data.
+It helps teachers organize, review, tag, score, and respond to written
+responses by connecting specific student evidence to standards metadata,
+comments, rubric scores, review states, and structured instructional data.
+
+Quillan is not an ELA-only grader. It supports written response review across
+subjects, including English / ELA, history / social studies, science, computer
+science, technical writing, world languages, arts/humanities, and
+interdisciplinary writing tasks. NJ ELA starter materials are one optional
+installable starter pack, not the identity of the whole application.
 
 Quillan is part of the broader Paper Data Suite concept, alongside ScoreForm.
 
@@ -83,11 +92,30 @@ Opening evidence delegates only to the local system viewer. Exports are derived 
 
 Quillan is not an AI essay grader.
 
-It is a teacher-controlled system for turning student writing into structured instructional evidence.
+It is a teacher-controlled system for turning written student work into
+structured instructional evidence.
 
 Teacher judgment remains primary. Teachers read the work, decide what matters, choose tags and comments, enter scores, and decide review state.
 
 Quillan may eventually help summarize teacher-created data, but final scoring and feedback decisions belong to the teacher.
+
+## Prepared Review Workflow
+
+Teachers prepare reusable review materials before grading, then select and
+snapshot those materials while reviewing actual student evidence. Comment
+banks provide student-facing feedback language, tag banks provide structured
+teacher observations, rubrics/scoring profiles provide reusable criteria and
+levels, notes remain private teacher context, and requirement checks document
+teacher-confirmed assignment conditions.
+
+Selected comments, tags, and rubric scores are copied into `review.json` with
+source provenance. Later edits to source banks or rubrics do not silently
+change old reviews. Student feedback, class summaries, and standards summaries
+are derived from teacher-confirmed review records, not live source banks.
+
+The full subject-agnostic workflow, storage map, snapshot behavior, and
+starter-material boundaries are documented in
+[`docs/prepared_review_workflow.md`](docs/prepared_review_workflow.md).
 
 ## Implemented v0.8.0 Workflow
 
@@ -751,6 +779,12 @@ The canonical teacher-review `review.json` contract is documented in:
 docs/review_record_contract.md
 ```
 
+The subject-agnostic prepared-review workflow is documented in:
+
+```text
+docs/prepared_review_workflow.md
+```
+
 The printable response contract and implemented generator are described in:
 
 ```text
@@ -761,6 +795,12 @@ The shared workspace layout and the distinction between active and reserved path
 
 ```text
 docs/workspace_lifecycle.md
+```
+
+The rubric / scoring profile contract is documented in:
+
+```text
+docs/rubric_contract.md
 ```
 
 The scan-routing rules and failure behavior are documented in:

--- a/docs/comment_bank_contract.md
+++ b/docs/comment_bank_contract.md
@@ -26,8 +26,8 @@ student's review by itself.
 This document defines comment bank schema version `1`. Runtime loading,
 validation, direct student-facing selection, and teacher-facing creation and
 editing through Review Student Work -> Manage Review Materials -> Comment
-Banks are implemented. Assignment
-activation, automatic suggestions, and AI-generated comments are not.
+Banks are implemented. Assignment activation, automatic suggestions,
+automatic feedback, and AI-generated comments are not.
 
 Teachers can create, view, edit, extend, and validate shared banks from:
 
@@ -46,6 +46,11 @@ Comment-bank authoring is subject-agnostic and writing-type-aware. Banks may
 support essays, constructed responses, lab reports, reflections, research
 papers, mathematical explanations, technical documentation, design rationale,
 portfolio reflection, and other local written-work contexts.
+
+For the full prepared-review workflow and the relationship among comment
+banks, tag banks, rubrics, notes, requirement checks, review targets, exports,
+and snapshots, see
+[`prepared_review_workflow.md`](prepared_review_workflow.md).
 
 Optional `standard_ids` are durable pds-core references only. Quillan stores
 them as metadata but does not create, import, edit, retire, reactivate, or

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -18,6 +18,11 @@ contract is implemented and used by printable PDF generation.
 For the expected workspace layout and file lifecycle of these records, see
 [`workspace_lifecycle.md`](workspace_lifecycle.md).
 
+For the subject-agnostic prepared-review workflow, including the differences
+among reusable materials, source evidence, review artifacts, exports, snapshot
+behavior, and starter-material boundaries, see
+[`prepared_review_workflow.md`](prepared_review_workflow.md).
+
 For the teacher-controlled relationship among evidence, review artifacts,
 scores, feedback, and reports, see
 [`teacher_review_model.md`](teacher_review_model.md).
@@ -53,7 +58,12 @@ For the required structure and human-readable elements of a printable
 writing-response page, see
 [`printable_response_template.md`](printable_response_template.md).
 
-All examples must use synthetic data only. No real student names, writing, rosters, scores, or personally identifiable student information should be committed to the repository.
+All examples must use synthetic data only. No real student names, writing,
+rosters, scores, or personally identifiable student information should be
+committed to the repository. ELA starter files are examples of one
+subject-specific starter pack. They do not make Quillan's data contracts
+ELA-specific, and ordinary examples should remain synthetic unless they are
+explicitly starter-material content.
 
 ## Design Principles
 
@@ -81,7 +91,8 @@ Quillan does not store or validate an independent standards-profile JSON shape. 
 
 ## Shared Comment Bank
 
-A shared comment bank is reusable teacher-authored source data stored at:
+A shared comment bank is subject-agnostic, reusable teacher-authored feedback
+language stored at:
 
 ```text
 shared/comment_banks/<bank_id>.json
@@ -115,7 +126,8 @@ validate standards through comment-bank workflows.
 
 ## Shared Tag Bank
 
-A shared tag bank is reusable teacher-authored source data stored at:
+A shared tag bank is subject-agnostic, reusable teacher-authored observation
+source data stored at:
 
 ```text
 shared/tag_banks/<tag_bank_id>.json
@@ -487,51 +499,37 @@ writing area, and output location are defined in
 ## Requirements Check
 
 A requirements check records structural or compliance information about basic
-assignment conditions. It may be manually entered, teacher-confirmed, or
-eventually computed for low-risk facts such as word count or paragraph count.
-It remains separate from writing-quality scoring and does not determine a
-score or feedback decision.
+assignment conditions. Current Quillan requirement checks are teacher-entered
+booleans generated from assignment `basic_requirements`. They remain separate
+from writing-quality scoring and do not determine a score or feedback
+decision.
 
-Suggested path:
+Storage location:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/requirements.json
+review.json.requirement_checks
 ```
 
-Requirement status values:
+Quillan does not count words, count paragraphs, parse writing, run OCR, use
+AI, or infer whether a required element is present. The teacher records
+whether each requirement was met.
 
-* `met`
-* `partially_met`
-* `not_met`
-* `not_checked`
-
-Example:
+Example item:
 
 ```json
 {
-  "submission_id": "sub_0001_villainy_final_essay_synthetic",
-  "student_id": "stu_0001",
-  "assignment_id": "villainy_final_essay_synthetic",
-  "requirements_check": {
-    "paragraph_count": {
-      "expected_min": 4,
-      "expected_max": 6,
-      "actual": 5,
-      "status": "met"
-    },
-    "word_count": {
-      "expected_min": 500,
-      "actual": 487,
-      "status": "partially_met"
-    },
-    "required_elements": {
-      "thesis": "met",
-      "textual evidence": "met",
-      "comparative reasoning": "partially_met"
-    }
-  }
+  "requirement_check_id": "requirement_check_0001",
+  "requirement_key": "required_elements:claim",
+  "label": "Required element: claim",
+  "expected": "claim",
+  "met": true,
+  "updated_at": "2026-06-29T00:00:00+00:00",
+  "module_details": {}
 }
 ```
+
+The complete current shape is defined in
+[`review_record_contract.md`](review_record_contract.md#requirement-checks).
 
 ## Review Tags and Scores
 

--- a/docs/nj_ela_starter_materials.md
+++ b/docs/nj_ela_starter_materials.md
@@ -11,6 +11,12 @@ common high school ELA writing tasks and 2023 NJSLS-ELA references. They are
 not official state curriculum, not district grading policy, and not automatic
 evaluation.
 
+Quillan is not an ELA-only grader. These files are one optional installable
+starter pack for ELA classrooms; Quillan's comment-bank, tag-bank, rubric,
+assignment, submission, and review-record structures remain subject-agnostic.
+For the general prepared-review model, see
+[`prepared_review_workflow.md`](prepared_review_workflow.md).
+
 ## What Is Included
 
 Each grade band includes comment banks, tag banks, and rubrics for:

--- a/docs/prepared_review_workflow.md
+++ b/docs/prepared_review_workflow.md
@@ -1,0 +1,236 @@
+# Prepared Review Workflow
+
+## Purpose
+
+Quillan is a local-first prepared-review system for written student work.
+Teachers prepare reusable review materials before grading, then select and
+snapshot the relevant comments, tags, rubric scores, notes, targets, and
+requirement checks while reviewing actual student evidence.
+
+This workflow is teacher-controlled. Quillan helps organize review decisions;
+it does not read student work, generate feedback, score automatically, infer
+mastery, run OCR, or use AI.
+
+## Subject-Agnostic Design
+
+Quillan is subject-agnostic. It is designed for teacher review of written
+responses across disciplines. ELA starter materials are included as one
+optional starter pack, but the underlying comment-bank, tag-bank, rubric,
+assignment, submission, and review-record structures are not ELA-specific.
+
+Useful local contexts include English / ELA, history / social studies,
+science, computer science, technical writing, world languages,
+arts/humanities, and interdisciplinary writing tasks. Subject-neutral review
+materials can support claim/evidence/reasoning responses, lab explanations,
+research responses, reflection journals, technical explanations, design
+rationales, and short constructed responses.
+
+## Review Materials
+
+Reusable review materials live under `shared/`. They are prepared before or
+between reviews and selected during review. Selected values are copied into
+`review.json` so old reviews stay stable when source materials change later.
+
+### Comment Banks
+
+Comment banks are reusable student-facing feedback language stored at:
+
+```text
+shared/comment_banks/<bank_id>.json
+```
+
+They are selected into `review.json.comments` and copied at selection time.
+They may include `include_in_feedback_default`, standards metadata, criterion
+metadata, and writing-type metadata. They can be used across assignments and
+subjects.
+
+Comment banks are not automatic feedback, AI feedback, grades, or student
+records.
+
+### Tag Banks
+
+Tag banks are reusable teacher observations stored at:
+
+```text
+shared/tag_banks/<tag_bank_id>.json
+```
+
+They support fast review, grouping, and reporting. A tag template may include
+polarity, severity, standards metadata, criterion IDs, and a private note
+prompt. Selected tags are copied into `review.json.tags`.
+
+Tag banks are not scores, automatic suggestions, proof of mastery, or
+student-facing feedback by default.
+
+### Rubrics / Scoring Profiles
+
+Rubrics and scoring profiles are reusable criteria and levels stored at:
+
+```text
+shared/rubrics/<rubric_id>.json
+```
+
+They help teachers select criterion scores during review. Selected scores are
+snapshotted into `review.json.scores`.
+
+Rubrics do not automatically grade, calculate percentages, calculate final
+grades, infer mastery, or turn level feedback metadata into comments.
+
+### Notes
+
+Notes are private, freeform teacher observations stored in:
+
+```text
+review.json.notes
+```
+
+They support teacher memory, review process notes, private context, and
+conference reminders. Notes are not student-facing feedback exports,
+structured reporting data, or scores.
+
+### Requirement Checks
+
+Requirement checks are teacher-entered booleans generated from assignment
+`basic_requirements` and stored in:
+
+```text
+review.json.requirement_checks
+```
+
+They document whether basic assignment conditions were met and help teachers
+review consistently. They are not automatic counting, OCR, AI, quality
+scoring, or grade calculation.
+
+### Review Targets
+
+Tags and comments may include teacher-entered target metadata:
+
+```text
+review.json.tags[].page_number
+review.json.tags[].evidence_id
+review.json.tags[].location
+review.json.comments[].page_number
+review.json.comments[].evidence_id
+review.json.comments[].location
+```
+
+Targets point feedback to a paragraph, page, evidence item, whole submission,
+or another controlled location. They are not automatic paragraph detection,
+OCR, AI, or text parsing.
+
+## Before Review
+
+1. Create or select standards/profile data in pds-core if standards are being used.
+2. Create or select a Quillan assignment.
+3. Prepare or install comment banks.
+4. Prepare or install tag banks.
+5. Prepare or install rubrics/scoring profiles.
+6. Print response pages when using the paper workflow.
+7. Scan, route, and assemble student submissions.
+8. Confirm each selected student has reviewable evidence.
+
+Standards are optional metadata references. Quillan does not own or mutate
+pds-core standards definitions, standards profiles, or route helpers.
+
+## During Review
+
+1. Select class, assignment, and student.
+2. Open submission evidence.
+3. View current review details if resuming work.
+4. Record minimum requirement checks when applicable.
+5. Add reusable or custom tags.
+6. Add reusable comments.
+7. Add page, paragraph, or evidence targets when helpful.
+8. Score rubric criteria or use custom scoring.
+9. Add private notes only when needed.
+10. Update review state.
+11. Export student feedback.
+12. Export assignment summaries when needed.
+
+These are teacher workflow actions. Opening evidence does not mark a
+submission reviewed, and exporting feedback does not rescore work.
+
+## Snapshot Behavior
+
+When a teacher selects a reusable comment, Quillan stores provenance such as
+`bank_id` and `comment_id`, copies the selected label and text into
+`review.json.comments`, and stores the teacher's feedback-inclusion choice.
+Later edits to the source comment bank do not rewrite previous review records.
+
+When a teacher selects a reusable tag, Quillan stores provenance such as
+`tag_bank_id` and `tag_template_id`, then copies the selected label, polarity,
+severity, and optional metadata into `review.json.tags`. Later edits to the
+source tag bank do not rewrite previous review records.
+
+When a teacher scores from a rubric, Quillan stores the chosen criterion,
+score, max score, scale, and optional teacher note in `review.json.scores`.
+Later edits to the rubric do not rewrite previous review scores.
+
+Student feedback exports and summary exports are derived from `review.json`,
+not live source banks.
+
+## Storage Map
+
+```text
+shared/comment_banks/<bank_id>.json          reusable student-facing comments
+shared/tag_banks/<tag_bank_id>.json          reusable teacher observations
+shared/rubrics/<rubric_id>.json              reusable scoring profiles
+classes/<class_id>/assignments/<assignment_id>/assignment.json
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+```
+
+`submission.json` is source evidence metadata. `review.json` is teacher
+review. Exports are derived artifacts. Reusable review materials live under
+`shared/`.
+
+## Starter Materials
+
+Starter materials are optional, teacher-editable review materials. They are
+not official curriculum, not district grading policy, and not automatic
+evaluation.
+
+Synthetic starter materials are small, portable examples for testing and
+onboarding. NJ ELA starter materials are larger teacher-editable classroom
+starter packs. Both install through the same Starter Materials workflow and
+copy only shared review materials into:
+
+```text
+shared/comment_banks/
+shared/tag_banks/
+shared/rubrics/
+```
+
+Starter installation does not create or modify standards, assignments,
+rosters, scans, submissions, review records, exports, pds-core standards
+files, pds-core standards profiles, or pds-core route helpers.
+
+## Safety Boundaries
+
+Quillan preserves the teacher-controlled model:
+
+* reusable materials do not act until the teacher selects them;
+* source evidence, review artifacts, reusable materials, and exports stay
+  distinct;
+* exports are derived from teacher-confirmed `review.json` records;
+* standards references are optional pds-core metadata;
+* examples and tests must use synthetic data unless they are explicitly
+  labeled starter-material content.
+
+Do not commit real student names, rosters, writing, grades, scans, review
+notes, feedback, exports, or personally identifiable information.
+
+## Related Docs
+
+* [`data_contracts.md`](data_contracts.md)
+* [`comment_bank_contract.md`](comment_bank_contract.md)
+* [`tag_bank_contract.md`](tag_bank_contract.md)
+* [`rubric_contract.md`](rubric_contract.md)
+* [`review_record_contract.md`](review_record_contract.md)
+* [`teacher_review_model.md`](teacher_review_model.md)
+* [`starter_materials.md`](starter_materials.md)
+* [`nj_ela_starter_materials.md`](nj_ela_starter_materials.md)
+* [`workspace_lifecycle.md`](workspace_lifecycle.md)

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -28,6 +28,11 @@ contract. Runtime loading and validation are implemented by
 implemented by `quillan.review_record_paths`. Teacher-facing commands and
 derived exports are implemented for the v0.7 review workflows.
 
+For the subject-agnostic prepared-review workflow that explains how reusable
+materials, source evidence, review artifacts, exports, targets, and snapshots
+fit together, see
+[`prepared_review_workflow.md`](prepared_review_workflow.md).
+
 ## Top-Level Structure
 
 Every version `1` review record contains:

--- a/docs/rubric_contract.md
+++ b/docs/rubric_contract.md
@@ -4,6 +4,13 @@ Rubrics and scoring profiles are teacher-authored reusable review materials.
 They let a teacher score prepared criteria by selecting a criterion and level
 during review instead of typing raw score fields.
 
+Rubrics are subject-agnostic scoring profiles. They define criteria and
+levels; they do not automatically grade, calculate final grades or
+percentages, infer mastery, or generate feedback. For the full
+prepared-review workflow and the relationship among rubrics, comment banks,
+tag banks, notes, requirement checks, review targets, exports, and snapshots,
+see [`prepared_review_workflow.md`](prepared_review_workflow.md).
+
 Quillan stores shared rubric profiles at:
 
 ```text

--- a/docs/starter_materials.md
+++ b/docs/starter_materials.md
@@ -6,6 +6,13 @@ local development, and teacher-editable classroom starting points.
 Starter materials are examples and starting points only. They are not official
 curriculum, not a recommended grading policy, and not a substitute for
 teacher-created local review materials.
+They are not automatic evaluation.
+
+Quillan itself is subject-agnostic. Synthetic examples are portable examples
+for testing and onboarding, while NJ ELA starter materials are one optional
+subject-specific starter pack. Neither group changes the underlying
+prepared-review workflow described in
+[`prepared_review_workflow.md`](prepared_review_workflow.md).
 
 ## What Is Included
 
@@ -25,6 +32,10 @@ banks, and rubrics for argument, informational/expository writing, literary and
 comparative analysis, research writing, narrative/creative writing, poetry,
 journals, reflections, open responses, short responses, short stories, and
 memoir/personal narrative contexts.
+
+Both groups install through the same workflow and copy only shared review
+materials. Neither group creates assignments, rosters, submissions, review
+records, exports, or standards profiles.
 
 The source files live under:
 

--- a/docs/tag_bank_contract.md
+++ b/docs/tag_bank_contract.md
@@ -10,7 +10,14 @@ shared/tag_banks/<tag_bank_id>.json
 ```
 
 Tags are review aids. They are not grades, scores, mastery determinations,
-generated feedback, automatic judgments, or automatic tag suggestions.
+generated feedback, student-facing feedback by default, automatic judgments,
+or automatic tag suggestions.
+
+Tag banks are subject-agnostic and can support teacher observations for
+written work across disciplines. For the full prepared-review workflow and
+the relationship among tag banks, comment banks, rubrics, notes, requirement
+checks, review targets, exports, and snapshots, see
+[`prepared_review_workflow.md`](prepared_review_workflow.md).
 
 Quillan owns tag-bank review-material files. Optional `standard_ids` are
 pds-core durable standard references only; Quillan does not create, import,
@@ -102,7 +109,8 @@ are skipped unless exact overwrite confirmation is provided. See
 
 Review mode can select reusable tags by bank, category, and template. Selected
 values are snapshotted into `review.json.tags` with `source: "tag_bank"`,
-`tag_bank_id`, and `tag_template_id`. Later edits to the source tag bank do not
+`tag_bank_id`, and `tag_template_id`, plus copied label, polarity, optional
+severity, and optional metadata. Later edits to the source tag bank do not
 rewrite prior review records.
 
 Custom one-off tags remain available and existing direct CLI add-tag behavior

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -12,6 +12,12 @@ teacher-approved language, and summarize confirmed records. It must not
 present an unconfirmed software judgment as a teacher evaluation or encourage
 review without reading the student's work.
 
+Quillan is subject-agnostic. It can support teacher review of written
+responses across disciplines, such as lab explanations, research responses,
+reflection journals, technical explanations, design rationales, short
+constructed responses, and ELA writing. ELA starter materials are one optional
+starter pack, not the boundary of the review model.
+
 This document defines the review model and data boundaries. Quillan currently
 validates relevant data contracts, can prepare printable writing-response
 pages, supports direct teacher-entered notes, tags, comments, and criterion
@@ -20,6 +26,10 @@ supports teacher-entered minimum requirement checks from assignment
 configuration, and can export student feedback and assignment summaries. AI
 tagging, AI scoring, AI feedback, automatic requirements evaluation, and
 automatic grading are not implemented.
+
+For the teacher workflow before and during review, including reusable
+materials, snapshot behavior, storage paths, and starter-material boundaries,
+see [`prepared_review_workflow.md`](prepared_review_workflow.md).
 
 ## Source Evidence
 
@@ -69,6 +79,11 @@ where a tag or comment applies.
 Earlier designs named separate `tags.json` and `scores.json` files. Those are
 historical concepts, not alternate active v0.7 records. Their content belongs
 in `review.json`.
+
+Prepared reusable materials, source evidence, teacher-review artifacts, and
+exports serve different roles: source banks and rubrics live under `shared/`,
+`submission.json` describes reviewable evidence, `review.json` stores teacher
+review decisions, and exports are derived from those canonical records.
 
 ## Derived Exports and Reports
 

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -19,6 +19,12 @@ The shared `pds-core` contracts define assignment and submission locations as
 well as the active scan source-retention and routing-review layout.
 Quillan-specific files remain inside those shared routes.
 
+Quillan is subject-agnostic. The workspace layout supports written-response
+review across disciplines; optional NJ ELA starter materials are one
+installable starter pack, not a separate workspace model. For the
+prepared-review sequence and subject-neutral storage map, see
+[`prepared_review_workflow.md`](prepared_review_workflow.md).
+
 ## Workspace vs. Installation
 
 The PDS workspace root is teacher-controlled data storage. It is separate from
@@ -66,6 +72,19 @@ The expected current and reserved layout is:
             class_summary.csv
           debug/
 ```
+
+Reusable prepared-review materials live outside individual assignments:
+
+```text
+<PDS workspace root>/shared/comment_banks/<bank_id>.json
+<PDS workspace root>/shared/tag_banks/<tag_bank_id>.json
+<PDS workspace root>/shared/rubrics/<rubric_id>.json
+```
+
+Starter-material installation is bounded to those shared review-material
+folders. It does not create assignments, rosters, scans, submissions, review
+records, exports, pds-core standards files, pds-core standards profiles, or
+pds-core route helpers.
 
 The active scan paths, assignment directory, `assignment.json`,
 `submissions/`, and each student's submission directory follow shared PDS
@@ -173,10 +192,11 @@ evidence is not rewritten as teacher judgment is added.
 
 ### `submissions/<student_id>/requirements.json`
 
-A future requirements-check result for basic teacher-defined assignment
-requirements. It should record whether requirements were met, partially met,
-not met, or not checked. It is a teacher-review support artifact, not a score.
-Requirements checking is not implemented by this document.
+A reserved future requirements-check location for basic teacher-defined
+assignment requirements. The implemented workflow stores current
+teacher-entered requirement checks in `review.json.requirement_checks`, not in
+a sibling `requirements.json`. Requirement checks are teacher-review support
+artifacts, not scores.
 
 ### `submissions/<student_id>/review.json`
 
@@ -188,8 +208,8 @@ comments, and an explicit `review_state`. It references the adjacent
 `review_state` is independent of `submission_state`; neither state
 automatically determines the other. The complete record contract is defined
 in [`review_record_contract.md`](review_record_contract.md). Loading, writing,
-direct review commands, and derived exports are implemented by the runtime;
-guided teacher-facing menu review is not.
+direct review commands, guided teacher-facing menu review, and derived exports
+are implemented by the runtime.
 
 Earlier separate `tags.json` and `scores.json` designs are historical and are
 not alternate active v0.7 paths.
@@ -251,13 +271,13 @@ tags, selected comments, or feedback export.
 Teacher-review artifacts are records created by the teacher or confirmed
 through teacher review:
 
-* `requirements.json`
 * `review.json`
 
 These records support efficient review while preserving the teacher as the
 source of evaluative judgment. They should remain connected to, but separate
 from, the source evidence. `review.json` is the canonical active v0.7
-container for notes, tags, criterion scores, and selected comments.
+container for notes, tags, criterion scores, selected comments, and
+teacher-entered requirement checks.
 
 ### Derived Exports and Reports
 


### PR DESCRIPTION
## Summary

Documents Quillan’s subject-agnostic prepared-review workflow.

Closes #170

## Added

* `docs/prepared_review_workflow.md`

## Updated

* `README.md`
* `docs/data_contracts.md`
* `docs/comment_bank_contract.md`
* `docs/tag_bank_contract.md`
* `docs/rubric_contract.md`
* `docs/review_record_contract.md`
* `docs/teacher_review_model.md`
* `docs/workspace_lifecycle.md`
* `docs/starter_materials.md`
* `docs/nj_ela_starter_materials.md`

## What Changed

This documentation update explains that Quillan is a subject-agnostic prepared-review system for written student work, not an ELA-only grader.

It documents how teachers prepare reusable review materials before grading, then select and snapshot those materials while reviewing student evidence.

The new workflow doc covers:

* subject-agnostic review design
* comment banks
* tag banks
* rubrics / scoring profiles
* private teacher notes
* teacher-entered requirement checks
* review targets
* student feedback exports
* class and standards summaries
* storage paths
* snapshot behavior
* starter-material boundaries
* safety boundaries

## Key Clarifications

* NJ ELA starter materials are one optional installable starter pack, not the identity of Quillan.
* Comment banks are reusable student-facing feedback language.
* Tag banks are reusable teacher observations.
* Rubrics/scoring profiles define reusable criteria and levels.
* Notes are private teacher context.
* Requirement checks are teacher-entered booleans stored in `review.json.requirement_checks`.
* Review targets are teacher-entered page, paragraph, evidence, or whole-submission metadata.
* Selected comments, tags, and scores are snapshotted into `review.json`.
* Later edits to source banks or rubrics do not silently change old review records.
* Exports are derived from teacher-confirmed review records, not live source banks.

## Requirement Check Cleanup

Updated stale documentation that referred to a future sibling `requirements.json` workflow.

Current behavior is now documented correctly:

```text
review.json.requirement_checks
```

The reserved `requirements.json` path remains described as future/reserved only.

## Safety

This PR does not change runtime behavior.

It does not:

* change schemas
* change starter-material JSON
* create assignments
* create rosters
* create scans
* create submissions
* create review records
* create exports
* modify pds-core standards files
* modify pds-core standards profiles
* modify pds-core route helpers
* add AI
* add OCR
* imply automatic scoring
* imply automatic feedback generation
* imply standards mastery inference

## Validation

Ran:

```powershell
.\run_tests.ps1
```

Result:

* pytest: `1091 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
* manual Markdown link-target check: passed
