### PR TITLE
Implement review unit observation workflow

### DIFF
--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -14,6 +14,11 @@ from quillan.evidence_filing import EvidenceFilingError, RoutedEvidenceFile
 from quillan.feedback_export import ExportedFeedback
 from quillan.review_comments import AddedReviewComment
 from quillan.review_notes import AddedReviewNote
+from quillan.review_observations import (
+    CompletedReviewUnitObservations,
+    UpdatedReviewUnitObservation,
+    UpdatedReviewUnits,
+)
 from quillan.review_scores import UpdatedReviewScore
 from quillan.review_tags import AddedReviewTag
 from quillan.route_planning import RouteFailure
@@ -105,6 +110,54 @@ def print_updated_review_score(updated: UpdatedReviewScore) -> None:
     print(f"Action: {'created' if updated.was_created else 'updated'}")
     print(f"Review state: {updated.review_state}")
     print(f"Review record: {updated.review_record_relative_path}")
+
+
+def print_updated_review_units(updated: UpdatedReviewUnits) -> None:
+    """Print a concise teacher-facing review-unit summary."""
+    print("Updated review units:")
+    print(f"Class: {updated.class_id}")
+    print(f"Assignment: {updated.assignment_id}")
+    print(f"Student: {updated.student_id}")
+    print(f"Units: {updated.unit_count}")
+    print(f"Review state: {updated.review_state}")
+    print(f"Review record: {updated.review_record_relative_path}")
+
+
+def print_updated_review_unit_observation(
+    updated: UpdatedReviewUnitObservation,
+) -> None:
+    """Print a concise teacher-facing observation summary."""
+    print("Updated Focus Standard observation:")
+    print(f"Class: {updated.class_id}")
+    print(f"Assignment: {updated.assignment_id}")
+    print(f"Student: {updated.student_id}")
+    print(f"Unit: {updated.unit_label} ({updated.unit_id})")
+    print(f"Standard: {updated.standard_id}")
+    print(f"Observation: {updated.observation_id}")
+    print(f"Applicable: {format_bool(updated.applicable)}")
+    evidence = "not applicable"
+    if updated.evidence_present is not None:
+        evidence = format_bool(updated.evidence_present)
+    print(f"Evidence present: {evidence}")
+    print(f"Include in feedback: {format_bool(updated.include_in_feedback)}")
+    print(f"Action: {'created' if updated.was_created else 'updated'}")
+    print(f"Review state: {updated.review_state}")
+    print(f"Review record: {updated.review_record_relative_path}")
+
+
+def print_completed_review_unit_observations(
+    completed: CompletedReviewUnitObservations,
+) -> None:
+    """Print a concise teacher-facing observation-completion summary."""
+    print("Marked review-unit observations complete:")
+    print(f"Class: {completed.class_id}")
+    print(f"Assignment: {completed.assignment_id}")
+    print(f"Student: {completed.student_id}")
+    print(f"Units: {completed.unit_count}")
+    print(f"Observations: {completed.observation_count}")
+    print(f"Unobserved unit-standard pairs: {completed.missing_focus_standard_pairs}")
+    print(f"Review state: {completed.review_state}")
+    print(f"Review record: {completed.review_record_relative_path}")
 
 
 def print_exported_feedback(exported: ExportedFeedback) -> None:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -33,7 +33,10 @@ from quillan.cli_app.output import (
     print_exported_class_summary,
     print_exported_feedback,
     print_exported_standards_summary,
+    print_completed_review_unit_observations,
     print_opened_submission_review,
+    print_updated_review_unit_observation,
+    print_updated_review_units,
     print_updated_review_score,
     print_updated_submission_review_state,
 )
@@ -49,6 +52,12 @@ from quillan.standards_summary_export import (
 )
 from quillan.tag_bank_writing import list_valid_tag_banks
 from quillan.review_notes import ReviewNoteError, add_review_note
