### PR TITLE
Implement minimum requirements return workflow

### DIFF
--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -10,8 +10,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.review_record import ReviewRecordError, load_review_record
 from quillan.review_record_paths import ReviewRecordPathError, review_record_path
+from quillan.storage import assignment_config_path
 from quillan.submission_manifest import (
     SubmissionManifestError,
     load_submission_manifest,
@@ -122,16 +124,34 @@ def export_student_feedback(
         student_id=student_id,
     )
 
-    included_comments = _included_feedback_comments(review)
-    ratings = review["overall_standard_ratings"]
-    markdown = _render_markdown(
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-        created_at=normalized_created_at,
-        ratings=ratings,
-        comments=included_comments,
-    )
+    if review["review_state"] == "returned_without_full_review":
+        unmet_requirements = _validated_returned_work_requirements(
+            resolved_workspace_root,
+            class_id,
+            assignment_id,
+            review,
+        )
+        included_comments: list[dict[str, Any]] = []
+        ratings: list[dict[str, Any]] = []
+        markdown = _render_returned_work_markdown(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            created_at=normalized_created_at,
+            outcome=review["minimum_requirement_outcome"],
+            unmet_requirements=unmet_requirements,
+        )
+    else:
+        included_comments = _included_feedback_comments(review)
+        ratings = review["overall_standard_ratings"]
+        markdown = _render_markdown(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            created_at=normalized_created_at,
+            ratings=ratings,
+            comments=included_comments,
+        )
     overwrote_existing = output_path.exists()
     if overwrote_existing and not overwrite:
         raise FeedbackExportError(
@@ -200,6 +220,50 @@ def _render_markdown(
     return "\n".join(lines)
 
 
+def _render_returned_work_markdown(
+    *,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    created_at: str,
+    outcome: dict[str, Any],
+    unmet_requirements: list[dict[str, Any]],
+) -> str:
+    lines = [
+        "# Returned for Revision",
+        "",
+        f"Class: {_plain_text(class_id)}",
+        f"Assignment: {_plain_text(assignment_id)}",
+        f"Student: {_plain_text(student_id)}",
+        f"Generated: {_plain_text(created_at)}",
+        "",
+        (
+            "This submission was returned without full standards review because "
+            "minimum requirements were not met."
+        ),
+        "",
+        "## Minimum Requirements Not Met",
+        "",
+    ]
+    for requirement in unmet_requirements:
+        lines.append(f"- {_plain_text(requirement['label'])}")
+        lines.append(f"  Expected: {_plain_text(requirement['expected'])}")
+        if note := _non_empty(requirement.get("teacher_note")):
+            lines.append(f"  Teacher note: {_plain_text(note)}")
+    lines.extend(
+        [
+            "",
+            "## Return Note",
+            "",
+            _plain_text(outcome["teacher_note"]),
+            "",
+            "No full standards ratings were completed for this submission.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def _included_feedback_comments(review: dict[str, Any]) -> list[dict[str, Any]]:
     included: list[dict[str, Any]] = []
     for standard_feedback in review["feedback"]["standard_feedback"]:
@@ -209,6 +273,66 @@ def _included_feedback_comments(review: dict[str, Any]) -> list[dict[str, Any]]:
             if comment["include_in_feedback"]
         )
     return included
+
+
+def _validated_returned_work_requirements(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    review: dict[str, Any],
+) -> list[dict[str, Any]]:
+    outcome = review["minimum_requirement_outcome"]
+    if outcome["returned_without_full_review"] is not True:
+        raise FeedbackExportError(
+            "Returned-work export requires "
+            "minimum_requirement_outcome.returned_without_full_review to be true."
+        )
+    if not _non_empty(outcome.get("teacher_note")):
+        raise FeedbackExportError(
+            "Returned-work export requires a non-empty outcome teacher note."
+        )
+
+    try:
+        assignment = load_assignment_config(
+            assignment_config_path(workspace_root, class_id, assignment_id)
+        )
+    except (AssignmentConfigError, OSError) as error:
+        raise FeedbackExportError(
+            f"Could not load assignment config: {error}"
+        ) from error
+    configured_keys = _configured_requirement_keys(assignment)
+    unmet_requirements = [
+        check
+        for check in review["minimum_requirement_checks"]
+        if check["requirement_key"] in configured_keys and check["met"] is False
+    ]
+    if not unmet_requirements:
+        raise FeedbackExportError(
+            "Returned-work export requires at least one checked configured "
+            "minimum requirement marked not met."
+        )
+    return unmet_requirements
+
+
+def _configured_requirement_keys(assignment: dict[str, Any]) -> set[str]:
+    basic_requirements = assignment.get("basic_requirements")
+    if not isinstance(basic_requirements, dict):
+        return set()
+    keys: set[str] = set()
+    for key in (
+        "paragraphs_min",
+        "paragraphs_max",
+        "word_count_min",
+        "word_count_max",
+    ):
+        if key in basic_requirements:
+            keys.add(key)
+    required_elements = basic_requirements.get("required_elements")
+    if isinstance(required_elements, list):
+        for element in required_elements:
+            if isinstance(element, str) and element.strip():
+                keys.add(f"required_elements:{element.strip()}")
+    return keys
 
 
 def _write_feedback(path: Path, content: str, *, overwrite: bool) -> None:
@@ -309,6 +433,10 @@ def _validate_identity(
 
 def _plain_text(value: object) -> str:
     return re.sub(r"\s+", " ", str(value)).strip()
+
+
+def _non_empty(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
 
 
 def _format_number(value: int | float) -> str:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -64,6 +64,7 @@ from quillan.review_targets import (
 )
 from quillan.review_requirements import (
     ReviewRequirementError,
+    set_minimum_requirement_outcome,
     set_requirement_check,
 )
 from quillan.review_scores import ReviewScoreError, set_review_score
@@ -412,7 +413,7 @@ def _launch_selected_student_review(
             continue
         print("1. Open submission evidence")
         print("2. View current review details")
-        print("3. Record minimum requirement checks")
+        print("3. Review minimum requirements")
         print("4. Manage submission pages")
         print("5. Add teacher note")
         print("6. Update submission review state")
@@ -443,7 +444,7 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "3":
-            _menu_record_requirement_checks(
+            _menu_review_minimum_requirements(
                 workspace_root,
                 class_id,
                 assignment_id,
@@ -2019,6 +2020,10 @@ def _format_yes_no(value: bool) -> str:
     return "yes" if value else "no"
 
 
+def _non_empty(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
 def _suggest_identifier(label: str) -> str:
     normalized = "".join(
         character.lower() if character.isalnum() else "_"
@@ -2210,6 +2215,7 @@ def _print_review_record_summary(
         class_id,
         assignment_id,
         _current_requirement_checks(workspace_root, class_id, assignment_id, student_id),
+        record["minimum_requirement_outcome"],
     )
 
 
@@ -2248,6 +2254,7 @@ def _print_requirement_check_summary(
     class_id: str,
     assignment_id: str,
     checks: dict[str, dict[str, Any]],
+    outcome: dict[str, Any] | None = None,
 ) -> None:
     assignment = _load_assignment_for_summary(workspace_root, class_id, assignment_id)
     requirements = (
@@ -2270,6 +2277,18 @@ def _print_requirement_check_summary(
         f"{len(relevant_checks)}/{len(requirements)} complete; "
         f"{unmet_count} unmet"
     )
+    if outcome is not None:
+        print(f"Minimum-requirements outcome: {outcome['status']}")
+        print(
+            "Returned without full standards review: "
+            f"{_format_yes_no(outcome['returned_without_full_review'])}"
+        )
+        if outcome["returned_without_full_review"]:
+            print(
+                "Minimum-requirements outcome: returned without full standards review"
+            )
+        elif _non_empty(outcome.get("teacher_note")):
+            print("Minimum-requirements outcome note: present")
 
 
 def _load_assignment_for_summary(
@@ -2372,7 +2391,7 @@ def _choose_submission_evidence_page(
     return _BACK
 
 
-def _menu_record_requirement_checks(
+def _menu_review_minimum_requirements(
     workspace_root: Path,
     class_id: str,
     assignment_id: str,
@@ -2380,7 +2399,7 @@ def _menu_record_requirement_checks(
 ) -> None:
     while True:
         _print_review_action_header(
-            "Requirement Checks", class_id, assignment_id, student_id
+            "Review Minimum Requirements", class_id, assignment_id, student_id
         )
         assignment = _load_assignment_for_review(
             workspace_root, class_id, assignment_id
@@ -2390,7 +2409,7 @@ def _menu_record_requirement_checks(
             return
         requirements = _requirement_items_from_assignment(assignment)
         if not requirements:
-            print("Minimum requirements: none configured")
+            print("Minimum requirements: none configured.")
             print()
             print("No review record was changed.")
             input("Press Enter to continue...")
@@ -2399,35 +2418,194 @@ def _menu_record_requirement_checks(
         existing = _current_requirement_checks(
             workspace_root, class_id, assignment_id, student_id
         )
-        print("Requirement Checks")
+        outcome = _current_minimum_requirement_outcome(
+            workspace_root, class_id, assignment_id, student_id
+        )
+        summary = _minimum_requirement_summary(requirements, existing)
+        print("Minimum Requirements")
         print()
-        for index, requirement in enumerate(requirements, start=1):
-            print(
-                f"{index}. {requirement['label']}: "
-                f"{_requirement_status(existing.get(requirement['key']))}"
-            )
-        print("B. Back")
+        _print_minimum_requirement_statuses(requirements, existing)
         print()
-        selection = input("Select requirement: ").strip()
-        if selection == "" or selection.casefold() == "b":
+        _print_minimum_requirement_summary(summary, outcome)
+        print()
+        print("1. Record/update requirement check")
+        print("2. Finalize minimum-requirements outcome")
+        print("3. Export returned-work feedback")
+        print("4. Back")
+        print()
+        selection = input("Select an option: ").strip()
+        if selection in {"", "4"} or selection.casefold() == "b":
             return
-        if not selection.isdigit() or not (1 <= int(selection) <= len(requirements)):
-            print("Invalid requirement selection. Please choose a listed item or Back.")
+        if selection == "1":
+            _menu_record_requirement_checks(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                requirements,
+                existing,
+            )
+        elif selection == "2":
+            _menu_finalize_minimum_requirement_outcome(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                assignment,
+                requirements,
+                existing,
+            )
             input("Press Enter to continue...")
-            continue
+        elif selection == "3":
+            _menu_export_student_feedback(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+            input("Press Enter to continue...")
+        else:
+            print("Invalid selection. Please enter a number from 1 to 4.")
+            input("Press Enter to continue...")
 
-        requirement = requirements[int(selection) - 1]
-        result = _prompt_and_set_requirement_check(
+
+def _menu_record_requirement_checks(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    requirements: list[dict[str, Any]],
+    existing: dict[str, dict[str, Any]],
+) -> None:
+    _print_review_action_header(
+        "Record Requirement Check", class_id, assignment_id, student_id
+    )
+    print("Requirement Checks")
+    print()
+    for index, requirement in enumerate(requirements, start=1):
+        print(
+            f"{index}. {requirement['label']}: "
+            f"{_requirement_status(existing.get(requirement['key']))}"
+        )
+    print("B. Back")
+    print()
+    selection = input("Select requirement: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return
+    if not selection.isdigit() or not (1 <= int(selection) <= len(requirements)):
+        print("Invalid requirement selection. Please choose a listed item or Back.")
+        return
+
+    requirement = requirements[int(selection) - 1]
+    _prompt_and_set_requirement_check(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        requirement,
+        existing.get(requirement["key"]),
+    )
+
+
+def _menu_finalize_minimum_requirement_outcome(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+    requirements: list[dict[str, Any]],
+    existing: dict[str, dict[str, Any]],
+) -> None:
+    _print_review_action_header(
+        "Finalize Minimum Requirements", class_id, assignment_id, student_id
+    )
+    _print_minimum_requirement_statuses(requirements, existing)
+    print()
+    summary = _minimum_requirement_summary(requirements, existing)
+    _print_minimum_requirement_summary(
+        summary,
+        _current_minimum_requirement_outcome(
+            workspace_root, class_id, assignment_id, student_id
+        ),
+    )
+    print()
+    if summary["unchecked"]:
+        print(
+            "Some configured requirements have not been checked. Missing checks "
+            "will not be treated as unmet."
+        )
+        print()
+    allow_return = _allow_return_without_full_review(assignment)
+    options: list[tuple[str, str]] = []
+    if summary["checked"] == len(requirements) and summary["unmet"] == 0:
+        options.append(("met", "Mark minimum requirements as met"))
+    if summary["unmet"] > 0:
+        options.append(
+            (
+                "unmet_continue_review",
+                "Continue full standards review despite unmet requirements",
+            )
+        )
+        if allow_return:
+            options.append(
+                (
+                    "returned_without_full_review",
+                    "Return without full standards review",
+                )
+            )
+        else:
+            print(
+                "Assignment policy does not allow returning work without full "
+                "standards review."
+            )
+            print()
+    if not options:
+        print("No final outcome is available yet. Record requirement checks first.")
+        return
+
+    for index, (_status, label) in enumerate(options, start=1):
+        print(f"{index}. {label}")
+    print("B. Back")
+    print()
+    selection = input("Select outcome: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Minimum-requirements outcome was not changed.")
+        return
+    if not selection.isdigit() or not (1 <= int(selection) <= len(options)):
+        print("Invalid outcome selection. Please choose a listed item or Back.")
+        return
+
+    status = options[int(selection) - 1][0]
+    teacher_note = None
+    if status == "returned_without_full_review":
+        teacher_note = input("Return note for student: ").strip()
+    else:
+        teacher_note = input(
+            "Outcome note (leave blank if not applicable): "
+        ).strip() or None
+    try:
+        updated = set_minimum_requirement_outcome(
             workspace_root,
             class_id,
             assignment_id,
             student_id,
-            requirement,
-            existing.get(requirement["key"]),
+            status=status,
+            teacher_note=teacher_note,
+            allow_return_without_full_review=allow_return,
         )
-        if result is _BACK:
-            continue
-        input("Press Enter to continue...")
+    except (ReviewRequirementError, OSError) as error:
+        print(f"Error: could not finalize minimum requirements: {error}")
+        return
+
+    print()
+    print("Finalized minimum-requirements outcome:")
+    print(f"Status: {updated.status}")
+    print(
+        "Returned without full standards review: "
+        f"{_format_yes_no(updated.returned_without_full_review)}"
+    )
+    print(f"Review state: {updated.review_state}")
+    print(f"Review record: {updated.review_record_relative_path}")
 
 
 def _prompt_and_set_requirement_check(
@@ -2576,6 +2754,93 @@ def _current_requirement_checks(
         for check in checks
         if isinstance(check, dict) and isinstance(check.get("requirement_key"), str)
     }
+
+
+def _current_minimum_requirement_outcome(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> dict[str, Any] | None:
+    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
+    if not path.exists():
+        return None
+    try:
+        record = load_review_record(path)
+    except (OSError, ReviewRecordError):
+        return None
+    outcome = record.get("minimum_requirement_outcome")
+    return outcome if isinstance(outcome, dict) else None
+
+
+def _minimum_requirement_summary(
+    requirements: list[dict[str, Any]],
+    checks: dict[str, dict[str, Any]],
+) -> dict[str, int]:
+    requirement_keys = {str(requirement["key"]) for requirement in requirements}
+    relevant_checks = [
+        check
+        for key, check in checks.items()
+        if key in requirement_keys and isinstance(check, dict)
+    ]
+    checked = len(relevant_checks)
+    unmet = sum(1 for check in relevant_checks if check.get("met") is False)
+    return {
+        "total": len(requirements),
+        "checked": checked,
+        "unchecked": len(requirements) - checked,
+        "met": sum(1 for check in relevant_checks if check.get("met") is True),
+        "unmet": unmet,
+    }
+
+
+def _print_minimum_requirement_statuses(
+    requirements: list[dict[str, Any]],
+    checks: dict[str, dict[str, Any]],
+) -> None:
+    for index, requirement in enumerate(requirements, start=1):
+        print(
+            f"{index}. {requirement['label']}: "
+            f"{_requirement_status(checks.get(requirement['key']))}"
+        )
+
+
+def _print_minimum_requirement_summary(
+    summary: dict[str, int],
+    outcome: dict[str, Any] | None,
+) -> None:
+    print(
+        "Summary: "
+        f"{summary['checked']}/{summary['total']} checked; "
+        f"{summary['unchecked']} unchecked; "
+        f"{summary['met']} met; "
+        f"{summary['unmet']} unmet"
+    )
+    if outcome is None:
+        print("Outcome status: not_checked")
+        print("Returned without full standards review: no")
+        return
+    print(f"Outcome status: {outcome.get('status', 'not_checked')}")
+    returned = outcome.get("returned_without_full_review") is True
+    print(
+        "Returned without full standards review: "
+        f"{_format_yes_no(returned)}"
+    )
+    if returned:
+        print(
+            "Minimum-requirements outcome: returned without full standards review"
+        )
+    if note := _non_empty(outcome.get("teacher_note")):
+        print(f"Outcome teacher note: {note}")
+    else:
+        print("Outcome teacher note: none")
+
+
+def _allow_return_without_full_review(assignment: dict[str, Any]) -> bool:
+    policy = assignment.get("minimum_requirement_policy")
+    if not isinstance(policy, dict):
+        return False
+    return policy.get("allow_return_without_full_review") is True
 
 
 def _requirement_status(check: dict[str, Any] | None) -> str:

--- a/quillan/review_requirements.py
+++ b/quillan/review_requirements.py
@@ -55,6 +55,22 @@ class UpdatedRequirementCheck:
     was_created: bool
 
 
+@dataclass(frozen=True, slots=True)
+class UpdatedMinimumRequirementOutcome:
+    """Information about a minimum-requirements outcome update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    status: str
+    returned_without_full_review: bool
+    review_state: str
+    teacher_note: str | None
+    updated_at: str
+
+
 def set_requirement_check(
     workspace_root: str | Path,
     class_id: str,
@@ -219,6 +235,169 @@ def set_requirement_check(
     )
 
 
+def set_minimum_requirement_outcome(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    status: str,
+    teacher_note: str | None = None,
+    updated_at: datetime | str | None = None,
+    allow_return_without_full_review: bool | None = None,
+) -> UpdatedMinimumRequirementOutcome:
+    """Set the teacher-controlled minimum-requirements outcome."""
+    normalized_status = _normalize_outcome_status(status)
+    normalized_note = _normalize_optional_string(teacher_note, "teacher_note")
+    normalized_updated_at = _normalize_timestamp(updated_at)
+
+    if normalized_status == "returned_without_full_review":
+        if normalized_note is None:
+            raise ReviewRequirementError(
+                "teacher_note must be a non-empty string when returning work "
+                "without full review."
+            )
+        if allow_return_without_full_review is not True:
+            raise ReviewRequirementError(
+                "Assignment policy does not allow returning work without "
+                "full standards review."
+            )
+    elif allow_return_without_full_review is not None and not isinstance(
+        allow_return_without_full_review, bool
+    ):
+        raise ReviewRequirementError(
+            "allow_return_without_full_review must be a boolean when provided."
+        )
+
+    try:
+        resolved_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        record_path = review_record_path(
+            resolved_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewRequirementError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise ReviewRequirementError(missing_submission_guidance())
+
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise ReviewRequirementError(
+            f"Could not load submission manifest: {error}"
+        ) from error
+    _validate_identity(
+        manifest,
+        record_name="Submission manifest",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+
+    if record_path.exists():
+        try:
+            review = load_review_record(record_path)
+        except (OSError, ReviewRecordError) as error:
+            raise ReviewRequirementError(
+                f"Could not load review record: {error}"
+            ) from error
+        _validate_identity(
+            review,
+            record_name="Review record",
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+        )
+        updated_review = copy.deepcopy(review)
+    else:
+        updated_review = build_empty_review_record(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            submission_manifest_path=_workspace_relative_path(
+                manifest_path, resolved_root, "submission manifest"
+            ),
+            assignment_path=(
+                f"classes/{class_id}/assignments/{assignment_id}/assignment.json"
+            ),
+            created_at=normalized_updated_at,
+        )
+
+    returned_without_full_review = (
+        normalized_status == "returned_without_full_review"
+    )
+    if returned_without_full_review and not any(
+        check.get("met") is False
+        for check in updated_review["minimum_requirement_checks"]
+        if isinstance(check, dict)
+    ):
+        raise ReviewRequirementError(
+            "Returning work without full review requires at least one checked "
+            "minimum requirement marked not met."
+        )
+
+    updated_review["minimum_requirement_outcome"] = {
+        "status": normalized_status,
+        "returned_without_full_review": returned_without_full_review,
+        "teacher_note": normalized_note,
+        "updated_at": normalized_updated_at,
+    }
+    updated_review["review_state"] = (
+        "returned_without_full_review"
+        if returned_without_full_review
+        else "requirements_checked"
+    )
+    updated_review["updated_at"] = normalized_updated_at
+
+    try:
+        validate_review_record(updated_review)
+        write_review_record(
+            record_path,
+            updated_review,
+            overwrite=record_path.exists(),
+        )
+        relative_path = _workspace_relative_path(
+            record_path, resolved_root, "review record"
+        )
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        ReviewRecordError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewRequirementError(
+            f"Could not write review record: {error}"
+        ) from error
+
+    return UpdatedMinimumRequirementOutcome(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=record_path,
+        review_record_relative_path=relative_path,
+        status=normalized_status,
+        returned_without_full_review=returned_without_full_review,
+        review_state=updated_review["review_state"],
+        teacher_note=normalized_note,
+        updated_at=normalized_updated_at,
+    )
+
+
 def _normalize_required_string(value: str, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ReviewRequirementError(f"{field} must be a non-empty string.")
@@ -245,6 +424,16 @@ def _normalize_expected(value: str | int | float) -> str | int | float:
     ):
         raise ReviewRequirementError(
             "expected must be a non-empty string or finite number."
+        )
+    return value
+
+
+def _normalize_outcome_status(value: str) -> str:
+    allowed = {"met", "unmet_continue_review", "returned_without_full_review"}
+    if not isinstance(value, str) or value not in allowed:
+        raise ReviewRequirementError(
+            "status must be one of: met, unmet_continue_review, "
+            "returned_without_full_review."
         )
     return value
 

--- a/quillan/review_snapshot.py
+++ b/quillan/review_snapshot.py
@@ -64,6 +64,30 @@ def _identity_error(
 def _append_requirement_checks(lines: list[str], record: dict[str, Any]) -> None:
     lines.append("Minimum Requirement Checks")
     checks = _record_list(record, "minimum_requirement_checks")
+    unmet_count = sum(1 for check in checks if check.get("met") is False)
+    outcome = record.get("minimum_requirement_outcome")
+    outcome_status = "not_checked"
+    returned = False
+    outcome_note = None
+    if isinstance(outcome, dict):
+        outcome_status = str(outcome.get("status", "not_checked"))
+        returned = outcome.get("returned_without_full_review") is True
+        outcome_note = _non_empty(outcome.get("teacher_note"))
+    lines.append(f"Check completion count: {len(checks)}")
+    lines.append(f"Unmet count: {unmet_count}")
+    lines.append(f"Outcome status: {outcome_status}")
+    lines.append(
+        "Returned without full standards review: "
+        f"{'yes' if returned else 'no'}"
+    )
+    if returned:
+        lines.append(
+            "Minimum-requirements outcome: returned without full standards review"
+        )
+    if outcome_note:
+        lines.append(f"Outcome teacher note: {outcome_note}")
+    else:
+        lines.append("Outcome teacher note: none")
     if not checks:
         lines.append("No minimum requirement checks recorded.")
         lines.append("")

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from quillan.feedback_export import (
     export_student_feedback,
     feedback_export_path,
 )
+from quillan.review_record_paths import review_record_path, write_review_record
 from quillan.submission_manifest_paths import submission_manifest_path, write_submission_manifest
 from tests.test_review_scores import _write_manifest, _write_review
 from tests.test_review_tags import (
@@ -25,6 +27,45 @@ from tests.test_review_tags import (
 )
 
 TIMESTAMP = "2026-06-23T12:30:00+00:00"
+
+
+def _write_assignment(root: Path) -> None:
+    assignment_dir = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True, exist_ok=True)
+    assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
+        "standards_profile_id": "synthetic_profile",
+        "focus_standard_ids": ["synthetic:W.A"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
+        "basic_requirements": {"paragraphs_min": 5},
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment), encoding="utf-8"
+    )
 
 
 def test_exports_ordered_student_content_without_mutating_sources(
@@ -191,6 +232,106 @@ def test_empty_scores_and_comments_have_clear_messages(tmp_path: Path) -> None:
     content = result.feedback_path.read_text(encoding="utf-8")
     assert "No standards ratings recorded." in content
     assert "No feedback comments selected." in content
+
+
+def test_exports_returned_work_notice_without_standards_ratings(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    review = _review()
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "paragraphs_min",
+            "label": "Minimum paragraphs",
+            "expected": 5,
+            "met": False,
+            "teacher_note": "Only three paragraphs were submitted.",
+            "updated_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Please revise to meet the assignment minimums.",
+        "updated_at": TIMESTAMP,
+    }
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "synthetic:W.A",
+            "rating": 4,
+            "rationale": "Should not render.",
+            "include_in_feedback": True,
+            "updated_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    _write_review(tmp_path, review)
+
+    result = export_student_feedback(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+
+    content = result.feedback_path.read_text(encoding="utf-8")
+    assert content.startswith("# Returned for Revision")
+    assert "returned without full standards review" in content
+    assert "Minimum paragraphs" in content
+    assert "Expected: 5" in content
+    assert "Only three paragraphs were submitted." in content
+    assert "Please revise to meet the assignment minimums." in content
+    assert "No full standards ratings were completed" in content
+    assert "synthetic:W.A: 4" not in content
+    assert "No standards ratings recorded." not in content
+    assert "tags" not in content
+    assert "scores" not in content
+
+
+def test_returned_work_export_requires_outcome_note_and_unmet_requirement(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    review = _review()
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_checks"] = []
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Return note.",
+        "updated_at": TIMESTAMP,
+    }
+    _write_review(tmp_path, review)
+
+    with pytest.raises(FeedbackExportError, match="marked not met"):
+        export_student_feedback(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    review["minimum_requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "paragraphs_min",
+            "label": "Minimum paragraphs",
+            "expected": 5,
+            "met": False,
+            "updated_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    review["minimum_requirement_outcome"]["teacher_note"] = None
+    write_review_record(
+        review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        review,
+        overwrite=True,
+    )
+
+    with pytest.raises(FeedbackExportError, match="teacher note"):
+        export_student_feedback(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -187,7 +187,7 @@ def test_review_menu_selected_student_excludes_legacy_review_entry_actions(
     assert "Selected Student Review" in output
     assert "1. Open submission evidence" in output
     assert "2. View current review details" in output
-    assert "3. Record minimum requirement checks" in output
+    assert "3. Review minimum requirements" in output
     assert "4. Manage submission pages" in output
     assert "5. Add teacher note" in output
     assert "6. Update submission review state" in output
@@ -215,13 +215,14 @@ def test_review_menu_records_minimum_requirement_check(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["3", "1", "1", "", "", "b"]
+        + ["3", "1", "1", "1", "", "4"]
         + _exit_selected_student_to_main(),
     )
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Requirement Checks" in output
+    assert "Review Minimum Requirements" in output
     assert "Minimum paragraphs: not checked" in output
     assert "Recorded requirement check:" in output
     review = json.loads(
@@ -232,6 +233,54 @@ def test_review_menu_records_minimum_requirement_check(
     assert review["minimum_requirement_checks"][0]["requirement_key"] == "paragraphs_min"
     assert review["minimum_requirement_checks"][0]["met"] is True
     assert manifest_path.read_bytes() == manifest_before
+
+
+def test_review_menu_returns_without_full_review_when_policy_allows(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + [
+            "3",
+            "1",
+            "1",
+            "2",
+            "Too short.",
+            "2",
+            "2",
+            "Add the required paragraph before resubmitting.",
+            "",
+            "4",
+        ]
+        + _exit_selected_student_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Return without full standards review" in output
+    assert "Finalized minimum-requirements outcome:" in output
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert review["review_state"] == "returned_without_full_review"
+    assert review["minimum_requirement_outcome"]["status"] == (
+        "returned_without_full_review"
+    )
+    assert review["minimum_requirement_outcome"]["returned_without_full_review"] is True
+    assert review["minimum_requirement_outcome"]["teacher_note"] == (
+        "Add the required paragraph before resubmitting."
+    )
+    assert "notes" not in review
+    assert "tags" not in review
+    assert "scores" not in review
+    assert "comments" not in review
+    assert "requirement_checks" not in review
 
 
 def test_review_menu_blank_note_cancels_without_review_record(

--- a/tests/test_review_requirements.py
+++ b/tests/test_review_requirements.py
@@ -10,7 +10,11 @@ import pytest
 
 from quillan.review_record import ReviewRecordError, build_empty_review_record, validate_review_record
 from quillan.review_record_paths import review_record_path, write_review_record
-from quillan.review_requirements import ReviewRequirementError, set_requirement_check
+from quillan.review_requirements import (
+    ReviewRequirementError,
+    set_minimum_requirement_outcome,
+    set_requirement_check,
+)
 from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
@@ -267,3 +271,187 @@ def test_missing_submission_manifest_errors_without_review_write(
         )
 
     assert not review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+
+
+def test_sets_minimum_requirement_outcome_to_met_and_preserves_data(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    review = _review("requirements_checked")
+    review["created_at"] = ORIGINAL_TIMESTAMP
+    review["updated_at"] = FIRST_TIMESTAMP
+    review["minimum_requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "paragraphs_min",
+            "label": "Minimum paragraphs",
+            "expected": 5,
+            "met": True,
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    review["private_notes"] = [
+        {
+            "private_note_id": "note_0001",
+            "text": "Preserve me.",
+            "created_at": FIRST_TIMESTAMP,
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    path = write_review_record(
+        review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        review,
+    )
+
+    result = set_minimum_requirement_outcome(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        status="met",
+        teacher_note="Ready for standards review.",
+        updated_at=SECOND_TIMESTAMP,
+    )
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert result.status == "met"
+    assert result.returned_without_full_review is False
+    assert result.review_state == "requirements_checked"
+    assert written["schema_version"] == "2"
+    assert written["review_state"] == "requirements_checked"
+    assert written["created_at"] == ORIGINAL_TIMESTAMP
+    assert written["updated_at"] == SECOND_TIMESTAMP
+    assert written["minimum_requirement_checks"] == review["minimum_requirement_checks"]
+    assert written["private_notes"] == review["private_notes"]
+    assert written["minimum_requirement_outcome"] == {
+        "status": "met",
+        "returned_without_full_review": False,
+        "teacher_note": "Ready for standards review.",
+        "updated_at": SECOND_TIMESTAMP,
+    }
+    for legacy_field in ("notes", "tags", "scores", "comments", "requirement_checks"):
+        assert legacy_field not in written
+
+
+def test_sets_minimum_requirement_outcome_to_unmet_continue_review(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+
+    result = set_minimum_requirement_outcome(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        status="unmet_continue_review",
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    written = json.loads(
+        review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert result.status == "unmet_continue_review"
+    assert written["review_state"] == "requirements_checked"
+    assert written["minimum_requirement_outcome"]["teacher_note"] is None
+
+
+def test_sets_minimum_requirement_outcome_to_returned_without_full_review(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    set_requirement_check(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        requirement_key="paragraphs_min",
+        label="Minimum paragraphs",
+        expected=5,
+        met=False,
+        teacher_note="Only three paragraphs.",
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    result = set_minimum_requirement_outcome(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        status="returned_without_full_review",
+        teacher_note="Revise to meet the paragraph minimum.",
+        updated_at=SECOND_TIMESTAMP,
+        allow_return_without_full_review=True,
+    )
+
+    written = json.loads(
+        review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert result.returned_without_full_review is True
+    assert written["review_state"] == "returned_without_full_review"
+    assert written["minimum_requirement_outcome"] == {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Revise to meet the paragraph minimum.",
+        "updated_at": SECOND_TIMESTAMP,
+    }
+    assert len(written["minimum_requirement_checks"]) == 1
+
+
+def test_returned_without_full_review_requires_note_policy_and_unmet_check(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+
+    with pytest.raises(ReviewRequirementError, match="teacher_note"):
+        set_minimum_requirement_outcome(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            status="returned_without_full_review",
+            teacher_note=" ",
+            updated_at=FIRST_TIMESTAMP,
+            allow_return_without_full_review=True,
+        )
+
+    set_requirement_check(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        requirement_key="paragraphs_min",
+        label="Minimum paragraphs",
+        expected=5,
+        met=True,
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    with pytest.raises(ReviewRequirementError, match="does not allow"):
+        set_minimum_requirement_outcome(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            status="returned_without_full_review",
+            teacher_note="Revise first.",
+            updated_at=SECOND_TIMESTAMP,
+            allow_return_without_full_review=False,
+        )
+
+    with pytest.raises(ReviewRequirementError, match="marked not met"):
+        set_minimum_requirement_outcome(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            status="returned_without_full_review",
+            teacher_note="Revise first.",
+            updated_at=SECOND_TIMESTAMP,
+            allow_return_without_full_review=True,
+        )


### PR DESCRIPTION
## Summary

Implements the minimum-requirements return workflow for Quillan’s v0.8.6 standards-based review model.

Teachers can now record minimum-requirement checks, finalize the minimum-requirements outcome, and return work without full standards review when the assignment policy allows it.

## Changes

* Adds `set_minimum_requirement_outcome` and a result dataclass in `review_requirements.py`.
* Reworks the selected-student menu option into `Review minimum requirements`.
* Adds a minimum-requirements workflow with:

  * check entry;
  * outcome finalization;
  * policy-gated return without full standards review;
  * returned-work export entry point.
* Adds returned-without-full-review Markdown export rendering in `feedback_export.py`.
* Adds returned-work export precondition checks.
* Updates review detail/summary output to show:

  * requirement completion;
  * unmet count;
  * outcome status;
  * returned-without-full-review flag;
  * requirement/outcome notes.
* Adds focused helper, menu, and export tests.

## Behavior

When work is returned without full standards review, Quillan records:

* `review_state: "returned_without_full_review"`
* `minimum_requirement_outcome.status: "returned_without_full_review"`
* `minimum_requirement_outcome.returned_without_full_review: true`
* a non-empty teacher note
* an outcome timestamp

Returned-work Markdown is generated through the existing:

`exports/feedback.md`

The export clearly states that full standards review was not completed and lists unmet minimum requirements. It does not create fake standards ratings or use legacy v1 tags, comments, or scores.

## Verification

Targeted suite:

* `163 passed`

Full suite:

* `973 passed`

Changed-file Ruff:

* `All checks passed`

## Notes

This PR does not update `review.exports.feedback_markdown` metadata. Returned-work Markdown is generated through the existing export path, but review-record export metadata is left untouched to keep this workflow focused. Export metadata handling can be addressed with the later student feedback export work.

This PR does not implement review-unit observations, overall Focus Standard ratings, Focus Standard feedback composition, polished PDF export, class summaries, standards summaries, or assignment result manifests.

Closes #228
