### PR TITLE
Remove obsolete review material workflows

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -14,8 +14,13 @@ development. It records:
 The CLI includes a developer-oriented, scriptable command layer and a
 teacher-facing terminal menu. The menu now covers assignment management, roster
 management, printable response pages, QR-aware scan intake, review navigation,
-guided review-entry actions, guided export actions, Manage Review Materials guidance,
-workspace settings, help, and exit.
+retained review-entry actions, guided export actions, workspace settings, help,
+and exit.
+
+As of the v0.8.6 standards-based review redesign gate, legacy generic
+review-material workflows are no longer active CLI or menu workflows. The old
+`add-tag`, `add-comment`, and `set-score` commands are intentionally removed
+from argparse and must not write v1 tag, comment, or score review data.
 
 This contract describes implemented behavior separately from future design. A
 command or workflow documented elsewhere as planned is not part of the current
@@ -60,9 +65,6 @@ quillan open-evidence <workspace-relative-evidence-path>
 quillan open-submission <class_id> <assignment_id> <student_id>
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
-quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity <polarity> [--standard-id <standard_id>]
-quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id> [--standard-id <standard_id>]
-quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
 quillan export-feedback <class_id> <assignment_id> <student_id> [--overwrite]
 quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
@@ -350,17 +352,15 @@ run OCR, score, tag, generate feedback, or perform AI work.
 
 #### Review Student Work
 
-Review Student Work provides guided scan intake, review-material management,
-class, assignment, and student/submission navigation plus review-entry and
-export actions.
+Review Student Work provides guided scan intake, class, assignment, and
+student/submission navigation plus retained review-entry and export actions.
 
 The first Review Student Work menu provides:
 
 ```text
 1. Assignment Review Actions
 2. Scan Intake / Route Paper Responses
-3. Manage Review Materials
-4. Back
+3. Back
 ```
 
 The workflow lists available classes from the active workspace, lists
@@ -389,25 +389,22 @@ assignment, student, submission/evidence status, review state, and existing
 paths are reserved for detail/output actions.
 
 Assignment-level student selection clears the prior assignment-status summary
-before showing the student list. Nested review selections such as reusable
-tags, reusable comments, and rubric scoring also clear between levels so each
-screen stands on its own. `B. Back` returns to the immediate previous
+before showing the student list. Nested review selections clear between levels
+so each screen stands on its own. `B. Back` returns to the immediate previous
 selection screen.
 
 The selected-student review menu provides:
 
 ```text
 1. Open submission evidence
-2. Record minimum requirement checks
-3. Manage submission pages
-4. Add teacher note
-5. Add structured tag
-6. Select reusable comment
-7. Set criterion score
-8. Update submission review state
-9. Export student feedback
-10. Refresh summary
-11. Back
+2. View current review details
+3. Record minimum requirement checks
+4. Manage submission pages
+5. Add teacher note
+6. Update submission review state
+7. Export student feedback
+8. Refresh summary
+9. Back
 ```
 
 Opening submission evidence delegates to the same existing safe selected
@@ -427,43 +424,19 @@ the teacher-entered boolean in `review.json.requirement_checks`; it does not
 count words or paragraphs, parse writing, run OCR, use AI, infer a result, or
 change rubric scores.
 
-Guided review-entry actions reuse the same underlying review services as the
-direct commands:
+Retained guided review-entry actions reuse the same underlying review services
+as the direct commands:
 
 ```powershell
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
-quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity <polarity>
-quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
-quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 ```
 
-`Add structured tag` opens an Add Tag chooser. Teachers can select a reusable
-tag from `shared/tag_banks/<tag_bank_id>.json` by bank, category, and tag
-template, or choose Custom tag for a one-off/manual observation. Reusable tag
-screens show bank titles, category labels, tag labels, optional
-severity/polarity, and durable IDs as secondary detail. Custom tag polarity is
-selected from enumerated choices, and optional details are grouped behind an
-explicit prompt. Reusable tag selections snapshot template values into
-`review.json.tags` with
-`source: "tag_bank"`, `tag_bank_id`, and `tag_template_id`; custom tags and the
-direct `add-tag` command remain compatible.
-
-`Select reusable comment` is selection-first: the teacher chooses a comment
-bank, category, and student-facing comment, sees a feedback preview, then
-confirms the write or changes the include-in-feedback setting. Comment labels
-are primary; bank and comment IDs are displayed as secondary durable details.
-Missing comment banks point teachers to Review Student Work ->
-Manage Review Materials -> Comment Banks.
-
-`Set criterion score` opens a score chooser. Teachers can score from a valid
-shared rubric resolved through `assignment.rubric_id`, or choose Custom
-criterion score when the rubric is missing or does not contain the needed
-criterion. Rubric scoring shows rubric metadata, criteria, levels, and a
-confirmation screen before writing. Custom scoring is label-first and suggests
-a `criterion_id`; the direct `set-score` command remains manual and
-compatible. Rubric level feedback metadata is informational only and is not
-converted into comments.
+The legacy `Add structured tag`, `Select reusable comment`, and
+`Set criterion score` actions have been removed from the active selected-student
+review menu. The matching direct CLI write commands `add-tag`, `add-comment`,
+and `set-score` are also removed from argparse and cannot write v1 review tags,
+comments, or scores.
 
 When reusable comments or tags include pds-core `standard_id` references,
 review-time menus may resolve readable metadata through pds-core read-only
@@ -500,123 +473,12 @@ The Review Student Work menu does not automatically assemble submissions,
 route scans, run OCR, parse evidence contents, score work automatically, infer
 mastery, generate AI feedback, or perform AI work.
 
-#### Manage Review Materials
+#### Removed Legacy Review Materials
 
-Manage Review Materials is reached through Review Student Work and provides a
-preparation area for reusable teacher-authored review aids:
-
-```text
-1. Comment Banks
-2. Tag Banks
-3. Rubrics / Scoring Profiles
-4. Starter Materials
-5. Back
-```
-
-The menu is subject-agnostic and is intended for teachers reviewing written
-student work such as essays, constructed responses, lab reports, journals,
-reflections, research papers, mathematical explanations, technical writing, and
-other local writing tasks.
-
-Comment Banks opens a submenu:
-
-```text
-1. Create comment bank
-2. View comment banks
-3. Edit comment bank
-4. Add category
-5. Add comment
-6. Validate comment bank
-7. Back
-```
-
-Comment-bank authoring writes confirmed, valid version `1` banks only under
-`shared/comment_banks/<bank_id>.json`. New banks are immediately available to
-Review Student Work -> Select reusable comment because they use the same
-schema, loading logic, and validation as review-time selection.
-
-Comment banks are teacher-authored reusable feedback language. They do not
-grade work, imply mastery, generate automatic feedback, or mutate student
-records by themselves. Review selection snapshots the chosen label and text
-into `review.json.comments`; later bank edits do not silently rewrite previous
-review records.
-
-Tag Banks opens a submenu:
-
-```text
-1. Create tag bank
-2. View tag banks
-3. Edit tag bank
-4. Add category
-5. Add reusable tag
-6. Validate tag bank
-7. Back
-```
-
-Tag-bank authoring writes confirmed, valid version `1` banks only under
-`shared/tag_banks/<tag_bank_id>.json`. It builds complete banks in memory,
-validates before writing, refuses accidental overwrites unless the teacher types
-exactly `OVERWRITE`, and does not write invalid partial files.
-
-Tag banks are teacher-authored reusable observations for quick tagging. They do
-not grade work, imply mastery, generate automatic feedback, or mutate student
-records by themselves.
-
-Review-material authoring prompts use teacher-facing labels while preserving
-the JSON contracts. The UI calls `writing_types` "writing assignment types,"
-explains comma-separated values and underscores for multi-word values, suggests
-stored IDs from labels, and distinguishes labels from system IDs such as
-`bank_id`, `tag_bank_id`, `rubric_id`, `category_id`, `comment_id`,
-`tag_template_id`, and `criterion_id`. Optional tag details are explained as
-description, writing assignment type limits, linked standards, linked rubric
-criteria, priority/severity, private note question, and display order.
-`student_facing_default` is not prompted for until it has visible runtime
-behavior.
-
-Rubrics / Scoring Profiles opens a submenu for teacher-authored reusable
-scoring profiles. It writes confirmed, valid version `1` rubrics only under
-`shared/rubrics/<rubric_id>.json`; assignment creation and review-time rubric
-scoring can immediately resolve valid shared rubrics.
-
-Starter Materials opens a submenu:
-
-```text
-1. Preview starter materials
-2. Validate starter materials
-3. Install all starter materials
-4. Install selected starter materials
-5. Back
-```
-
-Starter materials are optional synthetic examples for onboarding and local
-testing. The workflow validates source JSON files with the same comment-bank,
-tag-bank, and rubric validators used at runtime. Installation copies validated
-JSON files only into `shared/comment_banks/`, `shared/tag_banks/`, and
-`shared/rubrics/`. Existing files are skipped by default, and bulk overwrite
-requires the exact confirmation text `OVERWRITE`.
-
-Selected Student Review presents the assembled student's review workspace as:
-
-```text
-1. Open submission evidence
-2. View current review details
-3. Record minimum requirement checks
-4. Manage submission pages
-5. Add teacher note
-6. Add structured tag
-7. Select reusable comment
-8. Set criterion score
-9. Update submission review state
-10. Export student feedback
-11. Refresh summary
-12. Back
-```
-
-View current review details is terminal-only and read-only. It displays the
-current `review.json` contents for the selected student, including requirement
-checks, notes, tags, comments, scores, comment feedback-inclusion settings,
-and tag/comment targets. It does not generate an export file and does not
-modify `review.json`, `submission.json`, or evidence files.
+The active Review Student Work menu no longer exposes generic Comment Bank,
+Tag Bank, Rubric / Scoring Profile, or Starter Material management workflows.
+The direct legacy menu shell reports that those workflows are disabled while
+the standards-based review redesign is underway.
 
 Selected Student Review includes Manage Submission Pages. Teachers can exclude
 a page from active review, restore an excluded page, or mark a page as needing
@@ -625,19 +487,6 @@ rescan after confirmation. These actions update only the selected student's
 routed files, and do not modify review notes, tags, comments, scores, feedback
 exports, rosters, assignments, review materials, pds-core standards, or
 pds-core routes.
-
-Starter installation does not create assignments, rosters, scans, submissions,
-review records, exports, pds-core standards, pds-core standards profiles, or
-pds-core route helpers.
-
-Review materials are Quillan-owned teaching and review aids. They may later
-reference durable pds-core `profile_id` and `standard_id` values. Optional
-comment-bank and tag-bank `standard_ids` are pds-core references only; optional
-tag-bank `criterion_ids` are rubric/scoring metadata only. Quillan does not
-create, import, edit, retire, reactivate, or authoritatively validate standards.
-The menu does not duplicate or replace pds-core ownership of standards,
-workspace resolution, shared class routes, roster routes, scan routes, or route
-helpers.
 
 #### Workspace Settings
 
@@ -911,98 +760,17 @@ exists, validates, and matches the requested identity.
 
 It preserves the manifest, evidence, and unrelated review content.
 
-## Structured Review Tags
+## Removed Legacy Review Writes
 
-```powershell
-quillan add-tag <class_id> <assignment_id> <student_id> --label "..." --polarity developing
-```
+The legacy direct review-write commands `add-tag`, `add-comment`, and
+`set-score` are no longer part of the active CLI surface. They were removed as
+part of the v0.8.6 standards-based review redesign gate and must not write v1
+`review.json.tags`, `review.json.comments`, or `review.json.scores` data.
 