+from quillan.review_observations import (
+    ReviewObservationError,
+    mark_observations_complete,
+    set_review_unit_observation,
+    set_review_units,
+)
 from quillan.review_comments import ReviewCommentError, add_review_comment
 from quillan.review_record import (
     ALLOWED_TAG_POLARITIES,
@@ -414,18 +423,19 @@ def _launch_selected_student_review(
         print("1. Open submission evidence")
         print("2. View current review details")
         print("3. Review minimum requirements")
-        print("4. Manage submission pages")
-        print("5. Add teacher note")
-        print("6. Update submission review state")
-        print("7. Export student feedback")
-        print("8. Refresh summary")
-        print("9. Back")
+        print("4. Review units and Focus Standard observations")
+        print("5. Manage submission pages")
+        print("6. Add teacher note")
+        print("7. Update submission review state")
+        print("8. Export student feedback")
+        print("9. Refresh summary")
+        print("10. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "9"}:
+        if choice in {"", "10"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -451,6 +461,13 @@ def _launch_selected_student_review(
                 student_id,
             )
         elif choice == "4":
+            _menu_review_unit_observations(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+        elif choice == "5":
             _menu_manage_submission_pages(
                 workspace_root,
                 class_id,
@@ -458,7 +475,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "5":
+        elif choice == "6":
             _menu_add_review_note(
                 workspace_root,
                 class_id,
@@ -466,7 +483,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "6":
+        elif choice == "7":
             _menu_update_submission_review_state(
                 workspace_root,
                 class_id,
@@ -474,7 +491,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "7":
+        elif choice == "8":
             _menu_export_student_feedback(
                 workspace_root,
                 class_id,
@@ -482,10 +499,10 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "8":
+        elif choice == "9":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 9.")
+            print("Invalid selection. Please enter a number from 1 to 10.")
             input("Press Enter to continue...")
 
 
@@ -2016,6 +2033,11 @@ def _prompt_yes_no_default_no(prompt: str) -> bool:
     return response in {"y", "yes"}
 
 
+def _prompt_yes_no_default_yes(prompt: str) -> bool:
+    response = input(f"{prompt} (Y/n): ").strip().casefold()
+    return response not in {"n", "no"}
+
+
 def _format_yes_no(value: bool) -> str:
     return "yes" if value else "no"
 
@@ -2090,6 +2112,96 @@ def _review_record_counts(
         "included_comments": included_comments,
         "ratings": _count_record_items(record, "overall_standard_ratings"),
     }
+
+
+def _current_review_record(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> dict[str, Any] | None:
+    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
+    if not path.exists():
+        return None
+    try:
+        return load_review_record(path)
+    except (OSError, ReviewRecordError) as error:
+        print(f"Error: could not load review record: {error}")
+        return None
+
+
+def _print_review_observation_status(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is None:
+        print("Review units: 0")
+        print("Observations: 0")
+        print("Included for feedback: 0")
+        print("Review record state: not_started")
+        return
+    print(f"Review units: {_count_record_items(record, 'review_units')}")
+    print(f"Observations: {_count_review_unit_observations(record)}")
+    print(f"Included for feedback: {_count_included_review_unit_observations(record)}")
+    print(f"Review record state: {record['review_state']}")
+
+
+def _count_included_review_unit_observations(record: dict[str, Any]) -> int:
+    units = record.get("review_units")
+    if not isinstance(units, list):
+        return 0
+    total = 0
+    for unit in units:
+        observations = unit.get("standard_observations") if isinstance(unit, dict) else None
+        if isinstance(observations, list):
+            total += sum(
+                1
+                for observation in observations
+                if isinstance(observation, dict) and observation.get("include_in_feedback")
+            )
+    return total
+
+
+def _prompt_review_unit(units: list[dict[str, Any]]) -> dict[str, Any] | None:
+    print("Review units:")
+    for index, unit in enumerate(units, start=1):
+        observation_count = len(unit.get("standard_observations", []))
+        print(f"{index}. {unit['label']} ({observation_count} observations)")
+    print("B. Back")
+    print()
+    selection = input("Select review unit: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(units):
+        return units[int(selection) - 1]
+    for unit in units:
+        if unit["unit_id"] == selection:
+            return unit
+    print("Invalid review unit selection.")
+    return None
+
+
+def _prompt_focus_standard(
+    workspace_root: Path,
+    focus_standard_ids: list[str],
+) -> str | None:
+    print("Focus Standards:")
+    for index, standard_id in enumerate(focus_standard_ids, start=1):
+        print(f"{index}. {_format_standard_display(workspace_root, standard_id)}")
+    print("B. Back")
+    print()
+    selection = input("Select Focus Standard: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(focus_standard_ids):
+        return focus_standard_ids[int(selection) - 1]
+    if selection in focus_standard_ids:
+        return selection
+    print("Invalid Focus Standard selection.")
+    return None
 
 
 def _parse_optional_positive_int(value: str) -> int | None:
@@ -2207,6 +2319,7 @@ def _print_review_record_summary(
     print("Review record: exists")
     print(f"Review record state: {record['review_state']}")
     print(f"Private notes: {_count_record_items(record, 'private_notes')}")
+    print(f"Review units: {_count_record_items(record, 'review_units')}")
     print(f"Review-unit observations: {_count_review_unit_observations(record)}")
     print(f"Feedback comments: {_count_feedback_comments(record)}")
     print(f"Overall ratings: {_count_record_items(record, 'overall_standard_ratings')}")
@@ -2389,6 +2502,212 @@ def _choose_submission_evidence_page(
             return pages[index - 1].page_number
     print("Invalid selection. Please choose a listed page, A, or B.")
     return _BACK
+
+
+def _menu_review_unit_observations(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    while True:
+        _print_review_action_header(
+            "Review Units and Focus Standard Observations",
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        assignment = _load_assignment_for_review(
+            workspace_root, class_id, assignment_id
+        )
+        if assignment is None:
+            input("Press Enter to continue...")
+            return
+        _print_review_observation_status(
+            workspace_root, class_id, assignment_id, student_id
+        )
+        print()
+        print("1. Define/replace review units")
+        print("2. Record/update Focus Standard observation")
+        print("3. Mark observations complete")
+        print("4. Back")
+        print()
+        choice = input("Select an option: ").strip()
+        print()
+        if choice in {"", "4"}:
+            return
+        if choice == "1":
+            _menu_define_review_units(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+            input("Press Enter to continue...")
+        elif choice == "2":
+            _menu_record_review_unit_observation(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+            input("Press Enter to continue...")
+        elif choice == "3":
+            _menu_mark_observations_complete(
+                workspace_root, class_id, assignment_id, student_id
+            )
+            input("Press Enter to continue...")
+        else:
+            print("Invalid selection. Please enter a number from 1 to 4.")
+            input("Press Enter to continue...")
+
+
+def _menu_define_review_units(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    review_unit = assignment["review_unit"]
+    unit_type = str(review_unit["type"])
+    plural_label = str(review_unit["plural_label"])
+    existing = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    existing_units = existing.get("review_units", []) if existing is not None else []
+    print(f"Assignment review unit type: {unit_type}")
+    print(f"Focus Standards: {len(assignment['focus_standard_ids'])}")
+    if existing_units:
+        existing_observations = _count_review_unit_observations(existing)
+        print(
+            f"Existing review units: {len(existing_units)}; "
+            f"observations: {existing_observations}"
+        )
+        print("Replacing units keeps observations only when unit IDs still match.")
+    count_text = input(f"How many {plural_label} does this submission have? ").strip()
+    if not count_text:
+        print("Review unit definition canceled.")
+        return
+    try:
+        unit_count = int(count_text)
+    except ValueError:
+        print("Review unit definition canceled. Enter a positive whole number.")
+        return
+    if unit_count < 1:
+        print("Review unit definition canceled. Enter at least 1.")
+        return
+    print()
+    print(f"Create {unit_count} {plural_label}?")
+    print("1. Save review units")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Review unit definition canceled.")
+        return
+    try:
+        updated = set_review_units(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            [{"sequence": sequence} for sequence in range(1, unit_count + 1)],
+        )
+    except ReviewObservationError as error:
+        print(f"Error: could not update review units: {error}")
+        return
+    print_updated_review_units(updated)
+
+
+def _menu_record_review_unit_observation(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is None or not record.get("review_units"):
+        print("Define review units before recording observations.")
+        return
+    unit = _prompt_review_unit(record["review_units"])
+    if unit is None:
+        print("Observation entry canceled.")
+        return
+    standard_id = _prompt_focus_standard(workspace_root, assignment["focus_standard_ids"])
+    if standard_id is None:
+        print("Observation entry canceled.")
+        return
+    print()
+    print("Applicability")
+    print("1. Applicable")
+    print("2. Not applicable")
+    print("B. Back")
+    print()
+    applicability = input("Select applicability: ").strip().casefold()
+    if applicability in {"", "b"}:
+        print("Observation entry canceled.")
+        return
+    applicable = applicability == "1"
+    if not applicable and applicability != "2":
+        print("Observation entry canceled. Invalid applicability selection.")
+        return
+    if applicable:
+        evidence_present = _prompt_yes_no_default_yes("Evidence present?")
+        include_in_feedback = _prompt_yes_no_default_yes("Include in feedback?")
+    else:
+        evidence_present = None
+        include_in_feedback = _prompt_yes_no_default_no("Include in feedback?")
+    rationale = input("Rationale/note (optional): ").strip() or None
+    print()
+    print("Save this observation?")
+    print("1. Save observation")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Observation entry canceled.")
+        return
+    try:
+        updated = set_review_unit_observation(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            unit_id=unit["unit_id"],
+            standard_id=standard_id,
+            applicable=applicable,
+            evidence_present=evidence_present,
+            rationale=rationale,
+            include_in_feedback=include_in_feedback,
+        )
+    except ReviewObservationError as error:
+        print(f"Error: could not update observation: {error}")
+        return
+    print_updated_review_unit_observation(updated)
+
+
+def _menu_mark_observations_complete(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is None or not record.get("review_units"):
+        print("Define review units before marking observations complete.")
+        return
+    print("Observations may be marked complete without observing every unit-standard pair.")
+    print("1. Mark observations complete")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Observations were not changed.")
+        return
+    try:
+        completed = mark_observations_complete(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewObservationError as error:
+        print(f"Error: could not mark observations complete: {error}")
+        return
+    if completed.missing_focus_standard_pairs:
+        print(
+            "Unobserved unit-standard pairs: "
+            f"{completed.missing_focus_standard_pairs}"
+        )
+    print_completed_review_unit_observations(completed)
 
 
 def _menu_review_minimum_requirements(

--- a/quillan/review_observations.py
+++ b/quillan/review_observations.py
@@ -1,0 +1,579 @@
+"""Review-unit and Focus Standard observation mutation helpers."""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.review_record import (
+    ReviewRecordError,
+    build_empty_review_record,
+    load_review_record,
+    validate_review_record,
+)
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
+from quillan.storage import assignment_config_path
+from quillan.submission_guidance import missing_submission_guidance
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+_SEQUENTIAL_OBSERVATION_ID = re.compile(r"^observation_(\d{4})$")
+
+
+class ReviewObservationError(Exception):
+    """Raised when review-unit observations cannot be changed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class UpdatedReviewUnits:
+    """Information about review units written to a review record."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    unit_count: int
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class UpdatedReviewUnitObservation:
+    """Information about one Focus Standard observation update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    unit_id: str
+    unit_label: str
+    standard_id: str
+    observation_id: str
+    applicable: bool
+    evidence_present: bool | None
+    include_in_feedback: bool
+    was_created: bool
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class CompletedReviewUnitObservations:
+    """Information about an observations-complete review-state update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    unit_count: int
+    observation_count: int
+    missing_focus_standard_pairs: int
+    updated_at: str
+
+
+def set_review_units(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    units: list[dict[str, Any]],
+    *,
+    updated_at: datetime | str | None = None,
+) -> UpdatedReviewUnits:
+    """Create or replace review units for one assembled student submission."""
+    normalized_updated_at = _normalize_timestamp(updated_at)
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    assignment = context["assignment"]
+    review = _load_or_create_review(context, normalized_updated_at)
+    _guard_returned_without_full_review(review)
+
+    existing_by_id = {
+        unit["unit_id"]: unit
+        for unit in review["review_units"]
+        if isinstance(unit, dict) and isinstance(unit.get("unit_id"), str)
+    }
+    canonical_units: list[dict[str, Any]] = []
+    review_unit_config = assignment["review_unit"]
+    unit_type = str(review_unit_config["type"]).strip()
+    singular_label = str(review_unit_config["singular_label"]).strip()
+    for index, unit in enumerate(units, start=1):
+        sequence = _normalize_sequence(unit.get("sequence", index), index)
+        unit_id = f"{unit_type}_{sequence}"
+        label = _normalize_optional_string(unit.get("label"), "label")
+        if label is None:
+            label = f"{_display_label(singular_label)} {sequence}"
+        canonical = {
+            "unit_id": unit_id,
+            "sequence": sequence,
+            "label": label,
+            "unit_type": unit_type,
+            "standard_observations": copy.deepcopy(
+                existing_by_id.get(unit_id, {}).get("standard_observations", [])
+            ),
+            "module_details": {},
+        }
+        page_number = unit.get("page_number")
+        if page_number is not None:
+            canonical["page_number"] = _normalize_positive_int(
+                page_number, "page_number"
+            )
+        evidence_id = _normalize_optional_string(unit.get("evidence_id"), "evidence_id")
+        if evidence_id is not None:
+            canonical["evidence_id"] = evidence_id
+        canonical_units.append(canonical)
+
+    review["review_units"] = canonical_units
+    _drop_stale_feedback_observation_references(review)
+    review["review_state"] = _observations_in_progress_state(review["review_state"])
+    review["updated_at"] = normalized_updated_at
+
+    _write_review(context, review)
+    return UpdatedReviewUnits(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        unit_count=len(canonical_units),
+        updated_at=normalized_updated_at,
+    )
+
+
+def set_review_unit_observation(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    unit_id: str,
+    standard_id: str,
+    applicable: bool,
+    evidence_present: bool | None,
+    rationale: str | None = None,
+    include_in_feedback: bool | None = None,
+    rating: int | None = None,
+    updated_at: datetime | str | None = None,
+) -> UpdatedReviewUnitObservation:
+    """Create or update one review-unit Focus Standard observation."""
+    if not isinstance(applicable, bool):
+        raise ReviewObservationError("applicable must be a boolean.")
+    normalized_unit_id = _normalize_required_string(unit_id, "unit_id")
+    normalized_standard_id = _normalize_required_string(standard_id, "standard_id")
+    normalized_rationale = _normalize_optional_string(rationale, "rationale")
+    normalized_updated_at = _normalize_timestamp(updated_at)
+    normalized_rating = _normalize_rating(rating)
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    assignment = context["assignment"]
+    if normalized_standard_id not in assignment["focus_standard_ids"]:
+        raise ReviewObservationError(
+            f"standard_id {normalized_standard_id!r} is not a Focus Standard for this assignment."
+        )
+
+    review = _load_existing_review(context)
+    _guard_returned_without_full_review(review)
+    if not review["review_units"]:
+        raise ReviewObservationError("Define review units before recording observations.")
+    unit = next(
+        (candidate for candidate in review["review_units"] if candidate["unit_id"] == normalized_unit_id),
+        None,
+    )
+    if unit is None:
+        raise ReviewObservationError(f"Review unit not found: {normalized_unit_id}")
+
+    if applicable:
+        if not isinstance(evidence_present, bool):
+            raise ReviewObservationError(
+                "evidence_present must be a boolean when applicable is true."
+            )
+        normalized_evidence_present: bool | None = evidence_present
+        normalized_include = True if include_in_feedback is None else include_in_feedback
+    else:
+        normalized_evidence_present = None
+        normalized_rating = None
+        normalized_include = False if include_in_feedback is None else include_in_feedback
+    if not isinstance(normalized_include, bool):
+        raise ReviewObservationError("include_in_feedback must be a boolean.")
+
+    observations = unit["standard_observations"]
+    observation = next(
+        (
+            candidate
+            for candidate in observations
+            if candidate["standard_id"] == normalized_standard_id
+        ),
+        None,
+    )
+    was_created = observation is None
+    if observation is None:
+        observation_id = _next_observation_id(review)
+        observation = {"observation_id": observation_id}
+        observations.append(observation)
+    else:
+        observation_id = observation["observation_id"]
+
+    observation.clear()
+    observation.update(
+        {
+            "observation_id": observation_id,
+            "standard_id": normalized_standard_id,
+            "applicable": applicable,
+            "evidence_present": normalized_evidence_present,
+            "rating": normalized_rating,
+            "rationale": normalized_rationale,
+            "include_in_feedback": normalized_include,
+            "updated_at": normalized_updated_at,
+            "module_details": {},
+        }
+    )
+    review["review_state"] = _observations_in_progress_state(review["review_state"])
+    review["updated_at"] = normalized_updated_at
+
+    _write_review(context, review)
+    return UpdatedReviewUnitObservation(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        unit_id=normalized_unit_id,
+        unit_label=unit["label"],
+        standard_id=normalized_standard_id,
+        observation_id=observation_id,
+        applicable=applicable,
+        evidence_present=normalized_evidence_present,
+        include_in_feedback=normalized_include,
+        was_created=was_created,
+        updated_at=normalized_updated_at,
+    )
+
+
+def mark_observations_complete(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    updated_at: datetime | str | None = None,
+) -> CompletedReviewUnitObservations:
+    """Explicitly mark review-unit observations complete."""
+    normalized_updated_at = _normalize_timestamp(updated_at)
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    review = _load_existing_review(context)
+    _guard_returned_without_full_review(review)
+    if not review["review_units"]:
+        raise ReviewObservationError("Define review units before marking observations complete.")
+
+    review["review_state"] = "observations_complete"
+    review["updated_at"] = normalized_updated_at
+    _write_review(context, review)
+
+    focus_count = len(context["assignment"]["focus_standard_ids"])
+    observation_count = _count_observations(review)
+    return CompletedReviewUnitObservations(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        unit_count=len(review["review_units"]),
+        observation_count=observation_count,
+        missing_focus_standard_pairs=max(
+            len(review["review_units"]) * focus_count - observation_count, 0
+        ),
+        updated_at=normalized_updated_at,
+    )
+
+
+def _load_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> dict[str, Any]:
+    try:
+        resolved_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_root, class_id, assignment_id, student_id
+        )
+        record_path = review_record_path(
+            resolved_root, class_id, assignment_id, student_id
+        )
+        assignment_path = assignment_config_path(resolved_root, class_id, assignment_id)
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewObservationError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise ReviewObservationError(missing_submission_guidance())
+
+    try:
+        manifest = load_submission_manifest(manifest_path)
+        assignment = load_assignment_config(assignment_path)
+    except (OSError, SubmissionManifestError, AssignmentConfigError) as error:
+        raise ReviewObservationError(str(error)) from error
+
+    _validate_identity(
+        manifest,
+        record_name="Submission manifest",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+    if class_id not in assignment["class_ids"]:
+        raise ReviewObservationError(
+            f"Assignment config class_ids does not include {class_id!r}."
+        )
+    if assignment["assignment_id"] != assignment_id:
+        raise ReviewObservationError(
+            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
+        )
+
+    return {
+        "workspace_root": resolved_root,
+        "manifest_path": manifest_path,
+        "record_path": record_path,
+        "assignment_path": assignment_path,
+        "assignment": assignment,
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+
+
+def _load_or_create_review(context: dict[str, Any], created_at: str) -> dict[str, Any]:
+    record_path = context["record_path"]
+    if record_path.exists():
+        return _load_existing_review(context)
+    return build_empty_review_record(
+        class_id=context["class_id"],
+        assignment_id=context["assignment_id"],
+        student_id=context["student_id"],
+        submission_manifest_path=_workspace_relative_path(
+            context["manifest_path"], context["workspace_root"], "submission manifest"
+        ),
+        assignment_path=_workspace_relative_path(
+            context["assignment_path"], context["workspace_root"], "assignment"
+        ),
+        created_at=created_at,
+    )
+
+
+def _load_existing_review(context: dict[str, Any]) -> dict[str, Any]:
+    record_path = context["record_path"]
+    if not record_path.exists():
+        raise ReviewObservationError("Review units must be defined before recording observations.")
+    try:
+        review = load_review_record(record_path)
+    except (OSError, ReviewRecordError) as error:
+        raise ReviewObservationError(f"Could not load review record: {error}") from error
+    _validate_identity(
+        review,
+        record_name="Review record",
+        class_id=context["class_id"],
+        assignment_id=context["assignment_id"],
+        student_id=context["student_id"],
+    )
+    return copy.deepcopy(review)
+
+
+def _write_review(context: dict[str, Any], review: dict[str, Any]) -> None:
+    try:
+        validate_review_record(review)
+        write_review_record(
+            context["record_path"],
+            review,
+            overwrite=context["record_path"].exists(),
+        )
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        ReviewRecordError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewObservationError(f"Could not write review record: {error}") from error
+
+
+def _guard_returned_without_full_review(review: dict[str, Any]) -> None:
+    if review["review_state"] == "returned_without_full_review":
+        raise ReviewObservationError(
+            "This submission was returned without full standards review. "
+            "Change the minimum-requirements outcome before continuing with observations."
+        )
+
+
+def _observations_in_progress_state(current_state: str) -> str:
+    if current_state in {"not_started", "requirements_checked", "observations_complete"}:
+        return "observations_in_progress"
+    if current_state == "observations_in_progress":
+        return current_state
+    return current_state
+
+
+def _drop_stale_feedback_observation_references(review: dict[str, Any]) -> None:
+    valid_ids = {
+        observation["observation_id"]
+        for unit in review["review_units"]
+        for observation in unit["standard_observations"]
+    }
+    for item in review["feedback"]["standard_feedback"]:
+        item["included_observation_ids"] = [
+            observation_id
+            for observation_id in item["included_observation_ids"]
+            if observation_id in valid_ids
+        ]
+
+
+def _next_observation_id(review: dict[str, Any]) -> str:
+    existing_ids = {
+        observation["observation_id"]
+        for unit in review["review_units"]
+        for observation in unit["standard_observations"]
+    }
+    highest = max(
+        (
+            int(match.group(1))
+            for observation_id in existing_ids
+            if (match := _SEQUENTIAL_OBSERVATION_ID.fullmatch(observation_id))
+        ),
+        default=0,
+    )
+    candidate_number = highest + 1
+    while True:
+        candidate = f"observation_{candidate_number:04d}"
+        if candidate not in existing_ids:
+            return candidate
+        candidate_number += 1
+
+
+def _count_observations(review: dict[str, Any]) -> int:
+    return sum(len(unit["standard_observations"]) for unit in review["review_units"])
+
+
+def _normalize_sequence(value: Any, index: int) -> int:
+    if value is None:
+        return index
+    return _normalize_positive_int(value, "sequence")
+
+
+def _normalize_positive_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ReviewObservationError(f"{field} must be a positive integer.")
+    return value
+
+
+def _normalize_rating(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ReviewObservationError("rating must be an integer or null.")
+    return value
+
+
+def _normalize_required_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewObservationError(f"{field} must be a non-empty string.")
+    return value.strip()
+
+
+def _normalize_optional_string(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ReviewObservationError(f"{field} must be a string or null.")
+    if not value.strip():
+        return None
+    return value.strip()
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReviewObservationError("updated_at datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise ReviewObservationError(
+            "updated_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ReviewObservationError(
+            "updated_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewObservationError(
+            "updated_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    *,
+    record_name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    for field, expected in {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }.items():
+        actual = record[field]
+        if actual != expected:
+            raise ReviewObservationError(
+                f"{record_name} {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _workspace_relative_path(
+    path: Path,
+    workspace_root: Path,
+    description: str,
+) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewObservationError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error
+
+
+def _display_label(value: str) -> str:
+    return value[:1].upper() + value[1:]

--- a/quillan/review_record.py
+++ b/quillan/review_record.py
@@ -453,7 +453,8 @@ def _validate_standard_observations(
         applicable = _validate_boolean(item["applicable"], f"{item_context}.applicable")
         if applicable:
             _validate_boolean(item["evidence_present"], f"{item_context}.evidence_present")
-            _validate_integer(item["rating"], f"{item_context}.rating")
+            if item["rating"] is not None:
+                _validate_integer(item["rating"], f"{item_context}.rating")
         else:
             if item["evidence_present"] is not None:
                 raise ReviewRecordError(

--- a/quillan/review_snapshot.py
+++ b/quillan/review_snapshot.py
@@ -111,10 +111,14 @@ def _append_review_units(lines: list[str], record: dict[str, Any]) -> None:
         lines.append(f"{unit['sequence']}. {unit['label']} ({unit['unit_type']})")
         for observation in _record_list(unit, "standard_observations"):
             status = "applicable" if observation["applicable"] else "not applicable"
+            evidence = _format_evidence_present(observation["evidence_present"])
+            include = "yes" if observation["include_in_feedback"] else "no"
             lines.append(
                 f"   - {observation['standard_id']}: {status}; "
-                f"rating {_format_nullable(observation['rating'])}"
+                f"evidence present: {evidence}; include in feedback: {include}"
             )
+            if observation["rating"] is not None:
+                lines.append(f"     Rating: {observation['rating']}")
             if rationale := _non_empty(observation.get("rationale")):
                 lines.append(f"     Rationale: {rationale}")
         lines.append("")
@@ -177,5 +181,7 @@ def _non_empty(value: Any) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
 
 
-def _format_nullable(value: Any) -> str:
-    return "not recorded" if value is None else str(value)
+def _format_evidence_present(value: Any) -> str:
+    if value is None:
+        return "not applicable"
+    return "yes" if value is True else "no"

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -57,11 +57,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["9"] + _exit_assignment_review_actions_to_main()
+    return ["10"] + _exit_assignment_review_actions_to_main()
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "9"] + _exit_assignment_review_actions_to_main()
+    return ["", "10"] + _exit_assignment_review_actions_to_main()
 
 
 def _write_workspace(root: Path) -> None:
@@ -318,7 +318,7 @@ def test_selected_student_review_menu_includes_feedback_export(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
-    assert "7. Export student feedback" in output
+    assert "8. Export student feedback" in output
 
 
 def test_menu_export_student_feedback_creates_feedback_file(
@@ -358,7 +358,7 @@ def test_menu_export_student_feedback_creates_feedback_file(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1"]
+        + ["8", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -460,7 +460,7 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "2"]
+        + ["8", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -491,7 +491,7 @@ def test_menu_export_feedback_reports_missing_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1"]
+        + ["8", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -525,7 +525,7 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1", "1"]
+        + ["8", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -559,7 +559,7 @@ def test_menu_export_feedback_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "1", "2"]
+        + ["8", "1", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -160,11 +160,11 @@ def _enter_selected_student() -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["9", "6", "", "3", "6"]
+    return ["10", "6", "", "3", "6"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "9", "6", "", "3", "6"]
+    return ["", "10", "6", "", "3", "6"]
 
 
 @pytest.fixture
@@ -188,12 +188,13 @@ def test_review_menu_selected_student_excludes_legacy_review_entry_actions(
     assert "1. Open submission evidence" in output
     assert "2. View current review details" in output
     assert "3. Review minimum requirements" in output
-    assert "4. Manage submission pages" in output
-    assert "5. Add teacher note" in output
-    assert "6. Update submission review state" in output
-    assert "7. Export student feedback" in output
-    assert "8. Refresh summary" in output
-    assert "9. Back" in output
+    assert "4. Review units and Focus Standard observations" in output
+    assert "5. Manage submission pages" in output
+    assert "6. Add teacher note" in output
+    assert "7. Update submission review state" in output
+    assert "8. Export student feedback" in output
+    assert "9. Refresh summary" in output
+    assert "10. Back" in output
     assert "Add structured tag" not in output
     assert "Select reusable comment" not in output
     assert "Set criterion score" not in output
@@ -295,7 +296,7 @@ def test_review_menu_blank_note_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["5", ""]
+        + ["6", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -313,7 +314,7 @@ def test_review_menu_updates_submission_review_state(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", "in_progress", "1"]
+        + ["7", "in_progress", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -13,6 +13,7 @@ import pytest
 from quillan.cli import main
 import quillan.review_menu as review_menu
 from quillan.review_record import build_empty_review_record
+from quillan.review_record_paths import review_record_path
 from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
@@ -272,7 +273,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "9", "6", "", "3", "6"])
+    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "10", "6", "", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -317,7 +318,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "9", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "10", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -328,6 +329,213 @@ def test_review_summary_includes_existing_review_record_counts(
     assert "Private notes: 1" in output
     assert "Review-unit observations: 0" in output
     assert review_path.read_bytes() == review_before
+
+
+def test_review_menu_defines_review_units(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        [
+            "2",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "4",
+            "1",
+            "2",
+            "1",
+            "",
+            "4",
+            "10",
+            "6",
+            "",
+            "3",
+            "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Review Units and Focus Standard Observations" in output
+    assert "Updated review units:" in output
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    assert [unit["unit_id"] for unit in review["review_units"]] == [
+        "paragraph_1",
+        "paragraph_2",
+    ]
+    assert [unit["label"] for unit in review["review_units"]] == [
+        "Paragraph 1",
+        "Paragraph 2",
+    ]
+    assert review["review_state"] == "observations_in_progress"
+
+
+def test_review_menu_records_applicable_focus_standard_observation(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        [
+            "2",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "4",
+            "1",
+            "1",
+            "1",
+            "",
+            "2",
+            "1",
+            "1",
+            "1",
+            "",
+            "",
+            "Clear evidence.",
+            "1",
+            "",
+            "4",
+            "10",
+            "6",
+            "",
+            "3",
+            "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Updated Focus Standard observation:" in output
+    assert "Action: created" in output
+    assert "Rating:" not in output
+    review = json.loads(
+        review_record_path(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+        ).read_text(encoding="utf-8")
+    )
+    observation = review["review_units"][0]["standard_observations"][0]
+    assert observation["standard_id"] == "njsls-ela:W.1"
+    assert observation["applicable"] is True
+    assert observation["evidence_present"] is True
+    assert observation["rating"] is None
+    assert observation["rationale"] == "Clear evidence."
+    assert observation["include_in_feedback"] is True
+    assert review["overall_standard_ratings"] == []
+    assert review["feedback"]["standard_feedback"] == []
+
+
+def test_review_menu_marks_observations_complete(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review = _review_record()
+    review["review_state"] = "observations_in_progress"
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [],
+            "module_details": {},
+        }
+    ]
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        [
+            "2",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "4",
+            "3",
+            "1",
+            "",
+            "4",
+            "10",
+            "6",
+            "",
+            "3",
+            "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Marked review-unit observations complete:" in output
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review["review_state"] == "observations_complete"
+    assert review["overall_standard_ratings"] == []
+
+
+def test_review_menu_blocks_observations_for_returned_without_full_review(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review = build_empty_review_record(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        created_at=TIMESTAMP,
+    )
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Missing required work.",
+        "updated_at": TIMESTAMP,
+    }
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    before = review_path.read_bytes()
+
+    _menu_input(
+        monkeypatch,
+        [
+            "2",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "4",
+            "1",
+            "1",
+            "1",
+            "",
+            "4",
+            "10",
+            "6",
+            "",
+            "3",
+            "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "returned without full standards review" in output
+    assert review_path.read_bytes() == before
 
 
 def test_review_menu_views_current_review_details_read_only(
@@ -394,14 +602,18 @@ def test_review_menu_views_current_review_details_read_only(
 
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "2", "", "9", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "2", "", "10", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Current Review Details" in output
     assert "Paragraph 2 (paragraph)" in output
-    assert "njsls-ela:W.1: applicable; rating 1" in output
+    assert (
+        "njsls-ela:W.1: applicable; evidence present: yes; "
+        "include in feedback: yes"
+    ) in output
+    assert "Rating: 1" in output
     assert "Explain how this evidence supports the claim." in output
     assert review_path.read_bytes() == review_before
 
@@ -448,7 +660,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "", "9", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "", "10", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -504,7 +716,7 @@ def test_review_menu_multi_page_open_submission_selects_one_page(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "2", "", "9", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "2", "", "10", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -566,7 +778,7 @@ def test_review_menu_multi_page_open_submission_opens_all_pages(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "A", "", "9", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "A", "", "10", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -611,10 +823,10 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "1",
             "1",
             "1",
-            "5",
+            "6",
             "This is a test note.",
             "",
-            "9",
+            "10",
             "6",
             "",
             "3",
@@ -654,11 +866,11 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "1",
-            "6",
+            "7",
             "in_progress",
             "1",
             "",
-            "9",
+            "10",
             "6",
             "",
             "3",
@@ -706,12 +918,12 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
             "1",
             "1",
             "1",
-            "4",
+            "5",
             "1",
             "1",
             "1",
             "",
-            "9",
+            "10",
             "6",
             "",
             "3",

--- a/tests/test_review_observations.py
+++ b/tests/test_review_observations.py
@@ -1,0 +1,438 @@
+"""Tests for review-unit Focus Standard observation helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.review_observations import (
+    ReviewObservationError,
+    mark_observations_complete,
+    set_review_unit_observation,
+    set_review_units,
+)
+from quillan.review_record import build_empty_review_record
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
+FIRST_TIMESTAMP = "2026-07-02T12:00:00+00:00"
+SECOND_TIMESTAMP = "2026-07-02T13:00:00+00:00"
+THIRD_TIMESTAMP = "2026-07-02T14:00:00+00:00"
+
+
+def _assignment() -> dict[str, Any]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Write an argument.",
+        "standards_profile_id": "synthetic_profile",
+        "focus_standard_ids": ["njsls-ela:W.1", "njsls-ela:L.2"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {"value": 1, "label": "Developing", "description": "Limited."},
+                {"value": 2, "label": "Secure", "description": "Clear."},
+            ],
+        },
+        "basic_requirements": {"paragraphs_min": 1},
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
+    }
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [
+                    {
+                        "evidence_id": "evidence_001",
+                        "routed_evidence_path": (
+                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            "scans/response_00107_pg_001.pdf"
+                        ),
+                        "evidence_role": "selected",
+                        "evidence_state": "active",
+                        "duplicate_number": None,
+                        "created_at": ORIGINAL_TIMESTAMP,
+                        "retained_source": None,
+                        "module_details": {},
+                    }
+                ],
+            }
+        ],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def _write_workspace(root: Path) -> None:
+    assignment_dir = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(_assignment()),
+        encoding="utf-8",
+    )
+    write_submission_manifest(
+        submission_manifest_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        _manifest(),
+    )
+
+
+def _read_review(root: Path) -> dict[str, Any]:
+    return json.loads(
+        review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def test_setting_review_units_creates_v2_record_with_assignment_unit_type(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+
+    result = set_review_units(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}, {"sequence": 2, "page_number": 1, "evidence_id": "evidence_001"}],
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    review = _read_review(tmp_path)
+    assert result.unit_count == 2
+    assert review["schema_version"] == "2"
+    assert review["created_at"] == FIRST_TIMESTAMP
+    assert review["updated_at"] == FIRST_TIMESTAMP
+    assert review["review_state"] == "observations_in_progress"
+    assert review["review_units"][0] == {
+        "unit_id": "paragraph_1",
+        "sequence": 1,
+        "label": "Paragraph 1",
+        "unit_type": "paragraph",
+        "standard_observations": [],
+        "module_details": {},
+    }
+    assert review["review_units"][1]["unit_id"] == "paragraph_2"
+    assert review["review_units"][1]["label"] == "Paragraph 2"
+    assert review["review_units"][1]["unit_type"] == "paragraph"
+    assert review["review_units"][1]["page_number"] == 1
+    assert review["review_units"][1]["evidence_id"] == "evidence_001"
+    assert review["overall_standard_ratings"] == []
+    assert review["feedback"]["standard_feedback"] == []
+    for legacy_field in ("notes", "tags", "scores", "comments", "requirement_checks"):
+        assert legacy_field not in review
+
+
+def test_replacing_review_units_preserves_matching_unit_observations(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+    set_review_units(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=FIRST_TIMESTAMP,
+    )
+    first = set_review_unit_observation(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        unit_id="paragraph_1",
+        standard_id="njsls-ela:W.1",
+        applicable=True,
+        evidence_present=True,
+        rationale="Clear claim.",
+        include_in_feedback=True,
+        updated_at=SECOND_TIMESTAMP,
+    )
+
+    set_review_units(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}, {"sequence": 2}],
+        updated_at=THIRD_TIMESTAMP,
+    )
+
+    review = _read_review(tmp_path)
+    observations = review["review_units"][0]["standard_observations"]
+    assert observations[0]["observation_id"] == first.observation_id
+    assert observations[0]["standard_id"] == "njsls-ela:W.1"
+    assert review["review_units"][1]["standard_observations"] == []
+    assert review["created_at"] == FIRST_TIMESTAMP
+    assert review["updated_at"] == THIRD_TIMESTAMP
+
+
+def test_setting_observations_writes_applicable_and_not_applicable_shapes(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+    set_review_units(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    first = set_review_unit_observation(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        unit_id="paragraph_1",
+        standard_id="njsls-ela:W.1",
+        applicable=True,
+        evidence_present=True,
+        rationale="Relevant evidence is present.",
+        include_in_feedback=True,
+        updated_at=SECOND_TIMESTAMP,
+    )
+    second = set_review_unit_observation(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        unit_id="paragraph_1",
+        standard_id="njsls-ela:L.2",
+        applicable=False,
+        evidence_present=True,
+        rationale="This unit is only a transition.",
+        include_in_feedback=None,
+        updated_at=THIRD_TIMESTAMP,
+    )
+
+    review = _read_review(tmp_path)
+    observations = review["review_units"][0]["standard_observations"]
+    assert first.was_created is True
+    assert second.was_created is True
+    assert observations[0] == {
+        "observation_id": "observation_0001",
+        "standard_id": "njsls-ela:W.1",
+        "applicable": True,
+        "evidence_present": True,
+        "rating": None,
+        "rationale": "Relevant evidence is present.",
+        "include_in_feedback": True,
+        "updated_at": SECOND_TIMESTAMP,
+        "module_details": {},
+    }
+    assert observations[1] == {
+        "observation_id": "observation_0002",
+        "standard_id": "njsls-ela:L.2",
+        "applicable": False,
+        "evidence_present": None,
+        "rating": None,
+        "rationale": "This unit is only a transition.",
+        "include_in_feedback": False,
+        "updated_at": THIRD_TIMESTAMP,
+        "module_details": {},
+    }
+    assert review["review_state"] == "observations_in_progress"
+    assert review["updated_at"] == THIRD_TIMESTAMP
+    assert review["overall_standard_ratings"] == []
+    assert review["feedback"]["standard_feedback"] == []
+
+
+def test_updating_existing_observation_preserves_observation_id(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+    set_review_units(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=FIRST_TIMESTAMP,
+    )
+    created = set_review_unit_observation(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        unit_id="paragraph_1",
+        standard_id="njsls-ela:W.1",
+        applicable=True,
+        evidence_present=True,
+        rationale=None,
+        include_in_feedback=True,
+        updated_at=SECOND_TIMESTAMP,
+    )
+
+    updated = set_review_unit_observation(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        unit_id="paragraph_1",
+        standard_id="njsls-ela:W.1",
+        applicable=True,
+        evidence_present=False,
+        rationale="Evidence is attempted but missing.",
+        include_in_feedback=False,
+        updated_at=THIRD_TIMESTAMP,
+    )
+
+    observation = _read_review(tmp_path)["review_units"][0]["standard_observations"][0]
+    assert updated.was_created is False
+    assert updated.observation_id == created.observation_id
+    assert observation["observation_id"] == "observation_0001"
+    assert observation["evidence_present"] is False
+    assert observation["rating"] is None
+    assert observation["include_in_feedback"] is False
+
+
+def test_observation_requires_existing_unit_and_assignment_focus_standard(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+
+    with pytest.raises(ReviewObservationError, match="Review units"):
+        set_review_unit_observation(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            unit_id="paragraph_1",
+            standard_id="njsls-ela:W.1",
+            applicable=True,
+            evidence_present=True,
+            updated_at=FIRST_TIMESTAMP,
+        )
+
+    set_review_units(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=FIRST_TIMESTAMP,
+    )
+    with pytest.raises(ReviewObservationError, match="not a Focus Standard"):
+        set_review_unit_observation(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            unit_id="paragraph_1",
+            standard_id="njsls-ela:W.MISSING",
+            applicable=True,
+            evidence_present=True,
+            updated_at=SECOND_TIMESTAMP,
+        )
+    with pytest.raises(ReviewObservationError, match="Review unit not found"):
+        set_review_unit_observation(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            unit_id="paragraph_99",
+            standard_id="njsls-ela:W.1",
+            applicable=True,
+            evidence_present=True,
+            updated_at=SECOND_TIMESTAMP,
+        )
+
+
+def test_mark_observations_complete_sets_state_without_creating_ratings(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+    set_review_units(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    result = mark_observations_complete(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        updated_at=SECOND_TIMESTAMP,
+    )
+
+    review = _read_review(tmp_path)
+    assert result.review_state == "observations_complete"
+    assert result.missing_focus_standard_pairs == 2
+    assert review["review_state"] == "observations_complete"
+    assert review["overall_standard_ratings"] == []
+    assert review["feedback"]["standard_feedback"] == []
+
+
+def test_returned_without_full_review_records_cannot_be_modified(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+    review = build_empty_review_record(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        created_at=ORIGINAL_TIMESTAMP,
+    )
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Missing required work.",
+        "updated_at": FIRST_TIMESTAMP,
+    }
+    write_review_record(
+        review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        review,
+    )
+
+    with pytest.raises(ReviewObservationError, match="returned without full standards review"):
+        set_review_units(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            [{"sequence": 1}],
+            updated_at=SECOND_TIMESTAMP,
+        )

--- a/tests/test_review_record.py
+++ b/tests/test_review_record.py
@@ -206,6 +206,62 @@ def test_populated_v2_record_validates() -> None:
     validate_review_record(_populated_record())
 
 
+def test_applicable_standard_observation_allows_null_rating() -> None:
+    record = _populated_record()
+    record["review_units"][0]["standard_observations"][0]["rating"] = None
+
+    validate_review_record(record)
+
+
+def test_applicable_standard_observation_allows_integer_rating() -> None:
+    record = _populated_record()
+    record["review_units"][0]["standard_observations"][0]["rating"] = 2
+
+    validate_review_record(record)
+
+
+def test_not_applicable_standard_observation_requires_null_evidence_and_rating() -> None:
+    record = _populated_record()
+    record["review_units"][0]["standard_observations"][1]["evidence_present"] = False
+    _assert_invalid(record, "evidence_present")
+
+    record = _populated_record()
+    record["review_units"][0]["standard_observations"][1]["rating"] = 1
+    _assert_invalid(record, "rating")
+
+
+def test_duplicate_observation_ids_are_rejected() -> None:
+    record = _populated_record()
+    record["review_units"].append(
+        {
+            "unit_id": "paragraph_2",
+            "sequence": 2,
+            "label": "Paragraph 2",
+            "unit_type": "paragraph",
+            "standard_observations": [
+                {
+                    **record["review_units"][0]["standard_observations"][0],
+                    "standard_id": "njsls-ela:W.IW.11-12.2",
+                }
+            ],
+            "module_details": {},
+        }
+    )
+
+    _assert_invalid(record, "Duplicate observation_id")
+
+
+def test_duplicate_standard_observations_within_unit_are_rejected() -> None:
+    record = _populated_record()
+    duplicate = {
+        **record["review_units"][0]["standard_observations"][0],
+        "observation_id": "observation_0003",
+    }
+    record["review_units"][0]["standard_observations"].append(duplicate)
+
+    _assert_invalid(record, "Duplicate standard_id")
+
+
 def test_valid_json_file_loads_successfully(tmp_path: Path) -> None:
     record = _populated_record()
     path = tmp_path / "review.json"
@@ -328,7 +384,7 @@ def test_updated_at_before_created_at_is_rejected() -> None:
         (("review_units", 0, "standard_observations"), {}, "standard_observations"),
         (("review_units", 0, "standard_observations", 0, "applicable"), "yes", "applicable"),
         (("review_units", 0, "standard_observations", 0, "evidence_present"), None, "evidence_present"),
-        (("review_units", 0, "standard_observations", 0, "rating"), None, "rating"),
+        (("review_units", 0, "standard_observations", 0, "rating"), 1.5, "rating"),
         (("review_units", 0, "standard_observations", 0, "rationale"), " ", "rationale"),
         (("review_units", 0, "standard_observations", 0, "include_in_feedback"), 1, "include_in_feedback"),
         (("overall_standard_ratings",), {}, "overall_standard_ratings"),

--- a/tests/test_review_snapshot.py
+++ b/tests/test_review_snapshot.py
@@ -44,7 +44,7 @@ def _review() -> dict[str, Any]:
                     "standard_id": "synthetic:W.A",
                     "applicable": True,
                     "evidence_present": True,
-                    "rating": 3,
+                    "rating": None,
                     "rationale": "Relevant evidence, uneven explanation.",
                     "include_in_feedback": True,
                     "updated_at": TIMESTAMP,
@@ -120,7 +120,11 @@ def test_current_review_details_formats_saved_artifacts(tmp_path: Path) -> None:
     assert "Review record: exists" in text
     assert "Minimum paragraphs: not met" in text
     assert "Paragraph 2 (paragraph)" in text
-    assert "synthetic:W.A: applicable; rating 3" in text
+    assert (
+        "synthetic:W.A: applicable; evidence present: yes; "
+        "include in feedback: yes"
+    ) in text
+    assert "rating not recorded" not in text
     assert "Include in feedback: yes" in text
     assert "synthetic:W.A: 3" in text
     assert "Needs conference about missing counterargument." in text


### PR DESCRIPTION
## Summary

Implements the review-unit Focus Standard observation workflow for Quillan’s v0.8.6 standards-based review model.

Teachers can now define or replace review units, record Focus Standard observations for those units, and explicitly mark observations complete without entering overall Focus Standard ratings.

## Changes

* Adds `review_observations.py` with helpers to:

  * define/replace review units;
  * create/update review-unit Focus Standard observations;
  * mark observations complete.
* Relaxes v2 review-record validation so applicable observations may use `rating: null`.
* Preserves the rule that not-applicable observations require:

  * `evidence_present: null`
  * `rating: null`
* Adds selected-student menu option:

  * `Review units and Focus Standard observations`
* Adds concise output printers for:

  * updated review units;
  * updated observations;
  * observations marked complete.
* Updates review snapshots so observations show:

  * applicability;
  * evidence presence;
  * include-in-feedback setting;
  * rationale.
* Avoids treating missing review-unit ratings as a problem.
* Adds and updates tests for:

  * validator behavior;
  * review observation helper behavior;
  * menu workflow;
  * snapshot output;
  * shifted selected-student menu numbering.

## Verification

Full test suite:

* `.\.venv\Scripts\python.exe -m pytest`

Result:

* `989 passed`

Changed-file Ruff:

* `.\.venv\Scripts\ruff.exe check ...`

Result:

* passed

## Notes

This PR does not implement overall Focus Standard ratings, rating averages, scoring inference, feedback composition, PDF export, class summaries, standards summaries, or assignment result manifests.

Overall Focus Standard ratings remain reserved for #227.

Closes #226
