### PR TITLE
Implement v2 assignment loader and validator

### DIFF
--- a/docs/assignment_contract.md
+++ b/docs/assignment_contract.md
@@ -760,7 +760,7 @@ The old assignment field `focus_standards` is superseded by `focus_standard_ids`
 
 The new name makes the field’s contents explicit: it stores durable standard IDs, not full standard records, display labels, or standards-profile data.
 
-Compatibility code may temporarily read old `focus_standards` fields during migration or validation work, but `focus_standard_ids` is the v0.8.6 canonical field.
+The v2 assignment loader does not accept old `focus_standards` fields as valid active assignment data. Use `focus_standard_ids` in schema version `2` records.
 
 ## Backward Compatibility and Migration
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -398,6 +398,8 @@ field belongs to the generic rubric/scoring-profile workflow. The old
 Because Quillan is still pre-pilot and no production classroom data is expected
 to depend on the old assignment contract, v0.8.6 may treat the schema version
 `2` assignment shape as a breaking cleanup with no production-data migration.
+Runtime assignment loading and discovery reject old assignment records as
+legacy configs rather than listing them as valid active assignments.
 Later implementation work must decide whether old assignment records are
 rejected with clear guidance, read as legacy records, migrated by a helper, or
 temporarily supported by compatibility code.

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from pds_core.classes import ClassFolder, list_class_folders
-from pds_core.identifiers import IdentifierValidationError, validate_identifier
 from pds_core.standards import StandardsReadError, StandardsValidationError
 from pds_core.standards_selection import (
     StandardSelectionItem,
@@ -21,13 +20,11 @@ from pds_core.standards_selection import (
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
 from quillan.assignments import (
-    ALLOWED_TAGGING_MODES,
     AssignmentConfigError,
     load_assignment_config,
     validate_assignment_config,
 )
 from quillan.assignment_picker import prompt_assignment_choice
-from quillan.rubric_writing import list_valid_rubrics
 from quillan.rubrics import RubricError, load_rubric, rubric_path
 from quillan.storage import assignment_config_path
 
@@ -76,23 +73,30 @@ def build_assignment_config(
     title: str,
     class_id: str,
     writing_type: str,
+    student_prompt: str,
     standards_profile_id: str,
-    tagging_mode: str,
-    focus_standards: Sequence[str],
+    focus_standard_ids: Sequence[str],
+    review_unit: Mapping[str, Any],
+    rating_scale: Mapping[str, Any],
     basic_requirements: Mapping[str, Any],
-    rubric_id: str,
+    minimum_requirement_policy: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Build and validate an assignment config using the existing contract."""
+    """Build and validate a v2 assignment config."""
     assignment: dict[str, Any] = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": assignment_id,
         "title": title,
         "class_ids": [class_id],
         "writing_type": writing_type,
+        "student_prompt": student_prompt,
         "standards_profile_id": standards_profile_id,
-        "tagging_mode": tagging_mode,
-        "focus_standards": list(focus_standards),
+        "focus_standard_ids": list(focus_standard_ids),
+        "review_unit": dict(review_unit),
+        "rating_scale": dict(rating_scale),
         "basic_requirements": dict(basic_requirements),
-        "rubric_id": rubric_id,
+        "minimum_requirement_policy": dict(minimum_requirement_policy),
     }
     validate_assignment_config(assignment)
     return assignment
@@ -131,25 +135,27 @@ def format_assignment_summary(
 ) -> str:
     """Return a concise human-readable assignment summary."""
     class_ids = ", ".join(str(value) for value in assignment["class_ids"])
-    focus_standards = [str(value) for value in assignment["focus_standards"]]
-    focus_text = ", ".join(focus_standards) if focus_standards else "(none)"
+    focus_standard_ids = [str(value) for value in assignment["focus_standard_ids"]]
+    focus_text = ", ".join(focus_standard_ids)
+    review_unit = assignment.get("review_unit", {})
+    rating_scale = assignment.get("rating_scale", {})
     lines = [
         f"Assignment path: {Path(assignment_path)}",
+        f"Schema version: {assignment['schema_version']}",
         f"Assignment ID: {assignment['assignment_id']}",
         f"Title: {assignment['title']}",
         f"Class IDs: {class_ids}",
         f"Writing type: {assignment['writing_type']}",
+        f"Student prompt: {assignment['student_prompt']}",
         f"Standards profile ID: {assignment['standards_profile_id']}",
-        f"Tagging mode: {assignment['tagging_mode']}",
-        f"Focus standards ({len(focus_standards)}): {focus_text}",
-        f"Rubric ID: {assignment['rubric_id']}",
+        f"Focus standard IDs ({len(focus_standard_ids)}): {focus_text}",
     ]
-    if workspace_root is not None:
-        rubric = resolve_assignment_rubric(workspace_root, assignment)
-        if rubric is None:
-            lines.append("Rubric profile: not found in shared/rubrics/")
-        else:
-            lines.append(f"Rubric profile: resolved - {rubric['title']}")
+    if isinstance(review_unit, Mapping):
+        lines.append(f"Review unit: {review_unit.get('singular_label')}")
+    if isinstance(rating_scale, Mapping):
+        levels = rating_scale.get("levels")
+        if isinstance(levels, Sequence) and not isinstance(levels, (str, bytes)):
+            lines.append(f"Rating scale: {rating_scale.get('scale_id')} ({len(levels)} levels)")
     return "\n".join(lines)
 
 
@@ -222,39 +228,6 @@ def _prompt_basic_requirements() -> dict[str, Any]:
     if required_elements:
         requirements["required_elements"] = required_elements
     return requirements
-
-
-def _prompt_rubric_id(workspace_root: Path) -> str:
-    rubrics = list_valid_rubrics(workspace_root)
-    if not rubrics:
-        print("No valid shared rubrics found.")
-        print()
-        print(
-            "Legacy rubric authoring workflows are disabled during the "
-            "standards-based review redesign."
-        )
-        print("You may still enter a custom rubric_id for now.")
-        print()
-        return _required_input("Rubric ID: ", "Rubric ID")
-
-    print("Available rubrics / scoring profiles:")
-    for index, item in enumerate(rubrics, start=1):
-        assert item.rubric is not None
-        print(f"{index}. {item.rubric['title']}")
-    custom_index = len(rubrics) + 1
-    print(f"{custom_index}. Custom rubric ID")
-    print()
-    selection = input("Select rubric: ").strip()
-    if selection.isdigit():
-        selected = int(selection)
-        if 1 <= selected <= len(rubrics):
-            rubric = rubrics[selected - 1].rubric
-            assert rubric is not None
-            return str(rubric["rubric_id"])
-        if selected == custom_index:
-            return _required_input("Rubric ID: ", "Rubric ID")
-    print(f"Error: rubric selection not found: {selection}")
-    raise ValueError("Rubric selection is required.")
 
 
 def _prompt_numbered_selection(
@@ -350,80 +323,12 @@ def prompt_create_assignment() -> int:
     from quillan.menu import print_menu_header
 
     print_menu_header("Create Writing Assignment")
-    workspace_root = _workspace_root()
-    if workspace_root is None:
-        return 1
-    class_folder = _prompt_class_folder(workspace_root)
-    if class_folder is None:
-        return 1
-
-    try:
-        title = _required_input("Assignment title: ", "Assignment title")
-        suggestion = suggest_assignment_id(title)
-        print(f"Suggested assignment_id: {suggestion}")
-        assignment_id = input(
-            "Press Enter to accept, or type a different assignment_id: "
-        ).strip()
-        if not assignment_id:
-            assignment_id = suggestion
-        validate_identifier(assignment_id, "assignment_id")
-
-        writing_type = _required_input("Writing type: ", "Writing type")
-        standards_selection = _prompt_standards_selection(workspace_root)
-        if standards_selection is None:
-            return 1
-        standards_profile_id, focus_standards = standards_selection
-        tagging_mode = input(
-            "Tagging mode [focus/focus_plus_past/benchmark/custom] "
-            "(default: focus): "
-        ).strip()
-        if not tagging_mode:
-            tagging_mode = "focus"
-        if tagging_mode not in ALLOWED_TAGGING_MODES:
-            allowed = "/".join(sorted(ALLOWED_TAGGING_MODES))
-            raise ValueError(f"Tagging mode must be one of: {allowed}.")
-        basic_requirements = _prompt_basic_requirements()
-        rubric_id = _prompt_rubric_id(workspace_root)
-        assignment = build_assignment_config(
-            assignment_id=assignment_id,
-            title=title,
-            class_id=class_folder.class_id,
-            writing_type=writing_type,
-            standards_profile_id=standards_profile_id,
-            tagging_mode=tagging_mode,
-            focus_standards=focus_standards,
-            basic_requirements=basic_requirements,
-            rubric_id=rubric_id,
-        )
-    except (AssignmentConfigError, IdentifierValidationError, ValueError) as error:
-        print(f"Error: {error}")
-        return 1
-
-    path = assignment_config_path(
-        workspace_root,
-        class_folder.class_id,
-        assignment_id,
+    print(
+        "Creating v2 standards-based assignments from the interactive menu is "
+        "temporarily unavailable pending the v2 assignment creation workflow."
     )
-    overwrite = False
-    if path.exists():
-        confirmation = input("Type OVERWRITE to replace it: ").strip()
-        if confirmation != "OVERWRITE":
-            print("Canceled: existing assignment config was not changed.")
-            return 1
-        overwrite = True
-
-    try:
-        saved_path = write_assignment_config(
-            workspace_root,
-            class_folder.class_id,
-            assignment,
-            overwrite=overwrite,
-        )
-    except (AssignmentConfigError, OSError) as error:
-        print(f"Error: {error}")
-        return 1
-    print(f"Saved assignment config: {saved_path}")
-    return 0
+    print("Use a schema_version '2' assignment JSON file for now.")
+    return 1
 
 
 def _normalize_path_input(value: str) -> str:

--- a/quillan/assignments.py
+++ b/quillan/assignments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -13,7 +14,11 @@ from pds_core.standards import (
     validate_profile_standard_selection,
 )
 
-ALLOWED_TAGGING_MODES = {"focus", "focus_plus_past", "benchmark", "custom"}
+ASSIGNMENT_SCHEMA_VERSION = "2"
+ASSIGNMENT_MODULE = "quillan"
+ASSIGNMENT_RECORD_TYPE = "assignment"
+_SIMPLE_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+_LEGACY_ASSIGNMENT_FIELDS = frozenset({"tagging_mode", "focus_standards", "rubric_id"})
 
 
 class AssignmentConfigError(ValueError):
@@ -47,33 +52,49 @@ def load_assignment_config(path: str | Path) -> dict[str, Any]:
 
 
 def validate_assignment_config(assignment: dict[str, Any]) -> None:
-    """Validate the structure of an assignment config."""
+    """Validate the v2 structure of an assignment config."""
+    _reject_legacy_assignment_config(assignment)
+
     required_fields = [
+        "schema_version",
+        "module",
+        "record_type",
         "assignment_id",
         "title",
         "class_ids",
         "writing_type",
+        "student_prompt",
         "standards_profile_id",
-        "tagging_mode",
-        "focus_standards",
+        "focus_standard_ids",
+        "review_unit",
+        "rating_scale",
         "basic_requirements",
-        "rubric_id",
+        "minimum_requirement_policy",
     ]
 
     for field in required_fields:
         _require_field(assignment, field, "assignment config")
 
+    _validate_fixed_value(
+        assignment["schema_version"], "schema_version", ASSIGNMENT_SCHEMA_VERSION
+    )
+    _validate_fixed_value(assignment["module"], "module", ASSIGNMENT_MODULE)
+    _validate_fixed_value(
+        assignment["record_type"], "record_type", ASSIGNMENT_RECORD_TYPE
+    )
     _validate_identifier(assignment["assignment_id"], "assignment_id")
     _validate_non_empty_string(assignment["title"], "title")
     _validate_class_ids(assignment["class_ids"])
     _validate_non_empty_string(assignment["writing_type"], "writing_type")
+    _validate_non_empty_string(assignment["student_prompt"], "student_prompt")
     _validate_non_empty_string(
         assignment["standards_profile_id"], "standards_profile_id"
     )
-    _validate_tagging_mode(assignment["tagging_mode"])
-    _validate_focus_standards(assignment["focus_standards"])
+    _validate_focus_standard_ids(assignment["focus_standard_ids"])
+    _validate_review_unit(assignment["review_unit"])
+    _validate_rating_scale(assignment["rating_scale"])
     _validate_basic_requirements(assignment["basic_requirements"])
-    _validate_non_empty_string(assignment["rubric_id"], "rubric_id")
+    _validate_minimum_requirement_policy(assignment["minimum_requirement_policy"])
 
 
 def validate_assignment_standards_selection(
@@ -90,19 +111,44 @@ def validate_assignment_standards_selection(
     validate_assignment_config(assignment)
 
     profile_id = cast(str, assignment["standards_profile_id"])
-    focus_standards = cast(list[str], assignment["focus_standards"])
+    focus_standard_ids = cast(list[str], assignment["focus_standard_ids"])
 
     try:
         return validate_profile_standard_selection(
             standards_library,
             profile_id=profile_id,
-            selected_standard_ids=focus_standards,
+            selected_standard_ids=focus_standard_ids,
         )
     except StandardsValidationError as error:
         raise AssignmentConfigError(
             "Invalid assignment standards selection for "
-            f"standards_profile_id {profile_id!r} and focus_standards: {error}"
+            f"standards_profile_id {profile_id!r} and focus_standard_ids: {error}"
         ) from error
+
+
+def _reject_legacy_assignment_config(assignment: dict[str, Any]) -> None:
+    schema_version = assignment.get("schema_version")
+    legacy_fields = sorted(_LEGACY_ASSIGNMENT_FIELDS.intersection(assignment))
+    if schema_version == ASSIGNMENT_SCHEMA_VERSION and not legacy_fields:
+        return
+
+    if schema_version != ASSIGNMENT_SCHEMA_VERSION:
+        detail = "missing" if schema_version is None else repr(schema_version)
+        if legacy_fields:
+            raise AssignmentConfigError(
+                "Legacy assignment configs are not supported by the v2 "
+                "standards-based assignment loader. Unsupported schema_version "
+                f"is {detail}; legacy fields present: {', '.join(legacy_fields)}."
+            )
+        raise AssignmentConfigError(
+            "Unsupported assignment schema_version "
+            f"{detail}; expected {ASSIGNMENT_SCHEMA_VERSION!r}."
+        )
+
+    raise AssignmentConfigError(
+        "Legacy assignment fields are not supported by the v2 standards-based "
+        f"assignment loader: {', '.join(legacy_fields)}."
+    )
 
 
 def _validate_class_ids(class_ids: Any) -> None:
@@ -117,28 +163,74 @@ def _validate_class_ids(class_ids: Any) -> None:
         _validate_identifier(class_id, "class_id")
 
 
-def _validate_tagging_mode(tagging_mode: Any) -> None:
-    """Validate assignment tagging mode."""
-    if not isinstance(tagging_mode, str):
-        raise AssignmentConfigError("Field 'tagging_mode' must be a string.")
+def _validate_focus_standard_ids(focus_standard_ids: Any) -> None:
+    """Validate assignment focus standard IDs."""
+    if not isinstance(focus_standard_ids, list):
+        raise AssignmentConfigError("Field 'focus_standard_ids' must be a list.")
 
-    if tagging_mode not in ALLOWED_TAGGING_MODES:
-        allowed = ", ".join(sorted(ALLOWED_TAGGING_MODES))
+    if not focus_standard_ids:
+        raise AssignmentConfigError("Field 'focus_standard_ids' must not be empty.")
+
+    for standard_id in focus_standard_ids:
+        if not isinstance(standard_id, str) or not standard_id.strip():
+            raise AssignmentConfigError(
+                "Each value in 'focus_standard_ids' must be a non-empty string."
+            )
+
+
+def _validate_review_unit(review_unit: Any) -> None:
+    if not isinstance(review_unit, dict):
+        raise AssignmentConfigError("Field 'review_unit' must be an object.")
+
+    for field in ("type", "singular_label", "plural_label"):
+        _require_field(review_unit, field, "review_unit")
+        _validate_non_empty_string(review_unit[field], f"review_unit.{field}")
+
+    unit_type = cast(str, review_unit["type"])
+    if _SIMPLE_IDENTIFIER_PATTERN.fullmatch(unit_type.strip()) is None:
         raise AssignmentConfigError(
-            f"Invalid tagging mode '{tagging_mode}'. Allowed values: {allowed}."
+            "Field 'review_unit.type' must be a simple identifier-like string."
         )
 
 
-def _validate_focus_standards(focus_standards: Any) -> None:
-    """Validate assignment focus standards."""
-    if not isinstance(focus_standards, list):
-        raise AssignmentConfigError("Field 'focus_standards' must be a list.")
+def _validate_rating_scale(rating_scale: Any) -> None:
+    if not isinstance(rating_scale, dict):
+        raise AssignmentConfigError("Field 'rating_scale' must be an object.")
 
-    for standard_code in focus_standards:
-        if not isinstance(standard_code, str) or not standard_code.strip():
+    for field in ("scale_id", "levels"):
+        _require_field(rating_scale, field, "rating_scale")
+    _validate_non_empty_string(rating_scale["scale_id"], "rating_scale.scale_id")
+
+    levels = rating_scale["levels"]
+    if not isinstance(levels, list):
+        raise AssignmentConfigError("Field 'rating_scale.levels' must be a list.")
+    if not levels:
+        raise AssignmentConfigError("Field 'rating_scale.levels' must not be empty.")
+
+    seen_values: set[int] = set()
+    for index, level in enumerate(levels):
+        if not isinstance(level, dict):
             raise AssignmentConfigError(
-                "Each value in 'focus_standards' must be a non-empty string."
+                f"Each value in 'rating_scale.levels' must be an object; "
+                f"level {index + 1} is invalid."
             )
+        for field in ("value", "label", "description"):
+            _require_field(level, field, f"rating_scale.levels[{index}]")
+
+        value = level["value"]
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise AssignmentConfigError(
+                "Each 'value' in 'rating_scale.levels' must be an integer."
+            )
+        if value in seen_values:
+            raise AssignmentConfigError(
+                f"Duplicate rating_scale level value: {value}."
+            )
+        seen_values.add(value)
+        _validate_non_empty_string(level["label"], "rating_scale.levels.label")
+        _validate_non_empty_string(
+            level["description"], "rating_scale.levels.description"
+        )
 
 
 def _validate_basic_requirements(basic_requirements: Any) -> None:
@@ -169,6 +261,50 @@ def _validate_basic_requirements(basic_requirements: Any) -> None:
                     "Each value in 'required_elements' must be a non-empty string."
                 )
 
+    _validate_min_max_requirement(
+        basic_requirements,
+        minimum_key="paragraphs_min",
+        maximum_key="paragraphs_max",
+    )
+    _validate_min_max_requirement(
+        basic_requirements,
+        minimum_key="word_count_min",
+        maximum_key="word_count_max",
+    )
+
+
+def _validate_min_max_requirement(
+    requirements: dict[str, Any],
+    *,
+    minimum_key: str,
+    maximum_key: str,
+) -> None:
+    minimum = requirements.get(minimum_key)
+    maximum = requirements.get(maximum_key)
+    if isinstance(minimum, int) and isinstance(maximum, int) and minimum > maximum:
+        raise AssignmentConfigError(
+            f"Field '{minimum_key}' in 'basic_requirements' must not exceed "
+            f"'{maximum_key}'."
+        )
+
+
+def _validate_minimum_requirement_policy(policy: Any) -> None:
+    if not isinstance(policy, dict):
+        raise AssignmentConfigError(
+            "Field 'minimum_requirement_policy' must be an object."
+        )
+    _require_field(
+        policy,
+        "allow_return_without_full_review",
+        "minimum_requirement_policy",
+    )
+    value = policy["allow_return_without_full_review"]
+    if not isinstance(value, bool):
+        raise AssignmentConfigError(
+            "Field 'allow_return_without_full_review' in "
+            "'minimum_requirement_policy' must be a boolean."
+        )
+
 
 def _validate_non_negative_integer_requirement(key: str, value: Any) -> None:
     """Validate a non-negative integer requirement value."""
@@ -190,6 +326,13 @@ def _validate_non_empty_string(value: Any, field: str) -> None:
     """Validate a required non-empty string field."""
     if not isinstance(value, str) or not value.strip():
         raise AssignmentConfigError(f"Field '{field}' must be a non-empty string.")
+
+
+def _validate_fixed_value(value: Any, field: str, expected: str) -> None:
+    if value != expected:
+        raise AssignmentConfigError(
+            f"Field '{field}' must be {expected!r}; got {value!r}."
+        )
 
 
 def _require_field(data: dict[str, Any], field: str, context: str) -> None:

--- a/tests/fixtures/paper_workflow/assignment.json
+++ b/tests/fixtures/paper_workflow/assignment.json
@@ -1,13 +1,36 @@
 {
+  "schema_version": "2",
+  "module": "quillan",
+  "record_type": "assignment",
   "assignment_id": "literary_argument_synthetic",
   "title": "Literary Argument Response",
   "class_ids": ["english12_p4_synthetic"],
-  "writing_type": "literary argument essay",
+  "writing_type": "literary_argument",
+  "student_prompt": "Write a literary argument using evidence from the text.",
   "standards_profile_id": "english_12_njsls_synthetic",
-  "tagging_mode": "focus",
-  "focus_standards": [
+  "focus_standard_ids": [
     "njsls-ela:W.AW.11-12.1"
   ],
+  "review_unit": {
+    "type": "paragraph",
+    "singular_label": "paragraph",
+    "plural_label": "paragraphs"
+  },
+  "rating_scale": {
+    "scale_id": "standards_4_level",
+    "levels": [
+      {
+        "value": 1,
+        "label": "Developing",
+        "description": "The response shows limited evidence of the standard."
+      },
+      {
+        "value": 2,
+        "label": "Meeting",
+        "description": "The response shows clear evidence of the standard."
+      }
+    ]
+  },
   "basic_requirements": {
     "paragraphs_min": 3,
     "word_count_min": 300,
@@ -17,5 +40,7 @@
       "reasoning"
     ]
   },
-  "rubric_id": "argument_essay_4pt_synthetic"
+  "minimum_requirement_policy": {
+    "allow_return_without_full_review": true
+  }
 }

--- a/tests/test_assignment_picker.py
+++ b/tests/test_assignment_picker.py
@@ -1,0 +1,106 @@
+"""Tests for assignment picker discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from quillan.assignment_picker import available_assignments
+
+
+CLASS_ID = "english_12_p3"
+
+
+def _assignment(
+    assignment_id: str,
+    *,
+    title: str = "Synthetic Assignment",
+) -> dict[str, Any]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": assignment_id,
+        "title": title,
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
+        "standards_profile_id": "synthetic_ela",
+        "focus_standard_ids": ["synthetic:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
+        "basic_requirements": {},
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
+    }
+
+
+def _write_assignment(
+    workspace_root: Path,
+    assignment_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    path = (
+        workspace_root
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / assignment_id
+        / "assignment.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(assignment), encoding="utf-8")
+
+
+def test_available_assignments_lists_valid_v2_assignments(tmp_path: Path) -> None:
+    _write_assignment(
+        tmp_path,
+        "valid_assignment",
+        _assignment("valid_assignment", title="Visible Title"),
+    )
+
+    choices = available_assignments(tmp_path, CLASS_ID)
+
+    assert [choice.assignment_id for choice in choices] == ["valid_assignment"]
+    assert choices[0].title == "Visible Title"
+
+
+def test_available_assignments_skips_invalid_and_legacy_configs(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path, "valid_assignment", _assignment("valid_assignment"))
+    _write_assignment(tmp_path, "invalid_assignment", {"assignment_id": "incomplete"})
+    _write_assignment(
+        tmp_path,
+        "legacy_assignment",
+        {
+            "assignment_id": "legacy_assignment",
+            "title": "Legacy",
+            "class_ids": [CLASS_ID],
+            "writing_type": "argument",
+            "standards_profile_id": "synthetic_ela",
+            "tagging_mode": "focus",
+            "focus_standards": ["synthetic:W.1"],
+            "basic_requirements": {},
+            "rubric_id": "legacy",
+        },
+    )
+
+    choices = available_assignments(tmp_path, CLASS_ID)
+
+    assert [choice.assignment_id for choice in choices] == ["valid_assignment"]

--- a/tests/test_assignment_standards_selection.py
+++ b/tests/test_assignment_standards_selection.py
@@ -19,19 +19,39 @@ def _valid_assignment_config() -> dict[str, object]:
         "title": "Villainy Final Essay",
         "class_ids": ["english12_period3_synthetic"],
         "writing_type": "literary argument essay",
+        "student_prompt": "Use evidence to support a literary argument.",
         "standards_profile_id": "english12_2023_njsls",
-        "tagging_mode": "focus",
-        "focus_standards": [
+        "focus_standard_ids": [
             "nj_ela_2023_rl_cr_11_12_1",
             "nj_ela_2023_w_aw_11_12_1",
         ],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_4_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {
             "paragraphs_min": 4,
             "paragraphs_max": 6,
             "word_count_min": 500,
             "required_elements": ["thesis", "textual evidence"],
         },
-        "rubric_id": "argument_essay_4pt_synthetic",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
     }
 
 
@@ -88,7 +108,7 @@ def test_assignment_standards_selection_accepts_valid_profile_and_focus() -> Non
 def test_assignment_standards_selection_returns_normalized_focus_ids() -> None:
     assignment = _valid_assignment_config()
     assignment["standards_profile_id"] = " english12_2023_njsls "
-    assignment["focus_standards"] = [" nj_ela_2023_rl_cr_11_12_1 "]
+    assignment["focus_standard_ids"] = [" nj_ela_2023_rl_cr_11_12_1 "]
 
     assert validate_assignment_standards_selection(
         assignment,
@@ -117,29 +137,29 @@ def test_assignment_standards_selection_rejects_unknown_profile_id() -> None:
 
 def test_assignment_standards_selection_rejects_unknown_focus_standard() -> None:
     assignment = _valid_assignment_config()
-    assignment["focus_standards"] = ["nj_ela_2023_missing"]
+    assignment["focus_standard_ids"] = ["nj_ela_2023_missing"]
 
     with pytest.raises(
         AssignmentConfigError,
-        match="focus_standards.*nj_ela_2023_missing",
+        match="focus_standard_ids.*nj_ela_2023_missing",
     ):
         validate_assignment_standards_selection(assignment, _standards_library())
 
 
 def test_assignment_standards_selection_rejects_standard_outside_profile() -> None:
     assignment = _valid_assignment_config()
-    assignment["focus_standards"] = ["nj_ela_2023_l_vi_11_12_4"]
+    assignment["focus_standard_ids"] = ["nj_ela_2023_l_vi_11_12_4"]
 
     with pytest.raises(
         AssignmentConfigError,
-        match="focus_standards.*nj_ela_2023_l_vi_11_12_4",
+        match="focus_standard_ids.*nj_ela_2023_l_vi_11_12_4",
     ):
         validate_assignment_standards_selection(assignment, _standards_library())
 
 
-def test_assignment_standards_selection_rejects_duplicate_focus_standards() -> None:
+def test_assignment_standards_selection_rejects_duplicate_focus_standard_ids() -> None:
     assignment = _valid_assignment_config()
-    assignment["focus_standards"] = [
+    assignment["focus_standard_ids"] = [
         "nj_ela_2023_rl_cr_11_12_1",
         " nj_ela_2023_rl_cr_11_12_1 ",
     ]
@@ -148,14 +168,12 @@ def test_assignment_standards_selection_rejects_duplicate_focus_standards() -> N
         validate_assignment_standards_selection(assignment, _standards_library())
 
 
-def test_assignment_standards_selection_accepts_empty_focus_standards() -> None:
+def test_assignment_standards_selection_rejects_empty_focus_standard_ids() -> None:
     assignment = _valid_assignment_config()
-    assignment["focus_standards"] = []
+    assignment["focus_standard_ids"] = []
 
-    assert validate_assignment_standards_selection(
-        assignment,
-        _standards_library(),
-    ) == ()
+    with pytest.raises(AssignmentConfigError, match="focus_standard_ids"):
+        validate_assignment_standards_selection(assignment, _standards_library())
 
 
 def test_structural_assignment_validation_accepts_valid_config_without_library() -> None:
@@ -164,7 +182,7 @@ def test_structural_assignment_validation_accepts_valid_config_without_library()
 
 def test_structural_assignment_validation_rejects_malformed_config_without_library() -> None:
     assignment = _valid_assignment_config()
-    assignment["focus_standards"] = "nj_ela_2023_rl_cr_11_12_1"
+    assignment["focus_standard_ids"] = "nj_ela_2023_rl_cr_11_12_1"
 
-    with pytest.raises(AssignmentConfigError, match="focus_standards.*list"):
+    with pytest.raises(AssignmentConfigError, match="focus_standard_ids.*list"):
         validate_assignment_config(assignment)

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -3,17 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-import json
 from pathlib import Path
 
 from pds_core.classes import write_class_roster
 from pds_core.rosters import create_roster
-from pds_core.standards import (
-    StandardDefinition,
-    StandardsLibrary,
-    StandardsProfile,
-    write_workspace_standards_library,
-)
 import pytest
 
 import quillan.assignment_workflows as workflows
@@ -21,12 +14,6 @@ from quillan.assignments import (
     AssignmentConfigError,
     load_assignment_config,
     validate_assignment_config,
-)
-from quillan.rubric_writing import (
-    build_rubric,
-    build_rubric_criterion,
-    build_rubric_level,
-    write_rubric,
 )
 
 
@@ -40,18 +27,40 @@ def _assignment(
         title="Literary Analysis Essay",
         class_id=class_id,
         writing_type="literary_analysis",
+        student_prompt="Analyze how the author develops a central idea.",
         standards_profile_id="synthetic_ela_11_12",
-        tagging_mode="focus",
-        focus_standards=[
+        focus_standard_ids=[
             "njsls-ela:W.AW.11-12.1",
             "njsls-ela:L.KL.11-12.2",
         ],
+        review_unit={
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        rating_scale={
+            "scale_id": "standards_4_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                },
+                {
+                    "value": 2,
+                    "label": "Meeting",
+                    "description": "Clear evidence.",
+                },
+            ],
+        },
         basic_requirements={
             "paragraphs_min": 4,
             "word_count_min": 500,
             "required_elements": ["claim", "textual evidence"],
         },
-        rubric_id="synthetic_argument_v1",
+        minimum_requirement_policy={
+            "allow_return_without_full_review": True,
+        },
     )
 
 
@@ -68,70 +77,6 @@ def _write_roster(workspace_root: Path, class_id: str = "english_12_p3") -> None
         ],
     )
     write_class_roster(workspace_root, roster)
-
-
-def _write_standards_library(workspace_root: Path) -> None:
-    write_workspace_standards_library(
-        workspace_root,
-        StandardsLibrary(
-            standards=(
-                StandardDefinition(
-                    standard_id="njsls-ela:W.AW.11-12.1",
-                    code="W.AW.11-12.1",
-                    source="NJSLS",
-                    short_name="Argument Writing",
-                    description="Synthetic argument writing standard.",
-                    subject="English Language Arts",
-                    course="English 12",
-                    domain="Writing",
-                    available_modules=("quillan",),
-                ),
-                StandardDefinition(
-                    standard_id="njsls-ela:L.KL.11-12.2",
-                    code="L.KL.11-12.2",
-                    source="NJSLS",
-                    short_name="Language Knowledge",
-                    description="Synthetic language knowledge standard.",
-                    subject="English Language Arts",
-                    course="English 12",
-                    domain="Language",
-                    available_modules=("quillan",),
-                ),
-            ),
-            profiles=(
-                StandardsProfile(
-                    profile_id="synthetic_ela_11_12",
-                    standards=(
-                        "njsls-ela:W.AW.11-12.1",
-                        "njsls-ela:L.KL.11-12.2",
-                    ),
-                    subject="English Language Arts",
-                    course="English 12",
-                    source="NJSLS",
-                    title="Synthetic ELA 11-12",
-                ),
-            ),
-        ),
-    )
-
-
-def _write_rubric(workspace_root: Path) -> None:
-    level = build_rubric_level(score=3, label="Clear explanation")
-    criterion = build_rubric_criterion(
-        criterion_id="reasoning",
-        label="Reasoning / Explanation",
-        max_score=4,
-        scale="4_point",
-        levels=[level],
-    )
-    rubric = build_rubric(
-        rubric_id="general_response",
-        title="General Response Rubric",
-        description="Synthetic scoring profile.",
-        writing_types=["general"],
-        criteria=[criterion],
-    )
-    write_rubric(workspace_root, rubric)
 
 
 def _inputs(
@@ -152,46 +97,24 @@ def _inputs(
     return prompts
 
 
-def _creation_responses(
-    *,
-    selection: str = "1",
-    assignment_id: str = "",
-    paragraphs_min: str = "4",
-    overwrite: str | None = None,
-) -> list[str]:
-    responses = [
-        selection,
-        "Literary Analysis Essay",
-        assignment_id,
-        "literary_analysis",
-        "1",
-        "1, 2",
-        "",
-        paragraphs_min,
-        "",
-        "500",
-        "",
-        "claim, textual evidence",
-        "synthetic_argument_v1",
-    ]
-    if overwrite is not None:
-        responses.append(overwrite)
-    return responses
-
-
-def test_build_assignment_config_has_required_fields_and_validates() -> None:
+def test_build_assignment_config_has_required_v2_fields_and_validates() -> None:
     assignment = _assignment()
 
     assert list(assignment) == [
+        "schema_version",
+        "module",
+        "record_type",
         "assignment_id",
         "title",
         "class_ids",
         "writing_type",
+        "student_prompt",
         "standards_profile_id",
-        "tagging_mode",
-        "focus_standards",
+        "focus_standard_ids",
+        "review_unit",
+        "rating_scale",
         "basic_requirements",
-        "rubric_id",
+        "minimum_requirement_policy",
     ]
     validate_assignment_config(assignment)
 
@@ -252,196 +175,16 @@ def test_assignment_parsing_helpers() -> None:
         workflows.parse_optional_nonnegative_int("many", "paragraphs_min")
 
 
-def test_prompt_create_assignment_selects_roster_class_and_writes_config(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+def test_prompt_create_assignment_is_unavailable_pending_v2_workflow(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    _write_roster(tmp_path)
-    _write_standards_library(tmp_path)
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(monkeypatch, _creation_responses())
-
-    assert workflows.prompt_create_assignment() == 0
-    path = (
-        tmp_path
-        / "classes"
-        / "english_12_p3"
-        / "assignments"
-        / "literary_analysis_essay"
-        / "assignment.json"
-    )
-    assignment = load_assignment_config(path)
-    assert assignment["class_ids"] == ["english_12_p3"]
-    assert assignment["focus_standards"] == [
-        "njsls-ela:W.AW.11-12.1",
-        "njsls-ela:L.KL.11-12.2",
-    ]
-    assert assignment["basic_requirements"] == {
-        "paragraphs_min": 4,
-        "word_count_min": 500,
-        "required_elements": ["claim", "textual evidence"],
-    }
-    assert "Saved assignment config:" in capsys.readouterr().out
-
-
-def test_prompt_create_assignment_can_select_shared_rubric(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_roster(tmp_path)
-    _write_standards_library(tmp_path)
-    _write_rubric(tmp_path)
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    responses = _creation_responses()
-    responses[-1] = "1"
-    _inputs(monkeypatch, responses)
-
-    assert workflows.prompt_create_assignment() == 0
-
-    assignment = load_assignment_config(
-        tmp_path
-        / "classes"
-        / "english_12_p3"
-        / "assignments"
-        / "literary_analysis_essay"
-        / "assignment.json"
-    )
-    assert assignment["rubric_id"] == "general_response"
-
-
-def test_prompt_create_assignment_accepts_exact_class_id_and_blank_options(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _write_roster(tmp_path)
-    _write_standards_library(tmp_path)
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    responses = _creation_responses(
-        selection="english_12_p3",
-        assignment_id="custom_assignment",
-        paragraphs_min="",
-    )
-    responses[9] = ""
-    responses[11] = ""
-    _inputs(monkeypatch, responses)
-
-    assert workflows.prompt_create_assignment() == 0
-    assignment = load_assignment_config(
-        tmp_path
-        / "classes"
-        / "english_12_p3"
-        / "assignments"
-        / "custom_assignment"
-        / "assignment.json"
-    )
-    assert assignment["focus_standards"] == [
-        "njsls-ela:W.AW.11-12.1",
-        "njsls-ela:L.KL.11-12.2",
-    ]
-    assert assignment["basic_requirements"] == {}
-
-
-def test_prompt_create_assignment_requires_existing_roster(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-
     assert workflows.prompt_create_assignment() == 1
-    assert "No class rosters found" in capsys.readouterr().out
-    assert not (tmp_path / "classes").exists()
+    output = capsys.readouterr().out
+    assert "temporarily unavailable" in output
+    assert "schema_version '2'" in output
 
 
-def test_prompt_create_assignment_rejects_invalid_teacher_id(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _write_roster(tmp_path)
-    _write_standards_library(tmp_path)
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(
-        monkeypatch,
-        ["1", "Synthetic Assignment", "invalid assignment id"],
-    )
-
-    assert workflows.prompt_create_assignment() == 1
-    assert "Error:" in capsys.readouterr().out
-    assert not list(tmp_path.rglob("assignment.json"))
-
-
-def test_prompt_create_assignment_explains_missing_standards_library(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _write_roster(tmp_path)
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(
-        monkeypatch,
-        ["1", "Synthetic Assignment", "", "argument"],
-    )
-
-    assert workflows.prompt_create_assignment() == 1
-    assert "Create or import standards through pds-core first" in (
-        capsys.readouterr().out
-    )
-    assert not list(tmp_path.rglob("assignment.json"))
-
-
-def test_prompt_create_assignment_rejects_invalid_numeric_requirement(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _write_roster(tmp_path)
-    _write_standards_library(tmp_path)
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(
-        monkeypatch,
-        _creation_responses(paragraphs_min="-1")[:8],
-    )
-
-    assert workflows.prompt_create_assignment() == 1
-    assert "paragraphs_min must be a non-negative integer" in capsys.readouterr().out
-
-
-@pytest.mark.parametrize(
-    ("confirmation", "expected_title"),
-    [
-        ("no", "Original Synthetic Assignment"),
-        ("OVERWRITE", "Literary Analysis Essay"),
-    ],
-)
-def test_prompt_create_assignment_overwrite_requires_exact_confirmation(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    confirmation: str,
-    expected_title: str,
-) -> None:
-    _write_roster(tmp_path)
-    _write_standards_library(tmp_path)
-    existing = _assignment()
-    existing["title"] = "Original Synthetic Assignment"
-    path = workflows.write_assignment_config(
-        tmp_path,
-        "english_12_p3",
-        existing,
-    )
-    original_text = path.read_text(encoding="utf-8")
-    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(monkeypatch, _creation_responses(overwrite=confirmation))
-
-    result = workflows.prompt_create_assignment()
-    assert result == (0 if confirmation == "OVERWRITE" else 1)
-    assert load_assignment_config(path)["title"] == expected_title
-    if confirmation != "OVERWRITE":
-        assert path.read_text(encoding="utf-8") == original_text
-
-
-def test_view_validate_assignment_prints_summary_without_rewriting(
+def test_view_validate_assignment_prints_v2_summary_without_rewriting(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -459,14 +202,16 @@ def test_view_validate_assignment_prints_summary_without_rewriting(
     assert workflows.prompt_view_validate_assignment() == 0
     output = capsys.readouterr().out
     assert "Assignment config is valid." in output
+    assert "Schema version: 2" in output
     assert "Assignment ID: literary_analysis_essay" in output
     assert "Title: Literary Analysis Essay" in output
     assert "Class IDs: english_12_p3" in output
     assert "Writing type: literary_analysis" in output
     assert "Standards profile ID: synthetic_ela_11_12" in output
-    assert "Tagging mode: focus" in output
-    assert "Focus standards (2)" in output
-    assert "Rubric ID: synthetic_argument_v1" in output
+    assert "Focus standard IDs (2)" in output
+    assert "Review unit: paragraph" in output
+    assert "Rating scale: standards_4_level (2 levels)" in output
+    assert "Rubric ID" not in output
     assert "Assignment JSON path" not in prompts
     assert path.read_bytes() == original_bytes
 
@@ -486,7 +231,7 @@ def test_view_validate_assignment_reports_error_without_traceback(
         / "assignment.json"
     )
     path.parent.mkdir(parents=True)
-    path.write_text(json.dumps({"assignment_id": "incomplete"}), encoding="utf-8")
+    path.write_text('{"assignment_id": "incomplete"}', encoding="utf-8")
     original_bytes = path.read_bytes()
     monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
     prompts = _inputs(monkeypatch, ["1"])

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -4,193 +4,279 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.assignments import (
+    AssignmentConfigError,
+    load_assignment_config,
+    validate_assignment_config,
+)
 
 
-def _valid_assignment_config() -> dict[str, object]:
-    """Return a valid synthetic assignment config."""
+def _valid_assignment_config() -> dict[str, Any]:
+    """Return a valid synthetic v2 assignment config."""
     return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": "villainy_final_essay_synthetic",
         "title": "Villainy Final Essay",
         "class_ids": ["english12_period3_synthetic"],
-        "writing_type": "literary argument essay",
+        "writing_type": "literary_argument",
+        "student_prompt": "Rank villains using evidence from the texts.",
         "standards_profile_id": "english_12_njsls_synthetic",
-        "tagging_mode": "focus",
-        "focus_standards": [
+        "focus_standard_ids": [
             "njsls-ela:W.AW.11-12.1",
             "njsls-ela:W.WP.11-12.4",
         ],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_4_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence of the standard.",
+                },
+                {
+                    "value": 2,
+                    "label": "Approaching",
+                    "description": "Partial evidence of the standard.",
+                },
+            ],
+        },
         "basic_requirements": {
             "paragraphs_min": 4,
             "paragraphs_max": 6,
             "word_count_min": 500,
+            "word_count_max": 1200,
             "required_elements": [
                 "thesis",
                 "textual evidence",
                 "comparative reasoning",
             ],
         },
-        "rubric_id": "argument_essay_4pt_synthetic",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
 
 
-def test_load_valid_assignment_config(tmp_path: Path) -> None:
+def _write_assignment(tmp_path: Path, assignment: dict[str, Any]) -> Path:
     assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
+    return assignment_path
 
-    loaded_assignment = load_assignment_config(assignment_path)
+
+def test_load_valid_assignment_config(tmp_path: Path) -> None:
+    assignment_data = _valid_assignment_config()
+
+    loaded_assignment = load_assignment_config(
+        _write_assignment(tmp_path, assignment_data)
+    )
 
     assert loaded_assignment == assignment_data
 
 
-def test_missing_required_field_raises_error(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    del assignment_data["rubric_id"]
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+def test_validate_assignment_config_accepts_example_assignment() -> None:
+    path = (
+        Path(__file__).parent.parent
+        / "examples"
+        / "assignments"
+        / "villainy_final_essay_synthetic.json"
+    )
 
-    with pytest.raises(
-        AssignmentConfigError, match="Missing required field 'rubric_id'"
-    ):
-        load_assignment_config(assignment_path)
-
-
-def test_invalid_tagging_mode_raises_error(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["tagging_mode"] = "everything"
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    with pytest.raises(AssignmentConfigError, match="Invalid tagging mode"):
-        load_assignment_config(assignment_path)
+    validate_assignment_config(json.loads(path.read_text(encoding="utf-8")))
 
 
-def test_invalid_assignment_identifier_raises_error(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["assignment_id"] = "../unsafe"
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+def test_optional_metadata_fields_do_not_break_validation(tmp_path: Path) -> None:
+    assignment = _valid_assignment_config()
+    assignment["created_at"] = "2026-07-02T00:00:00+00:00"
+    assignment["updated_at"] = "2026-07-02T00:00:00+00:00"
+    assignment["module_details"] = {}
 
-    with pytest.raises(AssignmentConfigError, match="assignment_id"):
-        load_assignment_config(assignment_path)
-
-
-def test_invalid_class_identifier_raises_error(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["class_ids"] = ["English 12"]
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    with pytest.raises(AssignmentConfigError, match="class_id"):
-        load_assignment_config(assignment_path)
+    assert load_assignment_config(_write_assignment(tmp_path, assignment)) == assignment
 
 
 @pytest.mark.parametrize(
     "field",
-    ["title", "writing_type", "standards_profile_id", "rubric_id"],
+    [
+        "schema_version",
+        "module",
+        "record_type",
+        "assignment_id",
+        "title",
+        "class_ids",
+        "writing_type",
+        "student_prompt",
+        "standards_profile_id",
+        "focus_standard_ids",
+        "review_unit",
+        "rating_scale",
+        "basic_requirements",
+        "minimum_requirement_policy",
+    ],
 )
-def test_required_string_field_must_be_string(tmp_path: Path, field: str) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data[field] = 123
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+def test_missing_required_field_raises_error(tmp_path: Path, field: str) -> None:
+    assignment = _valid_assignment_config()
+    del assignment[field]
 
     with pytest.raises(AssignmentConfigError, match=field):
-        load_assignment_config(assignment_path)
+        load_assignment_config(_write_assignment(tmp_path, assignment))
 
 
-def test_empty_class_ids_raises_error(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["class_ids"] = []
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", "1"),
+        ("module", "other"),
+        ("record_type", "other"),
+        ("assignment_id", "../unsafe"),
+        ("title", ""),
+        ("class_ids", []),
+        ("writing_type", ""),
+        ("student_prompt", ""),
+        ("standards_profile_id", ""),
+        ("focus_standard_ids", []),
+        ("review_unit", []),
+        ("rating_scale", []),
+        ("basic_requirements", []),
+        ("minimum_requirement_policy", []),
+    ],
+)
+def test_invalid_required_field_raises_error(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    assignment = _valid_assignment_config()
+    assignment[field] = value
 
-    with pytest.raises(AssignmentConfigError, match="class_ids.*must not be empty"):
-        load_assignment_config(assignment_path)
-
-
-def test_focus_standards_must_be_list(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["focus_standards"] = "njsls-ela:W.AW.11-12.1"
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    with pytest.raises(AssignmentConfigError, match="focus_standards.*must be a list"):
-        load_assignment_config(assignment_path)
-
-
-def test_focus_standards_reject_whitespace_only_value(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["focus_standards"] = ["   "]
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    with pytest.raises(AssignmentConfigError, match="focus_standards"):
-        load_assignment_config(assignment_path)
-
-
-def test_basic_requirements_must_be_object(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["basic_requirements"] = []
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    with pytest.raises(AssignmentConfigError, match="basic_requirements.*object"):
-        load_assignment_config(assignment_path)
+    with pytest.raises(AssignmentConfigError, match=field):
+        load_assignment_config(_write_assignment(tmp_path, assignment))
 
 
-def test_negative_requirement_value_raises_error(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["basic_requirements"] = {
-        "paragraphs_min": -1,
+def test_legacy_assignment_config_is_rejected_clearly(tmp_path: Path) -> None:
+    assignment = {
+        "assignment_id": "legacy_assignment",
+        "title": "Legacy Assignment",
+        "class_ids": ["english12"],
+        "writing_type": "argument",
+        "standards_profile_id": "synthetic",
+        "tagging_mode": "focus",
+        "focus_standards": ["synthetic:W.1"],
+        "basic_requirements": {},
+        "rubric_id": "legacy_rubric",
     }
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
 
-    with pytest.raises(AssignmentConfigError, match="paragraphs_min"):
-        load_assignment_config(assignment_path)
+    with pytest.raises(AssignmentConfigError, match="Legacy assignment configs"):
+        load_assignment_config(_write_assignment(tmp_path, assignment))
 
 
-def test_boolean_requirement_value_raises_error(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["basic_requirements"] = {
-        "paragraphs_min": True,
+@pytest.mark.parametrize("field", ["type", "singular_label", "plural_label"])
+def test_review_unit_requires_fields(tmp_path: Path, field: str) -> None:
+    assignment = _valid_assignment_config()
+    del assignment["review_unit"][field]
+
+    with pytest.raises(AssignmentConfigError, match=field):
+        load_assignment_config(_write_assignment(tmp_path, assignment))
+
+
+@pytest.mark.parametrize(
+    "review_unit",
+    [
+        {"type": "", "singular_label": "paragraph", "plural_label": "paragraphs"},
+        {"type": "two words", "singular_label": "paragraph", "plural_label": "paragraphs"},
+        {"type": "paragraph", "singular_label": "", "plural_label": "paragraphs"},
+        {"type": "paragraph", "singular_label": "paragraph", "plural_label": ""},
+    ],
+)
+def test_review_unit_rejects_invalid_values(
+    tmp_path: Path, review_unit: dict[str, str]
+) -> None:
+    assignment = _valid_assignment_config()
+    assignment["review_unit"] = review_unit
+
+    with pytest.raises(AssignmentConfigError, match="review_unit"):
+        load_assignment_config(_write_assignment(tmp_path, assignment))
+
+
+@pytest.mark.parametrize(
+    "rating_scale",
+    [
+        {"levels": [{"value": 1, "label": "Developing", "description": "Some."}]},
+        {"scale_id": "scale"},
+        {"scale_id": "scale", "levels": []},
+        {"scale_id": "scale", "levels": "bad"},
+        {"scale_id": "scale", "levels": [{"label": "Developing", "description": "Some."}]},
+        {"scale_id": "scale", "levels": [{"value": True, "label": "Developing", "description": "Some."}]},
+        {"scale_id": "scale", "levels": [{"value": 1, "label": "A", "description": "A."}, {"value": 1, "label": "B", "description": "B."}]},
+        {"scale_id": "scale", "levels": [{"value": 1, "label": "", "description": "Some."}]},
+        {"scale_id": "scale", "levels": [{"value": 1, "label": "Developing", "description": ""}]},
+    ],
+)
+def test_rating_scale_rejects_invalid_values(
+    tmp_path: Path, rating_scale: dict[str, object]
+) -> None:
+    assignment = _valid_assignment_config()
+    assignment["rating_scale"] = rating_scale
+
+    with pytest.raises(AssignmentConfigError, match="rating_scale|Duplicate"):
+        load_assignment_config(_write_assignment(tmp_path, assignment))
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("paragraphs_min", -1),
+        ("paragraphs_max", True),
+        ("word_count_min", 1.5),
+        ("word_count_max", "500"),
+    ],
+)
+def test_known_requirement_numbers_must_be_non_negative_integers(
+    tmp_path: Path, key: str, value: object
+) -> None:
+    assignment = _valid_assignment_config()
+    assignment["basic_requirements"] = {key: value}
+
+    with pytest.raises(AssignmentConfigError, match=key):
+        load_assignment_config(_write_assignment(tmp_path, assignment))
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [
+        {"paragraphs_min": 7, "paragraphs_max": 6},
+        {"word_count_min": 1201, "word_count_max": 1200},
+        {"required_elements": "thesis"},
+        {"required_elements": ["thesis", " "]},
+    ],
+)
+def test_basic_requirements_reject_invalid_values(
+    tmp_path: Path, requirements: dict[str, object]
+) -> None:
+    assignment = _valid_assignment_config()
+    assignment["basic_requirements"] = requirements
+
+    with pytest.raises(AssignmentConfigError, match="basic_requirements|required_elements"):
+        load_assignment_config(_write_assignment(tmp_path, assignment))
+
+
+def test_minimum_requirement_policy_requires_boolean(tmp_path: Path) -> None:
+    assignment = _valid_assignment_config()
+    assignment["minimum_requirement_policy"] = {
+        "allow_return_without_full_review": "yes"
     }
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    with pytest.raises(AssignmentConfigError, match="paragraphs_min"):
-        load_assignment_config(assignment_path)
-
-
-def test_required_elements_must_be_list(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["basic_requirements"] = {
-        "required_elements": "thesis",
-    }
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
 
     with pytest.raises(
-        AssignmentConfigError, match="required_elements.*must be a list"
+        AssignmentConfigError, match="allow_return_without_full_review"
     ):
-        load_assignment_config(assignment_path)
-
-
-def test_required_elements_reject_whitespace_only_value(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = _valid_assignment_config()
-    assignment_data["basic_requirements"] = {
-        "required_elements": ["   "],
-    }
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    with pytest.raises(AssignmentConfigError, match="required_elements"):
-        load_assignment_config(assignment_path)
+        load_assignment_config(_write_assignment(tmp_path, assignment))
 
 
 def test_missing_file_raises_clear_error() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,16 +87,34 @@ def test_cli_validates_assignment_config(
 ) -> None:
     assignment_path = tmp_path / "assignment.json"
     assignment_data = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": "villainy_final_essay_synthetic",
         "title": "Villainy Final Essay",
         "class_ids": ["english12_period3_synthetic"],
         "writing_type": "literary argument essay",
+        "student_prompt": "Rank villains using evidence from the texts.",
         "standards_profile_id": "english_12_njsls_synthetic",
-        "tagging_mode": "focus",
-        "focus_standards": [
+        "focus_standard_ids": [
             "njsls-ela:W.AW.11-12.1",
             "njsls-ela:W.WP.11-12.4",
         ],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {
             "paragraphs_min": 4,
             "paragraphs_max": 6,
@@ -107,7 +125,9 @@ def test_cli_validates_assignment_config(
                 "comparative reasoning",
             ],
         },
-        "rubric_id": "argument_essay_4pt_synthetic",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
 

--- a/tests/test_cli_route_scan.py
+++ b/tests/test_cli_route_scan.py
@@ -56,15 +56,35 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         )
 
     assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["njsls-ela:W.1"],
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment),

--- a/tests/test_cli_route_scan_folder.py
+++ b/tests/test_cli_route_scan_folder.py
@@ -81,15 +81,35 @@ def _write_workspace(root: Path) -> None:
         assignment_dir = assignments_dir / assignment_id
         assignment_dir.mkdir()
         assignment = {
+            "schema_version": "2",
+            "module": "quillan",
+            "record_type": "assignment",
             "assignment_id": assignment_id,
             "title": "Synthetic Essay",
             "class_ids": [CLASS_ID],
             "writing_type": "argument",
+            "student_prompt": "Write a synthetic argument.",
             "standards_profile_id": "synthetic_profile",
-            "tagging_mode": "focus",
-            "focus_standards": ["njsls-ela:W.1"],
+            "focus_standard_ids": ["njsls-ela:W.1"],
+            "review_unit": {
+                "type": "paragraph",
+                "singular_label": "paragraph",
+                "plural_label": "paragraphs",
+            },
+            "rating_scale": {
+                "scale_id": "standards_2_level",
+                "levels": [
+                    {
+                        "value": 1,
+                        "label": "Developing",
+                        "description": "Limited evidence.",
+                    }
+                ],
+            },
             "basic_requirements": {"paragraphs_min": 1},
-            "rubric_id": "synthetic_rubric",
+            "minimum_requirement_policy": {
+                "allow_return_without_full_review": True,
+            },
         }
         (assignment_dir / "assignment.json").write_text(
             json.dumps(assignment),

--- a/tests/test_cli_route_scan_pdf.py
+++ b/tests/test_cli_route_scan_pdf.py
@@ -80,15 +80,35 @@ def _write_workspace(root: Path) -> None:
         )
 
     assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["njsls-ela:W.1"],
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment),

--- a/tests/test_cli_route_scan_qr.py
+++ b/tests/test_cli_route_scan_qr.py
@@ -70,15 +70,35 @@ def _write_workspace(
         )
 
     assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": assignment_id,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["njsls-ela:W.1"],
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment),

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -104,15 +104,35 @@ def _write_workspace(root: Path) -> None:
         )
 
     assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["njsls-ela:W.1"],
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment), encoding="utf-8"

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -68,15 +68,35 @@ def _write_workspace(root: Path) -> None:
         )
 
     assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["njsls-ela:W.1"],
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment), encoding="utf-8"

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -97,15 +97,35 @@ def _write_workspace(root: Path) -> None:
         )
 
     assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["njsls-ela:W.1"],
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment),

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -91,15 +91,35 @@ def _write_workspace(root: Path) -> None:
         )
 
     assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["njsls-ela:W.1"],
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment),

--- a/tests/test_printable_response_pdf.py
+++ b/tests/test_printable_response_pdf.py
@@ -48,10 +48,6 @@ def _write_roster_assignment(
     assignment = json.loads(ASSIGNMENT_PATH.read_text(encoding="utf-8"))
     assert isinstance(assignment, dict)
     assignment["class_ids"] = class_ids or ["english12_p3"]
-    assignment.setdefault("tagging_mode", "focus")
-    assignment.setdefault("focus_standards", [])
-    assignment.setdefault("basic_requirements", {})
-    assignment.setdefault("rubric_id", "synthetic_rubric")
     assignment_path = tmp_path / "assignment.json"
     assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
     return assignment_path

--- a/tests/test_printable_response_workflows.py
+++ b/tests/test_printable_response_workflows.py
@@ -59,15 +59,40 @@ def _write_roster(workspace_root: Path, class_id: str = CLASS_ID) -> Path:
 
 def _assignment(class_ids: list[str] | None = None) -> dict[str, object]:
     return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Writing Response",
         "class_ids": class_ids or [CLASS_ID],
         "writing_type": "synthetic_response",
+        "student_prompt": "Write a synthetic response.",
         "standards_profile_id": "synthetic_ela",
-        "tagging_mode": "focus",
-        "focus_standards": ["synthetic:W.SYN.1"],
+        "focus_standard_ids": ["synthetic:W.SYN.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                },
+                {
+                    "value": 2,
+                    "label": "Meeting",
+                    "description": "Clear evidence.",
+                },
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
 
 

--- a/tests/test_review_tags.py
+++ b/tests/test_review_tags.py
@@ -150,15 +150,35 @@ def _review(state: str = "not_started") -> dict[str, Any]:
 
 def _assignment() -> dict[str, Any]:
     return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": PROFILE_ID,
-        "tagging_mode": "focus",
-        "focus_standards": [STANDARD_ID],
+        "focus_standard_ids": [STANDARD_ID],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {},
-        "rubric_id": "argument_4pt",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
 
 

--- a/tests/test_roster_to_printable_response_smoke.py
+++ b/tests/test_roster_to_printable_response_smoke.py
@@ -26,19 +26,39 @@ def test_roster_to_printable_response_workflow(
     assignment_path.write_text(
         json.dumps(
             {
+                "schema_version": "2",
+                "module": "quillan",
+                "record_type": "assignment",
                 "assignment_id": assignment_id,
                 "title": "Synthetic Literary Argument",
                 "class_ids": [class_id],
                 "writing_type": "literary argument essay",
+                "student_prompt": "Write a literary argument using evidence.",
                 "standards_profile_id": "english_12_smoke",
-                "tagging_mode": "focus",
-                "focus_standards": ["W.AW.11-12.1"],
+                "focus_standard_ids": ["W.AW.11-12.1"],
+                "review_unit": {
+                    "type": "paragraph",
+                    "singular_label": "paragraph",
+                    "plural_label": "paragraphs",
+                },
+                "rating_scale": {
+                    "scale_id": "standards_2_level",
+                    "levels": [
+                        {
+                            "value": 1,
+                            "label": "Developing",
+                            "description": "Limited evidence.",
+                        }
+                    ],
+                },
                 "basic_requirements": {
                     "paragraphs_min": 3,
                     "word_count_min": 300,
                     "required_elements": ["claim", "evidence", "reasoning"],
                 },
-                "rubric_id": "argument_essay_smoke",
+                "minimum_requirement_policy": {
+                    "allow_return_without_full_review": True,
+                },
             }
         ),
         encoding="utf-8",

--- a/tests/test_route_planning.py
+++ b/tests/test_route_planning.py
@@ -55,15 +55,35 @@ def workspace(tmp_path: Path) -> Path:
         )
 
     assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
         "assignment_id": ASSIGNMENT_ID,
         "title": "Synthetic Essay",
         "class_ids": [CLASS_ID],
         "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
         "standards_profile_id": "synthetic_profile",
-        "tagging_mode": "focus",
-        "focus_standards": ["njsls-ela:W.1"],
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         "basic_requirements": {"paragraphs_min": 1},
-        "rubric_id": "synthetic_rubric",
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment),

--- a/tests/test_v070_smoke.py
+++ b/tests/test_v070_smoke.py
@@ -66,15 +66,35 @@ def test_v070_synthetic_teacher_review_and_export_workflow(
     _write_json(
         assignment_path,
         {
+            "schema_version": "2",
+            "module": "quillan",
+            "record_type": "assignment",
             "assignment_id": ASSIGNMENT_ID,
             "title": "Synthetic Villainy Essay",
             "class_ids": [CLASS_ID],
             "writing_type": "literary_analysis",
+            "student_prompt": "Analyze how the text develops villainy.",
             "standards_profile_id": PROFILE_ID,
-            "tagging_mode": "focus",
-            "focus_standards": [STANDARD_ID],
+            "focus_standard_ids": [STANDARD_ID],
+            "review_unit": {
+                "type": "paragraph",
+                "singular_label": "paragraph",
+                "plural_label": "paragraphs",
+            },
+            "rating_scale": {
+                "scale_id": "standards_2_level",
+                "levels": [
+                    {
+                        "value": 1,
+                        "label": "Developing",
+                        "description": "Limited evidence.",
+                    }
+                ],
+            },
             "basic_requirements": {},
-            "rubric_id": "synthetic_rubric",
+            "minimum_requirement_policy": {
+                "allow_return_without_full_review": True,
+            },
         },
     )
     write_workspace_standards_library(

--- a/tests/test_v080_end_to_end_smoke.py
+++ b/tests/test_v080_end_to_end_smoke.py
@@ -117,11 +117,28 @@ def _write_assignment(root: Path) -> Path:
         title="Synthetic Argument Essay",
         class_id=CLASS_ID,
         writing_type="argument",
+        student_prompt="Write an argument using claims, reasoning, and evidence.",
         standards_profile_id="synthetic_profile",
-        tagging_mode="focus",
-        focus_standards=[STANDARD_ID],
+        focus_standard_ids=[STANDARD_ID],
+        review_unit={
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        rating_scale={
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
         basic_requirements={"paragraphs_min": 1},
-        rubric_id="synthetic_rubric",
+        minimum_requirement_policy={
+            "allow_return_without_full_review": True,
+        },
     )
     return write_assignment_config(root, CLASS_ID, assignment)
 


### PR DESCRIPTION
## Summary

Implements the v2 assignment loader and validator foundation for the standards-based Quillan redesign.

This PR updates assignment runtime support so schema version `2` assignment records can be loaded, validated, discovered, summarized, and used by retained workflows such as printable response generation.

## Changes

* Updates `load_assignment_config` and `validate_assignment_config` to require schema version `2`.
* Validates the v2 assignment contract, including:

  * `student_prompt`
  * `focus_standard_ids`
  * `review_unit`
  * `rating_scale`
  * `basic_requirements`
  * `minimum_requirement_policy`
* Rejects legacy assignment configs with old fields such as:

  * `tagging_mode`
  * `focus_standards`
  * `rubric_id`
* Updates standards selection validation to use `focus_standard_ids`.
* Updates assignment summary and write support for v2 records.
* Temporarily marks interactive assignment creation unavailable pending the full v2 assignment creation workflow.
* Adds explicit v2 assignment discovery coverage for assignment picker behavior.
* Ensures invalid and legacy assignment configs are skipped by discovery.
* Updates printable response and route/review workflow test fixtures to use v2 assignments.
* Makes minimal contract/doc updates in:

  * `docs/assignment_contract.md`
  * `docs/data_contracts.md`

## Verification

Changed-file Ruff:

* Passed

Full test suite:

* `1092 passed`

Command run:

* `.\.venv\Scripts\python.exe -m pytest`

## Notes

Full-tree Ruff still reports pre-existing undefined-name issues in `quillan/review_menu.py`. Those issues are outside the scope of this PR. Changed-file Ruff is clean.

This PR does not implement the full v2 assignment creation workflow, v2 review-record validation, minimum-requirements workflow, review-unit observations, Focus Standard ratings, feedback composition, PDF export, or assignment-level reporting.

Closes #241