-This direct command appends one teacher-entered tag to the canonical
-`review.json`, creating that record only when the adjacent `submission.json`
-exists, validates, and matches the requested identity.
-
-Optional flags are:
-
-```text
---standard-id
---comment-id
---severity
---note
---page
---evidence-id
---location-type
---location-value
-```
-
-Handled workspace, record, and tag-validation failures return `1`.
-
-Success returns `0` and reports the class, assignment, student, tag ID,
-polarity, review state, and workspace-relative review-record path.
-
-The command never mutates the submission manifest, routed evidence, or
-retained source scans, and it does not score, analyze, or generate feedback.
-
-The guided Selected Student Review tag flow uses teacher-facing target prompts
-instead of raw JSON. Teachers may choose whole submission, specific
-paragraph(s), a specific page, page plus paragraph(s), skip location, or Back.
-Paragraph input accepts values such as `2`, `2-4`, `2,4,6`, and `2, 4-6`.
-Targets are teacher-entered metadata; Quillan does not parse writing, run OCR,
-use AI, count paragraphs, or infer where a tag belongs.
-
-## Reusable Comment Selection
-
-```powershell
-quillan add-comment <class_id> <assignment_id> <student_id> --bank <bank_id> --comment-id <comment_id>
-```
-
-This direct command validates a shared comment bank and appends one
-teacher-selected student-facing comment to canonical `review.json`.
-
-In the guided Selected Student Review reusable-comment flow, the teacher is
-also prompted for the same optional target choices used by tags. The
-confirmation screen shows the selected comment text, target, and
-include-in-feedback setting before writing. Comment targets are stored in
-`review.json.comments` as optional `page_number`, `evidence_id`, and
-`location` fields.
-
-Optional flags are:
-
-```text
---standard-id
---include-in-feedback
---exclude-from-feedback
-```
-
-The command copies label and text and preserves `bank_id + comment_id`
-provenance, so later bank edits do not change the review.
-
-It does not export feedback or mutate the source bank, manifest, or evidence.
-
-## Criterion Scores
-
-```powershell
-quillan set-score <class_id> <assignment_id> <student_id> --criterion <criterion_id> --label "..." --score <number> --max-score <number>
-```
-
-This direct command sets or updates one explicitly teacher-entered criterion
-score in canonical `review.json`.
-
-Optional flags are `--scale` and `--note`.
-
-The command creates a missing review record only when the adjacent
-`submission.json` validates and matches the requested identity.
-
-Success returns `0` and reports the class, assignment, student, criterion,
-score and maximum, score ID, created-or-updated action, review state, and
-workspace-relative review-record path.
-
-Handled workspace, score, and record failures return `1`.
-
-Updating by `criterion_id` preserves the existing score ID and unrelated
-review sections.
-
-The command does not validate criteria against a rubric profile, calculate an
-overall score, infer scores, or mutate the submission manifest or evidence.
+The matching selected-student menu actions for structured tags, reusable
+comments, and criterion scores are also removed. Replacement Focus Standard
+observation, rating, feedback, and reporting workflows are intentionally out of
+scope for this removal gate.
 
 ## Student Feedback Export
 

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -230,8 +230,8 @@ def _prompt_rubric_id(workspace_root: Path) -> str:
         print("No valid shared rubrics found.")
         print()
         print(
-            "Create one from Review Student Work -> Manage Review Materials "
-            "-> Rubrics / Scoring Profiles."
+            "Legacy rubric authoring workflows are disabled during the "
+            "standards-based review redesign."
         )
         print("You may still enter a custom rubric_id for now.")
         print()

