### PR TITLE
Support multi-page submission evidence review

### DIFF
--- a/quillan/cli_app/handlers/submissions.py
+++ b/quillan/cli_app/handlers/submissions.py
@@ -79,7 +79,7 @@ def handle_open_evidence(args: argparse.Namespace) -> int:
 
 
 def handle_open_submission(args: argparse.Namespace) -> int:
-    """Open the selected evidence for one canonical student submission."""
+    """Open selected evidence for one canonical student submission."""
     try:
         workspace_root = resolve_workspace_root()
         opened = open_student_submission_for_review(
@@ -87,6 +87,7 @@ def handle_open_submission(args: argparse.Namespace) -> int:
             args.class_id,
             args.assignment_id,
             args.student_id,
+            page_number=args.page,
         )
     except (WorkspaceRootError, SubmissionReviewOpeningError) as error:
         print(f"Error: could not open student submission: {error}")

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -31,10 +31,12 @@ def print_opened_submission_review(opened: OpenedSubmissionReview) -> None:
     print(f"Assignment: {opened.assignment_id}")
     print(f"Student: {opened.student_id}")
     print(f"Submission state: {opened.submission_state}")
-    print(f"Page: {opened.page_number}")
-    print(f"Page state: {opened.page_state}")
-    print(f"Evidence: {opened.evidence_id}")
-    print(f"Path: {opened.evidence_relative_path}")
+    print(f"Pages opened: {len(opened.opened_pages)}")
+    for page in opened.opened_pages:
+        print(
+            f"- Page {page.page_number}: {page.page_state}; "
+            f"Evidence: {page.evidence_id}; Path: {page.evidence_relative_path}"
+        )
     print(f"Manifest: {opened.manifest_relative_path}")
 
 

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -180,14 +180,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     open_submission_parser = subparsers.add_parser(
         "open-submission",
-        help="Open the selected evidence for one student submission.",
+        help="Open selected evidence pages for one student submission.",
         description=(
-            "Load one canonical student submission manifest and open its single "
-            "selected routed evidence file. This command is read-only and "
-            "requires exactly one selected evidence item."
+            "Open selected evidence pages for one student submission. By "
+            "default, opens all selected evidence pages in page-number order. "
+            "Use --page to open one logical response page."
         ),
     )
     _add_submission_identity_arguments(open_submission_parser)
+    open_submission_parser.add_argument(
+        "--page",
+        type=positive_integer,
+        help="Open only one logical response page number.",
+    )
     open_submission_parser.set_defaults(handler=handle_open_submission)
 
     review_state_parser = subparsers.add_parser(

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -73,8 +73,17 @@ from quillan.storage import assignment_config_path
 from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
     open_student_submission_for_review,
+    selected_submission_evidence_pages,
 )
