### PR TITLE
Implement Focus Standard feedback composer

### DIFF
--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -12,7 +12,14 @@ from quillan.assignment_submission_assembly import (
 from quillan.class_summary_export import ExportedClassSummary
 from quillan.evidence_filing import EvidenceFilingError, RoutedEvidenceFile
 from quillan.feedback_export import ExportedFeedback
+from quillan.focus_standard_comments import SavedReusableFocusStandardComment
 from quillan.review_comments import AddedReviewComment
+from quillan.review_feedback import (
+    AddedFeedbackComment,
+    CompletedFeedbackComposition,
+    SelectedReusableFeedbackComment,
+    UpdatedStandardFeedbackOptions,
+)
 from quillan.review_notes import AddedReviewNote
 from quillan.review_observations import (
     CompletedReviewUnitObservations,
@@ -193,6 +200,86 @@ def print_completed_overall_standard_ratings(
     print(f"Missing ratings: {completed.missing_rating_count}")
     print(f"Review state: {completed.review_state}")
     print(f"Review record: {completed.review_record_relative_path}")
+
+
+def print_updated_standard_feedback_options(
+    updated: UpdatedStandardFeedbackOptions,
+) -> None:
+    """Print a concise Focus Standard feedback options summary."""
+    print("Updated Focus Standard feedback options:")
+    print(f"Class: {updated.class_id}")
+    print(f"Assignment: {updated.assignment_id}")
+    print(f"Student: {updated.student_id}")
+    print(f"Standard: {updated.standard_id}")
+    print(f"Include overall rating: {format_bool(updated.include_overall_rating)}")
+    print(
+        "Include overall rationale: "
+        f"{format_bool(updated.include_overall_rationale)}"
+    )
+    print(f"Included observations: {updated.included_observation_count}")
+    print(f"Action: {'created' if updated.was_created else 'updated'}")
+    print(f"Review state: {updated.review_state}")
+    print(f"Review record: {updated.review_record_relative_path}")
+
+
+def print_added_feedback_comment(added: AddedFeedbackComment) -> None:
+    """Print a concise custom Focus Standard feedback comment summary."""
+    print("Added Focus Standard feedback comment:")
+    print(f"Class: {added.class_id}")
+    print(f"Assignment: {added.assignment_id}")
+    print(f"Student: {added.student_id}")
+    print(f"Standard: {added.standard_id}")
+    print(f"Feedback comment: {added.feedback_comment_id}")
+    print(f"Include in feedback: {format_bool(added.include_in_feedback)}")
+    print(f"Saved for reuse: {format_bool(added.save_for_reuse)}")
+    print(f"Review state: {added.review_state}")
+    print(f"Review record: {added.review_record_relative_path}")
+    if added.saved_reusable_comment is not None:
+        print_saved_reusable_focus_standard_comment(added.saved_reusable_comment)
+
+
+def print_selected_reusable_feedback_comment(
+    selected: SelectedReusableFeedbackComment,
+) -> None:
+    """Print a concise reusable Focus Standard comment selection summary."""
+    print("Selected reusable Focus Standard comment:")
+    print(f"Class: {selected.class_id}")
+    print(f"Assignment: {selected.assignment_id}")
+    print(f"Student: {selected.student_id}")
+    print(f"Standard: {selected.standard_id}")
+    print(f"Comment set: {selected.comment_set_id}")
+    print(f"Reusable comment: {selected.reusable_comment_id}")
+    print(f"Feedback comment: {selected.feedback_comment_id}")
+    print(f"Include in feedback: {format_bool(selected.include_in_feedback)}")
+    print(f"Review state: {selected.review_state}")
+    print(f"Review record: {selected.review_record_relative_path}")
+
+
+def print_completed_feedback_composition(
+    completed: CompletedFeedbackComposition,
+) -> None:
+    """Print a concise feedback-composed summary."""
+    print("Marked Focus Standard feedback composed:")
+    print(f"Class: {completed.class_id}")
+    print(f"Assignment: {completed.assignment_id}")
+    print(f"Student: {completed.student_id}")
+    print(f"Focus Standards: {completed.focus_standard_count}")
+    print(f"Standards with feedback: {completed.standard_feedback_count}")
+    print(f"Missing feedback records: {completed.missing_standard_feedback_count}")
+    print(f"Included comments: {completed.included_comment_count}")
+    print(f"Review state: {completed.review_state}")
+    print(f"Review record: {completed.review_record_relative_path}")
+
+
+def print_saved_reusable_focus_standard_comment(
+    saved: SavedReusableFocusStandardComment,
+) -> None:
+    """Print a concise saved reusable Focus Standard comment summary."""
+    print("Saved reusable Focus Standard comment:")
+    print(f"Comment set: {saved.comment_set_id}")
+    print(f"Reusable comment: {saved.comment_id}")
+    print(f"Standard: {saved.standard_id}")
+    print(f"Purpose: {saved.purpose}")
 
 
 def print_exported_feedback(exported: ExportedFeedback) -> None:

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -143,7 +143,8 @@ def export_student_feedback(
         )
     else:
         included_comments = _included_feedback_comments(review)
-        ratings = review["overall_standard_ratings"]
+        ratings = _included_standard_ratings(review)
+        observations = _included_review_unit_observations(review)
         markdown = _render_markdown(
             class_id=class_id,
             assignment_id=assignment_id,
@@ -151,6 +152,7 @@ def export_student_feedback(
             created_at=normalized_created_at,
             ratings=ratings,
             comments=included_comments,
+            observations=observations,
         )
     overwrote_existing = output_path.exists()
     if overwrote_existing and not overwrite:
@@ -187,6 +189,7 @@ def _render_markdown(
     created_at: str,
     ratings: list[dict[str, Any]],
     comments: list[dict[str, Any]],
+    observations: list[dict[str, Any]],
 ) -> str:
     lines = [
         "# Feedback",
@@ -216,6 +219,17 @@ def _render_markdown(
         lines.extend(f"- {_plain_text(comment['text'])}" for comment in comments)
     else:
         lines.append("No feedback comments selected.")
+    lines.extend(["", "## Review Unit Observations", ""])
+    if observations:
+        for observation in observations:
+            rendered = f"- {_plain_text(observation['standard_id'])}"
+            if observation.get("unit_label"):
+                rendered += f" ({_plain_text(observation['unit_label'])})"
+            if observation.get("rationale"):
+                rendered += f": {_plain_text(observation['rationale'])}"
+            lines.append(rendered)
+    else:
+        lines.append("No review-unit observations selected.")
     lines.append("")
     return "\n".join(lines)
 
@@ -272,6 +286,51 @@ def _included_feedback_comments(review: dict[str, Any]) -> list[dict[str, Any]]:
             for comment in standard_feedback["comments"]
             if comment["include_in_feedback"]
         )
+    return included
+
+
+def _included_standard_ratings(review: dict[str, Any]) -> list[dict[str, Any]]:
+    if not review["feedback"]["include_overall_standard_ratings"]:
+        return []
+    feedback_by_standard = {
+        item["standard_id"]: item for item in review["feedback"]["standard_feedback"]
+    }
+    included: list[dict[str, Any]] = []
+    for rating in review["overall_standard_ratings"]:
+        standard_feedback = feedback_by_standard.get(rating["standard_id"])
+        if standard_feedback is None:
+            if not rating["include_in_feedback"]:
+                continue
+            included.append(rating)
+            continue
+        if not standard_feedback["include_overall_rating"]:
+            continue
+        rendered = dict(rating)
+        if not standard_feedback["include_overall_rationale"]:
+            rendered["rationale"] = None
+        included.append(rendered)
+    return included
+
+
+def _included_review_unit_observations(review: dict[str, Any]) -> list[dict[str, Any]]:
+    if not review["feedback"]["include_review_unit_observations"]:
+        return []
+    selected_by_standard: dict[str, set[str]] = {}
+    for standard_feedback in review["feedback"]["standard_feedback"]:
+        selected_by_standard[standard_feedback["standard_id"]] = set(
+            standard_feedback["included_observation_ids"]
+        )
+    included: list[dict[str, Any]] = []
+    for unit in review["review_units"]:
+        for observation in unit["standard_observations"]:
+            if observation["observation_id"] not in selected_by_standard.get(
+                observation["standard_id"], set()
+            ):
+                continue
+            item = dict(observation)
+            item["unit_id"] = unit["unit_id"]
+            item["unit_label"] = unit["label"]
+            included.append(item)
     return included
 
 

--- a/quillan/focus_standard_comments.py
+++ b/quillan/focus_standard_comments.py
@@ -1,0 +1,765 @@
+"""Runtime support for reusable Focus Standard comment sets."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+import tempfile
+import unicodedata
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Final, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+REQUIRED_COMMENT_SET_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "module",
+        "record_type",
+        "comment_set_id",
+        "title",
+        "description",
+        "standards_profile_id",
+        "writing_types",
+        "grade_band",
+        "comments",
+        "created_at",
+        "updated_at",
+        "module_details",
+    }
+)
+REQUIRED_COMMENT_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "comment_id",
+        "standard_id",
+        "writing_types",
+        "rating_values",
+        "label",
+        "text",
+        "purpose",
+        "student_facing",
+        "active",
+        "created_at",
+        "updated_at",
+        "source",
+        "usage",
+        "module_details",
+    }
+)
+REQUIRED_SOURCE_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "type",
+        "class_id",
+        "assignment_id",
+        "student_id",
+        "review_path",
+        "feedback_comment_id",
+        "saved_at",
+    }
+)
+REQUIRED_USAGE_FIELDS: Final[frozenset[str]] = frozenset(
+    {"times_used", "last_used_at"}
+)
+ALLOWED_PURPOSES: Final[frozenset[str]] = frozenset(
+    {
+        "praise",
+        "next_step",
+        "clarification",
+        "evidence",
+        "reasoning",
+        "organization",
+        "style",
+        "conventions",
+        "revision",
+        "general",
+    }
+)
+ALLOWED_SOURCE_TYPES: Final[frozenset[str]] = frozenset(
+    {"manual", "teacher_saved_from_feedback", "migration", "starter_material"}
+)
+
+
+class FocusStandardCommentError(ValueError):
+    """Raised when reusable Focus Standard comments are missing or invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class FocusStandardCommentSetFile:
+    """One discovered reusable Focus Standard comment set."""
+
+    path: Path
+    comment_set: dict[str, Any] | None
+    error: str | None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.comment_set is not None and self.error is None
+
+
+@dataclass(frozen=True, slots=True)
+class ReusableFocusStandardComment:
+    """One reusable comment match for a Focus Standard."""
+
+    comment_set_id: str
+    comment_id: str
+    standard_id: str
+    label: str
+    text: str
+    purpose: str
+    rating_values: tuple[int | float, ...]
+    writing_types: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SavedReusableFocusStandardComment:
+    """Information about a reusable comment saved from feedback."""
+
+    comment_set_id: str
+    comment_id: str
+    path: Path
+    standard_id: str
+    label: str
+    text: str
+    purpose: str
+    created_at: str
+
+
+def focus_standard_comment_set_path(
+    workspace_root: str | Path, comment_set_id: str
+) -> Path:
+    """Return the canonical path for one reusable Focus Standard comment set."""
+    normalized_id = _validate_identifier(comment_set_id, "comment_set_id")
+    return _comment_sets_dir(workspace_root) / f"{normalized_id}.json"
+
+
+def list_focus_standard_comment_set_files(
+    workspace_root: str | Path,
+) -> tuple[FocusStandardCommentSetFile, ...]:
+    """List reusable Focus Standard comment set files without raising on invalid files."""
+    directory = _comment_sets_dir(workspace_root)
+    if not directory.is_dir():
+        return ()
+    files: list[FocusStandardCommentSetFile] = []
+    for path in sorted(directory.glob("*.json"), key=lambda item: item.name.casefold()):
+        try:
+            files.append(FocusStandardCommentSetFile(path, load_comment_set(path), None))
+        except (OSError, FocusStandardCommentError) as error:
+            files.append(FocusStandardCommentSetFile(path, None, str(error)))
+    return tuple(files)
+
+
+def list_valid_comment_sets(
+    workspace_root: str | Path,
+) -> tuple[FocusStandardCommentSetFile, ...]:
+    """Return valid reusable Focus Standard comment set files only."""
+    return tuple(
+        item for item in list_focus_standard_comment_set_files(workspace_root) if item.is_valid
+    )
+
+
+def load_comment_set(path: str | Path) -> dict[str, Any]:
+    """Load and validate a reusable Focus Standard comment set."""
+    comment_set_path = Path(path)
+    try:
+        with comment_set_path.open("r", encoding="utf-8") as file:
+            value = json.load(file)
+    except FileNotFoundError as error:
+        raise FocusStandardCommentError(
+            f"Focus Standard comment set not found: {comment_set_path}"
+        ) from error
+    except json.JSONDecodeError as error:
+        raise FocusStandardCommentError(
+            f"Focus Standard comment set is not valid JSON: {comment_set_path}"
+        ) from error
+    except OSError as error:
+        raise FocusStandardCommentError(
+            f"Could not read Focus Standard comment set {comment_set_path}: {error}"
+        ) from error
+    if not isinstance(value, dict):
+        raise FocusStandardCommentError(
+            f"Focus Standard comment set must be a JSON object: {comment_set_path}"
+        )
+    comment_set = cast(dict[str, Any], value)
+    validate_comment_set(comment_set)
+    if comment_set["comment_set_id"] != comment_set_path.stem:
+        raise FocusStandardCommentError(
+            "Focus Standard comment set comment_set_id is "
+            f"{comment_set['comment_set_id']!r}, expected {comment_set_path.stem!r}."
+        )
+    return comment_set
+
+
+def validate_comment_set(comment_set: dict[str, Any]) -> None:
+    """Validate the reusable Focus Standard comment set contract."""
+    if not isinstance(comment_set, dict):
+        raise FocusStandardCommentError("Focus Standard comment set must be an object.")
+    _validate_fields(comment_set, REQUIRED_COMMENT_SET_FIELDS, frozenset(), "comment set")
+    _validate_exact(comment_set["schema_version"], "schema_version", "1")
+    _validate_exact(comment_set["module"], "module", "quillan")
+    _validate_exact(
+        comment_set["record_type"],
+        "record_type",
+        "focus_standard_comment_set",
+    )
+    _validate_identifier(comment_set["comment_set_id"], "comment_set_id")
+    _validate_non_empty_string(comment_set["title"], "title")
+    _validate_non_empty_string(comment_set["description"], "description")
+    _validate_non_empty_string(
+        comment_set["standards_profile_id"], "standards_profile_id"
+    )
+    _validate_unique_strings(comment_set["writing_types"], "writing_types")
+    if comment_set["grade_band"] is not None:
+        _validate_non_empty_string(comment_set["grade_band"], "grade_band")
+    seen_comment_ids: set[str] = set()
+    comments = _validate_list(comment_set["comments"], "comments")
+    for index, value in enumerate(comments):
+        _validate_comment(value, f"comments[{index}]", seen_comment_ids)
+    created_at = _validate_timestamp(comment_set["created_at"], "created_at")
+    updated_at = _validate_timestamp(comment_set["updated_at"], "updated_at")
+    if updated_at < created_at:
+        raise FocusStandardCommentError(
+            "Field 'updated_at' must not precede field 'created_at'."
+        )
+    _validate_object(comment_set["module_details"], "module_details")
+
+
+def lookup_comments(
+    workspace_root: str | Path,
+    *,
+    standards_profile_id: str,
+    writing_type: str,
+    standard_id: str,
+    rating_value: int | float | None = None,
+    comment_set_id: str | None = None,
+) -> tuple[ReusableFocusStandardComment, ...]:
+    """Find active, student-facing reusable comments compatible with an assignment."""
+    matches: list[ReusableFocusStandardComment] = []
+    if comment_set_id is not None:
+        files = (
+            FocusStandardCommentSetFile(
+                focus_standard_comment_set_path(workspace_root, comment_set_id),
+                load_comment_set(focus_standard_comment_set_path(workspace_root, comment_set_id)),
+                None,
+            ),
+        )
+    else:
+        files = list_valid_comment_sets(workspace_root)
+    for file in files:
+        comment_set = file.comment_set
+        if comment_set is None:
+            continue
+        if comment_set["standards_profile_id"] != standards_profile_id:
+            continue
+        set_writing_types = comment_set["writing_types"]
+        if set_writing_types and writing_type not in set_writing_types:
+            continue
+        for comment in comment_set["comments"]:
+            if not _comment_matches(
+                comment,
+                standard_id=standard_id,
+                writing_type=writing_type,
+                rating_value=rating_value,
+            ):
+                continue
+            matches.append(
+                ReusableFocusStandardComment(
+                    comment_set_id=comment_set["comment_set_id"],
+                    comment_id=comment["comment_id"],
+                    standard_id=comment["standard_id"],
+                    label=comment["label"].strip(),
+                    text=comment["text"].strip(),
+                    purpose=comment["purpose"],
+                    rating_values=tuple(comment["rating_values"]),
+                    writing_types=tuple(comment["writing_types"]),
+                )
+            )
+    return tuple(matches)
+
+
+def append_saved_comment(
+    workspace_root: str | Path,
+    *,
+    standards_profile_id: str,
+    writing_type: str,
+    standard_id: str,
+    label: str,
+    text: str,
+    purpose: str,
+    rating_values: list[int | float] | None,
+    source: dict[str, Any],
+    created_at: datetime | str | None = None,
+    comment_set_id: str | None = None,
+    comment_id: str | None = None,
+) -> SavedReusableFocusStandardComment:
+    """Append a teacher-approved reusable comment, creating a default set if needed."""
+    normalized_created_at = _normalize_timestamp(created_at)
+    normalized_set_id = (
+        _validate_identifier(comment_set_id, "comment_set_id")
+        if comment_set_id is not None
+        else _default_comment_set_id(standards_profile_id, writing_type)
+    )
+    normalized_comment_id = (
+        _validate_identifier(comment_id, "comment_id")
+        if comment_id is not None
+        else suggest_identifier(label)
+    )
+    normalized_label = _normalize_required_string(label, "label")
+    normalized_text = _normalize_required_string(text, "text")
+    normalized_purpose = _validate_allowed(purpose, "purpose", ALLOWED_PURPOSES)
+    normalized_rating_values = _normalize_unique_numbers(
+        rating_values or [], "rating_values"
+    )
+    path = focus_standard_comment_set_path(workspace_root, normalized_set_id)
+    if path.exists():
+        comment_set = load_comment_set(path)
+        if comment_set["standards_profile_id"] != standards_profile_id:
+            raise FocusStandardCommentError(
+                "Existing Focus Standard comment set standards_profile_id does not "
+                f"match {standards_profile_id!r}."
+            )
+        if comment_set["writing_types"] and writing_type not in comment_set["writing_types"]:
+            raise FocusStandardCommentError(
+                "Existing Focus Standard comment set does not include writing_type "
+                f"{writing_type!r}."
+            )
+    else:
+        comment_set = _build_default_comment_set(
+            comment_set_id=normalized_set_id,
+            standards_profile_id=standards_profile_id,
+            writing_type=writing_type,
+            created_at=normalized_created_at,
+        )
+
+    existing_ids = {comment["comment_id"] for comment in comment_set["comments"]}
+    normalized_comment_id = _unique_identifier(normalized_comment_id, existing_ids)
+    comment = {
+        "comment_id": normalized_comment_id,
+        "standard_id": _normalize_required_string(standard_id, "standard_id"),
+        "writing_types": [writing_type],
+        "rating_values": normalized_rating_values,
+        "label": normalized_label,
+        "text": normalized_text,
+        "purpose": normalized_purpose,
+        "student_facing": True,
+        "active": True,
+        "created_at": normalized_created_at,
+        "updated_at": normalized_created_at,
+        "source": copy.deepcopy(source),
+        "usage": {"times_used": 0, "last_used_at": None},
+        "module_details": {},
+    }
+    comment_set["comments"].append(comment)
+    if not comment_set["writing_types"]:
+        comment_set["writing_types"] = [writing_type]
+    elif writing_type not in comment_set["writing_types"]:
+        comment_set["writing_types"].append(writing_type)
+    comment_set["updated_at"] = normalized_created_at
+    write_comment_set(workspace_root, comment_set, overwrite=path.exists())
+    return SavedReusableFocusStandardComment(
+        comment_set_id=normalized_set_id,
+        comment_id=normalized_comment_id,
+        path=path,
+        standard_id=standard_id,
+        label=normalized_label,
+        text=normalized_text,
+        purpose=normalized_purpose,
+        created_at=normalized_created_at,
+    )
+
+
+def increment_usage(
+    workspace_root: str | Path,
+    *,
+    comment_set_id: str,
+    comment_id: str,
+    used_at: datetime | str | None = None,
+) -> None:
+    """Increment usage metadata after a teacher selects a reusable comment."""
+    normalized_used_at = _normalize_timestamp(used_at)
+    path = focus_standard_comment_set_path(workspace_root, comment_set_id)
+    comment_set = load_comment_set(path)
+    for comment in comment_set["comments"]:
+        if comment["comment_id"] == comment_id:
+            comment["usage"]["times_used"] += 1
+            comment["usage"]["last_used_at"] = normalized_used_at
+            comment["updated_at"] = normalized_used_at
+            comment_set["updated_at"] = normalized_used_at
+            write_comment_set(workspace_root, comment_set, overwrite=True)
+            return
+    raise FocusStandardCommentError(
+        f"Reusable Focus Standard comment not found: {comment_id!r}."
+    )
+
+
+def write_comment_set(
+    workspace_root: str | Path,
+    comment_set: dict[str, Any],
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Validate and safely write a reusable Focus Standard comment set."""
+    validate_comment_set(comment_set)
+    path = focus_standard_comment_set_path(workspace_root, comment_set["comment_set_id"])
+    directory = _comment_sets_dir(workspace_root).resolve(strict=False)
+    resolved_path = path.resolve(strict=False)
+    try:
+        resolved_path.relative_to(directory)
+    except ValueError as error:
+        raise FocusStandardCommentError(
+            f"Focus Standard comment set path escapes shared directory: {path}"
+        ) from error
+    if path.exists() and not overwrite:
+        raise FocusStandardCommentError(
+            f"Focus Standard comment set already exists: {path}"
+        )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise FocusStandardCommentError(
+            f"Could not create Focus Standard comment directory {path.parent}: {error}"
+        ) from error
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=path.parent,
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            json.dump(comment_set, temporary_file, ensure_ascii=False, indent=2)
+            temporary_file.write("\n")
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        if overwrite:
+            os.replace(temporary_path, path)
+        else:
+            os.link(temporary_path, path)
+            temporary_path.unlink()
+        temporary_path = None
+    except FileExistsError as error:
+        raise FocusStandardCommentError(
+            f"Focus Standard comment set already exists: {path}"
+        ) from error
+    except (OSError, TypeError, ValueError) as error:
+        raise FocusStandardCommentError(
+            f"Could not write Focus Standard comment set {path}: {error}"
+        ) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+    return path
+
+
+def suggest_identifier(label: str) -> str:
+    """Suggest a reusable comment identifier from teacher-facing text."""
+    normalized = unicodedata.normalize("NFKD", label)
+    ascii_label = normalized.encode("ascii", "ignore").decode("ascii")
+    suggestion = re.sub(r"[^A-Za-z0-9_-]+", "_", ascii_label.strip())
+    suggestion = suggestion.strip("_-").lower()
+    return suggestion or "focus_standard_comment"
+
+
+def _comment_sets_dir(workspace_root: str | Path) -> Path:
+    return Path(workspace_root) / "shared" / "focus_standard_comments"
+
+
+def _comment_matches(
+    comment: dict[str, Any],
+    *,
+    standard_id: str,
+    writing_type: str,
+    rating_value: int | float | None,
+) -> bool:
+    if comment["standard_id"] != standard_id:
+        return False
+    if not comment["active"] or not comment["student_facing"]:
+        return False
+    if comment["writing_types"] and writing_type not in comment["writing_types"]:
+        return False
+    if rating_value is not None and comment["rating_values"]:
+        return rating_value in comment["rating_values"]
+    return True
+
+
+def _validate_comment(
+    value: Any, context: str, seen_comment_ids: set[str]
+) -> None:
+    comment = _validate_record(value, context)
+    _validate_fields(comment, REQUIRED_COMMENT_FIELDS, frozenset(), context)
+    comment_id = _validate_identifier(comment["comment_id"], f"{context}.comment_id")
+    if comment_id in seen_comment_ids:
+        raise FocusStandardCommentError(f"Duplicate comment_id '{comment_id}'.")
+    seen_comment_ids.add(comment_id)
+    _validate_non_empty_string(comment["standard_id"], f"{context}.standard_id")
+    _validate_unique_strings(comment["writing_types"], f"{context}.writing_types")
+    _normalize_unique_numbers(comment["rating_values"], f"{context}.rating_values")
+    _validate_non_empty_string(comment["label"], f"{context}.label")
+    _validate_non_empty_string(comment["text"], f"{context}.text")
+    _validate_allowed(comment["purpose"], f"{context}.purpose", ALLOWED_PURPOSES)
+    _validate_boolean(comment["student_facing"], f"{context}.student_facing")
+    _validate_boolean(comment["active"], f"{context}.active")
+    created_at = _validate_timestamp(comment["created_at"], f"{context}.created_at")
+    updated_at = _validate_timestamp(comment["updated_at"], f"{context}.updated_at")
+    if updated_at < created_at:
+        raise FocusStandardCommentError(
+            f"Field '{context}.updated_at' must not precede field '{context}.created_at'."
+        )
+    _validate_source(comment["source"], f"{context}.source")
+    _validate_usage(comment["usage"], f"{context}.usage")
+    _validate_object(comment["module_details"], f"{context}.module_details")
+
+
+def _validate_source(value: Any, context: str) -> None:
+    source = _validate_record(value, context)
+    _validate_fields(source, REQUIRED_SOURCE_FIELDS, frozenset(), context)
+    source_type = _validate_allowed(source["type"], f"{context}.type", ALLOWED_SOURCE_TYPES)
+    _validate_timestamp(source["saved_at"], f"{context}.saved_at")
+    for field in ("class_id", "assignment_id", "student_id", "feedback_comment_id"):
+        if source[field] is not None:
+            _validate_non_empty_string(source[field], f"{context}.{field}")
+    if source["review_path"] is not None:
+        _validate_workspace_relative_path(source["review_path"], f"{context}.review_path")
+    if source_type == "manual":
+        for field in ("class_id", "assignment_id", "student_id", "review_path", "feedback_comment_id"):
+            if source[field] is not None:
+                raise FocusStandardCommentError(
+                    f"Field '{context}.{field}' must be null for manual sources."
+                )
+    if source_type == "teacher_saved_from_feedback":
+        for field in ("class_id", "assignment_id", "student_id", "review_path", "feedback_comment_id"):
+            _validate_non_empty_string(source[field], f"{context}.{field}")
+
+
+def _validate_usage(value: Any, context: str) -> None:
+    usage = _validate_record(value, context)
+    _validate_fields(usage, REQUIRED_USAGE_FIELDS, frozenset(), context)
+    times_used = usage["times_used"]
+    if isinstance(times_used, bool) or not isinstance(times_used, int) or times_used < 0:
+        raise FocusStandardCommentError(
+            f"Field '{context}.times_used' must be a non-negative integer."
+        )
+    if usage["last_used_at"] is not None:
+        _validate_timestamp(usage["last_used_at"], f"{context}.last_used_at")
+    if times_used == 0 and usage["last_used_at"] is not None:
+        raise FocusStandardCommentError(
+            f"Field '{context}.last_used_at' must be null when times_used is 0."
+        )
+    if times_used > 0 and usage["last_used_at"] is None:
+        raise FocusStandardCommentError(
+            f"Field '{context}.last_used_at' must not be null when times_used is greater than 0."
+        )
+
+
+def _build_default_comment_set(
+    *,
+    comment_set_id: str,
+    standards_profile_id: str,
+    writing_type: str,
+    created_at: str,
+) -> dict[str, Any]:
+    title = f"{standards_profile_id} {writing_type} Focus Standard Comments"
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "focus_standard_comment_set",
+        "comment_set_id": comment_set_id,
+        "title": title,
+        "description": (
+            "Reusable teacher-authored Focus Standard comments saved from "
+            "Quillan feedback composition."
+        ),
+        "standards_profile_id": standards_profile_id,
+        "writing_types": [writing_type],
+        "grade_band": None,
+        "comments": [],
+        "created_at": created_at,
+        "updated_at": created_at,
+        "module_details": {},
+    }
+
+
+def _default_comment_set_id(standards_profile_id: str, writing_type: str) -> str:
+    return _validate_identifier(
+        suggest_identifier(f"{standards_profile_id}_{writing_type}_focus_comments"),
+        "comment_set_id",
+    )
+
+
+def _unique_identifier(identifier: str, existing: set[str]) -> str:
+    candidate = identifier
+    counter = 2
+    while candidate in existing:
+        candidate = f"{identifier}_{counter}"
+        counter += 1
+    return _validate_identifier(candidate, "comment_id")
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise FocusStandardCommentError("timestamp datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise FocusStandardCommentError(
+            "timestamp must be a timezone-aware datetime or ISO 8601 string."
+        )
+    _validate_timestamp(value, "timestamp")
+    return value
+
+
+def _normalize_required_string(value: Any, field: str) -> str:
+    return _validate_non_empty_string(value, field).strip()
+
+
+def _normalize_unique_numbers(value: Any, field: str) -> list[int | float]:
+    values = _validate_list(value, field)
+    seen: set[int | float] = set()
+    normalized: list[int | float] = []
+    for item in values:
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
+            raise FocusStandardCommentError(
+                f"Field '{field}' must contain finite numbers."
+            )
+        if item != item or item in {float("inf"), float("-inf")}:
+            raise FocusStandardCommentError(
+                f"Field '{field}' must contain finite numbers."
+            )
+        if item in seen:
+            raise FocusStandardCommentError(f"Field '{field}' contains duplicate {item!r}.")
+        seen.add(item)
+        normalized.append(item)
+    return normalized
+
+
+def _validate_identifier(value: Any, field: str) -> str:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise FocusStandardCommentError(str(error)) from error
+    return cast(str, value)
+
+
+def _validate_unique_strings(value: Any, field: str) -> list[str]:
+    values = _validate_list(value, field)
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in values:
+        text = _validate_non_empty_string(item, field)
+        if text in seen:
+            raise FocusStandardCommentError(f"Field '{field}' contains duplicate {text!r}.")
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _validate_workspace_relative_path(value: Any, field: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise FocusStandardCommentError(
+            f"Field '{field}' must be a non-empty workspace-relative path string."
+        )
+    if "\0" in value:
+        raise FocusStandardCommentError(f"Field '{field}' must not contain null bytes.")
+    variants = (PurePosixPath(value), PureWindowsPath(value))
+    if any(path.anchor or path.drive for path in variants):
+        raise FocusStandardCommentError(f"Field '{field}' must be workspace-relative.")
+    components = re.split(r"[\\/]", value)
+    if "." in components or ".." in components:
+        raise FocusStandardCommentError(
+            f"Field '{field}' must not contain '.' or '..' path components."
+        )
+
+
+def _validate_fields(
+    data: dict[str, Any],
+    required: frozenset[str],
+    optional: frozenset[str],
+    context: str,
+) -> None:
+    missing = required - data.keys()
+    if missing:
+        raise FocusStandardCommentError(
+            f"Missing required field '{sorted(missing)[0]}' in {context}."
+        )
+    unknown = data.keys() - required - optional
+    if unknown:
+        raise FocusStandardCommentError(
+            f"Unknown field '{sorted(unknown)[0]}' in {context}."
+        )
+
+
+def _validate_record(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FocusStandardCommentError(f"{context} must be an object.")
+    return cast(dict[str, Any], value)
+
+
+def _validate_list(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise FocusStandardCommentError(f"Field '{field}' must be a list.")
+    return value
+
+
+def _validate_object(value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        raise FocusStandardCommentError(f"Field '{field}' must be an object.")
+
+
+def _validate_non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise FocusStandardCommentError(f"Field '{field}' must be a non-empty string.")
+    return value
+
+
+def _validate_boolean(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise FocusStandardCommentError(f"Field '{field}' must be a boolean.")
+    return value
+
+
+def _validate_exact(value: Any, field: str, expected: str) -> None:
+    if value != expected:
+        raise FocusStandardCommentError(
+            f"Field '{field}' must be the string '{expected}'."
+        )
+
+
+def _validate_allowed(
+    value: Any, field: str, allowed_values: frozenset[str]
+) -> str:
+    if not isinstance(value, str) or value not in allowed_values:
+        allowed = ", ".join(sorted(allowed_values))
+        raise FocusStandardCommentError(
+            f"Invalid {field} {value!r}. Allowed values: {allowed}."
+        )
+    return value
+
+
+def _validate_timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise FocusStandardCommentError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise FocusStandardCommentError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise FocusStandardCommentError(
+            f"Field '{field}' must be a timezone-aware ISO 8601 string."
+        )
+    return parsed

--- a/quillan/review_feedback.py
+++ b/quillan/review_feedback.py
@@ -1,0 +1,760 @@
+"""Focus Standard feedback composition helpers."""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.focus_standard_comments import (
+    FocusStandardCommentError,
+    SavedReusableFocusStandardComment,
+    append_saved_comment,
+    focus_standard_comment_set_path,
+    increment_usage,
+    load_comment_set,
+    lookup_comments,
+)
+from quillan.review_record import ReviewRecordError, load_review_record, validate_review_record
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
+from quillan.storage import assignment_config_path
+from quillan.submission_guidance import missing_submission_guidance
+from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+_SEQUENTIAL_FEEDBACK_COMMENT_ID = re.compile(r"^feedback_comment_(\d{4})$")
+
+
+class ReviewFeedbackError(Exception):
+    """Raised when Focus Standard feedback cannot be composed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class UpdatedStandardFeedbackOptions:
+    """Information about one Focus Standard feedback option update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    standard_id: str
+    include_overall_rating: bool
+    include_overall_rationale: bool
+    included_observation_count: int
+    was_created: bool
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class AddedFeedbackComment:
+    """Information about one custom feedback comment added to a review."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    standard_id: str
+    feedback_comment_id: str
+    include_in_feedback: bool
+    save_for_reuse: bool
+    saved_reusable_comment: SavedReusableFocusStandardComment | None
+    created_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedReusableFeedbackComment:
+    """Information about one reusable comment copied into a review."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    standard_id: str
+    feedback_comment_id: str
+    comment_set_id: str
+    reusable_comment_id: str
+    include_in_feedback: bool
+    created_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class CompletedFeedbackComposition:
+    """Information about an explicit feedback-composed state update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_state: str
+    focus_standard_count: int
+    standard_feedback_count: int
+    missing_standard_feedback_count: int
+    included_comment_count: int
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class StandardFeedbackSummary:
+    """Compact feedback status for one Focus Standard."""
+
+    standard_id: str
+    has_overall_rating: bool
+    has_feedback_record: bool
+    comment_count: int
+    included_comment_count: int
+
+
+def summarize_standard_feedback(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> tuple[StandardFeedbackSummary, ...]:
+    """Summarize feedback composition status by Focus Standard."""
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    review = _load_existing_review(context)
+    ratings = {item["standard_id"] for item in review["overall_standard_ratings"]}
+    feedback_by_standard = {
+        item["standard_id"]: item for item in review["feedback"]["standard_feedback"]
+    }
+    summaries: list[StandardFeedbackSummary] = []
+    for standard_id in context["assignment"]["focus_standard_ids"]:
+        feedback = feedback_by_standard.get(standard_id)
+        comments = feedback["comments"] if feedback is not None else []
+        summaries.append(
+            StandardFeedbackSummary(
+                standard_id=standard_id,
+                has_overall_rating=standard_id in ratings,
+                has_feedback_record=feedback is not None,
+                comment_count=len(comments),
+                included_comment_count=sum(
+                    1 for comment in comments if comment["include_in_feedback"]
+                ),
+            )
+        )
+    return tuple(summaries)
+
+
+def set_standard_feedback_options(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    standard_id: str,
+    include_overall_rating: bool,
+    include_overall_rationale: bool,
+    included_observation_ids: list[str],
+    updated_at: datetime | str | None = None,
+) -> UpdatedStandardFeedbackOptions:
+    """Create or update feedback options for one Focus Standard."""
+    normalized_standard_id = _normalize_required_string(standard_id, "standard_id")
+    if not isinstance(include_overall_rating, bool):
+        raise ReviewFeedbackError("include_overall_rating must be a boolean.")
+    if not isinstance(include_overall_rationale, bool):
+        raise ReviewFeedbackError("include_overall_rationale must be a boolean.")
+    normalized_updated_at = _normalize_timestamp(updated_at)
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    _validate_focus_standard(context["assignment"], normalized_standard_id)
+    review = _load_existing_review(context)
+    _guard_returned_without_full_review(review)
+    _validate_observation_ids_for_standard(
+        review, normalized_standard_id, included_observation_ids
+    )
+
+    feedback = _standard_feedback_record(review, normalized_standard_id)
+    was_created = feedback is None
+    if feedback is None:
+        feedback = _empty_standard_feedback(normalized_standard_id)
+        review["feedback"]["standard_feedback"].append(feedback)
+    feedback["include_overall_rating"] = include_overall_rating
+    feedback["include_overall_rationale"] = include_overall_rationale
+    feedback["included_observation_ids"] = list(included_observation_ids)
+    review["feedback"]["include_review_unit_observations"] = any(
+        item["included_observation_ids"] for item in review["feedback"]["standard_feedback"]
+    )
+    review["review_state"] = _feedback_edit_state(review["review_state"])
+    review["updated_at"] = normalized_updated_at
+    _write_review(context, review)
+    return UpdatedStandardFeedbackOptions(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        standard_id=normalized_standard_id,
+        include_overall_rating=include_overall_rating,
+        include_overall_rationale=include_overall_rationale,
+        included_observation_count=len(included_observation_ids),
+        was_created=was_created,
+        updated_at=normalized_updated_at,
+    )
+
+
+def add_custom_feedback_comment(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    standard_id: str,
+    text: str,
+    include_in_feedback: bool,
+    save_for_reuse: bool,
+    created_at: datetime | str | None = None,
+    comment_id: str | None = None,
+    comment_set_id: str | None = None,
+    reusable_label: str | None = None,
+    reusable_text: str | None = None,
+    purpose: str = "general",
+    rating_values: list[int | float] | None = None,
+) -> AddedFeedbackComment:
+    """Add one teacher-authored feedback comment under a Focus Standard."""
+    normalized_standard_id = _normalize_required_string(standard_id, "standard_id")
+    normalized_text = _normalize_required_string(text, "text")
+    if not isinstance(include_in_feedback, bool):
+        raise ReviewFeedbackError("include_in_feedback must be a boolean.")
+    if not isinstance(save_for_reuse, bool):
+        raise ReviewFeedbackError("save_for_reuse must be a boolean.")
+    normalized_created_at = _normalize_timestamp(created_at)
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    assignment = context["assignment"]
+    _validate_focus_standard(assignment, normalized_standard_id)
+    review = _load_existing_review(context)
+    _guard_returned_without_full_review(review)
+    feedback = _ensure_standard_feedback(review, normalized_standard_id)
+    feedback_comment_id = (
+        _normalize_required_string(comment_id, "comment_id")
+        if comment_id is not None
+        else _next_feedback_comment_id(review)
+    )
+    if _feedback_comment_id_exists(review, feedback_comment_id):
+        raise ReviewFeedbackError(
+            f"feedback_comment_id {feedback_comment_id!r} already exists."
+        )
+
+    saved_reusable: SavedReusableFocusStandardComment | None = None
+    if save_for_reuse:
+        reusable_label_text = _normalize_required_string(
+            reusable_label, "reusable_label"
+        )
+        reusable_comment_text = _normalize_required_string(
+            reusable_text if reusable_text is not None else normalized_text,
+            "reusable_text",
+        )
+        rating_values_to_save = rating_values
+        if rating_values_to_save is None:
+            current_rating = _current_rating_value(review, normalized_standard_id)
+            rating_values_to_save = [] if current_rating is None else [current_rating]
+        saved_reusable = append_saved_comment(
+            context["workspace_root"],
+            standards_profile_id=assignment["standards_profile_id"],
+            writing_type=assignment["writing_type"],
+            standard_id=normalized_standard_id,
+            label=reusable_label_text,
+            text=reusable_comment_text,
+            purpose=purpose,
+            rating_values=rating_values_to_save,
+            source=_saved_comment_source(
+                context,
+                feedback_comment_id=feedback_comment_id,
+                saved_at=normalized_created_at,
+            ),
+            created_at=normalized_created_at,
+            comment_set_id=comment_set_id,
+        )
+
+    feedback["comments"].append(
+        {
+            "feedback_comment_id": feedback_comment_id,
+            "source": "custom",
+            "text": normalized_text,
+            "reusable_comment_id": None,
+            "save_for_reuse": save_for_reuse,
+            "include_in_feedback": include_in_feedback,
+            "created_at": normalized_created_at,
+            "module_details": {},
+        }
+    )
+    review["review_state"] = _feedback_edit_state(review["review_state"])
+    review["updated_at"] = normalized_created_at
+    _write_review(context, review)
+    return AddedFeedbackComment(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        standard_id=normalized_standard_id,
+        feedback_comment_id=feedback_comment_id,
+        include_in_feedback=include_in_feedback,
+        save_for_reuse=save_for_reuse,
+        saved_reusable_comment=saved_reusable,
+        created_at=normalized_created_at,
+    )
+
+
+def select_reusable_feedback_comment(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    standard_id: str,
+    comment_set_id: str,
+    comment_id: str,
+    include_in_feedback: bool,
+    created_at: datetime | str | None = None,
+) -> SelectedReusableFeedbackComment:
+    """Copy a reusable Focus Standard comment into the student review record."""
+    normalized_standard_id = _normalize_required_string(standard_id, "standard_id")
+    normalized_comment_set_id = _normalize_required_string(
+        comment_set_id, "comment_set_id"
+    )
+    normalized_comment_id = _normalize_required_string(comment_id, "comment_id")
+    if not isinstance(include_in_feedback, bool):
+        raise ReviewFeedbackError("include_in_feedback must be a boolean.")
+    normalized_created_at = _normalize_timestamp(created_at)
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    assignment = context["assignment"]
+    _validate_focus_standard(assignment, normalized_standard_id)
+    review = _load_existing_review(context)
+    _guard_returned_without_full_review(review)
+    rating_value = _current_rating_value(review, normalized_standard_id)
+    try:
+        comment_set = load_comment_set(
+            focus_standard_comment_set_path(
+                context["workspace_root"], normalized_comment_set_id
+            )
+        )
+    except (OSError, FocusStandardCommentError) as error:
+        raise ReviewFeedbackError(str(error)) from error
+    matches = lookup_comments(
+        context["workspace_root"],
+        standards_profile_id=assignment["standards_profile_id"],
+        writing_type=assignment["writing_type"],
+        standard_id=normalized_standard_id,
+        rating_value=rating_value,
+        comment_set_id=normalized_comment_set_id,
+    )
+    match = next(
+        (
+            item
+            for item in matches
+            if item.comment_id == normalized_comment_id
+            and item.comment_set_id == comment_set["comment_set_id"]
+        ),
+        None,
+    )
+    if match is None:
+        raise ReviewFeedbackError(
+            "Reusable Focus Standard comment is not compatible with this "
+            "assignment, standard, and rating."
+        )
+    feedback = _ensure_standard_feedback(review, normalized_standard_id)
+    feedback_comment_id = _next_feedback_comment_id(review)
+    feedback["comments"].append(
+        {
+            "feedback_comment_id": feedback_comment_id,
+            "source": "reusable_focus_standard_comment",
+            "text": match.text,
+            "reusable_comment_id": normalized_comment_id,
+            "save_for_reuse": False,
+            "include_in_feedback": include_in_feedback,
+            "created_at": normalized_created_at,
+            "module_details": {"comment_set_id": normalized_comment_set_id},
+        }
+    )
+    review["review_state"] = _feedback_edit_state(review["review_state"])
+    review["updated_at"] = normalized_created_at
+    _write_review(context, review)
+    try:
+        increment_usage(
+            context["workspace_root"],
+            comment_set_id=normalized_comment_set_id,
+            comment_id=normalized_comment_id,
+            used_at=normalized_created_at,
+        )
+    except FocusStandardCommentError as error:
+        raise ReviewFeedbackError(str(error)) from error
+    return SelectedReusableFeedbackComment(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        standard_id=normalized_standard_id,
+        feedback_comment_id=feedback_comment_id,
+        comment_set_id=normalized_comment_set_id,
+        reusable_comment_id=normalized_comment_id,
+        include_in_feedback=include_in_feedback,
+        created_at=normalized_created_at,
+    )
+
+
+def mark_feedback_composed(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    updated_at: datetime | str | None = None,
+) -> CompletedFeedbackComposition:
+    """Explicitly mark Focus Standard feedback composition complete."""
+    normalized_updated_at = _normalize_timestamp(updated_at)
+    context = _load_context(workspace_root, class_id, assignment_id, student_id)
+    review = _load_existing_review(context)
+    _guard_returned_without_full_review(review)
+    focus_standard_ids = set(context["assignment"]["focus_standard_ids"])
+    standards_with_feedback = {
+        item["standard_id"]
+        for item in review["feedback"]["standard_feedback"]
+        if item["standard_id"] in focus_standard_ids
+    }
+    included_comment_count = sum(
+        1
+        for item in review["feedback"]["standard_feedback"]
+        for comment in item["comments"]
+        if comment["include_in_feedback"]
+    )
+    review["review_state"] = "feedback_composed"
+    review["updated_at"] = normalized_updated_at
+    _write_review(context, review)
+    return CompletedFeedbackComposition(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        review_state=review["review_state"],
+        focus_standard_count=len(focus_standard_ids),
+        standard_feedback_count=len(standards_with_feedback),
+        missing_standard_feedback_count=max(
+            len(focus_standard_ids) - len(standards_with_feedback), 0
+        ),
+        included_comment_count=included_comment_count,
+        updated_at=normalized_updated_at,
+    )
+
+
+def _load_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> dict[str, Any]:
+    try:
+        resolved_root = Path(workspace_root).resolve(strict=False)
+        manifest_path = submission_manifest_path(
+            resolved_root, class_id, assignment_id, student_id
+        )
+        record_path = review_record_path(
+            resolved_root, class_id, assignment_id, student_id
+        )
+        assignment_path = assignment_config_path(resolved_root, class_id, assignment_id)
+    except (
+        OSError,
+        RuntimeError,
+        SubmissionManifestPathError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewFeedbackError(str(error)) from error
+    if not manifest_path.exists():
+        raise ReviewFeedbackError(missing_submission_guidance())
+    if not record_path.exists():
+        raise ReviewFeedbackError(
+            "A review record must exist before composing feedback."
+        )
+    try:
+        manifest = load_submission_manifest(manifest_path)
+        assignment = load_assignment_config(assignment_path)
+    except (OSError, SubmissionManifestError, AssignmentConfigError) as error:
+        raise ReviewFeedbackError(str(error)) from error
+    _validate_identity(
+        manifest,
+        record_name="Submission manifest",
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+    if class_id not in assignment["class_ids"]:
+        raise ReviewFeedbackError(
+            f"Assignment config class_ids does not include {class_id!r}."
+        )
+    if assignment["assignment_id"] != assignment_id:
+        raise ReviewFeedbackError(
+            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
+        )
+    return {
+        "workspace_root": resolved_root,
+        "manifest_path": manifest_path,
+        "record_path": record_path,
+        "assignment": assignment,
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
+
+
+def _load_existing_review(context: dict[str, Any]) -> dict[str, Any]:
+    try:
+        review = load_review_record(context["record_path"])
+    except (OSError, ReviewRecordError) as error:
+        raise ReviewFeedbackError(f"Could not load review record: {error}") from error
+    _validate_identity(
+        review,
+        record_name="Review record",
+        class_id=context["class_id"],
+        assignment_id=context["assignment_id"],
+        student_id=context["student_id"],
+    )
+    return copy.deepcopy(review)
+
+
+def _write_review(context: dict[str, Any], review: dict[str, Any]) -> None:
+    try:
+        validate_review_record(review)
+        write_review_record(context["record_path"], review, overwrite=True)
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        ReviewRecordError,
+        ReviewRecordPathError,
+    ) as error:
+        raise ReviewFeedbackError(f"Could not write review record: {error}") from error
+
+
+def _guard_returned_without_full_review(review: dict[str, Any]) -> None:
+    if review["review_state"] == "returned_without_full_review":
+        raise ReviewFeedbackError(
+            "This submission was returned without full standards review. "
+            "Change the minimum-requirements outcome before continuing with "
+            "Focus Standard feedback."
+        )
+
+
+def _validate_focus_standard(assignment: dict[str, Any], standard_id: str) -> None:
+    if standard_id not in assignment["focus_standard_ids"]:
+        raise ReviewFeedbackError(
+            f"standard_id {standard_id!r} is not a Focus Standard for this assignment."
+        )
+
+
+def _validate_observation_ids_for_standard(
+    review: dict[str, Any], standard_id: str, observation_ids: list[str]
+) -> None:
+    if not isinstance(observation_ids, list):
+        raise ReviewFeedbackError("included_observation_ids must be a list.")
+    observations_by_id = {
+        observation["observation_id"]: observation
+        for unit in review["review_units"]
+        for observation in unit["standard_observations"]
+    }
+    seen: set[str] = set()
+    for observation_id in observation_ids:
+        normalized_id = _normalize_required_string(observation_id, "observation_id")
+        if normalized_id in seen:
+            raise ReviewFeedbackError(
+                f"included_observation_ids contains duplicate {normalized_id!r}."
+            )
+        seen.add(normalized_id)
+        observation = observations_by_id.get(normalized_id)
+        if observation is None:
+            raise ReviewFeedbackError(
+                f"included_observation_ids references unknown observation_id {normalized_id!r}."
+            )
+        if observation["standard_id"] != standard_id:
+            raise ReviewFeedbackError(
+                f"observation_id {normalized_id!r} does not belong to standard_id {standard_id!r}."
+            )
+
+
+def _ensure_standard_feedback(
+    review: dict[str, Any], standard_id: str
+) -> dict[str, Any]:
+    feedback = _standard_feedback_record(review, standard_id)
+    if feedback is None:
+        feedback = _empty_standard_feedback(standard_id)
+        review["feedback"]["standard_feedback"].append(feedback)
+    return feedback
+
+
+def _standard_feedback_record(
+    review: dict[str, Any], standard_id: str
+) -> dict[str, Any] | None:
+    return next(
+        (
+            item
+            for item in review["feedback"]["standard_feedback"]
+            if item["standard_id"] == standard_id
+        ),
+        None,
+    )
+
+
+def _empty_standard_feedback(standard_id: str) -> dict[str, Any]:
+    return {
+        "standard_id": standard_id,
+        "include_overall_rating": True,
+        "include_overall_rationale": True,
+        "included_observation_ids": [],
+        "comments": [],
+        "module_details": {},
+    }
+
+
+def _next_feedback_comment_id(review: dict[str, Any]) -> str:
+    existing_ids = {
+        comment["feedback_comment_id"]
+        for item in review["feedback"]["standard_feedback"]
+        for comment in item["comments"]
+    }
+    highest = max(
+        (
+            int(match.group(1))
+            for comment_id in existing_ids
+            if (match := _SEQUENTIAL_FEEDBACK_COMMENT_ID.fullmatch(comment_id))
+        ),
+        default=0,
+    )
+    candidate_number = highest + 1
+    while True:
+        candidate = f"feedback_comment_{candidate_number:04d}"
+        if candidate not in existing_ids:
+            return candidate
+        candidate_number += 1
+
+
+def _feedback_comment_id_exists(review: dict[str, Any], comment_id: str) -> bool:
+    return any(
+        comment["feedback_comment_id"] == comment_id
+        for item in review["feedback"]["standard_feedback"]
+        for comment in item["comments"]
+    )
+
+
+def _current_rating_value(review: dict[str, Any], standard_id: str) -> int | None:
+    rating = next(
+        (
+            item
+            for item in review["overall_standard_ratings"]
+            if item["standard_id"] == standard_id
+        ),
+        None,
+    )
+    return rating["rating"] if rating is not None else None
+
+
+def _saved_comment_source(
+    context: dict[str, Any], *, feedback_comment_id: str, saved_at: str
+) -> dict[str, Any]:
+    return {
+        "type": "teacher_saved_from_feedback",
+        "class_id": context["class_id"],
+        "assignment_id": context["assignment_id"],
+        "student_id": context["student_id"],
+        "review_path": _workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        "feedback_comment_id": feedback_comment_id,
+        "saved_at": saved_at,
+    }
+
+
+def _feedback_edit_state(current_state: str) -> str:
+    if current_state in {"feedback_composed", "ready_for_export", "exported"}:
+        return "ratings_complete"
+    return current_state
+
+
+def _normalize_required_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewFeedbackError(f"{field} must be a non-empty string.")
+    return value.strip()
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ReviewFeedbackError("timestamp datetime must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise ReviewFeedbackError(
+            "timestamp must be a timezone-aware datetime or ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ReviewFeedbackError(
+            "timestamp must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewFeedbackError(
+            "timestamp must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    *,
+    record_name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    for field, expected in {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }.items():
+        actual = record[field]
+        if actual != expected:
+            raise ReviewFeedbackError(
+                f"{record_name} {field} is {actual!r}, expected {expected!r}."
+            )
+
+
+def _workspace_relative_path(
+    path: Path,
+    workspace_root: Path,
+    description: str,
+) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewFeedbackError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -35,7 +35,11 @@ from quillan.cli_app.output import (
     print_exported_standards_summary,
     print_completed_overall_standard_ratings,
     print_completed_review_unit_observations,
+    print_added_feedback_comment,
     print_opened_submission_review,
+    print_completed_feedback_composition,
+    print_selected_reusable_feedback_comment,
+    print_updated_standard_feedback_options,
     print_updated_overall_standard_rating,
     print_updated_review_unit_observation,
     print_updated_review_units,
@@ -48,6 +52,7 @@ from quillan.feedback_export import (
     export_student_feedback,
     feedback_export_path,
 )
+from quillan.focus_standard_comments import FocusStandardCommentError, lookup_comments
 from quillan.standards_summary_export import (
     StandardsSummaryExportError,
     export_standards_summary,
@@ -68,6 +73,14 @@ from quillan.review_ratings import (
     summarize_focus_standard_observations,
 )
 from quillan.review_comments import ReviewCommentError, add_review_comment
+from quillan.review_feedback import (
+    ReviewFeedbackError,
+    add_custom_feedback_comment,
+    mark_feedback_composed,
+    select_reusable_feedback_comment,
+    set_standard_feedback_options,
+    summarize_standard_feedback,
+)
 from quillan.review_record import (
     ALLOWED_TAG_POLARITIES,
     ReviewRecordError,
@@ -434,18 +447,19 @@ def _launch_selected_student_review(
         print("3. Review minimum requirements")
         print("4. Review units and Focus Standard observations")
         print("5. Overall Focus Standard ratings")
-        print("6. Manage submission pages")
-        print("7. Add teacher note")
-        print("8. Update submission review state")
-        print("9. Export student feedback")
-        print("10. Refresh summary")
-        print("11. Back")
+        print("6. Compose Focus Standard feedback")
+        print("7. Manage submission pages")
+        print("8. Add teacher note")
+        print("9. Update submission review state")
+        print("10. Export student feedback")
+        print("11. Refresh summary")
+        print("12. Back")
         print()
 
         choice = input("Select an option: ").strip()
         print()
 
-        if choice in {"", "11"}:
+        if choice in {"", "12"}:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -485,6 +499,13 @@ def _launch_selected_student_review(
                 student_id,
             )
         elif choice == "6":
+            _menu_compose_focus_standard_feedback(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+            )
+        elif choice == "7":
             _menu_manage_submission_pages(
                 workspace_root,
                 class_id,
@@ -492,7 +513,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "7":
+        elif choice == "8":
             _menu_add_review_note(
                 workspace_root,
                 class_id,
@@ -500,7 +521,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "8":
+        elif choice == "9":
             _menu_update_submission_review_state(
                 workspace_root,
                 class_id,
@@ -508,7 +529,7 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "9":
+        elif choice == "10":
             _menu_export_student_feedback(
                 workspace_root,
                 class_id,
@@ -516,10 +537,10 @@ def _launch_selected_student_review(
                 student_id,
             )
             input("Press Enter to continue...")
-        elif choice == "10":
+        elif choice == "11":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 11.")
+            print("Invalid selection. Please enter a number from 1 to 12.")
             input("Press Enter to continue...")
 
 
@@ -2779,6 +2800,397 @@ def _menu_overall_focus_standard_ratings(
             input("Press Enter to continue...")
 
 
+def _menu_compose_focus_standard_feedback(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    while True:
+        _print_review_action_header(
+            "Compose Focus Standard Feedback",
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        assignment = _load_assignment_for_review(
+            workspace_root, class_id, assignment_id
+        )
+        if assignment is None:
+            input("Press Enter to continue...")
+            return
+        record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+        _print_feedback_composer_status(
+            workspace_root, class_id, assignment_id, student_id, assignment, record
+        )
+        print()
+        print("1. Configure rating/rationale/observation inclusion")
+        print("2. Add custom Focus Standard comment")
+        print("3. Select reusable Focus Standard comment")
+        print("4. Mark feedback composed")
+        print("5. Back")
+        print()
+        choice = input("Select an option: ").strip()
+        print()
+        if choice in {"", "5"}:
+            return
+        if choice == "1":
+            _menu_configure_standard_feedback_options(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+            input("Press Enter to continue...")
+        elif choice == "2":
+            _menu_add_custom_focus_standard_feedback_comment(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+            input("Press Enter to continue...")
+        elif choice == "3":
+            _menu_select_reusable_focus_standard_feedback_comment(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+            input("Press Enter to continue...")
+        elif choice == "4":
+            _menu_mark_feedback_composed(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+            input("Press Enter to continue...")
+        else:
+            print("Invalid selection. Please enter a number from 1 to 5.")
+            input("Press Enter to continue...")
+
+
+def _print_feedback_composer_status(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+    record: dict[str, Any] | None,
+) -> None:
+    if record is None:
+        print("Review record state: not_started")
+        print("Focus Standards configured: 0")
+        print("Standards with feedback records: 0")
+        print("Included comments: 0")
+        print("Ratings complete: no")
+        return
+    try:
+        summaries = summarize_standard_feedback(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewFeedbackError as error:
+        print(f"Error: could not summarize feedback: {error}")
+        return
+    included_comments = sum(summary.included_comment_count for summary in summaries)
+    records = sum(1 for summary in summaries if summary.has_feedback_record)
+    print(f"Review record state: {record['review_state']}")
+    print(f"Focus Standards configured: {len(assignment['focus_standard_ids'])}")
+    print(f"Standards with feedback records: {records}")
+    print(f"Included comments: {included_comments}")
+    print(
+        "Ratings complete: "
+        f"{_format_yes_no(record['review_state'] in {'ratings_complete', 'feedback_composed'})}"
+    )
+    if record["review_state"] == "returned_without_full_review":
+        print(
+            "This submission was returned without full standards review. "
+            "Change the minimum-requirements outcome before composing feedback."
+        )
+
+
+def _menu_configure_standard_feedback_options(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is None:
+        print("A review record must exist before composing feedback.")
+        return
+    if record["review_state"] == "returned_without_full_review":
+        _print_returned_feedback_guard()
+        return
+    standard_id = _prompt_focus_standard_with_feedback_status(
+        workspace_root, assignment["focus_standard_ids"], record
+    )
+    if standard_id is None:
+        print("Feedback options update canceled.")
+        return
+    _print_current_rating_and_rationale(record, standard_id)
+    observations = _feedback_candidate_observations(record, standard_id)
+    if observations:
+        print()
+        print("Review-unit observations marked for feedback:")
+        for index, observation in enumerate(observations, start=1):
+            print(
+                f"{index}. {observation['unit_label']}: "
+                f"{observation.get('rationale') or 'no rationale'}"
+            )
+    else:
+        print()
+        print("No review-unit observations are currently marked for feedback.")
+    include_rating = _prompt_yes_no_default_yes("Include overall rating?")
+    include_rationale = _prompt_yes_no_default_yes("Include overall rationale?")
+    included_observation_ids = _prompt_observation_id_selection(observations)
+    print()
+    print("Save these Focus Standard feedback options?")
+    print(f"Standard: {standard_id}")
+    print(f"Include overall rating: {_format_yes_no(include_rating)}")
+    print(f"Include overall rationale: {_format_yes_no(include_rationale)}")
+    print(f"Included observations: {len(included_observation_ids)}")
+    print()
+    print("1. Save options")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Feedback options update canceled.")
+        return
+    try:
+        updated = set_standard_feedback_options(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            standard_id=standard_id,
+            include_overall_rating=include_rating,
+            include_overall_rationale=include_rationale,
+            included_observation_ids=included_observation_ids,
+        )
+    except ReviewFeedbackError as error:
+        print(f"Error: could not update Focus Standard feedback options: {error}")
+        return
+    print_updated_standard_feedback_options(updated)
+
+
+def _menu_add_custom_focus_standard_feedback_comment(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is None:
+        print("A review record must exist before composing feedback.")
+        return
+    if record["review_state"] == "returned_without_full_review":
+        _print_returned_feedback_guard()
+        return
+    standard_id = _prompt_focus_standard_with_feedback_status(
+        workspace_root, assignment["focus_standard_ids"], record
+    )
+    if standard_id is None:
+        print("Custom feedback comment canceled.")
+        return
+    _print_current_rating_and_rationale(record, standard_id)
+    _print_existing_standard_feedback_comments(record, standard_id)
+    print()
+    text = input("Feedback comment text:\n").strip()
+    if not text:
+        print("Custom feedback comment canceled.")
+        return
+    include_in_feedback = _prompt_yes_no_default_yes("Include this comment in feedback?")
+    save_for_reuse = _prompt_yes_no_default_no(
+        "Save a reusable Focus Standard comment from this text?"
+    )
+    reusable_label = None
+    reusable_text = None
+    purpose = "general"
+    rating_values = None
+    if save_for_reuse:
+        print()
+        print(
+            "Privacy reminder: remove student-specific details before saving "
+            "reusable Focus Standard comments."
+        )
+        reusable_label = input("Reusable comment label: ").strip()
+        if not reusable_label:
+            print("Custom feedback comment canceled.")
+            return
+        reusable_text = input("Reusable comment text:\n").strip() or text
+        purpose = _prompt_reusable_comment_purpose()
+        rating = _current_overall_rating(record, standard_id)
+        if rating is not None and _prompt_yes_no_default_yes(
+            f"Tag reusable comment with current rating {rating}?"
+        ):
+            rating_values = [rating]
+        else:
+            rating_values = []
+    print()
+    print("Save this Focus Standard feedback comment?")
+    print(f"Standard: {standard_id}")
+    print(f"Include in feedback: {_format_yes_no(include_in_feedback)}")
+    print(f"Save for reuse: {_format_yes_no(save_for_reuse)}")
+    print()
+    print("1. Save comment")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Custom feedback comment canceled.")
+        return
+    try:
+        added = add_custom_feedback_comment(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            standard_id=standard_id,
+            text=text,
+            include_in_feedback=include_in_feedback,
+            save_for_reuse=save_for_reuse,
+            reusable_label=reusable_label,
+            reusable_text=reusable_text,
+            purpose=purpose,
+            rating_values=rating_values,
+        )
+    except ReviewFeedbackError as error:
+        print(f"Error: could not add Focus Standard feedback comment: {error}")
+        return
+    print_added_feedback_comment(added)
+
+
+def _menu_select_reusable_focus_standard_feedback_comment(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is None:
+        print("A review record must exist before composing feedback.")
+        return
+    if record["review_state"] == "returned_without_full_review":
+        _print_returned_feedback_guard()
+        return
+    standard_id = _prompt_focus_standard_with_feedback_status(
+        workspace_root, assignment["focus_standard_ids"], record
+    )
+    if standard_id is None:
+        print("Reusable feedback comment selection canceled.")
+        return
+    rating_value = _current_overall_rating(record, standard_id)
+    try:
+        matches = lookup_comments(
+            workspace_root,
+            standards_profile_id=assignment["standards_profile_id"],
+            writing_type=assignment["writing_type"],
+            standard_id=standard_id,
+            rating_value=rating_value,
+        )
+    except FocusStandardCommentError as error:
+        print(f"Error: could not load reusable Focus Standard comments: {error}")
+        return
+    if not matches:
+        print("No reusable Focus Standard comments match this assignment and standard.")
+        if _prompt_yes_no_default_no("Add a custom Focus Standard comment instead?"):
+            _menu_add_custom_focus_standard_feedback_comment(
+                workspace_root, class_id, assignment_id, student_id, assignment
+            )
+        return
+    print("Reusable Focus Standard comments:")
+    for index, comment in enumerate(matches, start=1):
+        print(f"{index}. {comment.label} [{comment.comment_set_id}]")
+        print(f"   {_preview_text(comment.text)}")
+    print("B. Back")
+    print()
+    selection = input("Select reusable comment: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        print("Reusable feedback comment selection canceled.")
+        return
+    if not selection.isdigit() or not (1 <= int(selection) <= len(matches)):
+        print("Invalid reusable Focus Standard comment selection.")
+        return
+    selected = matches[int(selection) - 1]
+    print()
+    print(selected.text)
+    include_in_feedback = _prompt_yes_no_default_yes("Include this comment in feedback?")
+    print()
+    print("Copy this reusable Focus Standard comment into the review record?")
+    print("1. Copy comment")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Reusable feedback comment selection canceled.")
+        return
+    try:
+        result = select_reusable_feedback_comment(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            standard_id=standard_id,
+            comment_set_id=selected.comment_set_id,
+            comment_id=selected.comment_id,
+            include_in_feedback=include_in_feedback,
+        )
+    except ReviewFeedbackError as error:
+        print(f"Error: could not select reusable Focus Standard comment: {error}")
+        return
+    print_selected_reusable_feedback_comment(result)
+
+
+def _menu_mark_feedback_composed(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+) -> None:
+    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    if record is None:
+        print("A review record must exist before marking feedback composed.")
+        return
+    if record["review_state"] == "returned_without_full_review":
+        _print_returned_feedback_guard()
+        return
+    focus_standard_count = len(assignment["focus_standard_ids"])
+    feedback_records = {
+        item["standard_id"]
+        for item in record["feedback"]["standard_feedback"]
+        if item["standard_id"] in assignment["focus_standard_ids"]
+    }
+    included_comments = sum(
+        1
+        for item in record["feedback"]["standard_feedback"]
+        for comment in item["comments"]
+        if comment["include_in_feedback"]
+    )
+    ratings = {
+        rating["standard_id"]
+        for rating in record["overall_standard_ratings"]
+        if rating["standard_id"] in assignment["focus_standard_ids"]
+    }
+    print(f"Focus Standards: {focus_standard_count}")
+    print(f"Standards with feedback records: {len(feedback_records)}")
+    print(f"Included comments: {included_comments}")
+    if record["review_state"] != "ratings_complete":
+        print("Warning: ratings are not marked complete.")
+    if len(ratings) < focus_standard_count:
+        print("Warning: some Focus Standards do not have overall ratings.")
+    if len(feedback_records) < focus_standard_count:
+        print("Warning: some Focus Standards do not have feedback records.")
+    if included_comments == 0:
+        print("Warning: no feedback comments are included.")
+    print()
+    print("1. Mark feedback composed")
+    print("2. Back")
+    print()
+    if input("Select an option: ").strip() != "1":
+        print("Feedback composition was not changed.")
+        return
+    try:
+        completed = mark_feedback_composed(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewFeedbackError as error:
+        print(f"Error: could not mark feedback composed: {error}")
+        return
+    print_completed_feedback_composition(completed)
+
+
 def _print_overall_rating_status(
     assignment: dict[str, Any],
     record: dict[str, Any] | None,
@@ -2975,6 +3387,187 @@ def _prompt_focus_standard_with_rating_status(
         return selection
     print("Invalid Focus Standard selection.")
     return None
+
+
+def _prompt_focus_standard_with_feedback_status(
+    workspace_root: Path,
+    focus_standard_ids: list[str],
+    record: dict[str, Any],
+) -> str | None:
+    ratings = {
+        rating["standard_id"]: rating
+        for rating in record["overall_standard_ratings"]
+        if rating["standard_id"] in focus_standard_ids
+    }
+    feedback = {
+        item["standard_id"]: item
+        for item in record["feedback"]["standard_feedback"]
+        if item["standard_id"] in focus_standard_ids
+    }
+    print("Focus Standards:")
+    for index, standard_id in enumerate(focus_standard_ids, start=1):
+        rating_status = "rating recorded" if standard_id in ratings else "no rating"
+        feedback_record = feedback.get(standard_id)
+        comment_count = len(feedback_record["comments"]) if feedback_record else 0
+        included_count = (
+            sum(
+                1
+                for comment in feedback_record["comments"]
+                if comment["include_in_feedback"]
+            )
+            if feedback_record
+            else 0
+        )
+        record_status = "feedback record exists" if feedback_record else "no feedback record"
+        print(
+            f"{index}. {_format_standard_display(workspace_root, standard_id)} "
+            f"({rating_status}; {record_status}; comments {comment_count}; "
+            f"included {included_count})"
+        )
+    print("B. Back")
+    print()
+    selection = input("Select Focus Standard: ").strip()
+    if selection == "" or selection.casefold() == "b":
+        return None
+    if selection.isdigit() and 1 <= int(selection) <= len(focus_standard_ids):
+        return focus_standard_ids[int(selection) - 1]
+    if selection in focus_standard_ids:
+        return selection
+    print("Invalid Focus Standard selection.")
+    return None
+
+
+def _print_current_rating_and_rationale(record: dict[str, Any], standard_id: str) -> None:
+    rating = next(
+        (
+            item
+            for item in record["overall_standard_ratings"]
+            if item["standard_id"] == standard_id
+        ),
+        None,
+    )
+    print()
+    print(f"Selected Focus Standard: {standard_id}")
+    if rating is None:
+        print("Overall rating: not recorded")
+        print(
+            "Rating/rationale inclusion will have no effect until an overall "
+            "rating exists."
+        )
+        return
+    print(f"Overall rating: {rating['rating']}")
+    print(f"Overall rationale: {rating['rationale'] or 'none'}")
+
+
+def _feedback_candidate_observations(
+    record: dict[str, Any], standard_id: str
+) -> list[dict[str, Any]]:
+    observations: list[dict[str, Any]] = []
+    for unit in record["review_units"]:
+        for observation in unit["standard_observations"]:
+            if observation["standard_id"] != standard_id:
+                continue
+            if not observation["include_in_feedback"]:
+                continue
+            item = dict(observation)
+            item["unit_id"] = unit["unit_id"]
+            item["unit_label"] = unit["label"]
+            observations.append(item)
+    return observations
+
+
+def _prompt_observation_id_selection(observations: list[dict[str, Any]]) -> list[str]:
+    if not observations:
+        return []
+    raw = input(
+        "Select observations to include by number, comma-separated "
+        "(blank for none): "
+    ).strip()
+    if not raw:
+        return []
+    selected: list[str] = []
+    for part in raw.split(","):
+        text = part.strip()
+        if not text.isdigit() or not (1 <= int(text) <= len(observations)):
+            print(f"Ignoring invalid observation selection: {text}")
+            continue
+        observation_id = observations[int(text) - 1]["observation_id"]
+        if observation_id not in selected:
+            selected.append(observation_id)
+    return selected
+
+
+def _print_existing_standard_feedback_comments(
+    record: dict[str, Any], standard_id: str
+) -> None:
+    feedback = next(
+        (
+            item
+            for item in record["feedback"]["standard_feedback"]
+            if item["standard_id"] == standard_id
+        ),
+        None,
+    )
+    if feedback is None or not feedback["comments"]:
+        print("Existing feedback comments: none")
+        return
+    print("Existing feedback comments:")
+    for comment in feedback["comments"]:
+        print(
+            f"- {comment['feedback_comment_id']}: "
+            f"{_preview_text(comment['text'])} "
+            f"(include: {_format_yes_no(comment['include_in_feedback'])})"
+        )
+
+
+def _prompt_reusable_comment_purpose() -> str:
+    purposes = [
+        "praise",
+        "next_step",
+        "clarification",
+        "evidence",
+        "reasoning",
+        "organization",
+        "style",
+        "conventions",
+        "revision",
+        "general",
+    ]
+    print("Reusable comment purpose:")
+    for index, purpose in enumerate(purposes, start=1):
+        print(f"{index}. {purpose}")
+    selection = input("Select purpose (default general): ").strip()
+    if selection.isdigit() and 1 <= int(selection) <= len(purposes):
+        return purposes[int(selection) - 1]
+    if selection in purposes:
+        return selection
+    return "general"
+
+
+def _current_overall_rating(record: dict[str, Any], standard_id: str) -> int | None:
+    rating = next(
+        (
+            item
+            for item in record["overall_standard_ratings"]
+            if item["standard_id"] == standard_id
+        ),
+        None,
+    )
+    return rating["rating"] if rating is not None else None
+
+
+def _print_returned_feedback_guard() -> None:
+    print(
+        "This submission was returned without full standards review. "
+        "Change the minimum-requirements outcome before composing full feedback."
+    )
+
+
+def _preview_text(value: str, *, limit: int = 96) -> str:
+    text = " ".join(value.split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3].rstrip()}..."
 
 
 def _print_focus_standard_observation_summary(

--- a/quillan/review_snapshot.py
+++ b/quillan/review_snapshot.py
@@ -151,14 +151,37 @@ def _append_feedback(lines: list[str], record: dict[str, Any]) -> None:
         return
     for item in standard_feedback:
         lines.append(f"- {item['standard_id']}")
+        lines.append(
+            "  Include overall rating: "
+            f"{'yes' if item['include_overall_rating'] else 'no'}"
+        )
+        lines.append(
+            "  Include overall rationale: "
+            f"{'yes' if item['include_overall_rationale'] else 'no'}"
+        )
+        lines.append(
+            "  Included observations: "
+            f"{len(item['included_observation_ids'])}"
+        )
         comments = _record_list(item, "comments")
+        included_comment_count = sum(
+            1 for comment in comments if comment["include_in_feedback"]
+        )
+        lines.append(f"  Comments: {len(comments)}")
+        lines.append(f"  Included comments: {included_comment_count}")
         if not comments:
             lines.append("  No comments recorded.")
             continue
         for comment in comments:
             include = "yes" if comment["include_in_feedback"] else "no"
-            lines.append(f"  - Include in feedback: {include}")
-            lines.append(f"    Feedback: {comment['text']}")
+            source = (
+                "reusable Focus Standard comment"
+                if comment["source"] == "reusable_focus_standard_comment"
+                else "custom"
+            )
+            lines.append(f"  - Source: {source}")
+            lines.append(f"    Include in feedback: {include}")
+            lines.append(f"    Feedback: {_preview(comment['text'])}")
     lines.append("")
 
 
@@ -185,3 +208,10 @@ def _format_evidence_present(value: Any) -> str:
     if value is None:
         return "not applicable"
     return "yes" if value is True else "no"
+
+
+def _preview(value: str, *, limit: int = 120) -> str:
+    text = " ".join(value.split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3].rstrip()}..."

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -501,3 +501,88 @@ def test_source_comment_bank_is_not_read(tmp_path: Path) -> None:
     assert "Existing selected language." in result.feedback_path.read_text(
         encoding="utf-8"
     )
+
+
+def test_export_respects_composed_feedback_options_and_selected_observations(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    review = _review()
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "synthetic:W.A",
+            "rating": 3,
+            "rationale": "Hidden rationale.",
+            "include_in_feedback": True,
+            "updated_at": review["updated_at"],
+            "module_details": {},
+        }
+    ]
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [
+                {
+                    "observation_id": "observation_0001",
+                    "standard_id": "synthetic:W.A",
+                    "applicable": True,
+                    "evidence_present": True,
+                    "rating": None,
+                    "rationale": "Selected observation.",
+                    "include_in_feedback": True,
+                    "updated_at": review["updated_at"],
+                    "module_details": {},
+                }
+            ],
+            "module_details": {},
+        }
+    ]
+    review["feedback"]["include_review_unit_observations"] = True
+    review["feedback"]["standard_feedback"] = [
+        {
+            "standard_id": "synthetic:W.A",
+            "include_overall_rating": True,
+            "include_overall_rationale": False,
+            "included_observation_ids": ["observation_0001"],
+            "comments": [
+                {
+                    "feedback_comment_id": "feedback_comment_0001",
+                    "source": "reusable_focus_standard_comment",
+                    "text": "Reusable snapshot text.",
+                    "reusable_comment_id": "claim_next_step",
+                    "save_for_reuse": False,
+                    "include_in_feedback": True,
+                    "created_at": review["created_at"],
+                    "module_details": {
+                        "comment_set_id": "synthetic_argument_focus_comments"
+                    },
+                },
+                {
+                    "feedback_comment_id": "feedback_comment_0002",
+                    "source": "custom",
+                    "text": "Excluded custom text.",
+                    "reusable_comment_id": None,
+                    "save_for_reuse": False,
+                    "include_in_feedback": False,
+                    "created_at": review["created_at"],
+                    "module_details": {},
+                },
+            ],
+            "module_details": {},
+        }
+    ]
+    _write_review(tmp_path, review)
+
+    result = export_student_feedback(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+    text = result.feedback_path.read_text(encoding="utf-8")
+
+    assert "- synthetic:W.A: 3" in text
+    assert "Hidden rationale." not in text
+    assert "Reusable snapshot text." in text
+    assert "Excluded custom text." not in text
+    assert "Selected observation." in text

--- a/tests/test_focus_standard_comments.py
+++ b/tests/test_focus_standard_comments.py
@@ -1,0 +1,188 @@
+"""Tests for reusable Focus Standard comment runtime support."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.focus_standard_comments import (
+    FocusStandardCommentError,
+    append_saved_comment,
+    focus_standard_comment_set_path,
+    load_comment_set,
+    lookup_comments,
+    validate_comment_set,
+)
+
+TIMESTAMP = "2026-07-02T00:00:00+00:00"
+
+
+def _comment_set() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "focus_standard_comment_set",
+        "comment_set_id": "synthetic_argument_focus_comments",
+        "title": "Synthetic Argument Focus Comments",
+        "description": "Reusable teacher-authored Focus Standard comments.",
+        "standards_profile_id": "synthetic_profile",
+        "writing_types": ["argument"],
+        "grade_band": None,
+        "comments": [
+            {
+                "comment_id": "claim_next_step",
+                "standard_id": "njsls-ela:W.1",
+                "writing_types": ["argument"],
+                "rating_values": [1],
+                "label": "Develop claim explanation",
+                "text": "Explain how your evidence supports the claim.",
+                "purpose": "next_step",
+                "student_facing": True,
+                "active": True,
+                "created_at": TIMESTAMP,
+                "updated_at": TIMESTAMP,
+                "source": {
+                    "type": "manual",
+                    "class_id": None,
+                    "assignment_id": None,
+                    "student_id": None,
+                    "review_path": None,
+                    "feedback_comment_id": None,
+                    "saved_at": TIMESTAMP,
+                },
+                "usage": {"times_used": 0, "last_used_at": None},
+                "module_details": {},
+            }
+        ],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def test_valid_comment_set_loads(tmp_path: Path) -> None:
+    path = focus_standard_comment_set_path(tmp_path, "synthetic_argument_focus_comments")
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(_comment_set()), encoding="utf-8")
+
+    loaded = load_comment_set(path)
+
+    assert loaded["comment_set_id"] == "synthetic_argument_focus_comments"
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("schema", "schema_version"),
+        ("module", "module"),
+        ("record_type", "record_type"),
+        ("duplicate", "Duplicate comment_id"),
+        ("purpose", "purpose"),
+        ("source", "source.type"),
+        ("usage", "times_used"),
+    ],
+)
+def test_invalid_comment_sets_are_rejected(mutation: str, message: str) -> None:
+    data = _comment_set()
+    if mutation == "schema":
+        data["schema_version"] = "2"
+    elif mutation == "module":
+        data["module"] = "other"
+    elif mutation == "record_type":
+        data["record_type"] = "comment_bank"
+    elif mutation == "duplicate":
+        data["comments"].append(copy.deepcopy(data["comments"][0]))
+    elif mutation == "purpose":
+        data["comments"][0]["purpose"] = "score"
+    elif mutation == "source":
+        data["comments"][0]["source"]["type"] = "generated"
+    elif mutation == "usage":
+        data["comments"][0]["usage"]["times_used"] = -1
+
+    with pytest.raises(FocusStandardCommentError, match=message):
+        validate_comment_set(data)
+
+
+def test_path_helper_uses_focus_standard_comments_not_legacy_comment_banks(
+    tmp_path: Path,
+) -> None:
+    path = focus_standard_comment_set_path(tmp_path, "synthetic_argument_focus_comments")
+
+    assert path == tmp_path / "shared" / "focus_standard_comments" / (
+        "synthetic_argument_focus_comments.json"
+    )
+    assert "comment_banks" not in path.parts
+
+
+def test_lookup_filters_standard_writing_type_rating_active_and_student_facing(
+    tmp_path: Path,
+) -> None:
+    data = _comment_set()
+    hidden_wrong_standard = copy.deepcopy(data["comments"][0])
+    hidden_wrong_standard["comment_id"] = "wrong_standard"
+    hidden_wrong_standard["standard_id"] = "njsls-ela:L.2"
+    hidden_wrong_type = copy.deepcopy(data["comments"][0])
+    hidden_wrong_type["comment_id"] = "wrong_type"
+    hidden_wrong_type["writing_types"] = ["narrative"]
+    hidden_wrong_rating = copy.deepcopy(data["comments"][0])
+    hidden_wrong_rating["comment_id"] = "wrong_rating"
+    hidden_wrong_rating["rating_values"] = [2]
+    inactive = copy.deepcopy(data["comments"][0])
+    inactive["comment_id"] = "inactive"
+    inactive["active"] = False
+    teacher_only = copy.deepcopy(data["comments"][0])
+    teacher_only["comment_id"] = "teacher_only"
+    teacher_only["student_facing"] = False
+    data["comments"].extend(
+        [hidden_wrong_standard, hidden_wrong_type, hidden_wrong_rating, inactive, teacher_only]
+    )
+    path = focus_standard_comment_set_path(tmp_path, data["comment_set_id"])
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    matches = lookup_comments(
+        tmp_path,
+        standards_profile_id="synthetic_profile",
+        writing_type="argument",
+        standard_id="njsls-ela:W.1",
+        rating_value=1,
+    )
+
+    assert [match.comment_id for match in matches] == ["claim_next_step"]
+
+
+def test_saving_reusable_comment_creates_default_set_with_teacher_text(
+    tmp_path: Path,
+) -> None:
+    saved = append_saved_comment(
+        tmp_path,
+        standards_profile_id="synthetic_profile",
+        writing_type="argument",
+        standard_id="njsls-ela:W.1",
+        label="Reusable next step",
+        text="Teacher-approved reusable text.",
+        purpose="next_step",
+        rating_values=[1],
+        source={
+            "type": "teacher_saved_from_feedback",
+            "class_id": "english12_p3_synthetic",
+            "assignment_id": "essay_01_synthetic",
+            "student_id": "00107",
+            "review_path": (
+                "classes/english12_p3_synthetic/assignments/essay_01_synthetic/"
+                "submissions/00107/review.json"
+            ),
+            "feedback_comment_id": "feedback_comment_0001",
+            "saved_at": TIMESTAMP,
+        },
+        created_at=TIMESTAMP,
+    )
+
+    loaded = load_comment_set(saved.path)
+    assert saved.comment_set_id == "synthetic_profile_argument_focus_comments"
+    assert loaded["comments"][0]["source"]["type"] == "teacher_saved_from_feedback"
+    assert loaded["comments"][0]["text"] == "Teacher-approved reusable text."

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -57,11 +57,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["11"] + _exit_assignment_review_actions_to_main()
+    return ["12"] + _exit_assignment_review_actions_to_main()
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "11"] + _exit_assignment_review_actions_to_main()
+    return ["", "12"] + _exit_assignment_review_actions_to_main()
 
 
 def _write_workspace(root: Path) -> None:
@@ -318,7 +318,8 @@ def test_selected_student_review_menu_includes_feedback_export(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Selected Student Review" in output
-    assert "9. Export student feedback" in output
+    assert "6. Compose Focus Standard feedback" in output
+    assert "10. Export student feedback" in output
 
 
 def test_menu_export_student_feedback_creates_feedback_file(
@@ -358,7 +359,7 @@ def test_menu_export_student_feedback_creates_feedback_file(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "1"]
+        + ["10", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -460,7 +461,7 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "2"]
+        + ["10", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -491,7 +492,7 @@ def test_menu_export_feedback_reports_missing_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "1"]
+        + ["10", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -525,7 +526,7 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "1", "1"]
+        + ["10", "1", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -559,7 +560,7 @@ def test_menu_export_feedback_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "1", "2"]
+        + ["10", "1", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -160,11 +160,11 @@ def _enter_selected_student() -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["11", "6", "", "3", "6"]
+    return ["12", "6", "", "3", "6"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "11", "6", "", "3", "6"]
+    return ["", "12", "6", "", "3", "6"]
 
 
 @pytest.fixture
@@ -190,12 +190,13 @@ def test_review_menu_selected_student_excludes_legacy_review_entry_actions(
     assert "3. Review minimum requirements" in output
     assert "4. Review units and Focus Standard observations" in output
     assert "5. Overall Focus Standard ratings" in output
-    assert "6. Manage submission pages" in output
-    assert "7. Add teacher note" in output
-    assert "8. Update submission review state" in output
-    assert "9. Export student feedback" in output
-    assert "10. Refresh summary" in output
-    assert "11. Back" in output
+    assert "6. Compose Focus Standard feedback" in output
+    assert "7. Manage submission pages" in output
+    assert "8. Add teacher note" in output
+    assert "9. Update submission review state" in output
+    assert "10. Export student feedback" in output
+    assert "11. Refresh summary" in output
+    assert "12. Back" in output
     assert "Add structured tag" not in output
     assert "Select reusable comment" not in output
     assert "Set criterion score" not in output
@@ -297,7 +298,7 @@ def test_review_menu_blank_note_cancels_without_review_record(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["7", ""]
+        + ["8", ""]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -315,7 +316,7 @@ def test_review_menu_updates_submission_review_state(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["8", "in_progress", "1"]
+        + ["9", "in_progress", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -273,7 +273,7 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "11", "6", "", "3", "6"])
+    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "12", "6", "", "3", "6"])
 
     assert main(["menu"]) == 0
 
@@ -318,7 +318,7 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "11", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "12", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -351,7 +351,7 @@ def test_review_menu_defines_review_units(
             "1",
             "",
             "4",
-            "11",
+            "12",
             "6",
             "",
             "3",
@@ -408,7 +408,7 @@ def test_review_menu_records_applicable_focus_standard_observation(
             "1",
             "",
             "4",
-            "11",
+            "12",
             "6",
             "",
             "3",
@@ -471,7 +471,7 @@ def test_review_menu_marks_observations_complete(
             "1",
             "",
             "4",
-            "11",
+            "12",
             "6",
             "",
             "3",
@@ -540,7 +540,7 @@ def test_review_menu_records_and_completes_overall_focus_standard_rating(
             "1",
             "",
             "4",
-            "11",
+            "12",
             "6",
             "",
             "3",
@@ -611,7 +611,7 @@ def test_review_menu_blocks_observations_for_returned_without_full_review(
             "1",
             "",
             "4",
-            "11",
+            "12",
             "6",
             "",
             "3",
@@ -689,7 +689,7 @@ def test_review_menu_views_current_review_details_read_only(
 
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "2", "", "11", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "2", "", "12", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -747,7 +747,7 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "", "11", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "", "12", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -803,7 +803,7 @@ def test_review_menu_multi_page_open_submission_selects_one_page(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "2", "", "11", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "2", "", "12", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -865,7 +865,7 @@ def test_review_menu_multi_page_open_submission_opens_all_pages(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "A", "", "11", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "A", "", "12", "6", "", "3", "6"],
     )
 
     assert main(["menu"]) == 0
@@ -910,10 +910,10 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "1",
             "1",
             "1",
-            "7",
+            "8",
             "This is a test note.",
             "",
-            "11",
+            "12",
             "6",
             "",
             "3",
@@ -953,11 +953,11 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "1",
-            "8",
+            "9",
             "in_progress",
             "1",
             "",
-            "11",
+            "12",
             "6",
             "",
             "3",
@@ -975,6 +975,54 @@ def test_review_menu_updates_submission_review_state(
     )
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["submission_state"] == "in_progress"
+
+
+def test_review_menu_adds_custom_focus_standard_feedback_comment(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review = _review_record()
+    review["feedback"]["standard_feedback"] = []
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        [
+            "2",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "6",
+            "2",
+            "1",
+            "Focused feedback text.",
+            "",
+            "n",
+            "1",
+            "",
+            "5",
+            "12",
+            "6",
+            "",
+            "3",
+            "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Compose Focus Standard Feedback" in output
+    assert "Added Focus Standard feedback comment:" in output
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    comment = review["feedback"]["standard_feedback"][0]["comments"][0]
+    assert comment["source"] == "custom"
+    assert comment["text"] == "Focused feedback text."
+    assert comment["include_in_feedback"] is True
+    assert not {"comments", "scores", "tags", "notes"} & review.keys()
 
 
 def test_review_menu_excludes_submission_page_without_touching_review_record(
@@ -1005,12 +1053,12 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
             "1",
             "1",
             "1",
-            "6",
+            "7",
             "1",
             "1",
             "1",
             "",
-            "11",
+            "12",
             "6",
             "",
             "3",

--- a/tests/test_review_feedback.py
+++ b/tests/test_review_feedback.py
@@ -1,0 +1,365 @@
+"""Tests for Focus Standard feedback composition helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.focus_standard_comments import (
+    focus_standard_comment_set_path,
+    load_comment_set,
+)
+from quillan.review_feedback import (
+    ReviewFeedbackError,
+    add_custom_feedback_comment,
+    mark_feedback_composed,
+    select_reusable_feedback_comment,
+    set_standard_feedback_options,
+)
+from quillan.review_record_paths import review_record_path
+from tests.test_review_ratings import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    FIRST_TIMESTAMP,
+    ORIGINAL_TIMESTAMP,
+    SECOND_TIMESTAMP,
+    STUDENT_ID,
+    _review_record,
+    _write_workspace,
+)
+
+
+def _read_review(root: Path) -> dict[str, Any]:
+    return json.loads(
+        review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def _fresh_review() -> dict[str, Any]:
+    review = _review_record()
+    review["feedback"]["standard_feedback"] = []
+    review["feedback"]["include_review_unit_observations"] = False
+    return review
+
+
+def _write_fresh_workspace(root: Path) -> None:
+    _write_workspace(root, _fresh_review())
+
+
+def _write_comment_set(root: Path) -> None:
+    path = focus_standard_comment_set_path(root, "synthetic_argument_focus_comments")
+    path.parent.mkdir(parents=True)
+    data = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "focus_standard_comment_set",
+        "comment_set_id": "synthetic_argument_focus_comments",
+        "title": "Synthetic Argument Focus Comments",
+        "description": "Reusable teacher-authored Focus Standard comments.",
+        "standards_profile_id": "synthetic_profile",
+        "writing_types": ["argument"],
+        "grade_band": None,
+        "comments": [
+            {
+                "comment_id": "claim_next_step",
+                "standard_id": "njsls-ela:W.1",
+                "writing_types": ["argument"],
+                "rating_values": [2],
+                "label": "Explain evidence",
+                "text": "Explain why this evidence supports your claim.",
+                "purpose": "next_step",
+                "student_facing": True,
+                "active": True,
+                "created_at": ORIGINAL_TIMESTAMP,
+                "updated_at": ORIGINAL_TIMESTAMP,
+                "source": {
+                    "type": "manual",
+                    "class_id": None,
+                    "assignment_id": None,
+                    "student_id": None,
+                    "review_path": None,
+                    "feedback_comment_id": None,
+                    "saved_at": ORIGINAL_TIMESTAMP,
+                },
+                "usage": {"times_used": 0, "last_used_at": None},
+                "module_details": {},
+            }
+        ],
+        "created_at": ORIGINAL_TIMESTAMP,
+        "updated_at": ORIGINAL_TIMESTAMP,
+        "module_details": {},
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_setting_standard_feedback_options_creates_record(tmp_path: Path) -> None:
+    _write_fresh_workspace(tmp_path)
+
+    result = set_standard_feedback_options(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        include_overall_rating=True,
+        include_overall_rationale=False,
+        included_observation_ids=["observation_0001"],
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    review = _read_review(tmp_path)
+    feedback = review["feedback"]["standard_feedback"][0]
+    assert result.was_created is True
+    assert feedback["standard_id"] == "njsls-ela:W.1"
+    assert feedback["include_overall_rating"] is True
+    assert feedback["include_overall_rationale"] is False
+    assert feedback["included_observation_ids"] == ["observation_0001"]
+    assert review["feedback"]["include_review_unit_observations"] is True
+
+
+def test_setting_standard_feedback_options_preserves_existing_comments(
+    tmp_path: Path,
+) -> None:
+    review = _review_record()
+    review["feedback"]["standard_feedback"] = [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "include_overall_rating": True,
+            "include_overall_rationale": True,
+            "included_observation_ids": [],
+            "comments": [
+                {
+                    "feedback_comment_id": "feedback_comment_0001",
+                    "source": "custom",
+                    "text": "Existing comment.",
+                    "reusable_comment_id": None,
+                    "save_for_reuse": False,
+                    "include_in_feedback": True,
+                    "created_at": ORIGINAL_TIMESTAMP,
+                    "module_details": {},
+                }
+            ],
+            "module_details": {},
+        }
+    ]
+    _write_workspace(tmp_path, review)
+
+    set_standard_feedback_options(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        include_overall_rating=False,
+        include_overall_rationale=False,
+        included_observation_ids=[],
+        updated_at=FIRST_TIMESTAMP,
+    )
+
+    comments = _read_review(tmp_path)["feedback"]["standard_feedback"][0]["comments"]
+    assert comments[0]["text"] == "Existing comment."
+
+
+@pytest.mark.parametrize(
+    ("standard_id", "observation_ids", "message"),
+    [
+        ("missing:standard", [], "not a Focus Standard"),
+        ("njsls-ela:W.1", ["missing"], "unknown observation_id"),
+        ("njsls-ela:W.1", ["observation_0002"], "does not belong"),
+    ],
+)
+def test_feedback_options_validate_standard_and_observations(
+    tmp_path: Path, standard_id: str, observation_ids: list[str], message: str
+) -> None:
+    _write_fresh_workspace(tmp_path)
+
+    with pytest.raises(ReviewFeedbackError, match=message):
+        set_standard_feedback_options(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            standard_id=standard_id,
+            include_overall_rating=True,
+            include_overall_rationale=True,
+            included_observation_ids=observation_ids,
+            updated_at=FIRST_TIMESTAMP,
+        )
+
+
+def test_returned_without_full_review_rejects_feedback_composition(
+    tmp_path: Path,
+) -> None:
+    review = _review_record()
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Return and revise.",
+        "updated_at": ORIGINAL_TIMESTAMP,
+    }
+    _write_workspace(tmp_path, review)
+
+    with pytest.raises(ReviewFeedbackError, match="returned without full"):
+        add_custom_feedback_comment(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            standard_id="njsls-ela:W.1",
+            text="Student-facing text.",
+            include_in_feedback=True,
+            save_for_reuse=False,
+            created_at=FIRST_TIMESTAMP,
+        )
+
+
+def test_custom_comments_are_sequential_and_can_be_excluded(tmp_path: Path) -> None:
+    _write_fresh_workspace(tmp_path)
+
+    first = add_custom_feedback_comment(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        text="Included custom comment.",
+        include_in_feedback=True,
+        save_for_reuse=False,
+        created_at=FIRST_TIMESTAMP,
+    )
+    second = add_custom_feedback_comment(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        text="Excluded custom comment.",
+        include_in_feedback=False,
+        save_for_reuse=False,
+        created_at=SECOND_TIMESTAMP,
+    )
+
+    comments = _read_review(tmp_path)["feedback"]["standard_feedback"][0]["comments"]
+    assert first.feedback_comment_id == "feedback_comment_0001"
+    assert second.feedback_comment_id == "feedback_comment_0002"
+    assert [comment["include_in_feedback"] for comment in comments] == [True, False]
+    assert not (tmp_path / "shared" / "focus_standard_comments").exists()
+
+
+def test_custom_comment_can_be_saved_for_reuse_with_approved_text(
+    tmp_path: Path,
+) -> None:
+    review = _fresh_review()
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "rating": 2,
+            "rationale": "Clear claim.",
+            "include_in_feedback": True,
+            "updated_at": ORIGINAL_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    _write_workspace(tmp_path, review)
+
+    result = add_custom_feedback_comment(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        text="Student-specific custom text.",
+        include_in_feedback=True,
+        save_for_reuse=True,
+        reusable_label="General claim next step",
+        reusable_text="Reusable teacher-approved text.",
+        purpose="next_step",
+        created_at=FIRST_TIMESTAMP,
+    )
+
+    assert result.saved_reusable_comment is not None
+    saved = load_comment_set(result.saved_reusable_comment.path)
+    assert saved["comments"][0]["text"] == "Reusable teacher-approved text."
+    assert saved["comments"][0]["rating_values"] == [2]
+    assert _read_review(tmp_path)["feedback"]["standard_feedback"][0]["comments"][0][
+        "text"
+    ] == "Student-specific custom text."
+
+
+def test_selected_reusable_comment_is_snapshotted_and_usage_updates(
+    tmp_path: Path,
+) -> None:
+    review = _fresh_review()
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "njsls-ela:W.1",
+            "rating": 2,
+            "rationale": "Clear claim.",
+            "include_in_feedback": True,
+            "updated_at": ORIGINAL_TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    _write_workspace(tmp_path, review)
+    _write_comment_set(tmp_path)
+
+    result = select_reusable_feedback_comment(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        comment_set_id="synthetic_argument_focus_comments",
+        comment_id="claim_next_step",
+        include_in_feedback=True,
+        created_at=FIRST_TIMESTAMP,
+    )
+
+    comment = _read_review(tmp_path)["feedback"]["standard_feedback"][0]["comments"][0]
+    assert result.feedback_comment_id == "feedback_comment_0001"
+    assert comment["source"] == "reusable_focus_standard_comment"
+    assert comment["text"] == "Explain why this evidence supports your claim."
+    loaded = load_comment_set(
+        focus_standard_comment_set_path(tmp_path, "synthetic_argument_focus_comments")
+    )
+    loaded["comments"][0]["text"] = "Changed later."
+    assert comment["text"] != loaded["comments"][0]["text"]
+    assert loaded["comments"][0]["usage"]["times_used"] == 1
+
+
+def test_mark_feedback_composed_is_explicit(tmp_path: Path) -> None:
+    _write_fresh_workspace(tmp_path)
+    add_custom_feedback_comment(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        standard_id="njsls-ela:W.1",
+        text="Included custom comment.",
+        include_in_feedback=True,
+        save_for_reuse=False,
+        created_at=FIRST_TIMESTAMP,
+    )
+
+    before = _read_review(tmp_path)
+    assert before["review_state"] == "observations_complete"
+    completed = mark_feedback_composed(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        updated_at=SECOND_TIMESTAMP,
+    )
+
+    after = _read_review(tmp_path)
+    assert completed.review_state == "feedback_composed"
+    assert after["review_state"] == "feedback_composed"
+    assert not {"comments", "scores", "tags", "notes"} & after.keys()
+    assert after["overall_standard_ratings"] == before["overall_standard_ratings"]
+    assert after["review_units"] == before["review_units"]

--- a/tests/test_review_snapshot.py
+++ b/tests/test_review_snapshot.py
@@ -73,13 +73,15 @@ def _review() -> dict[str, Any]:
             "comments": [
                 {
                     "feedback_comment_id": "feedback_comment_0001",
-                    "source": "custom",
+                    "source": "reusable_focus_standard_comment",
                     "text": "The evidence is relevant, but explain the connection.",
-                    "reusable_comment_id": None,
+                    "reusable_comment_id": "evidence_next_step",
                     "save_for_reuse": False,
                     "include_in_feedback": True,
                     "created_at": TIMESTAMP,
-                    "module_details": {},
+                    "module_details": {
+                        "comment_set_id": "synthetic_argument_focus_comments"
+                    },
                 }
             ],
             "module_details": {},
@@ -125,6 +127,12 @@ def test_current_review_details_formats_saved_artifacts(tmp_path: Path) -> None:
         "include in feedback: yes"
     ) in text
     assert "rating not recorded" not in text
+    assert "Include overall rating: yes" in text
+    assert "Include overall rationale: yes" in text
+    assert "Included observations: 1" in text
+    assert "Comments: 1" in text
+    assert "Included comments: 1" in text
+    assert "Source: reusable Focus Standard comment" in text
     assert "Include in feedback: yes" in text
     assert "synthetic:W.A: 3" in text
     assert "Needs conference about missing counterargument." in text


### PR DESCRIPTION
## Summary

Implements the Focus Standard feedback composer for Quillan’s v0.8.6 standards-based review workflow.

Teachers can now compose student-facing feedback by Focus Standard after overall ratings have been recorded.

## Changes

* Adds `quillan/focus_standard_comments.py` for reusable Focus Standard comment support:

  * comment-set pathing;
  * validation;
  * lookup;
  * save-for-reuse;
  * usage updates.
* Adds `quillan/review_feedback.py` for:

  * per-standard feedback options;
  * custom feedback comments;
  * reusable comment snapshots;
  * save-for-reuse behavior;
  * explicit `feedback_composed` state transition.
* Adds selected-student menu workflow:

  * `Compose Focus Standard feedback`
* Updates Markdown feedback export so it respects composed choices for:

  * rating inclusion;
  * rationale inclusion;
  * comments;
  * selected review-unit observations.
* Updates review snapshots with Focus Standard feedback details.
* Updates CLI output printers with Focus Standard feedback terminology.
* Adds and updates focused tests for:

  * reusable Focus Standard comments;
  * feedback helper behavior;
  * Markdown export;
  * review snapshots;
  * selected-student menu numbering and workflow.

## Behavior

The workflow lets teachers compose feedback under each Focus Standard by:

* including or excluding the overall rating;
* including or excluding the overall rationale;
* selecting review-unit observations for feedback;
* adding custom comments;
* selecting reusable Focus Standard comments;
* optionally saving a custom comment for future reuse.

Reusable comment selections are copied into `review.json` as stable snapshots. Later edits to reusable comment source files do not silently change prior student review records.

Reusable comments use the new Focus Standard comment model under `shared/focus_standard_comments`. This PR does not reactivate legacy `shared/comment_banks`.

## Verification

Targeted tests:

* `166 passed`

Full test suite:

* `1019 passed`

Changed-file Ruff:

* `All checks passed!`

## Notes

This PR does not implement polished student feedback PDF export, assignment result manifests, class summaries, standards summaries, gradebook export, parent/admin reporting, AI-generated feedback, AI comment suggestions, OCR, or migration from legacy comment banks.

Closes #229