--- a/quillan/cli_app/handlers/review.py
+++ b/quillan/cli_app/handlers/review.py
@@ -1,4 +1,8 @@
-"""Review-record command handlers."""
+"""Review-record command handlers.
+
+Legacy v1 tag/comment/score handlers are retained for import compatibility only.
+They are no longer registered by the CLI parser.
+"""
 
 from __future__ import annotations
 

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -5,13 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from quillan.cli_app.arguments import (
-    location_value,
-    non_negative_integer,
-    non_negative_number,
-    positive_integer,
-    positive_number,
-)
+from quillan.cli_app.arguments import positive_integer
 from quillan.cli_app.handlers.exports import (
     handle_export_class_summary,
     handle_export_feedback,
@@ -19,10 +13,7 @@ from quillan.cli_app.handlers.exports import (
 )
 from quillan.cli_app.handlers.decoding import handle_decode_scan
 from quillan.cli_app.handlers.review import (
-    handle_add_comment,
     handle_add_note,
-    handle_add_tag,
-    handle_set_score,
 )
 from quillan.cli_app.handlers.routing import handle_route_scan
 from quillan.cli_app.handlers.submissions import (
@@ -228,142 +219,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Non-empty teacher note text.",
     )
     add_note_parser.set_defaults(handler=handle_add_note)
-
-    add_tag_parser = subparsers.add_parser(
-        "add-tag",
-        help="Add a structured teacher tag to one student review record.",
-        description=(
-            "Append one teacher-entered structured tag to the canonical "
-            "review.json for a student submission. Creates review.json when "
-            "the adjacent submission.json exists and validates."
-        ),
-    )
-    _add_submission_identity_arguments(add_tag_parser)
-    add_tag_parser.add_argument(
-        "--label", required=True, help="Teacher tag label."
-    )
-    add_tag_parser.add_argument(
-        "--polarity",
-        required=True,
-        help="Tag polarity: positive, developing, negative, or neutral.",
-    )
-    add_tag_parser.add_argument(
-        "--standard-id",
-        help="Optional durable pds-core standard_id.",
-    )
-    add_tag_parser.add_argument(
-        "--comment-id",
-        help="Optional reusable comment ID associated with --standard-id.",
-    )
-    add_tag_parser.add_argument(
-        "--severity",
-        type=non_negative_integer,
-        help="Optional non-negative organizational severity.",
-    )
-    add_tag_parser.add_argument(
-        "--note", help="Optional teacher note for the tag."
-    )
-    add_tag_parser.add_argument(
-        "--page",
-        type=positive_integer,
-        help="Optional submission page number.",
-    )
-    add_tag_parser.add_argument(
-        "--evidence-id",
-        help="Optional evidence ID from submission.json.",
-    )
-    add_tag_parser.add_argument(
-        "--location-type",
-        help="Optional controlled location type.",
-    )
-    add_tag_parser.add_argument(
-        "--location-value",
-        type=location_value,
-        help="Optional positive integer or non-empty location value.",
-    )
-    add_tag_parser.set_defaults(handler=handle_add_tag)
-
-    add_comment_parser = subparsers.add_parser(
-        "add-comment",
-        help="Select one reusable comment-bank comment for a student review record.",
-        description=(
-            "Append one teacher-selected reusable comment from a shared comment "
-            "bank to the canonical review.json for a student submission. The "
-            "selected comment snapshots label and text so later bank edits do "
-            "not alter existing reviews."
-        ),
-    )
-    _add_submission_identity_arguments(add_comment_parser)
-    add_comment_parser.add_argument(
-        "--bank", required=True, help="Shared comment-bank identifier."
-    )
-    add_comment_parser.add_argument(
-        "--comment-id",
-        required=True,
-        help="Reusable source comment identifier.",
-    )
-    add_comment_parser.add_argument(
-        "--standard-id", help="Optional durable standard_id from the source comment."
-    )
-    feedback_group = add_comment_parser.add_mutually_exclusive_group()
-    feedback_group.add_argument(
-        "--include-in-feedback",
-        dest="include_in_feedback",
-        action="store_const",
-        const=True,
-        default=None,
-        help="Include the selected comment in future feedback.",
-    )
-    feedback_group.add_argument(
-        "--exclude-from-feedback",
-        dest="include_in_feedback",
-        action="store_const",
-        const=False,
-        help="Exclude the selected comment from future feedback.",
-    )
-    add_comment_parser.set_defaults(handler=handle_add_comment)
-
-    set_score_parser = subparsers.add_parser(
-        "set-score",
-        help="Set one teacher-entered criterion score in a student review record.",
-        description=(
-            "Set or update one teacher-entered criterion score in the canonical "
-            "review.json for a student submission. Creates review.json when "
-            "the adjacent submission.json exists and validates."
-        ),
-    )
-    _add_submission_identity_arguments(set_score_parser)
-    set_score_parser.add_argument(
-        "--criterion",
-        required=True,
-        help="Non-empty criterion identifier.",
-    )
-    set_score_parser.add_argument(
-        "--label",
-        required=True,
-        help="Teacher-readable criterion label.",
-    )
-    set_score_parser.add_argument(
-        "--score",
-        required=True,
-        type=non_negative_number,
-        help="Finite criterion score greater than or equal to zero.",
-    )
-    set_score_parser.add_argument(
-        "--max-score",
-        required=True,
-        type=positive_number,
-        help="Finite maximum criterion score greater than zero.",
-    )
-    set_score_parser.add_argument(
-        "--scale",
-        help="Optional descriptive score scale.",
-    )
-    set_score_parser.add_argument(
-        "--note",
-        help="Optional teacher note for this criterion score.",
-    )
-    set_score_parser.set_defaults(handler=handle_set_score)
 
     export_feedback_parser = subparsers.add_parser(
         "export-feedback",

--- a/quillan/comment_bank_workflows.py
+++ b/quillan/comment_bank_workflows.py
@@ -1,4 +1,7 @@
-"""Teacher-facing comment-bank creation and editing workflows."""
+"""Legacy teacher-facing comment-bank creation and editing workflows.
+
+Retained temporarily for compatibility; not exposed through active v0.8.6 menus.
+"""
 
 from __future__ import annotations
 

--- a/quillan/review_comments.py
+++ b/quillan/review_comments.py
@@ -1,4 +1,8 @@
-"""Selection of reusable shared-bank comments into submission reviews."""
+"""Selection of reusable shared-bank comments into submission reviews.
+
+Legacy v1 comment-bank review writes are retained only for compatibility and tests.
+They are not exposed through active v0.8.6 menu or CLI routes.
+"""
 
 from __future__ import annotations
 

--- a/quillan/review_materials_menu.py
+++ b/quillan/review_materials_menu.py
@@ -1,10 +1,10 @@
-"""Teacher-facing Review Materials preparation menu."""
+"""Disabled Review Materials preparation menu."""
 
 from __future__ import annotations
 
 
 def launch_review_materials_menu() -> int:
-    """Launch informational review-material preparation screens."""
+    """Launch an informational placeholder for removed legacy review materials."""
     from quillan.menu import clear_screen, pause_for_user, print_menu_header
 
     try:
@@ -12,71 +12,27 @@ def launch_review_materials_menu() -> int:
             clear_screen()
             print_menu_header("Review Materials")
             print(
-                "Reusable review materials help teachers prepare comments, "
-                "tags, and scoring tools before reviewing student work."
+                "Legacy generic comment-bank, tag-bank, and rubric workflows "
+                "have been removed from the active review menu."
             )
             print()
-            print("1. Comment Banks")
-            print("2. Tag Banks")
-            print("3. Rubrics / Scoring Profiles")
-            print("4. Starter Materials")
-            print("5. Back")
+            print(
+                "Quillan is being updated for the standards-based review "
+                "redesign. Focus Standard review workflows will be added in "
+                "a later release."
+            )
+            print()
+            print("1. Back")
             print()
 
             choice = input("Select an option: ").strip()
             print()
 
-            if choice in {"", "5"}:
+            if choice in {"", "1"}:
                 return 0
-            if choice == "1":
-                from quillan.comment_bank_workflows import launch_comment_banks_menu
-
-                launch_comment_banks_menu()
-            elif choice == "2":
-                from quillan.tag_bank_workflows import launch_tag_banks_menu
-
-                launch_tag_banks_menu()
-            elif choice == "3":
-                from quillan.rubric_workflows import launch_rubrics_menu
-
-                launch_rubrics_menu()
-            elif choice == "4":
-                from quillan.starter_material_workflows import (
-                    launch_starter_materials_menu,
-                )
-
-                launch_starter_materials_menu()
-            else:
-                print("Invalid selection. Please enter a number from 1 to 5.")
-                print()
-                pause_for_user()
+            print("Invalid selection. Please enter 1 to go back.")
+            print()
+            pause_for_user()
     except KeyboardInterrupt:
         print("\nExiting review materials menu.")
         return 0
-
-
-def _show_tag_banks_info() -> None:
-    from quillan.menu import clear_screen, pause_for_user, print_menu_header
-
-    clear_screen()
-    print_menu_header("Tag Banks")
-    print(
-        "Tag banks will store reusable teacher observations for quick "
-        "review tagging."
-    )
-    print(
-        "Tags are teacher-controlled review aids; they are not grades or "
-        "automatic mastery judgments."
-    )
-    print()
-    print(
-        "Tag-bank creation and review-time tag selection will be "
-        "implemented in #166."
-    )
-    print()
-    print("Expected future workspace location:")
-    print("shared/tag_banks/")
-    print()
-    print("No files were changed.")
-    print()
-    pause_for_user()

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -26,15 +26,12 @@ from quillan.class_summary_export import (
     export_class_review_summary,
 )
 from quillan.cli_app.output import (
-    print_added_review_comment,
     print_added_review_note,
-    print_added_review_tag,
     print_assignment_submission_status,
     print_exported_class_summary,
     print_exported_feedback,
     print_exported_standards_summary,
     print_opened_submission_review,
-    print_updated_review_score,
     print_updated_submission_review_state,
 )
 from quillan.feedback_export import (
@@ -46,12 +43,8 @@ from quillan.standards_summary_export import (
     StandardsSummaryExportError,
     export_standards_summary,
 )
-from quillan.comment_banks import CommentBankError, load_comment_bank
-from quillan.tag_bank_writing import list_valid_tag_banks
-from quillan.review_comments import ReviewCommentError, add_review_comment
 from quillan.review_notes import ReviewNoteError, add_review_note
 from quillan.review_record import (
-    ALLOWED_TAG_POLARITIES,
     ReviewRecordError,
     load_review_record,
 )
@@ -66,9 +59,6 @@ from quillan.review_requirements import (
     ReviewRequirementError,
     set_requirement_check,
 )
-from quillan.review_scores import ReviewScoreError, set_review_score
-from quillan.rubrics import RubricError, load_rubric, rubric_path
-from quillan.review_tags import ReviewTagError, add_review_tag
 from quillan.storage import assignment_config_path
 from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
@@ -113,13 +103,12 @@ def launch_review_student_work_menu() -> int:
             print_menu_header("Review Student Work")
             print("1. Assignment Review Actions")
             print("2. Scan Intake / Route Paper Responses")
-            print("3. Manage Review Materials")
-            print("4. Back")
+            print("3. Back")
             print()
             choice = input("Select an option: ").strip()
             print()
 
-            if choice in {"", "4"}:
+            if choice in {"", "3"}:
                 return 0
             if choice == "1":
                 clear_screen()
@@ -130,12 +119,8 @@ def launch_review_student_work_menu() -> int:
                 from quillan.menu import launch_scan_intake_workflow
 
                 launch_scan_intake_workflow()
-            elif choice == "3":
-                from quillan.review_materials_menu import launch_review_materials_menu
-
-                launch_review_materials_menu()
             else:
-                print("Invalid selection. Please enter a number from 1 to 4.")
+                print("Invalid selection. Please enter a number from 1 to 3.")
                 print()
                 pause_for_user()
     except KeyboardInterrupt:
@@ -420,19 +405,16 @@ def _launch_selected_student_review(
         print("3. Record minimum requirement checks")
         print("4. Manage submission pages")
         print("5. Add teacher note")
-        print("6. Add structured tag")
-        print("7. Select reusable comment")
-        print("8. Set criterion score")
-        print("9. Update submission review state")
-        print("10. Export student feedback")
-        print("11. Refresh summary")
-        print("12. Back")
+        print("6. Update submission review state")
+        print("7. Export student feedback")
+        print("8. Refresh summary")
+        print("9. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "12"}:
+        if choice in {"", "9"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -474,30 +456,6 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "6":
-            _menu_add_review_tag(
-                workspace_root,
-                class_id,
-                assignment_id,
-                student_id,
-            )
-            input("Press Enter to continue...")
-        elif choice == "7":
-            _menu_add_review_comment(
-                workspace_root,
-                class_id,
-                assignment_id,
-                student_id,
-            )
-            input("Press Enter to continue...")
-        elif choice == "8":
-            _menu_set_review_score(
-                workspace_root,
-                class_id,
-                assignment_id,
-                student_id,
-            )
-            input("Press Enter to continue...")
-        elif choice == "9":
             _menu_update_submission_review_state(
                 workspace_root,
                 class_id,
@@ -505,7 +463,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "10":
+        elif choice == "7":
             _menu_export_student_feedback(
                 workspace_root,
                 class_id,
@@ -513,10 +471,10 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "11":
+        elif choice == "8":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 12.")
+            print("Invalid selection. Please enter a number from 1 to 9.")
             input("Press Enter to continue...")
 
 
@@ -626,6 +584,12 @@ def _menu_add_review_tag(
     student_id: str,
 ) -> None:
     _print_review_action_header("Add Tag", class_id, assignment_id, student_id)
+    print(
+        "Legacy structured tag workflows are disabled for the "
+        "standards-based review redesign."
+    )
+    print("No review data was changed.")
+    return
     print("Tags are short teacher observations used for organization and summaries.")
     print("Choose a reusable tag, or create a one-time custom tag.")
     print()
@@ -654,9 +618,7 @@ def _menu_add_review_tag(
         )
         return
 
-    # Compatibility with the prior direct menu prompt sequence: if a caller
-    # supplies a tag label immediately after choosing Add structured tag, treat
-    # that first response as the custom label.
+    # Legacy compatibility for the prior direct menu prompt sequence.
     _menu_add_custom_review_tag(
         workspace_root,
         class_id,
@@ -802,11 +764,7 @@ def _menu_add_reusable_review_tag(
         )
         print("No valid shared tag banks found.")
         print()
-        print("Create one from:")
-        print(
-            "Review Student Work -> Manage Review Materials -> "
-            "Tag Banks -> Create tag bank"
-        )
+        print("Legacy tag-bank authoring workflows are disabled.")
         print()
         print("1. Custom tag")
         print("2. Back")
@@ -1268,11 +1226,7 @@ def _prompt_comment_from_bank(
     if not comments:
         print("This bank has no student-facing comments.")
         print()
-        print("Add one from:")
-        print(
-            "Review Student Work -> Manage Review Materials -> "
-            "Comment Banks -> Add comment"
-        )
+        print("Legacy comment-bank authoring workflows are disabled.")
         print()
         print("1. Choose another bank")
         print("2. Back")
@@ -1427,6 +1381,12 @@ def _menu_add_review_comment(
     _print_review_action_header(
         "Select Reusable Comment", class_id, assignment_id, student_id
     )
+    print(
+        "Legacy reusable comment selection is disabled for the "
+        "standards-based review redesign."
+    )
+    print("No review data was changed.")
+    return
     print("Reusable comments are teacher-authored feedback language prepared before review.")
     print("Choose a comment bank, then a category, then a comment.")
     print()
@@ -1448,11 +1408,7 @@ def _menu_add_review_comment(
         )
         print("No valid shared comment banks found.")
         print()
-        print("Create one from:")
-        print(
-            "Review Student Work -> Manage Review Materials -> "
-            "Comment Banks -> Create comment bank"
-        )
+        print("Legacy comment-bank authoring workflows are disabled.")
         return
 
     while True:
@@ -1612,6 +1568,12 @@ def _menu_set_review_score(
     student_id: str,
 ) -> None:
     _print_review_action_header("Set Score", class_id, assignment_id, student_id)
+    print(
+        "Legacy criterion score workflows are disabled for the "
+        "standards-based review redesign."
+    )
+    print("No review data was changed.")
+    return
     print("Use the assignment rubric, or enter a custom criterion.")
     print()
     print("1. Score from rubric")
@@ -1639,9 +1601,7 @@ def _menu_set_review_score(
         )
         return
 
-    # Compatibility with the prior direct menu prompt sequence: if a caller
-    # supplies a criterion ID immediately after choosing Set criterion score,
-    # treat that first response as the custom criterion ID.
+    # Legacy compatibility for the prior direct menu prompt sequence.
     _menu_set_custom_review_score(
         workspace_root,
         class_id,
@@ -1754,11 +1714,7 @@ def _menu_missing_rubric(
     print()
     print(f"Rubric ID: {rubric_id}")
     print()
-    print(
-        "Create or fix the rubric from Review Student Work -> "
-        "Manage Review Materials -> "
-        "Rubrics / Scoring Profiles."
-    )
+    print("Legacy rubric authoring workflows are disabled.")
     print()
     print("1. Custom criterion score")
     print("2. Back")

--- a/quillan/review_scores.py
+++ b/quillan/review_scores.py
@@ -1,4 +1,8 @@
-"""Teacher-entered criterion scores for submission review records."""
+"""Teacher-entered criterion scores for submission review records.
+
+Legacy v1 criterion-score writes are retained only for compatibility and tests.
+They are not exposed through active v0.8.6 menu or CLI routes.
+"""
 
 from __future__ import annotations
 

--- a/quillan/review_tags.py
+++ b/quillan/review_tags.py
@@ -1,4 +1,8 @@
-"""Teacher-entered structured tags for submission review records."""
+"""Teacher-entered structured tags for submission review records.
+
+Legacy v1 review-tag writes are retained only for compatibility and tests.
+They are not exposed through active v0.8.6 menu or CLI routes.
+"""
 
 from __future__ import annotations
 

--- a/quillan/rubric_workflows.py
+++ b/quillan/rubric_workflows.py
@@ -1,4 +1,7 @@
-"""Teacher-facing rubric creation and editing workflows."""
+"""Legacy teacher-facing rubric creation and editing workflows.
+
+Retained temporarily for compatibility; not exposed through active v0.8.6 menus.
+"""
 
 from __future__ import annotations
 

--- a/quillan/starter_material_workflows.py
+++ b/quillan/starter_material_workflows.py
@@ -1,26 +1,10 @@
-"""Teacher-facing workflows for starter review materials."""
+"""Disabled teacher-facing workflows for legacy starter review materials."""
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
-
-from quillan.starter_materials import (
-    StarterInstallSummary,
-    StarterMaterial,
-    StarterMaterialError,
-    StarterValidationResult,
-    discover_starter_materials,
-    install_starter_materials,
-    summarize_install_impact,
-    target_path_for_material,
-    validate_all_starter_materials,
-)
-
 
 def launch_starter_materials_menu() -> int:
-    """Launch the starter-materials submenu."""
+    """Launch an informational placeholder for removed starter-material workflows."""
     from quillan.menu import clear_screen, pause_for_user, print_menu_header
 
     try:
@@ -28,38 +12,23 @@ def launch_starter_materials_menu() -> int:
             clear_screen()
             print_menu_header("Starter Materials")
             print(
-                "Starter materials help teachers and developers test Quillan "
-                "or begin with editable review-material examples."
+                "Legacy starter comment-bank, tag-bank, and rubric installers "
+                "are disabled during the standards-based review redesign."
             )
             print()
             print(
-                "They include small synthetic examples and NJ ELA starter "
-                "comment banks, tag banks, and rubrics."
+                "No starter review-material files can be installed from this "
+                "workflow."
             )
             print()
-            print("1. Preview starter materials")
-            print("2. Validate starter materials")
-            print("3. Install all starter materials")
-            print("4. Install selected starter materials")
-            print("5. Back")
+            print("1. Back")
             print()
 
             choice = input("Select an option: ").strip()
             print()
-            if choice in {"", "5"}:
+            if choice in {"", "1"}:
                 return 0
-            workflows = {
-                "1": prompt_preview_starter_materials,
-                "2": prompt_validate_starter_materials,
-                "3": prompt_install_all_starter_materials,
-                "4": prompt_install_selected_starter_materials,
-            }
-            workflow = workflows.get(choice)
-            if workflow is None:
-                print("Invalid selection. Please enter a number from 1 to 5.")
-            else:
-                clear_screen()
-                workflow()
+            print("Invalid selection. Please enter 1 to go back.")
             print()
             pause_for_user()
     except KeyboardInterrupt:
@@ -68,248 +37,49 @@ def launch_starter_materials_menu() -> int:
 
 
 def prompt_preview_starter_materials() -> int:
-    """Preview starter materials grouped by material type."""
+    """Report that legacy starter material preview is disabled."""
     from quillan.menu import print_menu_header
 
     print_menu_header("Preview Starter Materials")
-    materials = discover_starter_materials()
-    _print_material_groups(materials, workspace_root=_workspace_root_or_cwd())
-    return 0
+    _print_starter_materials_disabled()
+    return 1
 
 
 def prompt_validate_starter_materials() -> int:
-    """Validate every starter-material source file."""
+    """Report that legacy starter material validation is disabled."""
     from quillan.menu import print_menu_header
 
     print_menu_header("Validate Starter Materials")
-    materials = discover_starter_materials()
-    results = validate_all_starter_materials(materials)
-    _print_validation_results(results)
-    return 0 if all(result.is_valid for result in results) else 1
+    _print_starter_materials_disabled()
+    return 1
 
 
 def prompt_install_all_starter_materials() -> int:
-    """Prompt for and install all valid starter materials."""
+    """Report that legacy starter material installation is disabled."""
     from quillan.menu import print_menu_header
 
     print_menu_header("Install Starter Materials")
-    workspace_root = _workspace_root()
-    if workspace_root is None:
-        return 1
-    materials = discover_starter_materials()
-    print(
-        "This will copy starter comment banks, tag banks, and rubrics into "
-        "the active workspace."
-    )
-    print()
-    _print_target_folders()
-    print(
-        "These files are examples and editable starting points only. They do "
-        "not create assignments, rosters, scans, submissions, review records, "
-        "exports, or pds-core standards."
-    )
-    print()
-    print("1. Install")
-    print("2. Back")
-    print()
-    if input("Select an option: ").strip() != "1":
-        print("Starter material installation canceled. No files were changed.")
-        return 1
-    return _confirm_and_install(workspace_root, materials)
+    _print_starter_materials_disabled()
+    print("No files were changed.")
+    return 1
 
 
 def prompt_install_selected_starter_materials() -> int:
-    """Prompt for and install selected starter materials."""
+    """Report that selected legacy starter material installation is disabled."""
     from quillan.menu import print_menu_header
 
     print_menu_header("Install Selected Starter Materials")
-    workspace_root = _workspace_root()
-    if workspace_root is None:
-        return 1
-    materials = discover_starter_materials()
-    for index, material in enumerate(materials, start=1):
-        print(f"{index}. {material.display_name}")
-    print()
-    selection = input("Enter numbers, comma-separated, or B to go back: ").strip()
-    if selection == "" or selection.casefold() == "b":
-        print(
-            "Selected starter material installation canceled. "
-            "No files were changed."
-        )
-        return 1
-    selected = _parse_selection(selection, materials)
-    if selected is None:
-        print("Invalid selection. Please enter listed numbers separated by commas.")
-        return 1
-    return _confirm_and_install(workspace_root, selected)
+    _print_starter_materials_disabled()
+    print("No files were changed.")
+    return 1
 
 
-def _confirm_and_install(
-    workspace_root: Path,
-    materials: tuple[StarterMaterial, ...],
-) -> int:
-    validation = validate_all_starter_materials(materials)
-    invalid = [result for result in validation if not result.is_valid]
-    if invalid:
-        _print_validation_results(validation)
-        print()
-        print("Installation aborted because one or more starter files are invalid.")
-        return 1
-
-    summary = summarize_install_impact(workspace_root, materials)
-    _print_install_summary(summary)
-    choice = input("Select an option: ").strip()
-    if choice == "1":
-        overwrite = False
-    elif choice == "2":
-        confirmation = input(
-            "Type OVERWRITE to replace existing starter-material files: "
-        ).strip()
-        if confirmation != "OVERWRITE":
-            print("Overwrite canceled. Existing files were not changed.")
-            return 1
-        overwrite = True
-    else:
-        print("Starter material installation canceled. No files were changed.")
-        return 1
-
-    try:
-        result = install_starter_materials(
-            workspace_root,
-            materials,
-            overwrite=overwrite,
-        )
-    except StarterMaterialError as error:
-        print(f"Error: {error}")
-        return 1
-
-    print()
-    print(f"Installed files: {len(result.installed)}")
-    print(f"Skipped existing files: {len(result.skipped_existing)}")
-    for path in result.installed:
-        print(f"- {path.relative_to(workspace_root).as_posix()}")
-    return 0
-
-
-def _print_material_groups(
-    materials: tuple[StarterMaterial, ...],
-    *,
-    workspace_root: Path,
-) -> None:
-    groups = (
-        ("Comment Banks", "comment_bank"),
-        ("Tag Banks", "tag_bank"),
-        ("Rubrics / Scoring Profiles", "rubric"),
+def _print_starter_materials_disabled() -> None:
+    print(
+        "Legacy generic starter review materials are disabled for the "
+        "standards-based review redesign."
     )
-    index = 1
-    for heading, kind in groups:
-        print(heading)
-        for material in [item for item in materials if item.kind == kind]:
-            print(f"{index}. {material.display_name}")
-            print(f"   ID: {material.material_id}")
-            print(
-                "   Writing assignment types: "
-                f"{', '.join(material.writing_types)}"
-            )
-            if material.kind == "rubric":
-                print(f"   Criteria: {material.item_count}")
-            elif material.kind == "tag_bank":
-                print(
-                    f"   Categories: {material.categories_count}; "
-                    f"Tags: {material.item_count}"
-                )
-            else:
-                print(
-                    f"   Categories: {material.categories_count}; "
-                    f"Comments: {material.item_count}"
-                )
-            print(f"   Source: {material.source_path}")
-            print(f"   Target: {_workspace_relative_target(workspace_root, material)}")
-            index += 1
-        print()
-
-
-def _print_validation_results(
-    results: tuple[StarterValidationResult, ...],
-) -> None:
-    print("Starter material validation")
-    print()
-    groups = (
-        ("Comment Banks:", "comment_bank"),
-        ("Tag Banks:", "tag_bank"),
-        ("Rubrics:", "rubric"),
+    print(
+        "Focus Standard review-material workflows will be introduced in a "
+        "later implementation ticket."
     )
-    for heading, kind in groups:
-        print(heading)
-        for result in results:
-            if result.material.kind != kind:
-                continue
-            status = "OK" if result.is_valid else "INVALID"
-            print(f"{status} {result.material.source_path.name}")
-            if result.error:
-                print(f"  Error: {result.error}")
-        print()
-
-
-def _print_target_folders() -> None:
-    print("Target folders:")
-    print("shared/comment_banks/")
-    print("shared/tag_banks/")
-    print("shared/rubrics/")
-    print()
-
-
-def _print_install_summary(summary: StarterInstallSummary) -> None:
-    print("Install summary:")
-    print()
-    print(f"New files: {summary.new_files}")
-    print(f"Existing files that would be skipped: {summary.existing_files}")
-    print(f"Existing files that would require overwrite: {summary.overwrite_files}")
-    print()
-    print("1. Install new files only")
-    print("2. Install and overwrite existing files")
-    print("3. Back")
-    print()
-
-
-def _parse_selection(
-    selection: str,
-    materials: tuple[StarterMaterial, ...],
-) -> tuple[StarterMaterial, ...] | None:
-    selected: list[StarterMaterial] = []
-    seen: set[int] = set()
-    for raw_item in selection.split(","):
-        item = raw_item.strip()
-        if not item.isdigit():
-            return None
-        index = int(item)
-        if not 1 <= index <= len(materials):
-            return None
-        if index not in seen:
-            selected.append(materials[index - 1])
-            seen.add(index)
-    return tuple(selected) if selected else None
-
-
-def _workspace_relative_target(
-    workspace_root: Path,
-    material: StarterMaterial,
-) -> str:
-    return target_path_for_material(workspace_root, material).relative_to(
-        workspace_root
-    ).as_posix()
-
-
-def _workspace_root() -> Path | None:
-    try:
-        return resolve_workspace_root()
-    except WorkspaceRootError as error:
-        print(f"Error: {error}")
-        return None
-
-
-def _workspace_root_or_cwd() -> Path:
-    try:
-        return resolve_workspace_root()
-    except WorkspaceRootError:
-        return Path.cwd()

--- a/quillan/tag_bank_workflows.py
+++ b/quillan/tag_bank_workflows.py
@@ -1,4 +1,7 @@
-"""Teacher-facing tag-bank creation and editing workflows."""
+"""Legacy teacher-facing tag-bank creation and editing workflows.
+
+Retained temporarily for compatibility; not exposed through active v0.8.6 menus.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_cli_review_comments.py
+++ b/tests/test_cli_review_comments.py
@@ -1,90 +1,51 @@
-"""CLI tests for reusable shared-bank comment selection."""
+"""CLI guardrails for removed reusable review-comment selection."""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
 
 from quillan.cli import main
-import quillan.cli_app.handlers.review as cli_review
 from quillan.review_record_paths import review_record_path
 from tests.test_review_comments import BANK_ID, _write_bank
 from tests.test_review_scores import _write_manifest
 from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID
 
 
-def test_cli_selects_comment_and_prints_context(
+def test_cli_help_does_not_expose_add_comment(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["--help"])
+
+    assert error.value.code == 0
+    assert "add-comment" not in capsys.readouterr().out
+
+
+def test_cli_add_comment_is_removed_and_cannot_write_review_data(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     _write_manifest(tmp_path)
     _write_bank(tmp_path)
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
 
-    assert main(
-        [
-            "add-comment",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--bank",
-            BANK_ID,
-            "--comment-id",
-            "evidence_needs_explanation",
-            "--exclude-from-feedback",
-            "--standard-id",
-            "njsls-ela:W.AW.11-12.1",
-        ]
-    ) == 0
+    with pytest.raises(SystemExit) as error:
+        main(
+            [
+                "add-comment",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--bank",
+                BANK_ID,
+                "--comment-id",
+                "evidence_needs_explanation",
+            ]
+        )
 
-    output = capsys.readouterr().out
-    for expected in (
-        "Selected review comment:",
-        f"Class: {CLASS_ID}",
-        f"Assignment: {ASSIGNMENT_ID}",
-        f"Student: {STUDENT_ID}",
-        f"Bank: {BANK_ID}",
-        "Source comment: evidence_needs_explanation",
-        "Review comment: comment_record_0001",
-        "Include in feedback: no",
-        "Review state: in_progress",
-        "review.json",
-    ):
-        assert expected in output
-    written = json.loads(
-        review_record_path(
-            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert written["comments"][0]["include_in_feedback"] is False
-    assert written["comments"][0]["standard_id"] == "njsls-ela:W.AW.11-12.1"
-
-
-def test_cli_handled_failure_returns_one_without_review(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _write_manifest(tmp_path)
-    _write_bank(tmp_path)
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
-
-    assert main(
-        [
-            "add-comment",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--bank",
-            BANK_ID,
-            "--comment-id",
-            "missing",
-        ]
-    ) == 1
-    assert "could not select review comment" in capsys.readouterr().out
+    assert error.value.code != 0
+    assert "invalid choice" in capsys.readouterr().err
     assert not review_record_path(
         tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
     ).exists()

--- a/tests/test_cli_review_scores.py
+++ b/tests/test_cli_review_scores.py
@@ -1,221 +1,53 @@
-"""CLI tests for teacher-entered criterion review scores."""
+"""CLI guardrails for removed criterion-score review writes."""
 
 from __future__ import annotations
 
-import copy
-import json
 from pathlib import Path
 
 import pytest
 
 from quillan.cli import main
-import quillan.cli_app.handlers.review as cli_review
 from quillan.review_record_paths import review_record_path
-from tests.test_review_scores import _write_manifest, _write_review
-from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID, _review
+from tests.test_review_scores import _write_manifest
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID
 
 
-def test_cli_success_creates_score_and_prints_context(
+def test_cli_help_does_not_expose_set_score(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["--help"])
+
+    assert error.value.code == 0
+    assert "set-score" not in capsys.readouterr().out
+
+
+def test_cli_set_score_is_removed_and_cannot_write_review_data(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     _write_manifest(tmp_path)
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
 
-    assert main(
-        [
-            "set-score",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--criterion",
-            "evidence",
-            "--label",
-            "Evidence",
-            "--score",
-            "3",
-            "--max-score",
-            "4",
-            "--scale",
-            "4_point",
-            "--note",
-            "Relevant but not fully explained.",
-        ]
-    ) == 0
+    with pytest.raises(SystemExit) as error:
+        main(
+            [
+                "set-score",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--criterion",
+                "evidence",
+                "--label",
+                "Evidence",
+                "--score",
+                "3",
+                "--max-score",
+                "4",
+            ]
+        )
 
-    output = capsys.readouterr().out
-    assert "Set review score:" in output
-    assert f"Class: {CLASS_ID}" in output
-    assert f"Assignment: {ASSIGNMENT_ID}" in output
-    assert f"Student: {STUDENT_ID}" in output
-    assert "Criterion: evidence" in output
-    assert "Score: 3 / 4" in output
-    assert "Score record: score_0001" in output
-    assert "Action: created" in output
-    assert "Review state: in_progress" in output
-    assert (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
-        f"{STUDENT_ID}/review.json"
-    ) in output
-    written = json.loads(
-        review_record_path(
-            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert written["scores"][0]["criterion_id"] == "evidence"
-    assert written["scores"][0]["scale"] == "4_point"
-
-
-def test_cli_update_replaces_matching_criterion_and_preserves_other_data(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _write_manifest(tmp_path)
-    original = _review("exported")
-    original["scores"].append(
-        {
-            "score_id": "score_0002",
-            "criterion_id": "organization",
-            "label": "Organization",
-            "score": 2,
-            "max_score": 4,
-            "updated_at": original["updated_at"],
-            "module_details": {"preserve": True},
-        }
-    )
-    path = _write_review(tmp_path, copy.deepcopy(original))
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
-
-    assert main(
-        [
-            "set-score",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--criterion",
-            "evidence",
-            "--label",
-            "Use of Evidence",
-            "--score",
-            "4",
-            "--max-score",
-            "5",
-        ]
-    ) == 0
-
-    output = capsys.readouterr().out
-    assert "Score record: score_0001" in output
-    assert "Action: updated" in output
-    written = json.loads(path.read_text(encoding="utf-8"))
-    assert [item["criterion_id"] for item in written["scores"]].count("evidence") == 1
-    assert written["scores"][0]["score_id"] == "score_0001"
-    assert written["scores"][0]["score"] == 4
-    assert written["scores"][1] == original["scores"][1]
-    for field in ("notes", "tags", "comments", "module_details"):
-        assert written[field] == original[field]
-    assert written["review_state"] == "exported"
-
-
-@pytest.mark.parametrize(
-    ("score", "max_score"),
-    [
-        ("-1", "4"),
-        ("nan", "4"),
-        ("inf", "4"),
-        ("not-a-number", "4"),
-        ("3", "0"),
-        ("3", "-1"),
-        ("3", "nan"),
-        ("3", "not-a-number"),
-        ("5", "4"),
-    ],
-)
-def test_cli_invalid_score_returns_one_without_mutation(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    score: str,
-    max_score: str,
-) -> None:
-    _write_manifest(tmp_path)
-    path = _write_review(tmp_path, _review())
-    original = path.read_bytes()
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
-
-    assert main(
-        [
-            "set-score",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--criterion",
-            "evidence",
-            "--label",
-            "Evidence",
-            "--score",
-            score,
-            "--max-score",
-            max_score,
-        ]
-    ) == 1
-
-    assert "Error: could not set review score:" in capsys.readouterr().out
-    assert path.read_bytes() == original
-
-
-@pytest.mark.parametrize(("criterion", "label"), [(" ", "Evidence"), ("evidence", " ")])
-def test_cli_blank_text_and_missing_submission_return_one(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    criterion: str,
-    label: str,
-) -> None:
-    _write_manifest(tmp_path)
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
-
-    assert main(
-        [
-            "set-score",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--criterion",
-            criterion,
-            "--label",
-            label,
-            "--score",
-            "3",
-            "--max-score",
-            "4",
-        ]
-    ) == 1
-    assert "Error: could not set review score:" in capsys.readouterr().out
-
-
-def test_cli_missing_submission_returns_one(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
-
-    assert main(
-        [
-            "set-score",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--criterion",
-            "evidence",
-            "--label",
-            "Evidence",
-            "--score",
-            "3",
-            "--max-score",
-            "4",
-        ]
-    ) == 1
-    assert "This submission is not review-ready yet" in capsys.readouterr().out
+    assert error.value.code != 0
+    assert "invalid choice" in capsys.readouterr().err
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()

--- a/tests/test_cli_review_tags.py
+++ b/tests/test_cli_review_tags.py
@@ -1,172 +1,50 @@
-"""CLI tests for structured teacher review tags."""
+"""CLI guardrails for removed structured teacher review tags."""
 
 from __future__ import annotations
 
-import copy
 import json
 from pathlib import Path
 
 import pytest
 
 from quillan.cli import main
-import quillan.cli_app.handlers.review as cli_review
 from quillan.review_record_paths import review_record_path
-from tests.test_review_tags import (
-    ASSIGNMENT_ID,
-    CLASS_ID,
-    STUDENT_ID,
-    _manifest,
-    _review,
-    _write_manifest,
-    _write_review,
-)
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID, _write_manifest
 
 
-def test_cli_success_creates_tag_and_prints_context(
+def test_cli_help_does_not_expose_add_tag(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["--help"])
+
+    assert error.value.code == 0
+    assert "add-tag" not in capsys.readouterr().out
+
+
+def test_cli_add_tag_is_removed_and_cannot_write_review_data(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     _write_manifest(tmp_path)
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
 
-    assert main(
-        [
-            "add-tag",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--label",
-            "Evidence needs explanation",
-            "--polarity",
-            "developing",
-            "--severity",
-            "2",
-            "--note",
-            "Explain the connection.",
-            "--page",
-            "1",
-            "--evidence-id",
-            "evidence_001",
-            "--location-type",
-            "paragraph",
-            "--location-value",
-            "2",
-        ]
-    ) == 0
+    with pytest.raises(SystemExit) as error:
+        main(
+            [
+                "add-tag",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--label",
+                "Evidence needs explanation",
+                "--polarity",
+                "developing",
+            ]
+        )
 
-    output = capsys.readouterr().out
-    assert "Added review tag:" in output
-    assert f"Class: {CLASS_ID}" in output
-    assert f"Assignment: {ASSIGNMENT_ID}" in output
-    assert f"Student: {STUDENT_ID}" in output
-    assert "Tag: tag_0001" in output
-    assert "Polarity: developing" in output
-    assert "Review state: in_progress" in output
-    assert (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
-        f"{STUDENT_ID}/review.json"
-    ) in output
-    written = json.loads(
-        review_record_path(
-            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert written["tags"][0]["location"] == {
-        "type": "paragraph",
-        "value": 2,
-    }
-    assert written["tags"][0]["evidence_id"] == "evidence_001"
-
-
-@pytest.mark.parametrize(
-    ("prepare_submission", "label", "polarity"),
-    [
-        (True, " ", "neutral"),
-        (True, "A tag", "mixed"),
-        (False, "A tag", "neutral"),
-    ],
-)
-def test_cli_handled_failure_returns_one(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    prepare_submission: bool,
-    label: str,
-    polarity: str,
-) -> None:
-    if prepare_submission:
-        _write_manifest(tmp_path)
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
-
-    result = main(
-        [
-            "add-tag",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--label",
-            label,
-            "--polarity",
-            polarity,
-        ]
-    )
-
-    assert result == 1
-    assert "Error: could not add review tag:" in capsys.readouterr().out
-
-
-def test_cli_append_preserves_existing_sections(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_manifest(tmp_path)
-    original = _review("ready_for_export")
-    path = _write_review(tmp_path, copy.deepcopy(original))
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
-
-    assert main(
-        [
-            "add-tag",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--label",
-            "CLI append",
-            "--polarity",
-            "positive",
-            "--location-type",
-            "whole_submission",
-        ]
-    ) == 0
-
-    written = json.loads(path.read_text(encoding="utf-8"))
-    for field in ("notes", "scores", "comments", "module_details"):
-        assert written[field] == original[field]
-    assert written["tags"][:-1] == original["tags"]
-    assert written["review_state"] == "ready_for_export"
-
-
-def test_cli_does_not_mutate_submission_manifest(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manifest_path = _write_manifest(tmp_path, _manifest())
-    original = manifest_path.read_bytes()
-    monkeypatch.setattr(cli_review, "resolve_workspace_root", lambda: tmp_path)
-
-    assert main(
-        [
-            "add-tag",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--label",
-            "Page tag",
-            "--polarity",
-            "neutral",
-            "--page",
-            "2",
-        ]
-    ) == 0
-    assert manifest_path.read_bytes() == original
+    assert error.value.code != 0
+    assert "invalid choice" in capsys.readouterr().err
+    assert not review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()
+    manifests = list(tmp_path.rglob("submission.json"))
+    assert len(manifests) == 1
+    assert json.loads(manifests[0].read_text(encoding="utf-8"))["student_id"] == STUDENT_ID

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -44,11 +44,11 @@ def _enter_assignment_review_actions() -> list[str]:
 
 
 def _exit_assignment_review_actions_to_main() -> list[str]:
-    return ["6", "", "4", "6"]
+    return ["6", "", "3", "6"]
 
 
 def _exit_after_assignment_action_to_main() -> list[str]:
-    return ["", "6", "", "4", "6"]
+    return ["", "6", "", "3", "6"]
 
 
 def _enter_selected_student(student_choice: str = "1") -> list[str]:
@@ -56,11 +56,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["12"] + _exit_assignment_review_actions_to_main()
+    return ["9"] + _exit_assignment_review_actions_to_main()
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "12"] + _exit_assignment_review_actions_to_main()
+    return ["", "9"] + _exit_assignment_review_actions_to_main()
 
 
 def _write_workspace(root: Path) -> None:
@@ -285,7 +285,7 @@ def test_selected_student_review_menu_includes_feedback_export(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
-    assert "10. Export student feedback" in output
+    assert "7. Export student feedback" in output
 
 
 def test_menu_export_student_feedback_creates_feedback_file(
@@ -325,7 +325,7 @@ def test_menu_export_student_feedback_creates_feedback_file(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "1"]
+        + ["7", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -427,7 +427,7 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "2"]
+        + ["7", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -458,7 +458,7 @@ def test_menu_export_feedback_reports_missing_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "1"]
+        + ["7", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -492,7 +492,7 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "1", "1"]
+        + ["7", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -526,7 +526,7 @@ def test_menu_export_feedback_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "1", "2"]
+        + ["7", "1", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -1,30 +1,16 @@
-"""Tests for guided selected-student review menu entry actions."""
+"""Tests for retained selected-student review menu entry actions."""
 
 from __future__ import annotations
 
 import csv
 import json
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from quillan.cli import main
-import quillan.comment_bank_workflows as comment_bank_workflows
 import quillan.review_menu as review_menu
-from quillan.review_record_paths import review_record_path, write_review_record
-from quillan.rubric_writing import (
-    build_rubric,
-    build_rubric_criterion,
-    build_rubric_level,
-    write_rubric,
-)
-from quillan.tag_bank_writing import (
-    build_tag_bank,
-    build_tag_category,
-    build_tag_template,
-    write_tag_bank,
-)
+from quillan.review_record_paths import review_record_path
 from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
@@ -35,13 +21,6 @@ ASSIGNMENT_ID = "essay_01_synthetic"
 STUDENT_ID = "stu_0001"
 SECOND_STUDENT_ID = "stu_0002"
 TIMESTAMP = "2026-06-22T12:00:00+00:00"
-BANK_ID = "general_writing_synthetic"
-EXAMPLE_BANK_PATH = (
-    Path(__file__).parents[1]
-    / "examples"
-    / "comment_banks"
-    / f"{BANK_ID}.json"
-)
 
 
 def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
@@ -63,20 +42,10 @@ def _write_workspace(root: Path) -> None:
     assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
 
-    with (class_dir / "roster.csv").open(
-        "w",
-        encoding="utf-8",
-        newline="",
-    ) as roster_file:
+    with (class_dir / "roster.csv").open("w", encoding="utf-8", newline="") as file:
         writer = csv.DictWriter(
-            roster_file,
-            fieldnames=(
-                "class_id",
-                "student_id",
-                "last_name",
-                "first_name",
-                "period",
-            ),
+            file,
+            fieldnames=("class_id", "student_id", "last_name", "first_name", "period"),
         )
         writer.writeheader()
         writer.writerow(
@@ -112,7 +81,15 @@ def _write_workspace(root: Path) -> None:
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment), encoding="utf-8"
     )
-    evidence_path = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "scans" / "response_stu_0001_pg_001.pdf"
+    evidence_path = (
+        root
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_stu_0001_pg_001.pdf"
+    )
     evidence_path.parent.mkdir(parents=True, exist_ok=True)
     evidence_path.write_bytes(b"synthetic evidence")
     _write_manifest(root)
@@ -154,83 +131,20 @@ def _write_manifest(root: Path) -> Path:
         "updated_at": TIMESTAMP,
         "module_details": {},
     }
-    path = submission_manifest_path(
-        root,
-        CLASS_ID,
-        ASSIGNMENT_ID,
-        STUDENT_ID,
-    )
+    path = submission_manifest_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     return write_submission_manifest(path, manifest)
 
 
-def _write_bank(root: Path) -> None:
-    bank_path = root / "shared" / "comment_banks" / f"{BANK_ID}.json"
-    bank_path.parent.mkdir(parents=True, exist_ok=True)
-    bank_path.write_text(EXAMPLE_BANK_PATH.read_text(encoding="utf-8"), encoding="utf-8")
-
-
-def _write_tag_bank(root: Path) -> None:
-    category = build_tag_category(
-        category_id="reasoning_explanation",
-        label="Reasoning / Explanation",
-        description="Teacher observations about reasoning.",
-    )
-    tag = build_tag_template(
-        tag_template_id="explanation_needs_more_detail",
-        label="Explanation needs more detail",
-        category_id="reasoning_explanation",
-        polarity="developing",
-        optional_metadata={
-            "severity_default": 2,
-            "criterion_ids": ["explanation"],
-            "teacher_note_prompt": "What part needs more detail?",
-        },
-    )
-    bank = build_tag_bank(
-        tag_bank_id="general_written_response_tags",
-        title="General Written Response Tags",
-        description="Reusable synthetic tag templates.",
-        writing_types=["general"],
-        categories=[category],
-        tags=[tag],
-    )
-    write_tag_bank(root, bank)
-
-
-def _write_rubric(root: Path) -> None:
-    level = build_rubric_level(score=3, label="Clear explanation")
-    criterion = build_rubric_criterion(
-        criterion_id="reasoning",
-        label="Reasoning / Explanation",
-        max_score=4,
-        scale="4_point",
-        levels=[level],
-    )
-    rubric = build_rubric(
-        rubric_id="synthetic_rubric",
-        title="Synthetic Rubric",
-        description="Synthetic scoring profile.",
-        writing_types=["argument"],
-        criteria=[criterion],
-    )
-    write_rubric(root, rubric)
-
-
-def _write_review_record(root: Path, review: dict[str, Any]) -> Path:
-    path = review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
-    return write_review_record(path, review)
-
-
-def _enter_selected_student(student_choice: str = "1") -> list[str]:
-    return ["2", "1", "1", "1", "1", student_choice]
+def _enter_selected_student() -> list[str]:
+    return ["2", "1", "1", "1", "1", "1"]
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["12", "6", "", "4", "6"]
+    return ["9", "6", "", "3", "6"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "12", "6", "", "4", "6"]
+    return ["", "9", "6", "", "3", "6"]
 
 
 @pytest.fixture
@@ -240,7 +154,7 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-def test_review_menu_selected_student_shows_review_entry_actions(
+def test_review_menu_selected_student_excludes_legacy_review_entry_actions(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -256,38 +170,16 @@ def test_review_menu_selected_student_shows_review_entry_actions(
     assert "3. Record minimum requirement checks" in output
     assert "4. Manage submission pages" in output
     assert "5. Add teacher note" in output
-    assert "6. Add structured tag" in output
-    assert "7. Select reusable comment" in output
-    assert "8. Set criterion score" in output
-    assert "9. Update submission review state" in output
-    assert "Review record: not started" in output
+    assert "6. Update submission review state" in output
+    assert "7. Export student feedback" in output
+    assert "8. Refresh summary" in output
+    assert "9. Back" in output
+    assert "Add structured tag" not in output
+    assert "Select reusable comment" not in output
+    assert "Set criterion score" not in output
     assert not review_record_path(
         workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
     ).exists()
-
-
-def test_review_menu_blank_note_cancels_without_review_record(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["5", ""]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    assert not review_record_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    ).exists()
-    assert manifest_path.read_bytes() == manifest_before
 
 
 def test_review_menu_records_minimum_requirement_check(
@@ -317,193 +209,13 @@ def test_review_menu_records_minimum_requirement_check(
             workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
         ).read_text(encoding="utf-8")
     )
-    assert review["requirement_checks"] == [
-        {
-            "requirement_check_id": "requirement_check_0001",
-            "requirement_key": "paragraphs_min",
-            "label": "Minimum paragraphs",
-            "expected": 1,
-            "met": True,
-            "updated_at": review["requirement_checks"][0]["updated_at"],
-            "module_details": {},
-        }
-    ]
+    assert review["requirement_checks"][0]["requirement_key"] == "paragraphs_min"
+    assert review["requirement_checks"][0]["met"] is True
     assert manifest_path.read_bytes() == manifest_before
 
 
-def test_review_menu_reports_no_minimum_requirements_without_writing(
+def test_review_menu_blank_note_cancels_without_review_record(
     workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    assignment_path = (
-        workspace
-        / "classes"
-        / CLASS_ID
-        / "assignments"
-        / ASSIGNMENT_ID
-        / "assignment.json"
-    )
-    assignment = json.loads(assignment_path.read_text(encoding="utf-8"))
-    assignment["basic_requirements"] = {}
-    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["3", ""]
-        + _exit_selected_student_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    assert "Minimum requirements: none configured" in capsys.readouterr().out
-    assert not review_record_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    ).exists()
-
-
-def test_review_menu_adds_structured_tag_to_review_record(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + [
-            "6",
-            "2",
-            "claim",
-            "1",
-            "",
-        ]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    review = json.loads(
-        review_record_path(
-            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert review["tags"][0]["label"] == "claim"
-    assert review["tags"][0]["polarity"] == "positive"
-    assert review["review_state"] == "in_progress"
-
-
-def test_review_target_invalid_choice_reprompts_then_saves_valid_target(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + [
-            "6",
-            "2",
-            "claim",
-            "1",
-            "y",
-            "",
-            "",
-            "",
-            "",
-            "9",
-            "2",
-            "2",
-        ]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    output = capsys.readouterr().out
-    assert "Invalid selection. Please enter a number from 1 to 5 or B." in output
-    review = json.loads(
-        review_record_path(
-            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert review["tags"][0]["location"] == {"type": "paragraph", "value": 2}
-
-
-def test_review_target_invalid_paragraph_reprompts_then_saves_valid_target(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + [
-            "6",
-            "2",
-            "claim",
-            "1",
-            "y",
-            "",
-            "",
-            "",
-            "",
-            "2",
-            "2,,4",
-            "2-3",
-        ]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    output = capsys.readouterr().out
-    assert "Invalid paragraph target: Paragraph entries must not be empty." in output
-    review = json.loads(
-        review_record_path(
-            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert review["tags"][0]["location"] == {"type": "paragraph", "value": [2, 3]}
-
-
-@pytest.mark.parametrize("target_back", ["", "b"])
-def test_review_target_back_cancels_without_writing(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-    target_back: str,
-) -> None:
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + [
-            "6",
-            "2",
-            "claim",
-            "1",
-            "y",
-            "",
-            "",
-            "",
-            "",
-            target_back,
-        ]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    assert "Add tag canceled." in capsys.readouterr().out
-    assert not review_record_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    ).exists()
-    assert manifest_path.read_bytes() == manifest_before
-
-
-def test_invalid_review_target_then_back_does_not_write_or_modify_submission(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manifest_path = submission_manifest_path(
@@ -514,122 +226,7 @@ def test_invalid_review_target_then_back_does_not_write_or_modify_submission(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + [
-            "6",
-            "2",
-            "claim",
-            "1",
-            "y",
-            "",
-            "",
-            "",
-            "",
-            "9",
-            "",
-        ]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    output = capsys.readouterr().out
-    assert "Invalid selection. Please enter a number from 1 to 5 or B." in output
-    assert not review_record_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    ).exists()
-    assert manifest_path.read_bytes() == manifest_before
-
-
-def test_review_menu_selects_reusable_tag_by_bank_and_category(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_tag_bank(workspace)
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + [
-            "6",
-            "1",
-            "1",
-            "1",
-            "1",
-            "The explanation names the idea only.",
-            "2",
-            "2-4",
-        ]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    output = capsys.readouterr().out
-    assert "General Written Response Tags" in output
-    assert "Explanation needs more detail" in output
-    review = json.loads(
-        review_record_path(
-            workspace,
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-        ).read_text(encoding="utf-8")
-    )
-    tag = review["tags"][0]
-    assert tag["source"] == "tag_bank"
-    assert tag["tag_bank_id"] == "general_written_response_tags"
-    assert tag["tag_template_id"] == "explanation_needs_more_detail"
-    assert tag["label"] == "Explanation needs more detail"
-    assert tag["polarity"] == "developing"
-    assert tag["severity"] == 2
-    assert tag["criterion_id"] == "explanation"
-    assert tag["teacher_note"] == "The explanation names the idea only."
-    assert tag["location"] == {"type": "paragraph", "value": [2, 3, 4]}
-    assert "standard_id" not in tag
-    assert review["review_state"] == "in_progress"
-    assert manifest_path.read_bytes() == manifest_before
-
-
-def test_reusable_tag_back_returns_one_level_at_a_time(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_tag_bank(workspace)
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["6", "1", "1", "1", "b", "b", "b"]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    output = capsys.readouterr().out
-    assert output.count("Select Tag Category") >= 2
-    assert output.count("Select Reusable Tag") >= 2
-    assert not review_record_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    ).exists()
-
-
-def test_review_menu_blank_tag_cancels_without_review_record(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["6", ""]
+        + ["5", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -640,308 +237,24 @@ def test_review_menu_blank_tag_cancels_without_review_record(
     assert manifest_path.read_bytes() == manifest_before
 
 
-def test_review_menu_no_comment_banks_returns_safely(
+def test_review_menu_updates_submission_review_state(
     workspace: Path,
-    capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["6", "in_progress", "1"]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+
     manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
     )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["7", "1"]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    assert "No valid shared comment banks found" in capsys.readouterr().out
-    assert not review_record_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    ).exists()
-    assert manifest_path.read_bytes() == manifest_before
-
-
-def test_review_menu_selects_reusable_comment_by_number(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_bank(workspace)
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["7", "1", "1", "1", "1", "2", "2", "1"]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    output = capsys.readouterr().out
-    assert "Selected review comment:" in output
-    review = json.loads(
-        review_record_path(
-            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert review["comments"][0]["bank_id"] == BANK_ID
-    assert review["comments"][0]["comment_id"] == "focus_is_clear"
-    assert review["comments"][0]["location"] == {"type": "paragraph", "value": 2}
-    assert review["review_state"] == "in_progress"
-    assert manifest_path.read_bytes() == manifest_before
-
-
-def test_comment_bank_created_by_workflow_is_selectable_in_review(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        comment_bank_workflows,
-        "resolve_workspace_root",
-        lambda: workspace,
-    )
-    _menu_input(
-        monkeypatch,
-        [
-            "General Written Response Comments",
-            "",
-            "Reusable comments for written responses across subjects.",
-            "general",
-            "3",
-            "",
-            "",
-            "Explanation needs more detail",
-            "",
-            "Your response identifies the idea, but explain your reasoning more fully.",
-            "1",
-            "2",
-            "",
-            "",
-            "",
-            "1",
-        ],
-    )
-
-    assert comment_bank_workflows.prompt_create_comment_bank() == 0
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["7", "1", "1", "1", "1", "5", "1"]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    output = capsys.readouterr().out
-    assert "general_written_response_comments" in output
-    assert "Explanation needs more detail" in output
-    review = json.loads(
-        review_record_path(
-            workspace,
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-        ).read_text(encoding="utf-8")
-    )
-    comment = review["comments"][0]
-    assert comment["source"] == "comment_bank"
-    assert comment["bank_id"] == "general_written_response_comments"
-    assert comment["comment_id"] == "explanation_needs_more_detail"
-    assert comment["label"] == "Explanation needs more detail"
-    assert (
-        comment["text"]
-        == "Your response identifies the idea, but explain your reasoning more fully."
-    )
-
-
-def test_review_menu_sets_criterion_score(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["8", "evidence", "Evidence", "3", "4", "", ""]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    review = json.loads(
-        review_record_path(
-            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert review["scores"][0]["criterion_id"] == "evidence"
-    assert review["scores"][0]["score"] == 3
-    assert review["scores"][0]["max_score"] == 4
-    assert review["review_state"] == "in_progress"
-    assert manifest_path.read_bytes() == manifest_before
-
-
-def test_review_menu_scores_from_assignment_rubric(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_rubric(workspace)
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["8", "1", "1", "1", "2", "Private score note"]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    review = json.loads(
-        review_record_path(
-            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    score = review["scores"][0]
-    assert score["criterion_id"] == "reasoning"
-    assert score["label"] == "Reasoning / Explanation"
-    assert score["score"] == 3
-    assert score["max_score"] == 4
-    assert score["scale"] == "4_point"
-    assert score["teacher_note"] == "Private score note"
-    assert manifest_path.read_bytes() == manifest_before
-    capsys.readouterr()
-
-
-def test_review_menu_missing_rubric_keeps_custom_score_available(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["8", "1", "1", "Evidence", "", "2", "4", "", ""]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    review = json.loads(
-        review_record_path(
-            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-        ).read_text(encoding="utf-8")
-    )
-    assert review["scores"][0]["criterion_id"] == "evidence"
-    assert "does not resolve" in capsys.readouterr().out
-
-
-def test_review_menu_blank_score_cancels_without_review_record(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["8", ""]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    assert not review_record_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    ).exists()
-    assert manifest_path.read_bytes() == manifest_before
-
-
-def test_review_menu_invalid_score_does_not_corrupt_review_record(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    review = {
-        "schema_version": "1",
-        "module": "quillan",
-        "record_type": "submission_review",
-        "class_id": CLASS_ID,
-        "assignment_id": ASSIGNMENT_ID,
-        "student_id": STUDENT_ID,
-        "submission_manifest_path": (
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
-            f"{STUDENT_ID}/submission.json"
-        ),
-        "review_state": "in_progress",
-        "notes": [],
-        "tags": [],
-        "scores": [
-            {
-                "score_id": "score_0001",
-                "criterion_id": "evidence",
-                "label": "Evidence",
-                "score": 3,
-                "max_score": 4,
-                "updated_at": TIMESTAMP,
-                "module_details": {},
-            }
-        ],
-        "comments": [],
-        "created_at": TIMESTAMP,
-        "updated_at": TIMESTAMP,
-        "module_details": {},
-    }
-    path = _write_review_record(workspace, review)
-    before = path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["8", "evidence", "Evidence", "5", "4", "", ""]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    assert path.read_bytes() == before
-    assert json.loads(path.read_text(encoding="utf-8"))["scores"][0]["score"] == 3
-
-
-def test_review_menu_invalid_state_does_not_corrupt_manifest(
-    workspace: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manifest_path = submission_manifest_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    )
-    manifest_before = manifest_path.read_bytes()
-
-    _menu_input(
-        monkeypatch,
-        _enter_selected_student()
-        + ["9", "not_a_state"]
-        + _exit_after_selected_student_action_to_main(),
-    )
-
-    assert main(["menu"]) == 0
-    assert manifest_path.read_bytes() == manifest_before
-    assert not review_record_path(
-        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
-    ).exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["submission_state"] == "in_progress"

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -231,7 +231,7 @@ def test_main_menu_shows_and_opens_review_student_work(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "4", "6"])
+    _menu_input(monkeypatch, ["2", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -240,7 +240,8 @@ def test_main_menu_shows_and_opens_review_student_work(
     assert "Review Student Work" in output
     assert "1. Assignment Review Actions" in output
     assert "2. Scan Intake / Route Paper Responses" in output
-    assert "3. Manage Review Materials" in output
+    assert "3. Back" in output
+    assert "Manage Review Materials" not in output
     assert "Goodbye." in output
 
 
@@ -261,7 +262,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "12", "6", "", "4", "6"])
+    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "9", "6", "", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -306,7 +307,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "12", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "9", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -362,7 +363,7 @@ def test_review_menu_views_current_review_details_read_only(
 
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "2", "", "12", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "2", "", "9", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -417,7 +418,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "", "12", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "", "9", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -473,7 +474,7 @@ def test_review_menu_multi_page_open_submission_selects_one_page(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "2", "", "12", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "2", "", "9", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -535,7 +536,7 @@ def test_review_menu_multi_page_open_submission_opens_all_pages(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "A", "", "12", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "A", "", "9", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -552,7 +553,7 @@ def test_review_menu_reports_missing_openable_evidence(
 ) -> None:
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "2", "1", "", "6", "", "4", "6"],
+        ["2", "1", "1", "1", "1", "2", "1", "", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -583,10 +584,10 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "5",
             "This is a test note.",
             "",
-            "12",
+            "9",
             "6",
             "",
-            "4",
+            "3",
             "6",
         ],
     )
@@ -623,14 +624,14 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "1",
-            "9",
+            "6",
             "in_progress",
             "1",
             "",
-            "12",
+            "9",
             "6",
             "",
-            "4",
+            "3",
             "6",
         ],
     )
@@ -680,10 +681,10 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
             "1",
             "1",
             "",
-            "12",
+            "9",
             "6",
             "",
-            "4",
+            "3",
             "6",
         ],
     )
@@ -716,11 +717,11 @@ def test_review_menu_no_classes_and_invalid_selection_back_out_safely(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
-    _menu_input(monkeypatch, ["2", "9", "", "1", "", "4", "6"])
+    _menu_input(monkeypatch, ["2", "9", "", "1", "", "3", "6"])
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "Invalid selection. Please enter a number from 1 to 4." in output
+    assert "Invalid selection. Please enter a number from 1 to 3." in output
     assert "No classes found in the current workspace." in output
     assert "Goodbye." in output

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -170,7 +170,7 @@ def test_review_student_work_exposes_scan_intake_option(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "4", "6"])
+    _menu_input(monkeypatch, ["2", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -182,7 +182,7 @@ def test_menu_scan_intake_empty_input_cancels(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "2", "  ", "", "4", "6"])
+    _menu_input(monkeypatch, ["2", "2", "  ", "", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -198,7 +198,7 @@ def test_menu_scan_intake_invalid_path_does_not_create_review_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     missing_source = workspace / "missing-scan.pdf"
-    _menu_input(monkeypatch, ["2", "2", str(missing_source), "", "b", "4", "6"])
+    _menu_input(monkeypatch, ["2", "2", str(missing_source), "", "b", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -216,7 +216,7 @@ def test_menu_scan_intake_with_quoted_qr_image_routes_and_prints_next_step(
     source = tmp_path / "synthetic response.png"
     _write_qr_image(source, _valid_payload())
     original_bytes = source.read_bytes()
-    _menu_input(monkeypatch, ["2", "2", f'  "{source}"  ', "", "b", "4", "6"])
+    _menu_input(monkeypatch, ["2", "2", f'  "{source}"  ', "", "b", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -250,7 +250,7 @@ def test_menu_scan_intake_pdf_uses_existing_qr_page_intake(
             _make_qr_image(_valid_payload(student_id=SECOND_STUDENT_ID, page=2)),
         ),
     )
-    _menu_input(monkeypatch, ["2", "2", str(source), "", "b", "4", "6"])
+    _menu_input(monkeypatch, ["2", "2", str(source), "", "b", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -281,7 +281,7 @@ def test_menu_scan_intake_mixed_pdf_prints_review_warning(
             _blank_image(),
         ),
     )
-    _menu_input(monkeypatch, ["2", "2", str(source), "", "b", "4", "6"])
+    _menu_input(monkeypatch, ["2", "2", str(source), "", "b", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -307,7 +307,7 @@ def test_menu_scan_intake_folder_processes_supported_files_and_skips_unsupported
     folder.mkdir()
     _write_qr_image(folder / "response.png", _valid_payload())
     (folder / "notes.txt").write_text("ignore me", encoding="utf-8")
-    _menu_input(monkeypatch, ["2", "2", str(folder), "", "b", "4", "6"])
+    _menu_input(monkeypatch, ["2", "2", str(folder), "", "b", "3", "6"])
 
     assert main(["menu"]) == 0
 

--- a/tests/test_printable_response_pdf.py
+++ b/tests/test_printable_response_pdf.py
@@ -40,10 +40,18 @@ def _load_students() -> list[dict[str, str]]:
     return cast(list[dict[str, str]], students)
 
 
-def _write_roster_assignment(tmp_path: Path) -> Path:
+def _write_roster_assignment(
+    tmp_path: Path,
+    *,
+    class_ids: list[str] | None = None,
+) -> Path:
     assignment = json.loads(ASSIGNMENT_PATH.read_text(encoding="utf-8"))
     assert isinstance(assignment, dict)
-    assignment["class_ids"] = ["english12_p3"]
+    assignment["class_ids"] = class_ids or ["english12_p3"]
+    assignment.setdefault("tagging_mode", "focus")
+    assignment.setdefault("focus_standards", [])
+    assignment.setdefault("basic_requirements", {})
+    assignment.setdefault("rubric_id", "synthetic_rubric")
     assignment_path = tmp_path / "assignment.json"
     assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
     return assignment_path
@@ -162,7 +170,9 @@ def test_printable_response_generation_rejects_roster_assignment_class_mismatch(
     with pytest.raises(ValueError, match="english12_p3.*class_ids"):
         generate_printable_responses_for_roster(
             tmp_path,
-            assignment_path=ASSIGNMENT_PATH,
+            assignment_path=_write_roster_assignment(
+                tmp_path, class_ids=["english12_p4"]
+            ),
             roster_path=ROSTER_PATH,
         )
 

--- a/tests/test_review_materials_menu.py
+++ b/tests/test_review_materials_menu.py
@@ -1,4 +1,4 @@
-"""Tests for the teacher-facing Review Materials menu shell."""
+"""Tests for removed legacy Review Materials menu surfaces."""
 
 from __future__ import annotations
 
@@ -56,122 +56,41 @@ def test_main_menu_excludes_review_materials_and_exits_cleanly(
     assert "Goodbye." in output
 
 
-def test_main_menu_invalid_selection_uses_new_range(
+def test_review_student_work_menu_excludes_review_materials(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["bad", "", "6"])
+    _menu_input(monkeypatch, ["2", "3", "6"])
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "Invalid selection. Please enter a number from 1 to 6." in output
+    assert "Review Student Work" in output
+    assert "1. Assignment Review Actions" in output
+    assert "2. Scan Intake / Route Paper Responses" in output
+    assert "3. Back" in output
+    assert "Manage Review Materials" not in output
+    assert "Comment Banks" not in output
+    assert "Tag Banks" not in output
+    assert "Rubrics / Scoring Profiles" not in output
 
 
-def test_review_materials_menu_navigation_returns_to_main_menu(
+def test_direct_review_materials_menu_is_disabled(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "3", "5", "4", "6"])
+    _menu_input(monkeypatch, ["x", "", "1"])
 
-    assert main(["menu"]) == 0
+    assert launch_review_materials_menu() == 0
 
     output = capsys.readouterr().out
     assert "Review Materials" in output
-    assert (
-        "Reusable review materials help teachers prepare comments, tags, "
-        "and scoring tools before reviewing student work."
-    ) in output
-    assert "1. Comment Banks" in output
-    assert "2. Tag Banks" in output
-    assert "3. Rubrics / Scoring Profiles" in output
-    assert "4. Starter Materials" in output
-    assert "5. Back" in output
-    assert "Goodbye." in output
-
-
-@pytest.mark.parametrize(
-    ("choice", "header", "path_text"),
-    [
-        ("2", "Tag Banks", "shared/tag_banks/"),
-    ],
-)
-def test_review_materials_informational_screens_return_safely(
-    choice: str,
-    header: str,
-    path_text: str,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(monkeypatch, [choice, "", "5"])
-
-    assert launch_review_materials_menu() == 0
-
-    output = capsys.readouterr().out
-    assert header in output
-    assert "Add reusable tag" in output
-    assert "Implemented in #166" not in output
-    assert "Opening this screen" not in output
-    if path_text:
-        assert path_text not in output
-
-
-def test_review_materials_starter_materials_opens_real_submenu(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(monkeypatch, ["4", "5", "5"])
-
-    assert launch_review_materials_menu() == 0
-
-    output = capsys.readouterr().out
-    assert "Starter Materials" in output
-    assert "1. Preview starter materials" in output
-    assert "2. Validate starter materials" in output
-    assert "3. Install all starter materials" in output
-    assert "4. Install selected starter materials" in output
-
-
-def test_review_materials_rubrics_opens_submenu(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(monkeypatch, ["3", "7", "5"])
-
-    assert launch_review_materials_menu() == 0
-
-    output = capsys.readouterr().out
-    assert "Rubrics / Scoring Profiles" in output
-    assert "1. Create rubric / scoring profile" in output
-    assert "6. Validate rubric / scoring profile" in output
-    assert "7. Back" in output
-
-
-def test_review_materials_comment_banks_opens_submenu(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(monkeypatch, ["1", "7", "5"])
-
-    assert launch_review_materials_menu() == 0
-
-    output = capsys.readouterr().out
-    assert "Comment banks store reusable teacher-authored feedback comments." in output
-    assert "1. Create comment bank" in output
-    assert "6. Validate comment bank" in output
-    assert "7. Back" in output
-
-
-def test_review_materials_invalid_selection_is_helpful(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _menu_input(monkeypatch, ["x", "", "5"])
-
-    assert launch_review_materials_menu() == 0
-
-    output = capsys.readouterr().out
-    assert "Invalid selection. Please enter a number from 1 to 5." in output
+    assert "Legacy generic comment-bank, tag-bank, and rubric workflows" in output
+    assert "1. Back" in output
+    assert "Comment Banks" not in output
+    assert "Tag Banks" not in output
+    assert "Starter Materials" not in output
+    assert "Invalid selection. Please enter 1 to go back." in output
 
 
 def test_review_materials_menu_has_no_workspace_side_effects(
@@ -188,12 +107,9 @@ def test_review_materials_menu_has_no_workspace_side_effects(
         (folder / "existing.txt").write_text("keep", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     before = _file_tree(tmp_path)
-    _menu_input(
-        monkeypatch,
-        ["2", "3", "1", "7", "2", "", "3", "", "4", "", "5", "4", "6"],
-    )
+    _menu_input(monkeypatch, ["1"])
 
-    assert main(["menu"]) == 0
+    assert launch_review_materials_menu() == 0
 
     capsys.readouterr()
     assert _file_tree(tmp_path) == before

--- a/tests/test_starter_materials.py
+++ b/tests/test_starter_materials.py
@@ -59,7 +59,8 @@ def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
 
 
 def _patch_workspace(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: root)
+    if hasattr(workflows, "resolve_workspace_root"):
+        monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: root)
 
 
 def _file_tree(root: Path) -> tuple[tuple[str, str, bytes | None], ...]:
@@ -316,13 +317,9 @@ def test_install_skips_existing_by_default_and_exact_overwrite_replaces(
 
     assert workflows.prompt_install_selected_starter_materials() == 1
     assert target.read_bytes() == before
-    assert "Overwrite canceled" in capsys.readouterr().out
-
-    _menu_input(monkeypatch, ["1", "2", "OVERWRITE"])
-
-    assert workflows.prompt_install_selected_starter_materials() == 0
-    assert target.read_bytes() != before
-    assert load_comment_bank(target)["bank_id"] == material.material_id
+    assert "Legacy generic starter review materials are disabled" in (
+        capsys.readouterr().out
+    )
 
 
 def test_install_summary_counts_existing_files(tmp_path: Path) -> None:
@@ -337,22 +334,21 @@ def test_install_summary_counts_existing_files(tmp_path: Path) -> None:
     assert summary.overwrite_files == 1
 
 
-def test_install_selected_one_of_each_type(
+def test_install_selected_workflow_is_disabled_without_writes(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _patch_workspace(monkeypatch, tmp_path)
-    materials = discover_starter_materials()
-    comment_count = sum(1 for material in materials if material.kind == "comment_bank")
-    tag_count = sum(1 for material in materials if material.kind == "tag_bank")
-    selections = f"1,{comment_count + 1},{comment_count + tag_count + 1}"
-    _menu_input(monkeypatch, [selections, "1"])
+    before = _file_tree(tmp_path)
+    _menu_input(monkeypatch, ["1,18,35", "1"])
 
-    assert workflows.prompt_install_selected_starter_materials() == 0
+    assert workflows.prompt_install_selected_starter_materials() == 1
 
-    assert len(list((tmp_path / "shared" / "comment_banks").glob("*.json"))) == 1
-    assert len(list((tmp_path / "shared" / "tag_banks").glob("*.json"))) == 1
-    assert len(list((tmp_path / "shared" / "rubrics").glob("*.json"))) == 1
+    assert _file_tree(tmp_path) == before
+    assert "Legacy generic starter review materials are disabled" in (
+        capsys.readouterr().out
+    )
 
 
 def test_invalid_selected_install_is_rejected_without_writes(
@@ -367,7 +363,9 @@ def test_invalid_selected_install_is_rejected_without_writes(
     assert workflows.prompt_install_selected_starter_materials() == 1
 
     assert _file_tree(tmp_path) == before
-    assert "Invalid selection" in capsys.readouterr().out
+    assert "Legacy generic starter review materials are disabled" in (
+        capsys.readouterr().out
+    )
 
 
 def test_cancel_paths_create_no_files(
@@ -393,16 +391,15 @@ def test_preview_and_validate_workflows_report_material_groups(
 ) -> None:
     _patch_workspace(monkeypatch, tmp_path)
 
-    assert workflows.prompt_preview_starter_materials() == 0
-    assert workflows.prompt_validate_starter_materials() == 0
+    assert workflows.prompt_preview_starter_materials() == 1
+    assert workflows.prompt_validate_starter_materials() == 1
 
     output = capsys.readouterr().out
-    assert "Comment Banks" in output
-    assert "Tag Banks" in output
-    assert "Rubrics / Scoring Profiles" in output
-    assert "OK general_written_response.json" in output
-    assert "OK general_written_response_tags.json" in output
-    assert "OK general_constructed_response.json" in output
+    assert "Legacy generic starter review materials are disabled" in output
+    assert "Comment Banks" not in output
+    assert "Tag Banks" not in output
+    assert "Rubrics / Scoring Profiles" not in output
+    assert "OK general_written_response.json" not in output
 
 
 def test_starter_materials_submenu_preview_and_back(
@@ -411,13 +408,16 @@ def test_starter_materials_submenu_preview_and_back(
     tmp_path: Path,
 ) -> None:
     _patch_workspace(monkeypatch, tmp_path)
-    _menu_input(monkeypatch, ["1", "", "5"])
+    _menu_input(monkeypatch, ["x", "", "1"])
 
     assert workflows.launch_starter_materials_menu() == 0
 
     output = capsys.readouterr().out
-    assert "Preview starter materials" in output
-    assert "General Written Response Comments" in output
+    assert "Starter Materials" in output
+    assert "Legacy starter comment-bank, tag-bank, and rubric installers" in output
+    assert "1. Back" in output
+    assert "Preview starter materials" not in output
+    assert "General Written Response Comments" not in output
 
 
 def test_installed_materials_are_discoverable_by_review_helpers(

--- a/tests/test_v080_end_to_end_smoke.py
+++ b/tests/test_v080_end_to_end_smoke.py
@@ -267,61 +267,10 @@ def test_v080_scan_review_export_end_to_end_smoke(
         ]
     ) == 0
 
-    assert main(
-        [
-            "add-tag",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--label",
-            "claim",
-            "--polarity",
-            "positive",
-            "--standard-id",
-            STANDARD_ID,
-            "--note",
-            "Claim is clear and defensible.",
-            "--page",
-            "1",
-            "--evidence-id",
-            selected_evidence_id,
-        ]
-    ) == 0
-
-    assert main(
-        [
-            "add-comment",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--bank",
-            BANK_ID,
-            "--comment-id",
-            COMMENT_ID,
-            "--include-in-feedback",
-        ]
-    ) == 0
-
-    assert main(
-        [
-            "set-score",
-            CLASS_ID,
-            ASSIGNMENT_ID,
-            STUDENT_ID,
-            "--criterion",
-            "evidence",
-            "--label",
-            "Evidence",
-            "--score",
-            "3",
-            "--max-score",
-            "4",
-            "--scale",
-            "4 point",
-            "--note",
-            "Uses relevant quoted evidence.",
-        ]
-    ) == 0
+    for removed_command in ("add-tag", "add-comment", "set-score"):
+        with pytest.raises(SystemExit) as error:
+            main([removed_command, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID])
+        assert error.value.code != 0
 
     assert main(
         [
@@ -344,16 +293,9 @@ def test_v080_scan_review_export_end_to_end_smoke(
     review = json.loads(review_path.read_text(encoding="utf-8"))
     assert review["review_state"] == "in_progress"
     assert review["notes"][0]["text"] == "Teacher observation: the claim is clear."
-    assert review["tags"][0]["standard_id"] == STANDARD_ID
-    assert review["tags"][0]["label"] == "claim"
-    assert review["tags"][0]["evidence_id"] == selected_evidence_id
-    assert review["comments"][0]["source"] == "comment_bank"
-    assert review["comments"][0]["bank_id"] == BANK_ID
-    assert review["comments"][0]["comment_id"] == COMMENT_ID
-    assert review["comments"][0]["include_in_feedback"] is True
-    assert review["scores"][0]["criterion_id"] == "evidence"
-    assert review["scores"][0]["score"] == 3
-    assert review["scores"][0]["max_score"] == 4
+    assert review["tags"] == []
+    assert review["comments"] == []
+    assert review["scores"] == []
 
     updated_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert updated_manifest["submission_state"] == "reviewed"
@@ -404,21 +346,16 @@ def test_v080_scan_review_export_end_to_end_smoke(
     assert standards_summary_path.is_file()
 
     feedback_text = feedback_path.read_text(encoding="utf-8")
-    selected_comment_text = str(review["comments"][0]["text"])
     assert f"Assignment: {ASSIGNMENT_ID}" in feedback_text
-    assert "Evidence: 3 / 4" in feedback_text
-    assert selected_comment_text in feedback_text
+    assert "Teacher Notes" not in feedback_text
 
     class_summary_text = class_summary_path.read_text(encoding="utf-8")
     assert STUDENT_ID in class_summary_text
     assert "in_progress" in class_summary_text
 
     standards_summary_text = standards_summary_path.read_text(encoding="utf-8")
-    assert STANDARD_ID in standards_summary_text
     assert "student_count" in standards_summary_text
-    assert "tag_student_count" in standards_summary_text
-    assert "positive_tag_count" in standards_summary_text
-    assert "review_tags_and_comments" in standards_summary_text
+    assert STANDARD_ID not in standards_summary_text
 
     output = capsys.readouterr().out
     assert "Routed Quillan response page." in output


### PR DESCRIPTION
## Summary

Removes or isolates obsolete generic review-material workflows that no longer fit the v0.8.6 standards-based review redesign.

This PR is a removal/isolation gate. It does not implement the new v2 assignment model, v2 review-record model, review-unit observations, Focus Standard ratings, feedback composer, PDF export, or standards-based reports.

## Changes

* Removes `Manage Review Materials` from the active Review Student Work menu.
* Removes selected-student actions for:

  * `Add structured tag`
  * `Select reusable comment`
  * `Set criterion score`
* Removes CLI parser registration for:

  * `add-tag`
  * `add-comment`
  * `set-score`
* Disables legacy Review Materials and Starter Materials menu shells with clear redesign messages.
* Adds fail-closed guards to dormant legacy review-menu helpers so accidental internal calls cannot write v1 tag/comment/score data.
* Marks remaining old workflow/entry modules as legacy compatibility-only where they still exist.
* Updates CLI contract documentation so removed workflows are no longer advertised.
* Replaces old menu/CLI tests with guardrail tests confirming removed paths are absent or rejected.
* Keeps retained workflows unchanged, including evidence opening, scan intake, submission assembly/status, exports, printable responses, page management, notes, and review state.

## Verification

Targeted suite:

* `65 passed`

Full suite:

* `1058 passed`

Command run:

```powershell
.\.venv\Scripts\python.exe -m pytest
```

## Notes

This PR intentionally does not implement the standards-based replacement workflows. It only removes or isolates obsolete v1 review-material surfaces so later v2 work can proceed without keeping active tag/comment/rubric/score workflows alive.

Closes #224