-from quillan.submission_manifest import ALLOWED_SUBMISSION_STATES
+from quillan.submission_manifest import (
+    ALLOWED_SUBMISSION_STATES,
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
 from quillan.submission_page_management import (
     SubmissionPageManagementError,
     exclude_submission_page,
@@ -2285,18 +2294,85 @@ def _open_submission_evidence(
     assignment_id: str,
     student_id: str,
 ) -> None:
+    page_number = _choose_submission_evidence_page(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+    )
+    if page_number is _BACK:
+        print("Open submission evidence canceled.")
+        return
+    assert page_number is None or isinstance(page_number, int)
+
     try:
         opened = open_student_submission_for_review(
             workspace_root,
             class_id,
             assignment_id,
             student_id,
+            page_number=page_number,
         )
     except SubmissionReviewOpeningError as error:
         print(f"Error: could not open student submission: {error}")
         return
 
     print_opened_submission_review(opened)
+
+
+def _choose_submission_evidence_page(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> int | None | object:
+    try:
+        manifest_path = submission_manifest_path(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        manifest = load_submission_manifest(manifest_path)
+        pages = selected_submission_evidence_pages(manifest)
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestError,
+        SubmissionManifestPathError,
+        SubmissionReviewOpeningError,
+    ) as error:
+        print(f"Error: could not load selected evidence pages: {error}")
+        return _BACK
+
+    if len(pages) == 1:
+        return pages[0].page_number
+
+    _print_review_action_header(
+        "Open Submission Evidence", class_id, assignment_id, student_id
+    )
+    print("Selected evidence pages:")
+    for index, page in enumerate(pages, start=1):
+        print(
+            f"{index}. Page {page.page_number} - {page.page_state} - "
+            f"{page.evidence_id}"
+        )
+    print("A. Open all selected pages")
+    print("B. Back")
+    print()
+
+    choice = input("Select page: ").strip()
+    print()
+    if choice.lower() == "b" or choice == "":
+        return _BACK
+    if choice.lower() == "a":
+        return None
+    if choice.isdecimal():
+        index = int(choice)
+        if 1 <= index <= len(pages):
+            return pages[index - 1].page_number
+    print("Invalid selection. Please choose a listed page, A, or B.")
+    return _BACK
 
 
 def _menu_record_requirement_checks(

--- a/quillan/submission_review_opening.py
+++ b/quillan/submission_review_opening.py
@@ -23,20 +23,57 @@ class SubmissionReviewOpeningError(Exception):
 
 
 @dataclass(frozen=True, slots=True)
+class SelectedSubmissionEvidencePage:
+    """Selected evidence metadata for one logical submission page."""
+
+    page_number: int
+    evidence_id: str
+    evidence_relative_path: str
+    page_state: str
+
+
+@dataclass(frozen=True, slots=True)
+class OpenedSubmissionEvidencePage:
+    """Information about one submission evidence file opened for review."""
+
+    page_number: int
+    evidence_id: str
+    evidence_path: Path
+    evidence_relative_path: str
+    page_state: str
+
+
+@dataclass(frozen=True, slots=True)
 class OpenedSubmissionReview:
-    """Information about a student submission evidence file opened for review."""
+    """Information about student submission evidence opened for review."""
 
     class_id: str
     assignment_id: str
     student_id: str
     manifest_path: Path
     manifest_relative_path: str
-    page_number: int
-    evidence_id: str
-    evidence_path: Path
-    evidence_relative_path: str
     submission_state: str
-    page_state: str
+    opened_pages: tuple[OpenedSubmissionEvidencePage, ...]
+
+    @property
+    def page_number(self) -> int:
+        return self.opened_pages[0].page_number
+
+    @property
+    def evidence_id(self) -> str:
+        return self.opened_pages[0].evidence_id
+
+    @property
+    def evidence_path(self) -> Path:
+        return self.opened_pages[0].evidence_path
+
+    @property
+    def evidence_relative_path(self) -> str:
+        return self.opened_pages[0].evidence_relative_path
+
+    @property
+    def page_state(self) -> str:
+        return self.opened_pages[0].page_state
 
 
 def open_student_submission_for_review(
@@ -44,8 +81,10 @@ def open_student_submission_for_review(
     class_id: str,
     assignment_id: str,
     student_id: str,
+    *,
+    page_number: int | None = None,
 ) -> OpenedSubmissionReview:
-    """Open the single selected routed evidence file for one submission."""
+    """Open selected routed evidence files for one submission."""
     try:
         resolved_workspace_root = Path(workspace_root).resolve(strict=False)
         manifest_path = submission_manifest_path(
@@ -73,7 +112,97 @@ def open_student_submission_for_review(
         assignment_id=assignment_id,
         student_id=student_id,
     )
-    page, selected_id = _find_selected_page(manifest)
+    selected_pages = selected_submission_evidence_pages(
+        manifest,
+        page_number=page_number,
+    )
+
+    try:
+        manifest_relative_path = manifest_path.resolve(strict=False).relative_to(
+            resolved_workspace_root
+        ).as_posix()
+    except (EvidenceOpeningError, OSError, RuntimeError, ValueError) as error:
+        raise SubmissionReviewOpeningError(
+            f"Could not resolve submission manifest path: {error}"
+        ) from error
+
+    opened_pages: list[OpenedSubmissionEvidencePage] = []
+    for selected_page in selected_pages:
+        try:
+            opened = open_workspace_evidence(
+                resolved_workspace_root,
+                selected_page.evidence_relative_path,
+            )
+        except (EvidenceOpeningError, OSError, RuntimeError, ValueError) as error:
+            raise SubmissionReviewOpeningError(
+                "Could not open selected evidence for "
+                f"page {selected_page.page_number} "
+                f"({selected_page.evidence_relative_path}): {error}"
+            ) from error
+        opened_pages.append(
+            OpenedSubmissionEvidencePage(
+                page_number=selected_page.page_number,
+                evidence_id=selected_page.evidence_id,
+                evidence_path=opened.evidence_path,
+                evidence_relative_path=opened.evidence_relative_path,
+                page_state=selected_page.page_state,
+            )
+        )
+
+    return OpenedSubmissionReview(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        manifest_path=manifest_path,
+        manifest_relative_path=manifest_relative_path,
+        submission_state=manifest["submission_state"],
+        opened_pages=tuple(opened_pages),
+    )
+
+
+def selected_submission_evidence_pages(
+    manifest: dict[str, Any],
+    *,
+    page_number: int | None = None,
+) -> tuple[SelectedSubmissionEvidencePage, ...]:
+    """Return selected evidence pages in ascending logical page order."""
+    pages = manifest["pages"]
+    if page_number is not None:
+        matching_page = next(
+            (page for page in pages if page["page_number"] == page_number),
+            None,
+        )
+        if matching_page is None:
+            raise SubmissionReviewOpeningError(
+                f"Submission page {page_number} does not exist."
+            )
+        selected = _selected_evidence_page(matching_page)
+        if selected is None:
+            raise SubmissionReviewOpeningError(
+                f"Submission page {page_number} has no selected evidence to open "
+                f"(page state: {matching_page['page_state']})."
+            )
+        return (selected,)
+
+    selected_pages = [
+        selected
+        for page in pages
+        if (selected := _selected_evidence_page(page)) is not None
+    ]
+    if not selected_pages:
+        raise SubmissionReviewOpeningError(
+            "Submission has no selected evidence to open. Use status listing "
+            "to inspect missing, duplicate, needs-rescan, or unselected evidence."
+        )
+    return tuple(sorted(selected_pages, key=lambda page: page.page_number))
+
+
+def _selected_evidence_page(
+    page: dict[str, Any],
+) -> SelectedSubmissionEvidencePage | None:
+    selected_id = page["selected_evidence_id"]
+    if selected_id is None:
+        return None
     evidence = next(
         (
             candidate
@@ -87,31 +216,10 @@ def open_student_submission_for_review(
             f"Selected evidence ID '{selected_id}' was not found on "
             f"page {page['page_number']}."
         )
-
-    try:
-        opened = open_workspace_evidence(
-            resolved_workspace_root,
-            evidence["routed_evidence_path"],
-        )
-        manifest_relative_path = manifest_path.resolve(strict=False).relative_to(
-            resolved_workspace_root
-        ).as_posix()
-    except (EvidenceOpeningError, OSError, RuntimeError, ValueError) as error:
-        raise SubmissionReviewOpeningError(
-            f"Could not open selected evidence: {error}"
-        ) from error
-
-    return OpenedSubmissionReview(
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-        manifest_path=manifest_path,
-        manifest_relative_path=manifest_relative_path,
+    return SelectedSubmissionEvidencePage(
         page_number=page["page_number"],
         evidence_id=selected_id,
-        evidence_path=opened.evidence_path,
-        evidence_relative_path=opened.evidence_relative_path,
-        submission_state=manifest["submission_state"],
+        evidence_relative_path=evidence["routed_evidence_path"],
         page_state=page["page_state"],
     )
 
@@ -134,26 +242,3 @@ def _validate_manifest_identity(
             raise SubmissionReviewOpeningError(
                 f"Submission manifest {field} is {actual!r}, expected {expected!r}."
             )
-
-
-def _find_selected_page(
-    manifest: dict[str, Any],
-) -> tuple[dict[str, Any], str]:
-    selected = [
-        (page, page["selected_evidence_id"])
-        for page in manifest["pages"]
-        if page["selected_evidence_id"] is not None
-    ]
-    if not selected:
-        raise SubmissionReviewOpeningError(
-            "Submission has no selected evidence to open. Use status listing "
-            "to inspect missing, duplicate, needs-rescan, or unselected evidence."
-        )
-    if len(selected) > 1:
-        raise SubmissionReviewOpeningError(
-            "Submission has multiple selected evidence files; open-submission "
-            "currently requires exactly one selected evidence file."
-        )
-
-    page, selected_id = selected[0]
-    return page, selected_id

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -16,7 +16,10 @@ from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
 )
-from quillan.submission_review_opening import OpenedSubmissionReview
+from quillan.submission_review_opening import (
+    OpenedSubmissionEvidencePage,
+    OpenedSubmissionReview,
+)
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
@@ -154,6 +157,42 @@ def _write_manifest(root: Path) -> Path:
         STUDENT_ID,
     )
     return write_submission_manifest(path, manifest)
+
+
+def _write_two_page_manifest(root: Path) -> Path:
+    path = submission_manifest_path(
+        root,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    second_evidence_path = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+        "response_stu_0001_pg_002.pdf"
+    )
+    (root / second_evidence_path).write_bytes(b"synthetic evidence page 2")
+    manifest["expected_pages"] = 2
+    manifest["pages"].append(
+        {
+            "page_number": 2,
+            "page_state": "present",
+            "selected_evidence_id": "evidence_002",
+            "evidence": [
+                {
+                    "evidence_id": "evidence_002",
+                    "routed_evidence_path": second_evidence_path,
+                    "evidence_role": "selected",
+                    "evidence_state": "active",
+                    "duplicate_number": None,
+                    "created_at": TIMESTAMP,
+                    "retained_source": None,
+                    "module_details": {},
+                }
+            ],
+        }
+    )
+    return write_submission_manifest(path, manifest, overwrite=True)
 
 
 def _review_record() -> dict[str, Any]:
@@ -348,20 +387,27 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
         class_id: str,
         assignment_id: str,
         student_id: str,
+        *,
+        page_number: int | None = None,
     ) -> OpenedSubmissionReview:
         calls.append((Path(workspace_root), class_id, assignment_id, student_id))
+        assert page_number == 1
         return OpenedSubmissionReview(
             class_id=class_id,
             assignment_id=assignment_id,
             student_id=student_id,
             manifest_path=workspace / "submission.json",
             manifest_relative_path="classes/class/submissions/submission.json",
-            page_number=1,
-            evidence_id="evidence_001",
-            evidence_path=workspace / "evidence.pdf",
-            evidence_relative_path="classes/class/scans/evidence.pdf",
             submission_state="unreviewed",
-            page_state="present",
+            opened_pages=(
+                OpenedSubmissionEvidencePage(
+                    page_number=1,
+                    evidence_id="evidence_001",
+                    evidence_path=workspace / "evidence.pdf",
+                    evidence_relative_path="classes/class/scans/evidence.pdf",
+                    page_state="present",
+                ),
+            ),
         )
 
     monkeypatch.setattr(
@@ -379,7 +425,124 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     output = capsys.readouterr().out
     assert calls == [(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)]
     assert "Opened submission evidence for review:" in output
-    assert "Path: classes/class/scans/evidence.pdf" in output
+    assert (
+        "- Page 1: present; Evidence: evidence_001; "
+        "Path: classes/class/scans/evidence.pdf"
+    ) in output
+
+
+def test_review_menu_multi_page_open_submission_selects_one_page(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_two_page_manifest(workspace)
+    calls: list[int | None] = []
+
+    def open_submission(
+        _workspace_root: str | Path,
+        class_id: str,
+        assignment_id: str,
+        student_id: str,
+        *,
+        page_number: int | None = None,
+    ) -> OpenedSubmissionReview:
+        calls.append(page_number)
+        return OpenedSubmissionReview(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            manifest_path=workspace / "submission.json",
+            manifest_relative_path="classes/class/submissions/submission.json",
+            submission_state="unreviewed",
+            opened_pages=(
+                OpenedSubmissionEvidencePage(
+                    page_number=2,
+                    evidence_id="evidence_002",
+                    evidence_path=workspace / "evidence_2.pdf",
+                    evidence_relative_path="classes/class/scans/evidence_2.pdf",
+                    page_state="present",
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        review_menu,
+        "open_student_submission_for_review",
+        open_submission,
+    )
+    _menu_input(
+        monkeypatch,
+        ["2", "1", "1", "1", "1", "1", "1", "2", "", "12", "6", "", "4", "6"],
+    )
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert calls == [2]
+    assert "Open Submission Evidence" in output
+    assert "1. Page 1 - present - evidence_001" in output
+    assert "2. Page 2 - present - evidence_002" in output
+    assert "A. Open all selected pages" in output
+
+
+def test_review_menu_multi_page_open_submission_opens_all_pages(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_two_page_manifest(workspace)
+    calls: list[int | None] = []
+
+    def open_submission(
+        _workspace_root: str | Path,
+        class_id: str,
+        assignment_id: str,
+        student_id: str,
+        *,
+        page_number: int | None = None,
+    ) -> OpenedSubmissionReview:
+        calls.append(page_number)
+        return OpenedSubmissionReview(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            manifest_path=workspace / "submission.json",
+            manifest_relative_path="classes/class/submissions/submission.json",
+            submission_state="unreviewed",
+            opened_pages=(
+                OpenedSubmissionEvidencePage(
+                    page_number=1,
+                    evidence_id="evidence_001",
+                    evidence_path=workspace / "evidence.pdf",
+                    evidence_relative_path="classes/class/scans/evidence.pdf",
+                    page_state="present",
+                ),
+                OpenedSubmissionEvidencePage(
+                    page_number=2,
+                    evidence_id="evidence_002",
+                    evidence_path=workspace / "evidence_2.pdf",
+                    evidence_relative_path="classes/class/scans/evidence_2.pdf",
+                    page_state="present",
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        review_menu,
+        "open_student_submission_for_review",
+        open_submission,
+    )
+    _menu_input(
+        monkeypatch,
+        ["2", "1", "1", "1", "1", "1", "1", "A", "", "12", "6", "", "4", "6"],
+    )
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert calls == [None]
+    assert "Pages opened: 2" in output
 
 
 def test_review_menu_reports_missing_openable_evidence(

--- a/tests/test_submission_review_opening.py
+++ b/tests/test_submission_review_opening.py
@@ -17,6 +17,7 @@ from quillan.submission_manifest_paths import (
     write_submission_manifest,
 )
 from quillan.submission_review_opening import (
+    OpenedSubmissionEvidencePage,
     OpenedSubmissionReview,
     SubmissionReviewOpeningError,
     open_student_submission_for_review,
@@ -51,12 +52,14 @@ def _evidence(
 def _page(
     page_number: int = 1,
     evidence_id: str = "evidence_001",
+    *,
+    path: str = EVIDENCE_PATH,
 ) -> dict[str, Any]:
     return {
         "page_number": page_number,
         "page_state": "present",
         "selected_evidence_id": evidence_id,
-        "evidence": [_evidence(evidence_id)],
+        "evidence": [_evidence(evidence_id, path=path)],
     }
 
 
@@ -127,12 +130,16 @@ def test_success_opens_selected_evidence_and_returns_context(
             f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
             f"{STUDENT_ID}/submission.json"
         ),
-        page_number=1,
-        evidence_id="evidence_001",
-        evidence_path=evidence_path,
-        evidence_relative_path=EVIDENCE_PATH,
         submission_state="unreviewed",
-        page_state="present",
+        opened_pages=(
+            OpenedSubmissionEvidencePage(
+                page_number=1,
+                evidence_id="evidence_001",
+                evidence_path=evidence_path,
+                evidence_relative_path=EVIDENCE_PATH,
+                page_state="present",
+            ),
+        ),
     )
 
 
@@ -187,18 +194,128 @@ def test_no_selected_evidence_raises(tmp_path: Path) -> None:
         )
 
 
-def test_multiple_selected_evidence_files_raise(tmp_path: Path) -> None:
+def test_multiple_selected_evidence_files_open_in_page_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page_1_path = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+        "response_00107_pg_001.pdf"
+    )
+    page_2_path = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+        "response_00107_pg_002.pdf"
+    )
     _write_manifest(
         tmp_path,
-        _manifest(pages=[_page(), _page(2, "evidence_002")]),
+        _manifest(
+            pages=[
+                _page(2, "evidence_002", path=page_2_path),
+                _page(1, "evidence_001", path=page_1_path),
+            ]
+        ),
+    )
+    calls: list[str | Path] = []
+
+    def open_evidence(
+        _workspace_root: str | Path,
+        relative_path: str | Path,
+    ) -> OpenedEvidence:
+        calls.append(relative_path)
+        return OpenedEvidence(tmp_path / relative_path, str(relative_path))
+
+    monkeypatch.setattr(
+        quillan.submission_review_opening,
+        "open_workspace_evidence",
+        open_evidence,
     )
 
-    with pytest.raises(SubmissionReviewOpeningError, match="multiple selected"):
+    opened = open_student_submission_for_review(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+    )
+
+    assert calls == [page_1_path, page_2_path]
+    assert [page.page_number for page in opened.opened_pages] == [1, 2]
+
+
+def test_page_number_opens_only_requested_page(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page_2_path = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+        "response_00107_pg_002.pdf"
+    )
+    _write_manifest(
+        tmp_path,
+        _manifest(
+            pages=[
+                _page(1, "evidence_001"),
+                _page(2, "evidence_002", path=page_2_path),
+            ]
+        ),
+    )
+    calls: list[str | Path] = []
+
+    def open_evidence(
+        _workspace_root: str | Path,
+        relative_path: str | Path,
+    ) -> OpenedEvidence:
+        calls.append(relative_path)
+        return OpenedEvidence(tmp_path / relative_path, str(relative_path))
+
+    monkeypatch.setattr(
+        quillan.submission_review_opening,
+        "open_workspace_evidence",
+        open_evidence,
+    )
+
+    opened = open_student_submission_for_review(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        page_number=2,
+    )
+
+    assert calls == [page_2_path]
+    assert [page.page_number for page in opened.opened_pages] == [2]
+
+
+def test_missing_page_number_raises_clear_error(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, _manifest())
+
+    with pytest.raises(SubmissionReviewOpeningError, match="page 2 does not exist"):
         open_student_submission_for_review(
             tmp_path,
             CLASS_ID,
             ASSIGNMENT_ID,
             STUDENT_ID,
+            page_number=2,
+        )
+
+
+def test_page_number_without_selected_evidence_raises_clear_error(
+    tmp_path: Path,
+) -> None:
+    page = _page()
+    page["selected_evidence_id"] = None
+    page["evidence"][0]["evidence_role"] = "candidate"
+    _write_manifest(tmp_path, _manifest(pages=[page]))
+
+    with pytest.raises(
+        SubmissionReviewOpeningError,
+        match="page 1 has no selected evidence",
+    ):
+        open_student_submission_for_review(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            page_number=1,
         )
 
 
@@ -308,12 +425,23 @@ def test_cli_success_prints_teacher_context(
         student_id=STUDENT_ID,
         manifest_path=tmp_path / "submission.json",
         manifest_relative_path="classes/class/submissions/00107/submission.json",
-        page_number=1,
-        evidence_id="evidence_001",
-        evidence_path=tmp_path / "evidence.pdf",
-        evidence_relative_path="classes/class/scans/evidence.pdf",
         submission_state="unreviewed",
-        page_state="present",
+        opened_pages=(
+            OpenedSubmissionEvidencePage(
+                page_number=1,
+                evidence_id="evidence_001",
+                evidence_path=tmp_path / "evidence.pdf",
+                evidence_relative_path="classes/class/scans/evidence.pdf",
+                page_state="present",
+            ),
+            OpenedSubmissionEvidencePage(
+                page_number=2,
+                evidence_id="evidence_002",
+                evidence_path=tmp_path / "evidence_2.pdf",
+                evidence_relative_path="classes/class/scans/evidence_2.pdf",
+                page_state="present",
+            ),
+        ),
     )
     monkeypatch.setattr(
         cli_submissions, "resolve_workspace_root", lambda: tmp_path
@@ -321,7 +449,7 @@ def test_cli_success_prints_teacher_context(
     monkeypatch.setattr(
         cli_submissions,
         "open_student_submission_for_review",
-        lambda *_args: opened,
+        lambda *_args, **_kwargs: opened,
     )
 
     assert (
@@ -333,14 +461,70 @@ def test_cli_success_prints_teacher_context(
         f"Assignment: {ASSIGNMENT_ID}",
         f"Student: {STUDENT_ID}",
         "Submission state: unreviewed",
-        "Page: 1",
-        "Page state: present",
-        "Evidence: evidence_001",
+        "Pages opened: 2",
+        "- Page 1: present; Evidence: evidence_001; "
         "Path: classes/class/scans/evidence.pdf",
+        "- Page 2: present; Evidence: evidence_002; "
+        "Path: classes/class/scans/evidence_2.pdf",
         "Manifest: classes/class/submissions/00107/submission.json",
     ):
         assert expected in output
     assert str(tmp_path) not in output
+
+
+def test_cli_page_option_is_passed_to_opener(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int | None] = []
+    opened = OpenedSubmissionReview(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        manifest_path=tmp_path / "submission.json",
+        manifest_relative_path="classes/class/submissions/00107/submission.json",
+        submission_state="unreviewed",
+        opened_pages=(
+            OpenedSubmissionEvidencePage(
+                page_number=2,
+                evidence_id="evidence_002",
+                evidence_path=tmp_path / "evidence_2.pdf",
+                evidence_relative_path="classes/class/scans/evidence_2.pdf",
+                page_state="present",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        cli_submissions, "resolve_workspace_root", lambda: tmp_path
+    )
+
+    def open_submission(
+        *_args: object,
+        page_number: int | None = None,
+    ) -> OpenedSubmissionReview:
+        calls.append(page_number)
+        return opened
+
+    monkeypatch.setattr(
+        cli_submissions,
+        "open_student_submission_for_review",
+        open_submission,
+    )
+
+    assert (
+        main(
+            [
+                "open-submission",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--page",
+                "2",
+            ]
+        )
+        == 0
+    )
+    assert calls == [2]
 
 
 def test_cli_failure_returns_one(
@@ -352,7 +536,7 @@ def test_cli_failure_returns_one(
         cli_submissions, "resolve_workspace_root", lambda: tmp_path
     )
 
-    def fail(*_args: object) -> OpenedSubmissionReview:
+    def fail(*_args: object, **_kwargs: object) -> OpenedSubmissionReview:
         raise SubmissionReviewOpeningError("manifest is unavailable")
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- Updates submission evidence opening to support multi-page student submissions.
- Opens all selected evidence pages by default in logical page order.
- Adds `--page N` support for opening one logical response page from the CLI.
- Adds a review-menu chooser for multi-page submissions with individual page selection and open-all support.
- Updates opened-evidence summaries to list all opened pages.
- Preserves existing one-page behavior.

## Verification

- `.\.venv\Scripts\python.exe -m pytest tests/test_submission_review_opening.py tests/test_menu_review_student_work.py` → 30 passed
- `git diff --check` → passed, with only Git line-ending warnings
- Manual simulation test: opened both pages of a two-page student submission from the review workflow.