### PR TITLE
Implement overall Focus Standard rating workflow

### DIFF
--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -19,6 +19,10 @@ from quillan.review_observations import (
     UpdatedReviewUnitObservation,
     UpdatedReviewUnits,
 )
+from quillan.review_ratings import (
+    CompletedOverallStandardRatings,
+    UpdatedOverallStandardRating,
+)
 from quillan.review_scores import UpdatedReviewScore
 from quillan.review_tags import AddedReviewTag
 from quillan.route_planning import RouteFailure
@@ -156,6 +160,37 @@ def print_completed_review_unit_observations(
     print(f"Units: {completed.unit_count}")
     print(f"Observations: {completed.observation_count}")
     print(f"Unobserved unit-standard pairs: {completed.missing_focus_standard_pairs}")
+    print(f"Review state: {completed.review_state}")
+    print(f"Review record: {completed.review_record_relative_path}")
+
+
+def print_updated_overall_standard_rating(
+    updated: UpdatedOverallStandardRating,
+) -> None:
+    """Print a concise teacher-facing overall Focus Standard rating summary."""
+    print("Updated overall Focus Standard rating:")
+    print(f"Class: {updated.class_id}")
+    print(f"Assignment: {updated.assignment_id}")
+    print(f"Student: {updated.student_id}")
+    print(f"Standard: {updated.standard_id}")
+    print(f"Rating: {updated.rating} - {updated.rating_label}")
+    print(f"Include in feedback: {format_bool(updated.include_in_feedback)}")
+    print(f"Action: {'created' if updated.was_created else 'updated'}")
+    print(f"Review state: {updated.review_state}")
+    print(f"Review record: {updated.review_record_relative_path}")
+
+
+def print_completed_overall_standard_ratings(
+    completed: CompletedOverallStandardRatings,
+) -> None:
+    """Print a concise teacher-facing overall-ratings completion summary."""
+    print("Marked overall Focus Standard ratings complete:")
+    print(f"Class: {completed.class_id}")
+    print(f"Assignment: {completed.assignment_id}")
+    print(f"Student: {completed.student_id}")
+    print(f"Focus Standards: {completed.focus_standard_count}")
+    print(f"Ratings recorded: {completed.rating_count}")
+    print(f"Missing ratings: {completed.missing_rating_count}")
     print(f"Review state: {completed.review_state}")
     print(f"Review record: {completed.review_record_relative_path}")
 

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -33,8 +33,10 @@ from quillan.cli_app.output import (
     print_exported_class_summary,
     print_exported_feedback,
     print_exported_standards_summary,
+    print_completed_overall_standard_ratings,
     print_completed_review_unit_observations,
     print_opened_submission_review,
+    print_updated_overall_standard_rating,
     print_updated_review_unit_observation,
     print_updated_review_units,
     print_updated_review_score,
@@ -57,6 +59,13 @@ from quillan.review_observations import (
     mark_observations_complete,
     set_review_unit_observation,
     set_review_units,
+)
+from quillan.review_ratings import (
+    FocusStandardObservationSummary,
+    ReviewRatingError,
+    mark_overall_ratings_complete,
+    set_overall_standard_rating,
+    summarize_focus_standard_observations,
 )
 from quillan.review_comments import ReviewCommentError, add_review_comment
 from quillan.review_record import (
@@ -424,18 +433,19 @@ def _launch_selected_student_review(
         print("2. View current review details")
         print("3. Review minimum requirements")
         print("4. Review units and Focus Standard observations")
-        print("5. Manage submission pages")
-        print("6. Add teacher note")
-        print("7. Update submission review state")
-        print("8. Export student feedback")
-        print("9. Refresh summary")
-        print("10. Back")
+        print("5. Overall Focus Standard ratings")
+        print("6. Manage submission pages")
+        print("7. Add teacher note")
+        print("8. Update submission review state")
+        print("9. Export student feedback")
+        print("10. Refresh summary")
+        print("11. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "10"}:
+        if choice in {"", "11"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -468,6 +478,13 @@ def _launch_selected_student_review(
                 student_id,
             )
         elif choice == "5":
+            _menu_overall_focus_standard_ratings(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+        elif choice == "6":
             _menu_manage_submission_pages(
                 workspace_root,
                 class_id,
@@ -475,7 +492,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "6":
+        elif choice == "7":
             _menu_add_review_note(
                 workspace_root,
                 class_id,
@@ -483,7 +500,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "7":
+        elif choice == "8":
             _menu_update_submission_review_state(
                 workspace_root,
                 class_id,
@@ -491,7 +508,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "8":
+        elif choice == "9":
             _menu_export_student_feedback(
                 workspace_root,
                 class_id,
@@ -499,10 +516,10 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "9":
+        elif choice == "10":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 10.")
+            print("Invalid selection. Please enter a number from 1 to 11.")
             input("Press Enter to continue...")
 
 
@@ -2708,6 +2725,307 @@ def _menu_mark_observations_complete(
             f"{completed.missing_focus_standard_pairs}"
         )
     print_completed_review_unit_observations(completed)
+
+
+def _menu_overall_focus_standard_ratings(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    while True:
+        _print_review_action_header(
+            "Overall Focus Standard Ratings",
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        assignment = _load_assignment_for_review(
+            workspace_root, class_id, assignment_id
+        )
+        if assignment is None:
+            input("Press Enter to continue...")
+            return
+        record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+        _print_overall_rating_status(assignment, record)
+        _print_overall_rating_warnings(record)
+        print()
+        print("1. View Focus Standard observation summary")
+        print("2. Record/update overall Focus Standard rating")
+        print("3. Mark overall ratings complete")
+        print("4. Back")
+        print()
+        choice = input("Select an option: ").strip()
+        print()
+        if choice in {"", "4"}:
+            return
+        if choice == "1":
+            _menu_view_focus_standard_observation_summary(
+                workspace_root, class_id, assignment_id, student_id
+            )
+            input("Press Enter to continue...")
+        elif choice == "2":
+            _menu_record_overall_focus_standard_rating(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+            input("Press Enter to continue...")
+        elif choice == "3":
+            _menu_mark_overall_ratings_complete(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+            input("Press Enter to continue...")
+        else:
+            print("Invalid selection. Please enter a number from 1 to 4.")
+            input("Press Enter to continue...")
+
+
+def _print_overall_rating_status(
+    assignment: dict[str, Any],
+    record: dict[str, Any] | None,
+) -> None:
+    focus_standard_ids = assignment["focus_standard_ids"]
+    ratings = record.get("overall_standard_ratings", []) if record is not None else []
+    rated = {
+        rating.get("standard_id")
+        for rating in ratings
+        if isinstance(rating, dict) and rating.get("standard_id") in focus_standard_ids
+    }
+    print(f"Focus Standards configured: {len(focus_standard_ids)}")
+    print(f"Ratings recorded: {len(rated)}")
+    print(f"Missing ratings: {max(len(focus_standard_ids) - len(rated), 0)}")
+    print(f"Current review state: {record['review_state'] if record else 'not_started'}")
+
+
+def _print_overall_rating_warnings(record: dict[str, Any] | None) -> None:
+    if record is None:
+        print("Warning: no review record exists yet.")
+        return
+    if record["review_state"] == "returned_without_full_review":
+        print(
+            "This submission was returned without full standards review. "
+            "Change the minimum-requirements outcome before continuing with ratings."
+        )
+        return
+    if not record.get("review_units"):
+        print("Warning: no review units defined.")
+        return
+    observation_count = _count_review_unit_observations(record)
+    if observation_count == 0:
+        print("Warning: no observations recorded.")
+    if record["review_state"] != "observations_complete":
+        print("Warning: observations are not marked complete.")
+
+
+def _menu_view_focus_standard_observation_summary(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    try:
+        summaries = summarize_focus_standard_observations(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewRatingError as error:
+        print(f"Error: could not summarize observations: {error}")
+        return
+    for summary in summaries:
+        _print_focus_standard_observation_summary(summary)
+        print()
+
+
+def _menu_record_overall_focus_standard_rating(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is not None and record["review_state"] == "returned_without_full_review":
+        _print_overall_rating_warnings(record)
+        return
+    standard_id = _prompt_focus_standard_with_rating_status(
+        workspace_root,
+        assignment["focus_standard_ids"],
+        record,
+    )
+    if standard_id is None:
+        print("Overall rating entry canceled.")
+        return
+    try:
+        summaries = summarize_focus_standard_observations(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewRatingError as error:
+        print(f"Error: could not summarize observations: {error}")
+        return
+    summary = next(item for item in summaries if item.standard_id == standard_id)
+    _print_focus_standard_observation_summary(summary)
+    if summary.observation_count == 0:
+        print("Warning: selected Focus Standard has no observations.")
+    print()
+    _print_rating_scale(assignment)
+    rating = _prompt_rating_value(assignment)
+    if rating is None:
+        print("Overall rating entry canceled.")
+        return
+    rationale = input("Rationale (optional): ").strip() or None
+    include_in_feedback = _prompt_yes_no_default_yes("Include rating/rationale in feedback?")
+    print()
+    print("Save this overall Focus Standard rating?")
+    print(f"Standard: {standard_id}")
+    print(f"Rating: {rating}")
+    print(f"Rationale: {rationale if rationale else 'none'}")
+    print(f"Include in feedback: {_format_yes_no(include_in_feedback)}")
+    print()
+    print("1. Save rating")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Overall rating entry canceled.")
+        return
+    try:
+        updated = set_overall_standard_rating(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            standard_id=standard_id,
+            rating=rating,
+            rationale=rationale,
+            include_in_feedback=include_in_feedback,
+        )
+    except ReviewRatingError as error:
+        print(f"Error: could not update overall rating: {error}")
+        return
+    print_updated_overall_standard_rating(updated)
+
+
+def _menu_mark_overall_ratings_complete(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is not None and record["review_state"] == "returned_without_full_review":
+        _print_overall_rating_warnings(record)
+        return
+    focus_standard_ids = assignment["focus_standard_ids"]
+    ratings = record.get("overall_standard_ratings", []) if record is not None else []
+    rated = {
+        rating.get("standard_id")
+        for rating in ratings
+        if isinstance(rating, dict) and rating.get("standard_id") in focus_standard_ids
+    }
+    missing = max(len(focus_standard_ids) - len(rated), 0)
+    print(f"Focus Standards: {len(focus_standard_ids)}")
+    print(f"Ratings recorded: {len(rated)}")
+    print(f"Missing ratings: {missing}")
+    if missing:
+        print("Warning: some Focus Standards do not have overall ratings.")
+    print()
+    print("1. Mark overall ratings complete")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Overall ratings were not changed.")
+        return
+    try:
+        completed = mark_overall_ratings_complete(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewRatingError as error:
+        print(f"Error: could not mark overall ratings complete: {error}")
+        return
+    print_completed_overall_standard_ratings(completed)
+
+
+def _prompt_focus_standard_with_rating_status(
+    workspace_root: Path,
+    focus_standard_ids: list[str],
+    record: dict[str, Any] | None,
+) -> str | None:
+    ratings = record.get("overall_standard_ratings", []) if record is not None else []
+    ratings_by_standard = {
+        rating.get("standard_id"): rating
+        for rating in ratings
+        if isinstance(rating, dict)
+    }
+    print("Focus Standards:")
+    for index, standard_id in enumerate(focus_standard_ids, start=1):
+        current = ratings_by_standard.get(standard_id)
+        suffix = "not rated"
+        if current is not None:
+            suffix = f"current rating: {current['rating']}"
+        print(
+            f"{index}. {_format_standard_display(workspace_root, standard_id)} "
+            f"({suffix})"
+        )
+    print("B. Back")
+    print()
+    selection = input("Select Focus Standard: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(focus_standard_ids):
+        return focus_standard_ids[int(selection) - 1]
+    if selection in focus_standard_ids:
+        return selection
+    print("Invalid Focus Standard selection.")
+    return None
+
+
+def _print_focus_standard_observation_summary(
+    summary: FocusStandardObservationSummary,
+) -> None:
+    current = "not recorded"
+    if summary.current_rating is not None:
+        current = str(summary.current_rating)
+    print(f"Focus Standard: {summary.standard_id}")
+    print(f"Current overall rating: {current}")
+    if summary.current_include_in_feedback is not None:
+        print(
+            "Current include in feedback: "
+            f"{_format_yes_no(summary.current_include_in_feedback)}"
+        )
+    if summary.current_rationale:
+        print(f"Current rationale: {summary.current_rationale}")
+    print(f"Review units: {summary.total_review_units}")
+    print(f"Observations recorded: {summary.observation_count}")
+    print(f"Applicable: {summary.applicable_count}")
+    print(f"Not applicable: {summary.not_applicable_count}")
+    print(f"Evidence present: {summary.evidence_present_count}")
+    print(f"Evidence missing: {summary.evidence_missing_count}")
+    print(f"Included for feedback: {summary.included_for_feedback_count}")
+    print("Notes:")
+    notes = [detail for detail in summary.details if detail.rationale]
+    if not notes:
+        print("- none")
+        return
+    for detail in notes:
+        print(f"- {detail.unit_label}: {detail.rationale}")
+
+
+def _print_rating_scale(assignment: dict[str, Any]) -> None:
+    print(f"Rating scale: {assignment['rating_scale']['scale_id']}")
+    for level in assignment["rating_scale"]["levels"]:
+        print(f"- {level['value']}: {level['label']} - {level['description']}")
+
+
+def _prompt_rating_value(assignment: dict[str, Any]) -> int | None:
+    valid_values = {
+        level["value"] for level in assignment["rating_scale"]["levels"]
+    }
+    response = input("Enter rating value: ").strip()
+    if not response:
+        return None
+    try:
+        value = int(response)
+    except ValueError:
+        return None
+    return value if value in valid_values else None
 
 
 def _menu_review_minimum_requirements(

--- a/quillan/review_ratings.py
+++ b/quillan/review_ratings.py
@@ -1,0 +1,481 @@
+"""Overall Focus Standard rating helpers."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.review_record import ReviewRecordError, load_review_record, validate_review_record
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
+from quillan.storage import assignment_config_path
+from quillan.submission_guidance import missing_submission_guidance
+from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+
+class ReviewRatingError(Exception):
+    """Raised when overall Focus Standard ratings cannot be changed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class FocusStandardObservationDetail:
+    """One review-unit observation note for a Focus Standard summary."""
+
+    unit_id: str
+    unit_label: str
+    observation_id: str
+    applicable: bool
+    evidence_present: bool | None
+    include_in_feedback: bool
+    rationale: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class FocusStandardObservationSummary:
+    """Teacher-facing evidence summary for one assignment Focus Standard."""
+
+    standard_id: str
+    total_review_units: int
+    observation_count: int
+    applicable_count: int
+    not_applicable_count: int
+    evidence_present_count: int
+    evidence_missing_count: int
+    included_for_feedback_count: int
+    details: tuple[FocusStandardObservationDetail, ...]
+    current_rating: int | None
+    current_rationale: str | None
+    current_include_in_feedback: bool | None
+    rating_scale_levels: tuple[dict[str, Any], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class UpdatedOverallStandardRating:
+    """Information about one overall Focus Standard rating update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    standard_id: str
+    rating: int
+    rating_label: str
+    include_in_feedback: bool
+    was_created: bool
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class CompletedOverallStandardRatings:
+    """Information about an explicit overall-ratings completion update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    focus_standard_count: int
+    rating_count: int
+    missing_rating_count: int
+    updated_at: str
+
+
+def summarize_focus_standard_observations(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> tuple[FocusStandardObservationSummary, ...]:
+    """Summarize recorded observations by Focus Standard without scoring."""
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    review = _load_existing_review(context)
+    assignment = context["assignment"]
+    rating_scale_levels = tuple(
+        copy.deepcopy(level) for level in assignment["rating_scale"]["levels"]
+    )
+    ratings_by_standard = {
+        rating["standard_id"]: rating for rating in review["overall_standard_ratings"]
+    }
+
+    summaries: list[FocusStandardObservationSummary] = []
+    for standard_id in assignment["focus_standard_ids"]:
+        details: list[FocusStandardObservationDetail] = []
+        applicable_count = 0
+        not_applicable_count = 0
+        evidence_present_count = 0
+        evidence_missing_count = 0
+        included_count = 0
+        for unit in review["review_units"]:
+            for observation in unit["standard_observations"]:
+                if observation["standard_id"] != standard_id:
+                    continue
+                if observation["applicable"]:
+                    applicable_count += 1
+                    if observation["evidence_present"]:
+                        evidence_present_count += 1
+                    else:
+                        evidence_missing_count += 1
+                else:
+                    not_applicable_count += 1
+                if observation["include_in_feedback"]:
+                    included_count += 1
+                details.append(
+                    FocusStandardObservationDetail(
+                        unit_id=unit["unit_id"],
+                        unit_label=unit["label"],
+                        observation_id=observation["observation_id"],
+                        applicable=observation["applicable"],
+                        evidence_present=observation["evidence_present"],
+                        include_in_feedback=observation["include_in_feedback"],
+                        rationale=observation["rationale"],
+                    )
+                )
+        current = ratings_by_standard.get(standard_id)
+        summaries.append(
+            FocusStandardObservationSummary(
+                standard_id=standard_id,
+                total_review_units=len(review["review_units"]),
+                observation_count=len(details),
+                applicable_count=applicable_count,
+                not_applicable_count=not_applicable_count,
+                evidence_present_count=evidence_present_count,
+                evidence_missing_count=evidence_missing_count,
+                included_for_feedback_count=included_count,
+                details=tuple(details),
+                current_rating=current["rating"] if current else None,
+                current_rationale=current["rationale"] if current else None,
+                current_include_in_feedback=(
+                    current["include_in_feedback"] if current else None
+                ),
+                rating_scale_levels=rating_scale_levels,
+            )
+        )
+    return tuple(summaries)
+
+
+def set_overall_standard_rating(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    standard_id: str,
+    rating: int,
+    rationale: str | None = None,
+    include_in_feedback: bool,
+    updated_at: datetime | str | None = None,
+) -> UpdatedOverallStandardRating:
+    """Create or update one teacher-entered overall Focus Standard rating."""
+    normalized_standard_id = _normalize_required_string(standard_id, "standard_id")
+    normalized_rating = _normalize_rating(rating)
+    normalized_rationale = _normalize_optional_string(rationale, "rationale")
+    if not isinstance(include_in_feedback, bool):
+        raise ReviewRatingError("include_in_feedback must be a boolean.")
+    normalized_updated_at = _normalize_timestamp(updated_at)
+
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    assignment = context["assignment"]
+    if normalized_standard_id not in assignment["focus_standard_ids"]:
+        raise ReviewRatingError(
+            f"standard_id {normalized_standard_id!r} is not a Focus Standard for this assignment."
+        )
+    rating_labels = _rating_labels_by_value(assignment)
+    if normalized_rating not in rating_labels:
+        allowed = ", ".join(str(value) for value in sorted(rating_labels))
+        raise ReviewRatingError(
+            f"rating {normalized_rating!r} is not in the assignment rating scale. "
+            f"Allowed values: {allowed}."
+        )
+
+    review = _load_existing_review(context)
+    _guard_returned_without_full_review(review)
+    existing = next(
+        (
+            candidate
+            for candidate in review["overall_standard_ratings"]
+            if candidate["standard_id"] == normalized_standard_id
+        ),
+        None,
+    )
+    was_created = existing is None
+    if existing is None:
+        existing = {"standard_id": normalized_standard_id}
+        review["overall_standard_ratings"].append(existing)
+    existing.clear()
+    existing.update(
+        {
+            "standard_id": normalized_standard_id,
+            "rating": normalized_rating,
+            "rationale": normalized_rationale,
+            "include_in_feedback": include_in_feedback,
+            "updated_at": normalized_updated_at,
+            "module_details": {},
+        }
+    )
+    review["review_state"] = _rating_update_state(review["review_state"])
+    review["updated_at"] = normalized_updated_at
+
+    _write_review(context, review)
+    return UpdatedOverallStandardRating(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        standard_id=normalized_standard_id,
+        rating=normalized_rating,
+        rating_label=rating_labels[normalized_rating],
+        include_in_feedback=include_in_feedback,
+        was_created=was_created,
+        updated_at=normalized_updated_at,
+    )
+
+
+def mark_overall_ratings_complete(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    updated_at: datetime | str | None = None,
+) -> CompletedOverallStandardRatings:
+    """Explicitly mark teacher-entered overall Focus Standard ratings complete."""
+    normalized_updated_at = _normalize_timestamp(updated_at)
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    review = _load_existing_review(context)
+    _guard_returned_without_full_review(review)
+
+    focus_standard_ids = context["assignment"]["focus_standard_ids"]
+    rated_focus_standards = {
+        rating["standard_id"]
+        for rating in review["overall_standard_ratings"]
+        if rating["standard_id"] in focus_standard_ids
+    }
+    focus_count = len(focus_standard_ids)
+    rating_count = len(rated_focus_standards)
+    review["review_state"] = "ratings_complete"
+    review["updated_at"] = normalized_updated_at
+    _write_review(context, review)
+
+    return CompletedOverallStandardRatings(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        focus_standard_count=focus_count,
+        rating_count=rating_count,
+        missing_rating_count=max(focus_count - rating_count, 0),
+        updated_at=normalized_updated_at,
+    )
+
+
+def _load_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> dict[str, Any]:
+    try:
+        resolved_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_root, class_id, assignment_id, student_id
+        )
+        record_path = review_record_path(
+            resolved_root, class_id, assignment_id, student_id
+        )
+        assignment_path = assignment_config_path(resolved_root, class_id, assignment_id)
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewRatingError(str(error)) from error
+
+    if not manifest_path.exists():
+        raise ReviewRatingError(missing_submission_guidance())
+    if not record_path.exists():
+        raise ReviewRatingError("A review record must exist before recording ratings.")
+
+    try:
+        manifest = load_submission_manifest(manifest_path)
+        assignment = load_assignment_config(assignment_path)
+    except (OSError, SubmissionManifestError, AssignmentConfigError) as error:
+        raise ReviewRatingError(str(error)) from error
+
+    _validate_identity(
+        manifest,
+        record_name="Submission manifest",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+    if class_id not in assignment["class_ids"]:
+        raise ReviewRatingError(
+            f"Assignment config class_ids does not include {class_id!r}."
+        )
+    if assignment["assignment_id"] != assignment_id:
+        raise ReviewRatingError(
+            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
+        )
+    return {
+        "workspace_root": resolved_root,
+        "manifest_path": manifest_path,
+        "record_path": record_path,
+        "assignment": assignment,
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+
+
+def _load_existing_review(context: dict[str, Any]) -> dict[str, Any]:
+    try:
+        review = load_review_record(context["record_path"])
+    except (OSError, ReviewRecordError) as error:
+        raise ReviewRatingError(f"Could not load review record: {error}") from error
+    _validate_identity(
+        review,
+        record_name="Review record",
+        class_id=context["class_id"],
+        assignment_id=context["assignment_id"],
+        student_id=context["student_id"],
+    )
+    return copy.deepcopy(review)
+
+
+def _write_review(context: dict[str, Any], review: dict[str, Any]) -> None:
+    try:
+        validate_review_record(review)
+        write_review_record(context["record_path"], review, overwrite=True)
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        ReviewRecordError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewRatingError(f"Could not write review record: {error}") from error
+
+
+def _guard_returned_without_full_review(review: dict[str, Any]) -> None:
+    if review["review_state"] == "returned_without_full_review":
+        raise ReviewRatingError(
+            "This submission was returned without full standards review. "
+            "Change the minimum-requirements outcome before continuing with ratings."
+        )
+
+
+def _rating_update_state(current_state: str) -> str:
+    if current_state in {"not_started", "requirements_checked"}:
+        return "observations_in_progress"
+    if current_state in {"feedback_composed", "ready_for_export", "exported"}:
+        return "ratings_complete"
+    return current_state
+
+
+def _rating_labels_by_value(assignment: dict[str, Any]) -> dict[int, str]:
+    labels: dict[int, str] = {}
+    for level in assignment["rating_scale"]["levels"]:
+        labels[level["value"]] = level["label"]
+    return labels
+
+
+def _normalize_rating(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ReviewRatingError("rating must be an integer.")
+    return value
+
+
+def _normalize_required_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewRatingError(f"{field} must be a non-empty string.")
+    return value.strip()
+
+
+def _normalize_optional_string(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ReviewRatingError(f"{field} must be a string or null.")
+    if not value.strip():
+        return None
+    return value.strip()
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReviewRatingError("updated_at datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise ReviewRatingError(
+            "updated_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ReviewRatingError(
+            "updated_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewRatingError(
+            "updated_at must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    *,
+    record_name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    for field, expected in {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }.items():
+        actual = record[field]
+        if actual != expected:
+            raise ReviewRatingError(
+                f"{record_name} {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _workspace_relative_path(
+    path: Path,
+    workspace_root: Path,
+    description: str,
+) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewRatingError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error

--- a/quillan/review_snapshot.py
+++ b/quillan/review_snapshot.py
@@ -125,7 +125,7 @@ def _append_review_units(lines: list[str], record: dict[str, Any]) -> None:
 
 
 def _append_overall_ratings(lines: list[str], record: dict[str, Any]) -> None:
-    lines.append("Overall Standard Ratings")
+    lines.append("Overall Focus Standard Ratings")
     ratings = _record_list(record, "overall_standard_ratings")
     if not ratings:
         lines.append("No overall standard ratings recorded.")

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -57,11 +57,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["10"] + _exit_assignment_review_actions_to_main()
+    return ["11"] + _exit_assignment_review_actions_to_main()
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "10"] + _exit_assignment_review_actions_to_main()
+    return ["", "11"] + _exit_assignment_review_actions_to_main()
 
 
 def _write_workspace(root: Path) -> None:
@@ -318,7 +318,7 @@ def test_selected_student_review_menu_includes_feedback_export(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
-    assert "8. Export student feedback" in output
+    assert "9. Export student feedback" in output
 
 
 def test_menu_export_student_feedback_creates_feedback_file(
@@ -358,7 +358,7 @@ def test_menu_export_student_feedback_creates_feedback_file(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "1"]
+        + ["9", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -460,7 +460,7 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "2"]
+        + ["9", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -491,7 +491,7 @@ def test_menu_export_feedback_reports_missing_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "1"]
+        + ["9", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -525,7 +525,7 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "1", "1"]
+        + ["9", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -559,7 +559,7 @@ def test_menu_export_feedback_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "1", "2"]
+        + ["9", "1", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -160,11 +160,11 @@ def _enter_selected_student() -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["10", "6", "", "3", "6"]
+    return ["11", "6", "", "3", "6"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "10", "6", "", "3", "6"]
+    return ["", "11", "6", "", "3", "6"]
 
 
 @pytest.fixture
@@ -189,12 +189,13 @@ def test_review_menu_selected_student_excludes_legacy_review_entry_actions(
     assert "2. View current review details" in output
     assert "3. Review minimum requirements" in output
     assert "4. Review units and Focus Standard observations" in output
-    assert "5. Manage submission pages" in output
-    assert "6. Add teacher note" in output
-    assert "7. Update submission review state" in output
-    assert "8. Export student feedback" in output
-    assert "9. Refresh summary" in output
-    assert "10. Back" in output
+    assert "5. Overall Focus Standard ratings" in output
+    assert "6. Manage submission pages" in output
+    assert "7. Add teacher note" in output
+    assert "8. Update submission review state" in output
+    assert "9. Export student feedback" in output
+    assert "10. Refresh summary" in output
+    assert "11. Back" in output
     assert "Add structured tag" not in output
     assert "Select reusable comment" not in output
     assert "Set criterion score" not in output
@@ -296,7 +297,7 @@ def test_review_menu_blank_note_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["6", ""]
+        + ["7", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -314,7 +315,7 @@ def test_review_menu_updates_submission_review_state(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", "in_progress", "1"]
+        + ["8", "in_progress", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -273,7 +273,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "10", "6", "", "3", "6"])
+    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "11", "6", "", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -318,7 +318,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "10", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "11", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -351,7 +351,7 @@ def test_review_menu_defines_review_units(
             "1",
             "",
             "4",
-            "10",
+            "11",
             "6",
             "",
             "3",
@@ -408,7 +408,7 @@ def test_review_menu_records_applicable_focus_standard_observation(
             "1",
             "",
             "4",
-            "10",
+            "11",
             "6",
             "",
             "3",
@@ -471,7 +471,7 @@ def test_review_menu_marks_observations_complete(
             "1",
             "",
             "4",
-            "10",
+            "11",
             "6",
             "",
             "3",
@@ -485,6 +485,93 @@ def test_review_menu_marks_observations_complete(
     review = json.loads(review_path.read_text(encoding="utf-8"))
     assert review["review_state"] == "observations_complete"
     assert review["overall_standard_ratings"] == []
+
+
+def test_review_menu_records_and_completes_overall_focus_standard_rating(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review = _review_record()
+    review["review_state"] = "observations_complete"
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [
+                {
+                    "observation_id": "observation_0001",
+                    "standard_id": "njsls-ela:W.1",
+                    "applicable": True,
+                    "evidence_present": True,
+                    "rating": None,
+                    "rationale": "Clear evidence",
+                    "include_in_feedback": True,
+                    "updated_at": TIMESTAMP,
+                    "module_details": {},
+                }
+            ],
+            "module_details": {},
+        }
+    ]
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        [
+            "2",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "5",
+            "2",
+            "1",
+            "1",
+            "Good work.",
+            "",
+            "1",
+            "",
+            "3",
+            "1",
+            "",
+            "4",
+            "11",
+            "6",
+            "",
+            "3",
+            "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Overall Focus Standard Ratings" in output
+    assert "Rating scale: standards_2_level" in output
+    assert "Updated overall Focus Standard rating:" in output
+    assert "Marked overall Focus Standard ratings complete:" in output
+    assert "recommended" not in output.lower()
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review["review_state"] == "ratings_complete"
+    assert review["overall_standard_ratings"] == [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "rating": 1,
+            "rationale": "Good work.",
+            "include_in_feedback": True,
+            "updated_at": review["overall_standard_ratings"][0]["updated_at"],
+            "module_details": {},
+        }
+    ]
+    assert review["feedback"]["standard_feedback"] == _review_record()["feedback"][
+        "standard_feedback"
+    ]
+    for legacy_field in ("scores", "tags", "comments", "notes"):
+        assert legacy_field not in review
 
 
 def test_review_menu_blocks_observations_for_returned_without_full_review(
@@ -524,7 +611,7 @@ def test_review_menu_blocks_observations_for_returned_without_full_review(
             "1",
             "",
             "4",
-            "10",
+            "11",
             "6",
             "",
             "3",
@@ -602,7 +689,7 @@ def test_review_menu_views_current_review_details_read_only(
 
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "2", "", "10", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "2", "", "11", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -660,7 +747,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "", "10", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "", "11", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -716,7 +803,7 @@ def test_review_menu_multi_page_open_submission_selects_one_page(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "2", "", "10", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "2", "", "11", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -778,7 +865,7 @@ def test_review_menu_multi_page_open_submission_opens_all_pages(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "A", "", "10", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "A", "", "11", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -823,10 +910,10 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "1",
             "1",
             "1",
-            "6",
+            "7",
             "This is a test note.",
             "",
-            "10",
+            "11",
             "6",
             "",
             "3",
@@ -866,11 +953,11 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "1",
-            "7",
+            "8",
             "in_progress",
             "1",
             "",
-            "10",
+            "11",
             "6",
             "",
             "3",
@@ -918,12 +1005,12 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
             "1",
             "1",
             "1",
-            "5",
+            "6",
             "1",
             "1",
             "1",
             "",
-            "10",
+            "11",
             "6",
             "",
             "3",

--- a/tests/test_review_ratings.py
+++ b/tests/test_review_ratings.py
@@ -1,0 +1,489 @@
+"""Tests for overall Focus Standard rating helpers."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.review_ratings import (
+    ReviewRatingError,
+    mark_overall_ratings_complete,
+    set_overall_standard_rating,
+    summarize_focus_standard_observations,
+)
+from quillan.review_record import build_empty_review_record
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "00107"
+ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
+FIRST_TIMESTAMP = "2026-07-02T12:00:00+00:00"
+SECOND_TIMESTAMP = "2026-07-02T13:00:00+00:00"
+THIRD_TIMESTAMP = "2026-07-02T14:00:00+00:00"
+
+
+def _assignment() -> dict[str, Any]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Essay",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Write an argument.",
+        "standards_profile_id": "synthetic_profile",
+        "focus_standard_ids": ["njsls-ela:W.1", "njsls-ela:L.2"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {"value": 1, "label": "Developing", "description": "Limited."},
+                {"value": 2, "label": "Secure", "description": "Clear."},
+            ],
+        },
+        "basic_requirements": {"paragraphs_min": 1},
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
+    }
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": 1,
+        "submission_state": "unreviewed",
+        "pages": [
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [
+                    {
+                        "evidence_id": "evidence_001",
+                        "routed_evidence_path": (
+                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            "scans/response_00107_pg_001.pdf"
+                        ),
+                        "evidence_role": "selected",
+                        "evidence_state": "active",
+                        "duplicate_number": None,
+                        "created_at": ORIGINAL_TIMESTAMP,
+                        "retained_source": None,
+                        "module_details": {},
+                    }
+                ],
+            }
+        ],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def _write_workspace(root: Path, review: dict[str, Any] | None = None) -> None:
+    assignment_dir = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(_assignment()),
+        encoding="utf-8",
+    )
+    write_submission_manifest(
+        submission_manifest_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        _manifest(),
+    )
+    if review is None:
+        review = _review_record()
+    write_review_record(
+        review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        review,
+    )
+
+
+def _review_record() -> dict[str, Any]:
+    review = build_empty_review_record(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        created_at=ORIGINAL_TIMESTAMP,
+    )
+    review["review_state"] = "observations_complete"
+    review["minimum_requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "paragraphs_min",
+            "label": "Minimum paragraphs",
+            "expected": 1,
+            "met": True,
+            "updated_at": ORIGINAL_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    review["minimum_requirement_outcome"] = {
+        "status": "met",
+        "returned_without_full_review": False,
+        "teacher_note": None,
+        "updated_at": ORIGINAL_TIMESTAMP,
+    }
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [
+                {
+                    "observation_id": "observation_0001",
+                    "standard_id": "njsls-ela:W.1",
+                    "applicable": True,
+                    "evidence_present": True,
+                    "rating": None,
+                    "rationale": "Clear claim.",
+                    "include_in_feedback": True,
+                    "updated_at": ORIGINAL_TIMESTAMP,
+                    "module_details": {},
+                },
+                {
+                    "observation_id": "observation_0002",
+                    "standard_id": "njsls-ela:L.2",
+                    "applicable": False,
+                    "evidence_present": None,
+                    "rating": None,
+                    "rationale": "Not applicable here.",
+                    "include_in_feedback": False,
+                    "updated_at": ORIGINAL_TIMESTAMP,
+                    "module_details": {},
+                },
+            ],
+            "module_details": {},
+        },
+        {
+            "unit_id": "paragraph_2",
+            "sequence": 2,
+            "label": "Paragraph 2",
+            "unit_type": "paragraph",
+            "standard_observations": [
+                {
+                    "observation_id": "observation_0003",
+                    "standard_id": "njsls-ela:W.1",
+                    "applicable": True,
+                    "evidence_present": False,
+                    "rating": None,
+                    "rationale": "Evidence is attempted but missing.",
+                    "include_in_feedback": False,
+                    "updated_at": ORIGINAL_TIMESTAMP,
+                    "module_details": {},
+                }
+            ],
+            "module_details": {},
+        },
+    ]
+    review["feedback"]["standard_feedback"] = [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "include_overall_rating": True,
+            "include_overall_rationale": True,
+            "included_observation_ids": ["observation_0001"],
+            "comments": [
+                {
+                    "feedback_comment_id": "feedback_comment_0001",
+                    "source": "custom",
+                    "text": "Explain the evidence connection.",
+                    "reusable_comment_id": None,
+                    "save_for_reuse": False,
+                    "include_in_feedback": True,
+                    "created_at": ORIGINAL_TIMESTAMP,
+                    "module_details": {},
+                }
+            ],
+            "module_details": {},
+        }
+    ]
+    review["private_notes"] = [
+        {
+            "private_note_id": "note_0001",
+            "text": "Conference note.",
+            "created_at": ORIGINAL_TIMESTAMP,
+            "updated_at": ORIGINAL_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    return review
+
+
+def _read_review(root: Path) -> dict[str, Any]:
+    return json.loads(
+        review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def test_set_overall_rating_creates_record_and_preserves_review_data(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+    before = _read_review(tmp_path)
+
+    result = set_overall_standard_rating(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        rating=2,
+        rationale="Clear claim with uneven explanation.",
+        include_in_feedback=True,
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    review = _read_review(tmp_path)
+    assert result.was_created is True
+    assert result.rating_label == "Secure"
+    assert result.review_state == "observations_complete"
+    assert review["overall_standard_ratings"] == [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "rating": 2,
+            "rationale": "Clear claim with uneven explanation.",
+            "include_in_feedback": True,
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    assert review["updated_at"] == FIRST_TIMESTAMP
+    assert review["created_at"] == before["created_at"]
+    for field in (
+        "minimum_requirement_checks",
+        "minimum_requirement_outcome",
+        "review_units",
+        "feedback",
+        "private_notes",
+        "exports",
+    ):
+        assert review[field] == before[field]
+    for legacy_field in ("scores", "tags", "comments", "notes"):
+        assert legacy_field not in review
+
+
+def test_set_overall_rating_updates_existing_standard_only(tmp_path: Path) -> None:
+    review = _review_record()
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "rating": 1,
+            "rationale": "Earlier rationale.",
+            "include_in_feedback": False,
+            "updated_at": ORIGINAL_TIMESTAMP,
+            "module_details": {},
+        },
+        {
+            "standard_id": "njsls-ela:L.2",
+            "rating": 2,
+            "rationale": None,
+            "include_in_feedback": True,
+            "updated_at": ORIGINAL_TIMESTAMP,
+            "module_details": {},
+        },
+    ]
+    _write_workspace(tmp_path, review)
+
+    result = set_overall_standard_rating(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        rating=2,
+        rationale=" ",
+        include_in_feedback=True,
+        updated_at=SECOND_TIMESTAMP,
+    )
+
+    ratings = _read_review(tmp_path)["overall_standard_ratings"]
+    assert result.was_created is False
+    assert ratings[0]["standard_id"] == "njsls-ela:W.1"
+    assert ratings[0]["rating"] == 2
+    assert ratings[0]["rationale"] is None
+    assert ratings[0]["include_in_feedback"] is True
+    assert ratings[1] == review["overall_standard_ratings"][1]
+
+
+def test_set_overall_rating_validates_assignment_scale_and_standard(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+
+    with pytest.raises(ReviewRatingError, match="not a Focus Standard"):
+        set_overall_standard_rating(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            standard_id="njsls-ela:MISSING",
+            rating=2,
+            rationale=None,
+            include_in_feedback=True,
+            updated_at=FIRST_TIMESTAMP,
+        )
+    with pytest.raises(ReviewRatingError, match="rating"):
+        set_overall_standard_rating(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            standard_id="njsls-ela:W.1",
+            rating=3,
+            rationale=None,
+            include_in_feedback=True,
+            updated_at=FIRST_TIMESTAMP,
+        )
+    with pytest.raises(ReviewRatingError, match="include_in_feedback"):
+        set_overall_standard_rating(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            standard_id="njsls-ela:W.1",
+            rating=2,
+            rationale=None,
+            include_in_feedback=1,  # type: ignore[arg-type]
+            updated_at=FIRST_TIMESTAMP,
+        )
+
+
+def test_focus_standard_summary_groups_counts_and_current_rating(
+    tmp_path: Path,
+) -> None:
+    review = _review_record()
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "rating": 2,
+            "rationale": "Overall rationale.",
+            "include_in_feedback": True,
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    _write_workspace(tmp_path, review)
+
+    summaries = summarize_focus_standard_observations(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+
+    first = summaries[0]
+    assert first.standard_id == "njsls-ela:W.1"
+    assert first.total_review_units == 2
+    assert first.observation_count == 2
+    assert first.applicable_count == 2
+    assert first.not_applicable_count == 0
+    assert first.evidence_present_count == 1
+    assert first.evidence_missing_count == 1
+    assert first.included_for_feedback_count == 1
+    assert [detail.unit_label for detail in first.details] == [
+        "Paragraph 1",
+        "Paragraph 2",
+    ]
+    assert first.current_rating == 2
+    assert first.current_rationale == "Overall rationale."
+    assert "recommended" not in repr(first).lower()
+
+
+def test_mark_overall_ratings_complete_reports_missing_and_preserves_data(
+    tmp_path: Path,
+) -> None:
+    review = _review_record()
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "rating": 2,
+            "rationale": None,
+            "include_in_feedback": True,
+            "updated_at": FIRST_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    _write_workspace(tmp_path, review)
+    before = copy.deepcopy(_read_review(tmp_path))
+
+    result = mark_overall_ratings_complete(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        updated_at=THIRD_TIMESTAMP,
+    )
+
+    after = _read_review(tmp_path)
+    assert result.review_state == "ratings_complete"
+    assert result.focus_standard_count == 2
+    assert result.rating_count == 1
+    assert result.missing_rating_count == 1
+    assert after["review_state"] == "ratings_complete"
+    assert after["updated_at"] == THIRD_TIMESTAMP
+    for field in (
+        "minimum_requirement_checks",
+        "minimum_requirement_outcome",
+        "review_units",
+        "overall_standard_ratings",
+        "feedback",
+        "private_notes",
+        "exports",
+        "created_at",
+    ):
+        assert after[field] == before[field]
+
+
+def test_returned_without_full_review_records_reject_rating_changes(
+    tmp_path: Path,
+) -> None:
+    review = _review_record()
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Missing required work.",
+        "updated_at": ORIGINAL_TIMESTAMP,
+    }
+    _write_workspace(tmp_path, review)
+
+    with pytest.raises(ReviewRatingError, match="returned without full standards review"):
+        set_overall_standard_rating(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            standard_id="njsls-ela:W.1",
+            rating=2,
+            rationale=None,
+            include_in_feedback=True,
+            updated_at=FIRST_TIMESTAMP,
+        )
+    with pytest.raises(ReviewRatingError, match="returned without full standards review"):
+        mark_overall_ratings_complete(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            updated_at=FIRST_TIMESTAMP,
+        )


### PR DESCRIPTION
## Summary

Implements the overall Focus Standard rating workflow for Quillan’s v0.8.6 standards-based review model.

Teachers can now review observation evidence grouped by Focus Standard, enter one overall rating per Focus Standard, and explicitly mark overall ratings complete.

## Changes

* Adds `quillan/review_ratings.py` with support for:

  * observation summaries grouped by Focus Standard;
  * teacher-entered overall Focus Standard rating create/update;
  * explicit `ratings_complete` state transition;
  * returned-without-full-review protection.
* Adds a selected-student menu item and submenu for overall Focus Standard ratings.
* Adds teacher-facing output printers for:

  * updated overall Focus Standard ratings;
  * completed overall Focus Standard ratings.
* Updates snapshot wording to:

  * `Overall Focus Standard Ratings`
* Adds focused helper and menu coverage in `tests/test_review_ratings.py`.
* Updates affected selected-student menu tests.

## Behavior

The workflow summarizes recorded review-unit observations by Focus Standard so the teacher can make an overall judgment.

The summary is informational only. It does not calculate, infer, average, recommend, or select a rating.

Overall ratings are stored in `overall_standard_ratings` and use the assignment’s configured `rating_scale.levels`.

The workflow protects records in `returned_without_full_review` state from rating edits.

## Verification

Full test suite:

* `.\.venv\Scripts\python.exe -m pytest`

Result:

* `996 passed`

Changed-file Ruff:

* `.\.venv\Scripts\ruff.exe check ...`

Result:

* `All checks passed!`

## Notes

This PR does not implement feedback composition, reusable Focus Standard comments, PDF export, class summaries, standards summaries, assignment result manifests, gradebook export, parent/admin reporting, automatic scoring, averages, mastery inference, or AI/OCR-based review.

Closes #227
