### PR TITLE
Implement student feedback PDF export

### DIFF
--- a/quillan/cli_app/handlers/exports.py
+++ b/quillan/cli_app/handlers/exports.py
@@ -13,9 +13,14 @@ from quillan.class_summary_export import (
 from quillan.cli_app.output import (
     print_exported_class_summary,
     print_exported_feedback,
+    print_exported_feedback_pdf,
     print_exported_standards_summary,
 )
-from quillan.feedback_export import FeedbackExportError, export_student_feedback
+from quillan.feedback_export import (
+    FeedbackExportError,
+    export_student_feedback,
+    export_student_feedback_pdf,
+)
 from quillan.standards_summary_export import (
     StandardsSummaryExportError,
     export_standards_summary,
@@ -23,9 +28,31 @@ from quillan.standards_summary_export import (
 
 
 def handle_export_feedback(args: argparse.Namespace) -> int:
-    """Export one student-facing Markdown feedback artifact."""
+    """Export one student-facing feedback artifact."""
     try:
         workspace_root = resolve_workspace_root()
+        export_format = getattr(args, "format", "markdown")
+        if export_format == "pdf":
+            exported_pdf = export_student_feedback_pdf(
+                workspace_root,
+                args.class_id,
+                args.assignment_id,
+                args.student_id,
+                overwrite=args.overwrite,
+            )
+            print_exported_feedback_pdf(exported_pdf)
+            return 0
+        if export_format == "both":
+            exported_pdf = export_student_feedback_pdf(
+                workspace_root,
+                args.class_id,
+                args.assignment_id,
+                args.student_id,
+                overwrite=args.overwrite,
+                include_markdown_companion=True,
+            )
+            print_exported_feedback_pdf(exported_pdf)
+            return 0
         exported = export_student_feedback(
             workspace_root,
             args.class_id,

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -11,7 +11,7 @@ from quillan.assignment_submission_assembly import (
 )
 from quillan.class_summary_export import ExportedClassSummary
 from quillan.evidence_filing import EvidenceFilingError, RoutedEvidenceFile
-from quillan.feedback_export import ExportedFeedback
+from quillan.feedback_export import ExportedFeedback, ExportedFeedbackPdf
 from quillan.focus_standard_comments import SavedReusableFocusStandardComment
 from quillan.review_comments import AddedReviewComment
 from quillan.review_feedback import (
@@ -292,6 +292,22 @@ def print_exported_feedback(exported: ExportedFeedback) -> None:
     print(f"Scores: {exported.score_count}")
     print(f"Overwrote existing: {format_bool(exported.overwrote_existing)}")
     print(f"Feedback file: {exported.feedback_relative_path}")
+
+
+def print_exported_feedback_pdf(exported: ExportedFeedbackPdf) -> None:
+    """Print a concise student-feedback PDF export summary."""
+    print("Exported student feedback PDF:")
+    print(f"Class: {exported.class_id}")
+    print(f"Assignment: {exported.assignment_id}")
+    print(f"Student: {exported.student_id}")
+    print(f"Student name: {exported.student_display_name}")
+    print(f"Focus Standard ratings: {exported.included_standard_rating_count}")
+    print(f"Included comments: {exported.included_comment_count}")
+    print(f"Included observations: {exported.included_observation_count}")
+    print(f"Overwrote existing: {format_bool(exported.overwrote_existing)}")
+    print(f"PDF file: {exported.feedback_pdf_relative_path}")
+    if exported.feedback_markdown_relative_path is not None:
+        print(f"Markdown file: {exported.feedback_markdown_relative_path}")
 
 
 def print_exported_class_summary(exported: ExportedClassSummary) -> None:

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -224,18 +224,23 @@ def build_parser() -> argparse.ArgumentParser:
         "export-feedback",
         help="Export student-facing feedback from one review record.",
         description=(
-            "Generate a student-facing Markdown feedback file from the "
-            "canonical review.json for one student submission. The export "
-            "includes selected feedback comments and teacher-entered criterion "
-            "scores. It does not mutate the review record, submission manifest, "
-            "evidence files, or source comment banks."
+            "Generate student-facing feedback from the canonical review.json "
+            "for one student submission. PDF export updates feedback export "
+            "metadata after a successful write; Markdown remains available for "
+            "compatibility."
         ),
     )
     _add_submission_identity_arguments(export_feedback_parser)
     export_feedback_parser.add_argument(
+        "--format",
+        choices=("markdown", "pdf", "both"),
+        default="markdown",
+        help="Feedback export format. Defaults to markdown for compatibility.",
+    )
+    export_feedback_parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="Replace an existing exports/feedback.md file.",
+        help="Replace existing feedback export files for the selected format.",
     )
     export_feedback_parser.set_defaults(handler=handle_export_feedback)
 

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -1,4 +1,4 @@
-"""Student-facing Markdown export from canonical Quillan review records."""
+"""Student-facing feedback exports from canonical Quillan review records."""
 
 from __future__ import annotations
 
@@ -10,9 +10,31 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from pds_core.classes import load_class_roster
+from pds_core.rosters import RosterError, student_display_name
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
 from quillan.assignments import AssignmentConfigError, load_assignment_config
-from quillan.review_record import ReviewRecordError, load_review_record
-from quillan.review_record_paths import ReviewRecordPathError, review_record_path
+from quillan.review_record import (
+    ReviewRecordError,
+    load_review_record,
+    validate_review_record,
+)
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
 from quillan.storage import assignment_config_path
 from quillan.submission_manifest import (
     SubmissionManifestError,
@@ -47,6 +69,43 @@ class ExportedFeedback:
     overwrote_existing: bool
 
 
+@dataclass(frozen=True, slots=True)
+class ExportedFeedbackPdf:
+    """Information about one generated student-facing PDF feedback artifact."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    student_display_name: str
+    assignment_title: str
+    review_record_path: Path
+    review_record_relative_path: str
+    feedback_pdf_path: Path
+    feedback_pdf_relative_path: str
+    feedback_markdown_path: Path | None
+    feedback_markdown_relative_path: str | None
+    included_standard_rating_count: int
+    included_comment_count: int
+    included_observation_count: int
+    created_at: str
+    overwrote_existing: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _StudentFeedback:
+    class_id: str
+    assignment_id: str
+    student_id: str
+    student_display_name: str
+    assignment_title: str
+    class_display: str
+    created_at: str
+    ratings: list[dict[str, Any]]
+    comments: list[dict[str, Any]]
+    observations: list[dict[str, Any]]
+    returned_work: dict[str, Any] | None
+
+
 def feedback_export_path(
     workspace_root: str | Path,
     class_id: str,
@@ -61,6 +120,20 @@ def feedback_export_path(
     )
 
 
+def feedback_pdf_export_path(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> Path:
+    """Return the canonical student-facing PDF feedback export path."""
+    return (
+        submission_dir(workspace_root, class_id, assignment_id, student_id)
+        / "exports"
+        / "feedback.pdf"
+    )
+
+
 def export_student_feedback(
     workspace_root: str | Path,
     class_id: str,
@@ -72,6 +145,128 @@ def export_student_feedback(
 ) -> ExportedFeedback:
     """Generate student-facing Markdown from one canonical review record."""
     normalized_created_at = _normalize_timestamp(created_at)
+    context = _load_export_context(
+        workspace_root, class_id, assignment_id, student_id, normalized_created_at
+    )
+    output_path = feedback_export_path(
+        context["workspace_root"], class_id, assignment_id, student_id
+    )
+    feedback = _assemble_student_feedback(context)
+    markdown = _render_feedback_markdown(feedback)
+    included_comments = feedback.comments
+    ratings = feedback.ratings
+    overwrote_existing = output_path.exists()
+    if overwrote_existing and not overwrite:
+        raise FeedbackExportError(
+            f"Feedback export already exists: {output_path}. "
+            "Use --overwrite to replace it."
+        )
+
+    _write_feedback(output_path, markdown, overwrite=overwrite)
+    return ExportedFeedback(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        feedback_path=output_path,
+        feedback_relative_path=_workspace_relative_path(
+            output_path, context["workspace_root"], "feedback"
+        ),
+        included_comment_count=len(included_comments),
+        score_count=len(ratings),
+        created_at=normalized_created_at,
+        overwrote_existing=overwrote_existing,
+    )
+
+
+def export_student_feedback_pdf(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    overwrite: bool = False,
+    created_at: datetime | str | None = None,
+    include_markdown_companion: bool = False,
+) -> ExportedFeedbackPdf:
+    """Generate student-facing PDF feedback from one canonical review record."""
+    normalized_created_at = _normalize_timestamp(created_at)
+    context = _load_export_context(
+        workspace_root, class_id, assignment_id, student_id, normalized_created_at
+    )
+    pdf_path = feedback_pdf_export_path(
+        context["workspace_root"], class_id, assignment_id, student_id
+    )
+    markdown_path = (
+        feedback_export_path(context["workspace_root"], class_id, assignment_id, student_id)
+        if include_markdown_companion
+        else None
+    )
+    existing_paths = [
+        path for path in (pdf_path, markdown_path) if path is not None and path.exists()
+    ]
+    overwrote_existing = bool(existing_paths)
+    if existing_paths and not overwrite:
+        joined = ", ".join(str(path) for path in existing_paths)
+        raise FeedbackExportError(
+            f"Feedback export already exists: {joined}. "
+            "Use --overwrite to replace it."
+        )
+
+    feedback = _assemble_student_feedback(context)
+    _write_feedback_pdf(pdf_path, feedback, overwrite=overwrite)
+    if markdown_path is not None:
+        _write_feedback(
+            markdown_path,
+            _render_feedback_markdown(feedback),
+            overwrite=overwrite,
+        )
+    _update_export_metadata(
+        context,
+        created_at=normalized_created_at,
+        feedback_pdf_path=pdf_path,
+        feedback_markdown_path=markdown_path,
+    )
+
+    markdown_relative_path = (
+        _workspace_relative_path(markdown_path, context["workspace_root"], "feedback")
+        if markdown_path is not None
+        else None
+    )
+    return ExportedFeedbackPdf(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        student_display_name=feedback.student_display_name,
+        assignment_title=feedback.assignment_title,
+        review_record_path=context["record_path"],
+        review_record_relative_path=_workspace_relative_path(
+            context["record_path"], context["workspace_root"], "review record"
+        ),
+        feedback_pdf_path=pdf_path,
+        feedback_pdf_relative_path=_workspace_relative_path(
+            pdf_path, context["workspace_root"], "feedback PDF"
+        ),
+        feedback_markdown_path=markdown_path,
+        feedback_markdown_relative_path=markdown_relative_path,
+        included_standard_rating_count=len(feedback.ratings),
+        included_comment_count=len(feedback.comments),
+        included_observation_count=len(feedback.observations),
+        created_at=normalized_created_at,
+        overwrote_existing=overwrote_existing,
+    )
+
+
+def _load_export_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    created_at: str,
+) -> dict[str, Any]:
     try:
         resolved_workspace_root = Path(workspace_root).resolve(strict=False)
         manifest_path = submission_manifest_path(
@@ -80,8 +275,8 @@ def export_student_feedback(
         record_path = review_record_path(
             resolved_workspace_root, class_id, assignment_id, student_id
         )
-        output_path = feedback_export_path(
-            resolved_workspace_root, class_id, assignment_id, student_id
+        assignment_path = assignment_config_path(
+            resolved_workspace_root, class_id, assignment_id
         )
     except (
         OSError,
@@ -123,61 +318,93 @@ def export_student_feedback(
         assignment_id=assignment_id,
         student_id=student_id,
     )
+    try:
+        assignment = load_assignment_config(assignment_path)
+    except (AssignmentConfigError, OSError):
+        assignment = None
+    if assignment is not None:
+        if assignment["assignment_id"] != assignment_id:
+            raise FeedbackExportError(
+                "Assignment config assignment_id is "
+                f"{assignment['assignment_id']!r}, expected {assignment_id!r}."
+            )
+        if class_id not in assignment["class_ids"]:
+            raise FeedbackExportError(
+                f"Assignment config class_ids does not include {class_id!r}."
+            )
+    return {
+        "workspace_root": resolved_workspace_root,
+        "manifest_path": manifest_path,
+        "record_path": record_path,
+        "manifest": manifest,
+        "review": review,
+        "assignment": assignment,
+        "created_at": created_at,
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }
 
+
+def _assemble_student_feedback(context: dict[str, Any]) -> _StudentFeedback:
+    review = context["review"]
+    assignment = context["assignment"]
+    class_id = context["class_id"]
+    assignment_id = context["assignment_id"]
+    student_id = context["student_id"]
     if review["review_state"] == "returned_without_full_review":
         unmet_requirements = _validated_returned_work_requirements(
-            resolved_workspace_root,
+            context["workspace_root"],
             class_id,
             assignment_id,
             review,
+            assignment=assignment,
         )
-        included_comments: list[dict[str, Any]] = []
+        returned_work = {
+            "outcome": review["minimum_requirement_outcome"],
+            "unmet_requirements": unmet_requirements,
+        }
         ratings: list[dict[str, Any]] = []
-        markdown = _render_returned_work_markdown(
-            class_id=class_id,
-            assignment_id=assignment_id,
-            student_id=student_id,
-            created_at=normalized_created_at,
-            outcome=review["minimum_requirement_outcome"],
-            unmet_requirements=unmet_requirements,
-        )
+        comments: list[dict[str, Any]] = []
+        observations: list[dict[str, Any]] = []
     else:
-        included_comments = _included_feedback_comments(review)
         ratings = _included_standard_ratings(review)
+        comments = _included_feedback_comments(review)
         observations = _included_review_unit_observations(review)
-        markdown = _render_markdown(
-            class_id=class_id,
-            assignment_id=assignment_id,
-            student_id=student_id,
-            created_at=normalized_created_at,
-            ratings=ratings,
-            comments=included_comments,
-            observations=observations,
-        )
-    overwrote_existing = output_path.exists()
-    if overwrote_existing and not overwrite:
-        raise FeedbackExportError(
-            f"Feedback export already exists: {output_path}. "
-            "Use --overwrite to replace it."
-        )
-
-    _write_feedback(output_path, markdown, overwrite=overwrite)
-    return ExportedFeedback(
+        returned_work = None
+    return _StudentFeedback(
         class_id=class_id,
         assignment_id=assignment_id,
         student_id=student_id,
-        review_record_path=record_path,
-        review_record_relative_path=_workspace_relative_path(
-            record_path, resolved_workspace_root, "review record"
-        ),
-        feedback_path=output_path,
-        feedback_relative_path=_workspace_relative_path(
-            output_path, resolved_workspace_root, "feedback"
-        ),
-        included_comment_count=len(included_comments),
-        score_count=len(ratings),
-        created_at=normalized_created_at,
-        overwrote_existing=overwrote_existing,
+        student_display_name=_student_name(context["workspace_root"], class_id, student_id),
+        assignment_title=_assignment_title(assignment, assignment_id),
+        class_display=class_id,
+        created_at=context["created_at"],
+        ratings=_with_rating_labels(ratings, assignment),
+        comments=comments,
+        observations=observations,
+        returned_work=returned_work,
+    )
+
+
+def _render_feedback_markdown(feedback: _StudentFeedback) -> str:
+    if feedback.returned_work is not None:
+        return _render_returned_work_markdown(
+            class_id=feedback.class_id,
+            assignment_id=feedback.assignment_id,
+            student_id=feedback.student_id,
+            created_at=feedback.created_at,
+            outcome=feedback.returned_work["outcome"],
+            unmet_requirements=feedback.returned_work["unmet_requirements"],
+        )
+    return _render_markdown(
+        class_id=feedback.class_id,
+        assignment_id=feedback.assignment_id,
+        student_id=feedback.student_id,
+        created_at=feedback.created_at,
+        ratings=feedback.ratings,
+        comments=feedback.comments,
+        observations=feedback.observations,
     )
 
 
@@ -281,11 +508,11 @@ def _render_returned_work_markdown(
 def _included_feedback_comments(review: dict[str, Any]) -> list[dict[str, Any]]:
     included: list[dict[str, Any]] = []
     for standard_feedback in review["feedback"]["standard_feedback"]:
-        included.extend(
-            comment
-            for comment in standard_feedback["comments"]
-            if comment["include_in_feedback"]
-        )
+        for comment in standard_feedback["comments"]:
+            if comment["include_in_feedback"]:
+                rendered = dict(comment)
+                rendered["standard_id"] = standard_feedback["standard_id"]
+                included.append(rendered)
     return included
 
 
@@ -339,6 +566,8 @@ def _validated_returned_work_requirements(
     class_id: str,
     assignment_id: str,
     review: dict[str, Any],
+    *,
+    assignment: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     outcome = review["minimum_requirement_outcome"]
     if outcome["returned_without_full_review"] is not True:
@@ -351,14 +580,15 @@ def _validated_returned_work_requirements(
             "Returned-work export requires a non-empty outcome teacher note."
         )
 
-    try:
-        assignment = load_assignment_config(
-            assignment_config_path(workspace_root, class_id, assignment_id)
-        )
-    except (AssignmentConfigError, OSError) as error:
-        raise FeedbackExportError(
-            f"Could not load assignment config: {error}"
-        ) from error
+    if assignment is None:
+        try:
+            assignment = load_assignment_config(
+                assignment_config_path(workspace_root, class_id, assignment_id)
+            )
+        except (AssignmentConfigError, OSError) as error:
+            raise FeedbackExportError(
+                f"Could not load assignment config: {error}"
+            ) from error
     configured_keys = _configured_requirement_keys(assignment)
     unmet_requirements = [
         check
@@ -371,6 +601,332 @@ def _validated_returned_work_requirements(
             "minimum requirement marked not met."
         )
     return unmet_requirements
+
+
+def _write_feedback_pdf(path: Path, feedback: _StudentFeedback, *, overwrite: bool) -> None:
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise FeedbackExportError(
+            f"Could not create feedback export directory {parent}: {error}"
+        ) from error
+    if not parent.is_dir():
+        raise FeedbackExportError(
+            f"Feedback export parent is not a directory: {parent}"
+        )
+
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=parent,
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+        _render_pdf_to_path(temporary_path, feedback)
+        if overwrite:
+            os.replace(temporary_path, path)
+        else:
+            os.link(temporary_path, path)
+            temporary_path.unlink()
+        temporary_path = None
+    except FileExistsError as error:
+        raise FeedbackExportError(
+            f"Feedback export already exists: {path}. "
+            "Use --overwrite to replace it."
+        ) from error
+    except OSError as error:
+        raise FeedbackExportError(
+            f"Could not write feedback export {path}: {error}"
+        ) from error
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _render_pdf_to_path(path: Path, feedback: _StudentFeedback) -> None:
+    styles = getSampleStyleSheet()
+    styles.add(
+        ParagraphStyle(
+            name="FeedbackTitle",
+            parent=styles["Title"],
+            fontName="Helvetica-Bold",
+            fontSize=18,
+            leading=22,
+            spaceAfter=12,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="FeedbackSection",
+            parent=styles["Heading2"],
+            fontName="Helvetica-Bold",
+            fontSize=12,
+            leading=15,
+            spaceBefore=12,
+            spaceAfter=6,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="FeedbackBody",
+            parent=styles["BodyText"],
+            fontName="Helvetica",
+            fontSize=9.5,
+            leading=13,
+            spaceAfter=5,
+        )
+    )
+    story: list[Any] = []
+    title = "Returned for Revision" if feedback.returned_work else "Student Feedback"
+    story.append(Paragraph(title, styles["FeedbackTitle"]))
+    story.append(_metadata_table(feedback, styles["FeedbackBody"]))
+    story.append(Spacer(1, 0.08 * inch))
+    if feedback.returned_work is not None:
+        _append_returned_work_pdf(story, styles, feedback)
+    else:
+        _append_standard_feedback_pdf(story, styles, feedback)
+    story.append(Spacer(1, 0.12 * inch))
+    story.append(
+        Paragraph(
+            "Quillan student feedback export",
+            styles["FeedbackBody"],
+        )
+    )
+
+    document = SimpleDocTemplate(
+        str(path),
+        pagesize=letter,
+        rightMargin=0.65 * inch,
+        leftMargin=0.65 * inch,
+        topMargin=0.6 * inch,
+        bottomMargin=0.6 * inch,
+        title=title,
+    )
+    document.build(story, onFirstPage=_draw_pdf_footer, onLaterPages=_draw_pdf_footer)
+
+
+def _metadata_table(feedback: _StudentFeedback, style: ParagraphStyle) -> Table:
+    data = [
+        ("Student", feedback.student_display_name),
+        ("Student ID", feedback.student_id),
+        ("Class", feedback.class_display),
+        ("Assignment", feedback.assignment_title),
+        ("Assignment ID", feedback.assignment_id),
+        ("Generated", feedback.created_at),
+    ]
+    table = Table(
+        [
+            [
+                Paragraph(f"<b>{_escape_pdf_text(label)}:</b>", style),
+                Paragraph(_escape_pdf_text(value), style),
+            ]
+            for label, value in data
+        ],
+        colWidths=(1.15 * inch, 5.0 * inch),
+        hAlign="LEFT",
+    )
+    table.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+                ("TOPPADDING", (0, 0), (-1, -1), 1),
+                ("TEXTCOLOR", (0, 0), (0, -1), colors.HexColor("#333333")),
+            ]
+        )
+    )
+    return table
+
+
+def _append_standard_feedback_pdf(
+    story: list[Any], styles: dict[str, ParagraphStyle], feedback: _StudentFeedback
+) -> None:
+    story.append(Paragraph("Focus Standard Ratings", styles["FeedbackSection"]))
+    if feedback.ratings:
+        for rating in feedback.ratings:
+            value = _format_number(rating["rating"])
+            label = rating.get("rating_label")
+            label_suffix = f" ({_plain_text(label)})" if label else ""
+            story.append(
+                Paragraph(
+                    "<b>"
+                    f"{_escape_pdf_text(rating['standard_id'])}</b>: "
+                    f"{_escape_pdf_text(value + label_suffix)}",
+                    styles["FeedbackBody"],
+                )
+            )
+            if rating.get("rationale"):
+                story.append(
+                    Paragraph(
+                        f"Rationale: {_escape_pdf_text(rating['rationale'])}",
+                        styles["FeedbackBody"],
+                    )
+                )
+    else:
+        story.append(Paragraph("No Focus Standard ratings selected.", styles["FeedbackBody"]))
+
+    story.append(Paragraph("Feedback Comments", styles["FeedbackSection"]))
+    if feedback.comments:
+        for comment in feedback.comments:
+            prefix = f"{comment.get('standard_id')}: " if comment.get("standard_id") else ""
+            story.append(
+                Paragraph(
+                    f"{_escape_pdf_text(prefix)}{_escape_pdf_text(comment['text'])}",
+                    styles["FeedbackBody"],
+                )
+            )
+    else:
+        story.append(Paragraph("No feedback comments selected.", styles["FeedbackBody"]))
+
+    if feedback.observations:
+        story.append(Paragraph("Review Unit Observations", styles["FeedbackSection"]))
+        for observation in feedback.observations:
+            evidence = observation.get("evidence_present")
+            evidence_text = ""
+            if evidence is True:
+                evidence_text = " Evidence present: yes."
+            elif evidence is False:
+                evidence_text = " Evidence present: no."
+            unit = observation.get("unit_label") or "Review unit"
+            text = (
+                f"{unit} - {observation['standard_id']}."
+                f"{evidence_text}"
+            )
+            if observation.get("rationale"):
+                text += f" {_plain_text(observation['rationale'])}"
+            story.append(Paragraph(_escape_pdf_text(text), styles["FeedbackBody"]))
+
+
+def _append_returned_work_pdf(
+    story: list[Any], styles: dict[str, ParagraphStyle], feedback: _StudentFeedback
+) -> None:
+    assert feedback.returned_work is not None
+    story.append(
+        Paragraph(
+            "This submission was returned without full standards review because "
+            "minimum requirements were not met.",
+            styles["FeedbackBody"],
+        )
+    )
+    story.append(Paragraph("Minimum Requirements Not Met", styles["FeedbackSection"]))
+    for requirement in feedback.returned_work["unmet_requirements"]:
+        story.append(
+            Paragraph(
+                f"<b>{_escape_pdf_text(requirement['label'])}</b>",
+                styles["FeedbackBody"],
+            )
+        )
+        story.append(
+            Paragraph(
+                f"Expected: {_escape_pdf_text(requirement['expected'])}",
+                styles["FeedbackBody"],
+            )
+        )
+        if note := _non_empty(requirement.get("teacher_note")):
+            story.append(
+                Paragraph(f"Teacher note: {_escape_pdf_text(note)}", styles["FeedbackBody"])
+            )
+    story.append(Paragraph("Return Note", styles["FeedbackSection"]))
+    story.append(
+        Paragraph(
+            _escape_pdf_text(feedback.returned_work["outcome"]["teacher_note"]),
+            styles["FeedbackBody"],
+        )
+    )
+    story.append(
+        Paragraph(
+            "No full Focus Standard ratings were completed for this submission.",
+            styles["FeedbackBody"],
+        )
+    )
+
+
+def _draw_pdf_footer(canvas: Any, document: Any) -> None:
+    canvas.saveState()
+    canvas.setFont("Helvetica", 8)
+    canvas.setFillColor(colors.HexColor("#555555"))
+    canvas.drawString(0.65 * inch, 0.35 * inch, "Quillan student feedback export")
+    canvas.drawRightString(
+        letter[0] - 0.65 * inch,
+        0.35 * inch,
+        f"Page {document.page}",
+    )
+    canvas.restoreState()
+
+
+def _update_export_metadata(
+    context: dict[str, Any],
+    *,
+    created_at: str,
+    feedback_pdf_path: Path,
+    feedback_markdown_path: Path | None,
+) -> None:
+    review = dict(context["review"])
+    review["exports"] = dict(review["exports"])
+    review["exports"]["feedback_pdf"] = {
+        "path": _workspace_relative_path(
+            feedback_pdf_path, context["workspace_root"], "feedback PDF"
+        ),
+        "generated_at": created_at,
+        "source_review_updated_at": context["review"]["updated_at"],
+        "module_details": {},
+    }
+    if feedback_markdown_path is not None:
+        review["exports"]["feedback_markdown"] = {
+            "path": _workspace_relative_path(
+                feedback_markdown_path, context["workspace_root"], "feedback Markdown"
+            ),
+            "generated_at": created_at,
+            "source_review_updated_at": context["review"]["updated_at"],
+            "module_details": {},
+        }
+    try:
+        validate_review_record(review)
+        write_review_record(context["record_path"], review, overwrite=True)
+    except (ReviewRecordError, ReviewRecordPathError, OSError, ValueError) as error:
+        raise FeedbackExportError(f"Could not update review export metadata: {error}") from error
+
+
+def _student_name(workspace_root: Path, class_id: str, student_id: str) -> str:
+    try:
+        roster = load_class_roster(workspace_root, class_id)
+    except (RosterError, OSError):
+        return student_id
+    for student in roster.students:
+        if student.student_id == student_id:
+            return student_display_name(student)
+    return student_id
+
+
+def _assignment_title(assignment: dict[str, Any] | None, assignment_id: str) -> str:
+    if assignment is None:
+        return assignment_id
+    return _plain_text(assignment["title"])
+
+
+def _with_rating_labels(
+    ratings: list[dict[str, Any]], assignment: dict[str, Any] | None
+) -> list[dict[str, Any]]:
+    if assignment is None:
+        return ratings
+    labels = {
+        level["value"]: level["label"]
+        for level in assignment["rating_scale"]["levels"]
+    }
+    rendered: list[dict[str, Any]] = []
+    for rating in ratings:
+        item = dict(rating)
+        if item["rating"] in labels:
+            item["rating_label"] = labels[item["rating"]]
+        rendered.append(item)
+    return rendered
 
 
 def _configured_requirement_keys(assignment: dict[str, Any]) -> set[str]:
@@ -492,6 +1048,15 @@ def _validate_identity(
 
 def _plain_text(value: object) -> str:
     return re.sub(r"\s+", " ", str(value)).strip()
+
+
+def _escape_pdf_text(value: object) -> str:
+    text = _plain_text(value)
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
 
 
 def _non_empty(value: Any) -> str | None:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -32,6 +32,7 @@ from quillan.cli_app.output import (
     print_assignment_submission_status,
     print_exported_class_summary,
     print_exported_feedback,
+    print_exported_feedback_pdf,
     print_exported_standards_summary,
     print_completed_overall_standard_ratings,
     print_completed_review_unit_observations,
@@ -50,7 +51,9 @@ from quillan.comment_banks import CommentBankError, load_comment_bank
 from quillan.feedback_export import (
     FeedbackExportError,
     export_student_feedback,
+    export_student_feedback_pdf,
     feedback_export_path,
+    feedback_pdf_export_path,
 )
 from quillan.focus_standard_comments import FocusStandardCommentError, lookup_comments
 from quillan.standards_summary_export import (
@@ -4362,16 +4365,46 @@ def _menu_export_student_feedback(
     print(f"Comments included in feedback: {counts['included_comments']}")
     print(f"Overall ratings: {counts['ratings']}")
     print()
-    print("1. Export feedback")
-    print("2. Back")
+    try:
+        record = load_review_record(
+            review_record_path(workspace_root, class_id, assignment_id, student_id)
+        )
+    except (ReviewRecordError, OSError):
+        record = None
+    if record is not None:
+        print(f"Current review state: {record['review_state']}")
+        if record["review_state"] == "returned_without_full_review":
+            print("This will export returned-work feedback.")
+        elif record["review_state"] not in {
+            "feedback_composed",
+            "ready_for_export",
+            "exported",
+        }:
+            print("Warning: feedback is not marked composed yet.")
+        print()
+    print("1. Export PDF feedback")
+    print("2. Export Markdown feedback")
+    print("3. Export both PDF and Markdown")
+    print("4. Back")
     print()
-    if input("Select an option: ").strip() != "1":
+    selection = input("Select an option: ").strip()
+    if selection not in {"1", "2", "3"}:
         print("Export canceled.")
         return
 
-    output_path = feedback_export_path(workspace_root, class_id, assignment_id, student_id)
+    pdf_path = feedback_pdf_export_path(workspace_root, class_id, assignment_id, student_id)
+    markdown_path = feedback_export_path(workspace_root, class_id, assignment_id, student_id)
+    selected_paths = {
+        "1": [pdf_path],
+        "2": [markdown_path],
+        "3": [pdf_path, markdown_path],
+    }[selection]
+    print("Output files:")
+    for path in selected_paths:
+        print(f"- {path}")
     overwrite: bool
-    if output_path.exists():
+    existing_paths = [path for path in selected_paths if path.exists()]
+    if existing_paths:
         print()
         print("A feedback export already exists.")
         print()
@@ -4389,17 +4422,37 @@ def _menu_export_student_feedback(
         overwrite = False
 
     try:
-        exported = export_student_feedback(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-            overwrite=overwrite,
-        )
+        if selection == "1":
+            exported_pdf = export_student_feedback_pdf(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                overwrite=overwrite,
+            )
+            print_exported_feedback_pdf(exported_pdf)
+        elif selection == "2":
+            exported = export_student_feedback(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                overwrite=overwrite,
+            )
+            print_exported_feedback(exported)
+        else:
+            exported_pdf = export_student_feedback_pdf(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                overwrite=overwrite,
+                include_markdown_companion=True,
+            )
+            print_exported_feedback_pdf(exported_pdf)
     except (FeedbackExportError, OSError) as error:
         print(f"Error: could not export student feedback: {error}")
         return
-    print_exported_feedback(exported)
 
 
 def _menu_export_class_summary(

--- a/tests/test_cli_feedback_export.py
+++ b/tests/test_cli_feedback_export.py
@@ -8,7 +8,7 @@ import pytest
 
 from quillan.cli import main
 import quillan.cli_app.handlers.exports as cli_exports
-from quillan.feedback_export import feedback_export_path
+from quillan.feedback_export import feedback_export_path, feedback_pdf_export_path
 from tests.test_review_scores import _write_manifest, _write_review
 from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID, _review
 
@@ -102,6 +102,35 @@ def test_cli_missing_review_returns_one(
         ["export-feedback", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
     ) == 1
     assert "Review record does not exist" in capsys.readouterr().out
+
+
+def test_cli_exports_pdf_feedback_and_prints_pdf_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path)
+    _write_review(tmp_path, _review("feedback_composed"))
+    monkeypatch.setattr(cli_exports, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        [
+            "export-feedback",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--format",
+            "pdf",
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Exported student feedback PDF:" in output
+    assert "Focus Standard ratings:" in output
+    assert "PDF file:" in output
+    assert feedback_pdf_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).is_file()
 
 
 def test_cli_overwrite_flag_controls_replacement(

--- a/tests/test_feedback_pdf_export.py
+++ b/tests/test_feedback_pdf_export.py
@@ -1,0 +1,343 @@
+"""Tests for student-facing PDF feedback export."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pypdf import PdfReader
+
+import quillan.feedback_export as feedback_export
+from quillan.feedback_export import (
+    ExportedFeedbackPdf,
+    FeedbackExportError,
+    export_student_feedback_pdf,
+    feedback_export_path,
+    feedback_pdf_export_path,
+)
+from quillan.review_record_paths import review_record_path
+from tests.test_feedback_export import TIMESTAMP, _write_assignment
+from tests.test_review_scores import _write_manifest, _write_review
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID, _review
+
+
+def _pdf_text(path: Path) -> str:
+    reader = PdfReader(str(path))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+def _write_roster(root: Path) -> None:
+    class_dir = root / "classes" / CLASS_ID
+    class_dir.mkdir(parents=True, exist_ok=True)
+    (class_dir / "roster.csv").write_text(
+        "class_id,student_id,last_name,first_name,period\n"
+        f"{CLASS_ID},{STUDENT_ID},Rivera,Avery,3\n",
+        encoding="utf-8",
+    )
+
+
+def _write_assignment_with_rating_labels(root: Path) -> None:
+    _write_assignment(root)
+    path = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment = json.loads(path.read_text(encoding="utf-8"))
+    assignment["rating_scale"]["levels"].append(
+        {"value": 3, "label": "Meeting", "description": "Meets expectations."}
+    )
+    path.write_text(json.dumps(assignment), encoding="utf-8")
+
+
+def _feedback_ready_review() -> dict[str, Any]:
+    review = _review("feedback_composed")
+    review["private_notes"].append(
+        {
+            "private_note_id": "private_note_0001",
+            "text": "PRIVATE TEACHER NOTE",
+            "created_at": review["created_at"],
+            "updated_at": review["updated_at"],
+            "module_details": {},
+        }
+    )
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "synthetic:W.A",
+            "rating": 3,
+            "rationale": "Uses evidence clearly.",
+            "include_in_feedback": True,
+            "updated_at": review["updated_at"],
+            "module_details": {"debug": "rating metadata"},
+        }
+    ]
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [
+                {
+                    "observation_id": "observation_0001",
+                    "standard_id": "synthetic:W.A",
+                    "applicable": True,
+                    "evidence_present": True,
+                    "rating": None,
+                    "rationale": "Selected observation.",
+                    "include_in_feedback": True,
+                    "updated_at": review["updated_at"],
+                    "module_details": {},
+                }
+            ],
+            "module_details": {},
+        }
+    ]
+    review["feedback"]["include_review_unit_observations"] = True
+    review["feedback"]["standard_feedback"] = [
+        {
+            "standard_id": "synthetic:W.A",
+            "include_overall_rating": True,
+            "include_overall_rationale": True,
+            "included_observation_ids": ["observation_0001"],
+            "comments": [
+                {
+                    "feedback_comment_id": "feedback_comment_0001",
+                    "source": "reusable_focus_standard_comment",
+                    "text": "Student-facing comment.",
+                    "reusable_comment_id": "private_reusable_comment",
+                    "save_for_reuse": False,
+                    "include_in_feedback": True,
+                    "created_at": review["created_at"],
+                    "module_details": {"comment_set_id": "private_set"},
+                },
+                {
+                    "feedback_comment_id": "feedback_comment_0002",
+                    "source": "custom",
+                    "text": "EXCLUDED COMMENT",
+                    "reusable_comment_id": None,
+                    "save_for_reuse": False,
+                    "include_in_feedback": False,
+                    "created_at": review["created_at"],
+                    "module_details": {},
+                },
+            ],
+            "module_details": {},
+        }
+    ]
+    return review
+
+
+def test_normal_pdf_export_creates_student_facing_pdf_and_metadata(
+    tmp_path: Path,
+) -> None:
+    _write_roster(tmp_path)
+    _write_manifest(tmp_path)
+    _write_assignment_with_rating_labels(tmp_path)
+    review = _feedback_ready_review()
+    source_review_updated_at = review["updated_at"]
+    review_path = _write_review(tmp_path, review)
+
+    result = export_student_feedback_pdf(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+
+    expected_path = feedback_pdf_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    assert result == ExportedFeedbackPdf(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        student_display_name="Avery Rivera",
+        assignment_title="Synthetic Essay",
+        review_record_path=review_path,
+        review_record_relative_path=(
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/review.json"
+        ),
+        feedback_pdf_path=expected_path,
+        feedback_pdf_relative_path=(
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/exports/feedback.pdf"
+        ),
+        feedback_markdown_path=None,
+        feedback_markdown_relative_path=None,
+        included_standard_rating_count=1,
+        included_comment_count=1,
+        included_observation_count=1,
+        created_at=TIMESTAMP,
+        overwrote_existing=False,
+    )
+    text = _pdf_text(expected_path)
+    for expected in (
+        "Student Feedback",
+        "Avery Rivera",
+        STUDENT_ID,
+        CLASS_ID,
+        "Synthetic Essay",
+        ASSIGNMENT_ID,
+        TIMESTAMP,
+        "synthetic:W.A",
+        "Meeting",
+        "Uses evidence clearly.",
+        "Student-facing comment.",
+        "Paragraph 1",
+        "Selected observation.",
+    ):
+        assert expected in text
+    for private in (
+        "PRIVATE TEACHER NOTE",
+        "private_notes",
+        "module_details",
+        "feedback_comment_id",
+        "reusable_comment_id",
+        "comment_set_id",
+        "observation_id",
+        "review.json",
+        "private_reusable_comment",
+        "private_set",
+        "EXCLUDED COMMENT",
+        "scores",
+        "tags",
+    ):
+        assert private not in text
+
+    review_after = json.loads(review_path.read_text(encoding="utf-8"))
+    metadata = review_after["exports"]["feedback_pdf"]
+    assert metadata == {
+        "path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"{STUDENT_ID}/exports/feedback.pdf"
+        ),
+        "generated_at": TIMESTAMP,
+        "source_review_updated_at": source_review_updated_at,
+        "module_details": {},
+    }
+    assert review_after["exports"]["feedback_markdown"] is None
+
+
+def test_pdf_export_falls_back_to_student_id_without_roster(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    _write_assignment_with_rating_labels(tmp_path)
+    _write_review(tmp_path, _feedback_ready_review())
+
+    result = export_student_feedback_pdf(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+
+    assert result.student_display_name == STUDENT_ID
+    assert STUDENT_ID in _pdf_text(result.feedback_pdf_path)
+
+
+def test_pdf_overwrite_policy(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    _write_assignment_with_rating_labels(tmp_path)
+    _write_review(tmp_path, _feedback_ready_review())
+    first = export_student_feedback_pdf(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+
+    with pytest.raises(FeedbackExportError, match="--overwrite"):
+        export_student_feedback_pdf(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    second = export_student_feedback_pdf(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        overwrite=True,
+        created_at=TIMESTAMP,
+    )
+    assert second.overwrote_existing is True
+    assert first.feedback_pdf_path.is_file()
+
+
+def test_pdf_export_can_write_markdown_companion_and_metadata(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    _write_assignment_with_rating_labels(tmp_path)
+    _write_review(tmp_path, _feedback_ready_review())
+
+    result = export_student_feedback_pdf(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        include_markdown_companion=True,
+        created_at=TIMESTAMP,
+    )
+
+    assert result.feedback_markdown_path == feedback_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    assert result.feedback_markdown_path.is_file()
+    review_after = json.loads(
+        review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert review_after["exports"]["feedback_markdown"]["path"].endswith(
+        "/exports/feedback.md"
+    )
+
+
+def test_returned_work_pdf_export(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    review = _review()
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "paragraphs_min",
+            "label": "Minimum paragraphs",
+            "expected": 5,
+            "met": False,
+            "teacher_note": "Only three paragraphs were submitted.",
+            "updated_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Please revise to meet the assignment minimums.",
+        "updated_at": TIMESTAMP,
+    }
+    _write_review(tmp_path, review)
+
+    result = export_student_feedback_pdf(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+
+    text = _pdf_text(result.feedback_pdf_path)
+    assert "Returned for Revision" in text
+    assert "Minimum paragraphs" in text
+    assert "Expected: 5" in text
+    assert "Only three paragraphs were submitted." in text
+    assert "Please revise to meet the assignment minimums." in text
+    assert "No full Focus Standard ratings were completed" in text
+
+
+def test_no_metadata_update_occurs_if_pdf_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_manifest(tmp_path)
+    _write_assignment_with_rating_labels(tmp_path)
+    review_path = _write_review(tmp_path, _feedback_ready_review())
+    before = review_path.read_text(encoding="utf-8")
+
+    def fail_render(_path: Path, _feedback: object) -> None:
+        raise OSError("simulated PDF failure")
+
+    monkeypatch.setattr(feedback_export, "_render_pdf_to_path", fail_render)
+
+    with pytest.raises(FeedbackExportError, match="simulated PDF failure"):
+        export_student_feedback_pdf(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert review_path.read_text(encoding="utf-8") == before
+    assert not feedback_pdf_export_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ).exists()

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -359,7 +359,7 @@ def test_menu_export_student_feedback_creates_feedback_file(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "1"]
+        + ["10", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -375,6 +375,47 @@ def test_menu_export_student_feedback_creates_feedback_file(
     assert "This should not appear in student feedback." not in feedback_text
     assert manifest_path.read_bytes() == manifest_before
     assert review_path.read_bytes() == review_before
+
+
+def test_menu_export_student_feedback_pdf_creates_pdf_and_updates_metadata(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_review_record(workspace, _review_record())
+    pdf_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+        / "exports"
+        / "feedback.pdf"
+    )
+    assert not pdf_path.exists()
+
+    _menu_input(
+        monkeypatch,
+        _enter_selected_student()
+        + ["10", "1"]
+        + _exit_after_selected_student_action_to_main(),
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Exported student feedback PDF:" in output
+    assert "Focus Standard ratings: 1" in output
+    assert pdf_path.is_file()
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert review["exports"]["feedback_pdf"]["path"].endswith(
+        "/submissions/stu_0001/exports/feedback.pdf"
+    )
 
 
 def test_menu_export_class_summary_creates_summary_file(
@@ -461,7 +502,7 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "2"]
+        + ["10", "4"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -526,7 +567,7 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "1", "1"]
+        + ["10", "2", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -560,7 +601,7 @@ def test_menu_export_feedback_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["10", "1", "2"]
+        + ["10", "2", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
 


### PR DESCRIPTION
## Summary

Implements student-facing PDF feedback export for Quillan’s v0.8.6 standards-based review workflow.

Teachers can now export polished student feedback as PDF, Markdown, or both.

## Changes

* Adds `feedback_pdf_export_path` and `export_student_feedback_pdf` in `feedback_export.py`.
* Reuses the same composed-feedback selection logic for Markdown and PDF.
* Adds ReportLab PDF rendering for:

  * normal composed feedback;
  * returned-without-full-review feedback.
* Adds safe PDF writes with overwrite protection.
* Updates `review.exports.feedback_pdf` metadata only after successful PDF generation.
* Adds optional Markdown companion export for PDF calls.
* Resolves student display name from roster when available.
* Falls back to student ID when roster/name lookup is unavailable.
* Updates CLI support:

  * `export-feedback --format markdown|pdf|both`
* Updates selected-student menu export flow to offer:

  * PDF;
  * Markdown;
  * both;
  * back.
* Adds PDF summary output without legacy “Scores” wording.
* Adds tests for:

  * PDF content;
  * privacy boundaries;
  * export metadata;
  * overwrite behavior;
  * returned-work PDF export.

## Behavior

PDF feedback export includes student-facing review information such as:

* student display name or student ID fallback;
* class information;
* assignment title and ID;
* generated timestamp;
* selected Focus Standard ratings;
* selected rationales;
* selected feedback comments;
* selected review-unit observations.

The PDF excludes teacher-only and internal data such as private notes, internal metadata, reusable-comment provenance, debug details, and legacy v1 review fields.

Returned-without-full-review records generate a returned-work PDF rather than ordinary standards feedback.

## Verification

Full test suite:

* `.\.venv\Scripts\python.exe -m pytest`

Result:

* `1027 passed`

Changed-file Ruff:

* `.\.venv\Scripts\ruff.exe check ...`

Result:

* `All checks passed!`

## Notes

This PR does not implement class summaries, standards summaries, assignment result manifests, gradebook export, parent/admin reporting, email delivery, LMS upload, AI feedback, OCR, automatic scoring, or automatic comments.

Closes #230
