### PR TITLE
Implement assignment-local summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,39 +704,39 @@ Private notes, score notes, tags, and comment provenance are excluded.
 
 Existing feedback is protected unless `--overwrite` is supplied.
 
-Export a class review summary:
+Export an assignment-local class summary:
 
 ```powershell
 quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 ```
 
-This discovers immediate student directories under the assignment `submissions/` directory and writes:
+This reads the assignment config, roster when available, submission manifests, review records, and feedback export metadata, then writes:
 
 ```text
 classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
 ```
 
-Each student gets one deterministic row, including status rows for missing, invalid, or identity-mismatched records.
+Each rostered or discovered student gets one deterministic row, including status rows for missing, invalid, or identity-mismatched records.
 
-Ready rows summarize states, teacher-entered score totals, selected comments, tags, notes, and feedback-file existence.
+Rows summarize submission/review status, minimum-requirement outcomes, returned-without-full-review status, assignment Focus Standard ratings, and feedback PDF/Markdown status.
 
-The totals are transparent arithmetic, not grades.
+The export is assignment-local and does not calculate grades, percentages, or cross-assignment mastery.
 
-Export a standards summary:
+Export an assignment-local Focus Standard summary:
 
 ```powershell
 quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
 ```
 
-This reads valid matching `submission.json` and `review.json` records and writes:
+This reads the assignment's configured Focus Standards, valid matching `submission.json` and `review.json` records, and feedback export metadata, then writes:
 
 ```text
 classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
 ```
 
-It creates one sorted row per `standard_id` referenced by a structured tag or selected comment, including tag polarity, feedback-inclusion, and distinct-student counts.
+It creates one row per assignment Focus Standard in assignment order, including rating distributions, missing-rating counts, returned-without-full-review counts, and feedback PDF coverage.
 
-It does not include individual student IDs, scores, notes, mastery determinations, or grades.
+It does not include student writing, private notes, full feedback text, grades, percentages, or broad mastery determinations.
 
 All exports are derived files. Exports do not mutate:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -803,67 +803,73 @@ Without `--overwrite`, an existing feedback file is preserved.
 The command does not mutate review state, timestamps, canonical records, or
 evidence.
 
-## Class Review Summary Export
+## Assignment-Local Class Summary Export
 
 ```powershell
 quillan export-class-summary <class_id> <assignment_id> [--overwrite]
 ```
 
-This direct command discovers immediate student directories under the
-assignment's canonical `submissions/` directory and writes:
+This direct command reads the assignment config, roster when available,
+submission manifests, review records, and feedback export metadata, then
+writes:
 
 ```text
 classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
 ```
 
-Rows are sorted by `student_id`.
+Rows follow roster order when a roster is available, then discovered
+unrostered submission folders by `student_id`. Without a roster, rows are
+sorted by discovered `student_id`.
 
-Valid matching records produce `ready` rows with submission and review states,
-score counts and simple score/max-score totals, selected and included comment
-counts, tag and note counts, feedback-export existence, and
-workspace-relative paths.
+Rows include submission and review states, minimum-requirement outcomes,
+returned-without-full-review status, assignment Focus Standard ratings,
+rating labels from the assignment rating scale, feedback PDF/Markdown status,
+warnings, and workspace-relative paths.
 
 Missing, invalid, and identity-mismatched student records produce
-`missing_submission`, `invalid_submission`, `missing_review`,
-`invalid_review`, or `identity_mismatch` rows rather than aborting the whole
-export.
+stable warnings such as `missing_submission`, `invalid_submission`,
+`missing_review`, `invalid_review`, or `identity_mismatch` rather than
+aborting the whole export.
 
-A missing assignment submissions directory is a handled failure.
+A missing assignment config is a handled failure.
 
 Success returns `0` and prints row/status counts, overwrite status, and the
 summary path. Handled failures return `1`.
 
 The export is read-only with respect to canonical records. It does not read
-evidence files or comment banks, use a roster, infer missing students,
-calculate percentages, grades, mastery, or weighted results, or generate a
-standards summary.
+evidence files, source comment banks, student writing, private notes, or full
+feedback text. It does not calculate percentages, grades, mastery, or
+weighted results, or generate a standards summary.
 
 Existing CSV files require `--overwrite`.
 
-## Standards Summary Export
+## Assignment-Local Focus Standard Summary Export
 
 ```powershell
 quillan export-standards-summary <class_id> <assignment_id> [--overwrite]
 ```
 
-This command discovers immediate student directories under the assignment
-`submissions/` directory and writes:
+This command reads the assignment's configured Focus Standards, discovered
+or rostered student records, and feedback export metadata, then writes:
 
 ```text
 classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
 ```
 
 It validates each available `submission.json` and `review.json`, counts
-missing, invalid, and identity-mismatched records without aborting the
-assignment export, and emits one row per referenced standard sorted by
-`standard_id`.
+missing, invalid, returned-without-full-review, and identity-mismatched
+records without aborting the assignment export, and emits one row per
+assignment Focus Standard in assignment order.
 
-Rows aggregate standards-linked structured tags by polarity and selected
-comments by feedback inclusion, plus distinct student counts.
+Rows aggregate teacher-entered overall Focus Standard ratings from
+`overall_standard_ratings`, missing-rating counts, feedback-inclusion counts,
+and feedback PDF coverage.
 
-Artifacts without `standard_id` are ignored.
+Ratings outside the assignment Focus Standards produce warnings rather than
+ordinary rows.
 
-If no valid linked artifacts exist, the command writes a header-only CSV.
+If no valid reviews exist, the command still writes one row per assignment
+Focus Standard with zero counts.
 
 Success returns `0`. Handled workspace, validation, missing-directory, and
 overwrite failures return `1`.

--- a/quillan/assignment_summary_context.py
+++ b/quillan/assignment_summary_context.py
@@ -1,0 +1,252 @@
+"""Shared assignment-local summary helpers for Quillan exports."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pds_core.classes import load_class_roster
+from pds_core.rosters import RosterError, StudentRecord, student_display_name
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SummaryStudent:
+    """One student row candidate for assignment-local summaries."""
+
+    student_id: str
+    display_name: str
+    roster_status: str
+    student_dir: Path
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedStudentRecord:
+    """Submission and review data loaded for one student row."""
+
+    student: SummaryStudent
+    submission_manifest_path: Path
+    review_record_path: Path
+    submission: dict[str, Any] | None
+    review: dict[str, Any] | None
+    submission_valid: str
+    review_valid: str
+    warnings: tuple[str, ...]
+
+
+def assignment_path(workspace_root: Path, class_id: str, assignment_id: str) -> Path:
+    return workspace_root / "classes" / class_id / "assignments" / assignment_id / "assignment.json"
+
+
+def submissions_dir(workspace_root: Path, class_id: str, assignment_id: str) -> Path:
+    return workspace_root / "classes" / class_id / "assignments" / assignment_id / "submissions"
+
+
+def load_assignment(workspace_root: Path, class_id: str, assignment_id: str) -> dict[str, Any]:
+    try:
+        assignment = load_assignment_config(assignment_path(workspace_root, class_id, assignment_id))
+    except (OSError, AssignmentConfigError) as error:
+        raise ValueError(f"Could not load assignment config: {error}") from error
+    if class_id not in assignment["class_ids"]:
+        raise ValueError(f"Assignment {assignment_id!r} is not configured for class {class_id!r}.")
+    return assignment
+
+
+def discover_students(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> tuple[SummaryStudent, ...]:
+    base_submissions_dir = submissions_dir(workspace_root, class_id, assignment_id)
+    submission_ids = _submission_ids(base_submissions_dir)
+    roster_students = _roster_students(workspace_root, class_id)
+    students: list[SummaryStudent] = []
+
+    if roster_students is not None:
+        roster_ids = set()
+        for roster_student in roster_students:
+            roster_ids.add(roster_student.student_id)
+            students.append(
+                SummaryStudent(
+                    student_id=roster_student.student_id,
+                    display_name=student_display_name(roster_student),
+                    roster_status="rostered",
+                    student_dir=base_submissions_dir / roster_student.student_id,
+                )
+            )
+        for student_id in sorted(submission_ids - roster_ids):
+            students.append(
+                SummaryStudent(
+                    student_id=student_id,
+                    display_name=student_id,
+                    roster_status="unrostered_submission",
+                    student_dir=base_submissions_dir / student_id,
+                )
+            )
+        return tuple(students)
+
+    return tuple(
+        SummaryStudent(
+            student_id=student_id,
+            display_name=student_id,
+            roster_status="roster_unavailable",
+            student_dir=base_submissions_dir / student_id,
+        )
+        for student_id in sorted(submission_ids)
+    )
+
+
+def load_student_record(
+    student: SummaryStudent,
+    class_id: str,
+    assignment_id: str,
+) -> LoadedStudentRecord:
+    warnings: list[str] = []
+    if student.roster_status == "unrostered_submission":
+        warnings.append("unrostered_submission")
+
+    manifest_path = student.student_dir / "submission.json"
+    review_path = student.student_dir / "review.json"
+    submission: dict[str, Any] | None = None
+    review: dict[str, Any] | None = None
+    submission_valid = "false"
+    review_valid = "false"
+
+    if not manifest_path.is_file():
+        warnings.append("missing_submission")
+    else:
+        try:
+            submission = load_submission_manifest(manifest_path)
+            submission_valid = "true"
+        except (OSError, SubmissionManifestError):
+            warnings.append("invalid_submission")
+        if submission is not None and _has_identity_mismatch(
+            submission, class_id, assignment_id, student.student_id
+        ):
+            warnings.append("identity_mismatch")
+            submission_valid = "false"
+
+    if submission_valid == "true":
+        if not review_path.is_file():
+            warnings.append("missing_review")
+        else:
+            try:
+                review = load_review_record(review_path)
+                review_valid = "true"
+            except (OSError, ReviewRecordError):
+                warnings.append("invalid_review")
+            if review is not None and _has_identity_mismatch(
+                review, class_id, assignment_id, student.student_id
+            ):
+                warnings.append("identity_mismatch")
+                review_valid = "false"
+
+    return LoadedStudentRecord(
+        student=student,
+        submission_manifest_path=manifest_path,
+        review_record_path=review_path,
+        submission=submission if submission_valid == "true" else None,
+        review=review if review_valid == "true" else None,
+        submission_valid=submission_valid,
+        review_valid=review_valid,
+        warnings=tuple(dict.fromkeys(warnings)),
+    )
+
+
+def standard_column_keys(standard_ids: list[str]) -> tuple[dict[str, str], tuple[str, ...]]:
+    keys: dict[str, str] = {}
+    warnings: list[str] = []
+    used: dict[str, str] = {}
+    for standard_id in standard_ids:
+        base_key = re.sub(r"[^A-Za-z0-9_-]", "_", standard_id)
+        key = base_key
+        if key in used and used[key] != standard_id:
+            warnings.append("standard_column_key_collision")
+            suffix = 2
+            while f"{base_key}_{suffix}" in used:
+                suffix += 1
+            key = f"{base_key}_{suffix}"
+        used[key] = standard_id
+        keys[standard_id] = key
+    return keys, tuple(warnings)
+
+
+def rating_labels(assignment: dict[str, Any]) -> dict[int, str]:
+    return {
+        int(level["value"]): str(level["label"])
+        for level in assignment["rating_scale"]["levels"]
+    }
+
+
+def rating_values(assignment: dict[str, Any]) -> tuple[int, ...]:
+    return tuple(int(level["value"]) for level in assignment["rating_scale"]["levels"])
+
+
+def feedback_status(
+    workspace_root: Path,
+    review: dict[str, Any] | None,
+    field: str,
+    default_path: Path,
+) -> tuple[str, str, str, tuple[str, ...]]:
+    warnings: list[str] = []
+    relative_path = relative_path_for(default_path, workspace_root)
+    metadata = None if review is None else review["exports"].get(field)
+    if isinstance(metadata, dict):
+        relative_path = str(metadata["path"])
+        file_path = workspace_root / relative_path
+        if not file_path.is_file():
+            warnings.append(f"{field}_file_missing")
+            return relative_path, "missing", "false", tuple(warnings)
+        if metadata["source_review_updated_at"] != review["updated_at"]:
+            warnings.append(f"{field}_stale")
+            return relative_path, "stale", "true", tuple(warnings)
+        return relative_path, "present", "false", tuple(warnings)
+
+    if default_path.is_file():
+        warnings.append(f"{field}_metadata_missing")
+        return relative_path, "unknown", "unknown", tuple(warnings)
+    return relative_path, "missing", "false", tuple(warnings)
+
+
+def relative_path_for(path: Path, workspace_root: Path) -> str:
+    return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+
+
+def _submission_ids(path: Path) -> set[str]:
+    try:
+        return {entry.name for entry in path.iterdir() if entry.is_dir()}
+    except (FileNotFoundError, NotADirectoryError):
+        return set()
+    except OSError as error:
+        raise ValueError(f"Could not discover student submission directories: {error}") from error
+
+
+def _roster_students(workspace_root: Path, class_id: str) -> tuple[StudentRecord, ...] | None:
+    try:
+        return load_class_roster(workspace_root, class_id).students
+    except (OSError, RosterError):
+        return None
+
+
+def _has_identity_mismatch(
+    record: dict[str, Any],
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> bool:
+    return any(
+        record[field] != expected
+        for field, expected in (
+            ("class_id", class_id),
+            ("assignment_id", assignment_id),
+            ("student_id", student_id),
+        )
+    )

--- a/quillan/class_summary_export.py
+++ b/quillan/class_summary_export.py
@@ -1,4 +1,4 @@
-"""Teacher-facing class review summary CSV export."""
+"""Teacher-facing assignment-local class summary CSV export."""
 
 from __future__ import annotations
 
@@ -12,32 +12,40 @@ from typing import Any, Final
 
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
 
-from quillan.review_record import ReviewRecordError, load_review_record
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
+from quillan.assignment_summary_context import (
+    LoadedStudentRecord,
+    discover_students,
+    feedback_status,
+    load_assignment,
+    load_student_record,
+    rating_labels,
+    relative_path_for,
+    standard_column_keys,
 )
 
-CSV_COLUMNS: Final[tuple[str, ...]] = (
+BASE_CSV_COLUMNS: Final[tuple[str, ...]] = (
     "class_id",
     "assignment_id",
     "student_id",
-    "row_status",
-    "review_state",
-    "submission_state",
-    "score_count",
-    "total_score",
-    "total_max_score",
-    "included_comment_count",
-    "selected_comment_count",
-    "tag_count",
-    "note_count",
-    "feedback_export_exists",
+    "student_display_name",
+    "roster_status",
     "submission_manifest_path",
+    "submission_state",
+    "submission_valid",
     "review_record_path",
-    "feedback_export_path",
-    "error",
+    "review_state",
+    "review_valid",
+    "minimum_requirement_status",
+    "returned_without_full_review",
+    "feedback_pdf_path",
+    "feedback_pdf_status",
+    "feedback_pdf_stale",
+    "feedback_markdown_path",
+    "feedback_markdown_status",
+    "feedback_markdown_stale",
+    "warnings",
 )
+CSV_COLUMNS: Final[tuple[str, ...]] = BASE_CSV_COLUMNS
 
 
 class ClassSummaryExportError(Exception):
@@ -46,7 +54,7 @@ class ClassSummaryExportError(Exception):
 
 @dataclass(frozen=True, slots=True)
 class ExportedClassSummary:
-    """Information about one generated assignment-level class summary."""
+    """Information about one generated assignment-local class summary."""
 
     class_id: str
     assignment_id: str
@@ -59,6 +67,9 @@ class ExportedClassSummary:
     missing_submission_count: int
     invalid_submission_count: int
     identity_mismatch_count: int
+    returned_without_full_review_count: int
+    feedback_pdf_present_count: int
+    feedback_pdf_stale_count: int
     created_at: str
     overwrote_existing: bool
 
@@ -68,7 +79,7 @@ def class_summary_export_path(
     class_id: str,
     assignment_id: str,
 ) -> Path:
-    """Return the canonical assignment-level class summary CSV path."""
+    """Return the canonical assignment-local class summary CSV path."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
     return (
@@ -90,22 +101,20 @@ def export_class_review_summary(
     overwrite: bool = False,
     created_at: datetime | str | None = None,
 ) -> ExportedClassSummary:
-    """Export one deterministic CSV row per discovered student directory."""
+    """Export one deterministic CSV row per rostered or discovered student."""
     normalized_created_at = _normalize_timestamp(created_at)
     try:
         resolved_root = Path(workspace_root).resolve(strict=False)
         output_path = class_summary_export_path(
             resolved_root, class_id, assignment_id
         )
-    except (OSError, RuntimeError, ClassSummaryExportError) as error:
+        assignment = load_assignment(resolved_root, class_id, assignment_id)
+        focus_standard_ids = list(assignment["focus_standard_ids"])
+        column_keys, key_warnings = standard_column_keys(focus_standard_ids)
+        labels = rating_labels(assignment)
+        students = discover_students(resolved_root, class_id, assignment_id)
+    except (OSError, RuntimeError, ValueError, ClassSummaryExportError) as error:
         raise ClassSummaryExportError(str(error)) from error
-
-    submissions_dir = output_path.parent.parent / "submissions"
-    if not submissions_dir.is_dir():
-        raise ClassSummaryExportError(
-            "Assignment submissions directory does not exist: "
-            f"{submissions_dir}"
-        )
 
     overwrote_existing = output_path.exists()
     if overwrote_existing and not overwrite:
@@ -114,189 +123,157 @@ def export_class_review_summary(
             "Use --overwrite to replace it."
         )
 
-    try:
-        student_dirs = sorted(
-            (path for path in submissions_dir.iterdir() if path.is_dir()),
-            key=lambda path: path.name,
-        )
-    except OSError as error:
-        raise ClassSummaryExportError(
-            f"Could not discover student submission directories: {error}"
-        ) from error
-
+    fieldnames = _fieldnames(focus_standard_ids, column_keys)
+    loaded_records = [
+        load_student_record(student, class_id, assignment_id) for student in students
+    ]
     rows = [
         _build_student_row(
             resolved_root,
             class_id,
             assignment_id,
-            student_dir,
+            record,
+            focus_standard_ids,
+            column_keys,
+            labels,
+            key_warnings,
         )
-        for student_dir in student_dirs
+        for record in loaded_records
     ]
-    _write_csv(output_path, rows, overwrite=overwrite)
+    _write_csv(output_path, rows, fieldnames=fieldnames, overwrite=overwrite)
 
-    counts = {
-        status: sum(row["row_status"] == status for row in rows)
-        for status in (
-            "ready",
-            "missing_review",
-            "invalid_review",
-            "missing_submission",
-            "invalid_submission",
-            "identity_mismatch",
-        )
-    }
     return ExportedClassSummary(
         class_id=class_id,
         assignment_id=assignment_id,
         summary_path=output_path,
-        summary_relative_path=_relative_path(output_path, resolved_root),
+        summary_relative_path=relative_path_for(output_path, resolved_root),
         row_count=len(rows),
-        ready_count=counts["ready"],
-        missing_review_count=counts["missing_review"],
-        invalid_review_count=counts["invalid_review"],
-        missing_submission_count=counts["missing_submission"],
-        invalid_submission_count=counts["invalid_submission"],
-        identity_mismatch_count=counts["identity_mismatch"],
+        ready_count=sum(row["review_valid"] == "true" for row in rows),
+        missing_review_count=sum("missing_review" in row["warnings"].split(";") for row in rows),
+        invalid_review_count=sum("invalid_review" in row["warnings"].split(";") for row in rows),
+        missing_submission_count=sum("missing_submission" in row["warnings"].split(";") for row in rows),
+        invalid_submission_count=sum("invalid_submission" in row["warnings"].split(";") for row in rows),
+        identity_mismatch_count=sum("identity_mismatch" in row["warnings"].split(";") for row in rows),
+        returned_without_full_review_count=sum(
+            row["returned_without_full_review"] == "true" for row in rows
+        ),
+        feedback_pdf_present_count=sum(row["feedback_pdf_status"] == "present" for row in rows),
+        feedback_pdf_stale_count=sum(row["feedback_pdf_status"] == "stale" for row in rows),
         created_at=normalized_created_at,
         overwrote_existing=overwrote_existing,
     )
+
+
+def _fieldnames(
+    focus_standard_ids: list[str], column_keys: dict[str, str]
+) -> tuple[str, ...]:
+    dynamic_columns: list[str] = []
+    for standard_id in focus_standard_ids:
+        key = column_keys[standard_id]
+        dynamic_columns.extend(
+            (
+                f"rating__{key}",
+                f"rating_label__{key}",
+                f"rating_included_in_feedback__{key}",
+                f"rating_missing__{key}",
+            )
+        )
+    return BASE_CSV_COLUMNS[:-1] + tuple(dynamic_columns) + ("warnings",)
 
 
 def _build_student_row(
     workspace_root: Path,
     class_id: str,
     assignment_id: str,
-    student_dir: Path,
+    loaded: LoadedStudentRecord,
+    focus_standard_ids: list[str],
+    column_keys: dict[str, str],
+    labels: dict[int, str],
+    key_warnings: tuple[str, ...],
 ) -> dict[str, str]:
-    student_id = student_dir.name
-    manifest_path = student_dir / "submission.json"
-    review_path = student_dir / "review.json"
-    feedback_path = student_dir / "exports" / "feedback.md"
+    student = loaded.student
+    review = loaded.review
+    warnings = list(loaded.warnings) + list(key_warnings)
+    feedback_pdf_path = student.student_dir / "exports" / "feedback.pdf"
+    feedback_markdown_path = student.student_dir / "exports" / "feedback.md"
+    pdf_path, pdf_status, pdf_stale, pdf_warnings = feedback_status(
+        workspace_root, review, "feedback_pdf", feedback_pdf_path
+    )
+    md_path, md_status, md_stale, md_warnings = feedback_status(
+        workspace_root, review, "feedback_markdown", feedback_markdown_path
+    )
+    warnings.extend(pdf_warnings)
+    warnings.extend(md_warnings)
+
     row = {
         "class_id": class_id,
         "assignment_id": assignment_id,
-        "student_id": student_id,
-        "row_status": "",
-        "review_state": "",
-        "submission_state": "",
-        "score_count": "",
-        "total_score": "",
-        "total_max_score": "",
-        "included_comment_count": "",
-        "selected_comment_count": "",
-        "tag_count": "",
-        "note_count": "",
-        "feedback_export_exists": _csv_bool(feedback_path.is_file()),
-        "submission_manifest_path": _relative_path(
-            manifest_path, workspace_root
+        "student_id": student.student_id,
+        "student_display_name": student.display_name,
+        "roster_status": student.roster_status,
+        "submission_manifest_path": relative_path_for(
+            loaded.submission_manifest_path, workspace_root
         ),
-        "review_record_path": _relative_path(review_path, workspace_root),
-        "feedback_export_path": _relative_path(feedback_path, workspace_root),
-        "error": "",
+        "submission_state": _record_value(loaded.submission, "submission_state"),
+        "submission_valid": loaded.submission_valid,
+        "review_record_path": relative_path_for(loaded.review_record_path, workspace_root),
+        "review_state": _record_value(review, "review_state"),
+        "review_valid": loaded.review_valid,
+        "minimum_requirement_status": "",
+        "returned_without_full_review": "",
+        "feedback_pdf_path": pdf_path,
+        "feedback_pdf_status": pdf_status,
+        "feedback_pdf_stale": pdf_stale,
+        "feedback_markdown_path": md_path,
+        "feedback_markdown_status": md_status,
+        "feedback_markdown_stale": md_stale,
     }
 
-    if not manifest_path.is_file():
-        return _failed_row(
-            row,
-            "missing_submission",
-            f"Submission manifest is missing: {row['submission_manifest_path']}",
+    ratings_by_standard: dict[str, dict[str, Any]] = {}
+    if review is not None:
+        outcome = review["minimum_requirement_outcome"]
+        row["minimum_requirement_status"] = str(outcome["status"])
+        row["returned_without_full_review"] = _csv_bool(
+            bool(outcome["returned_without_full_review"])
         )
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        return _failed_row(
-            row, "invalid_submission", f"Invalid submission manifest: {error}"
+        for rating in review["overall_standard_ratings"]:
+            standard_id = rating["standard_id"]
+            if standard_id not in focus_standard_ids:
+                warnings.append("rating_for_non_assignment_standard")
+                continue
+            ratings_by_standard[standard_id] = rating
+
+    for standard_id in focus_standard_ids:
+        key = column_keys[standard_id]
+        rating = ratings_by_standard.get(standard_id)
+        if rating is None:
+            row[f"rating__{key}"] = ""
+            row[f"rating_label__{key}"] = ""
+            row[f"rating_included_in_feedback__{key}"] = ""
+            row[f"rating_missing__{key}"] = "true"
+            continue
+        value = int(rating["rating"])
+        label = labels.get(value)
+        if label is None:
+            warnings.append("unknown_rating_value")
+            label = ""
+        row[f"rating__{key}"] = str(value)
+        row[f"rating_label__{key}"] = label
+        row[f"rating_included_in_feedback__{key}"] = _csv_bool(
+            bool(rating["include_in_feedback"])
         )
+        row[f"rating_missing__{key}"] = "false"
 
-    row["submission_state"] = str(manifest["submission_state"])
-    mismatch = _identity_mismatch(
-        manifest, class_id, assignment_id, student_id, "Submission manifest"
-    )
-    if mismatch is not None:
-        return _failed_row(row, "identity_mismatch", mismatch)
-
-    if not review_path.is_file():
-        return _failed_row(
-            row,
-            "missing_review",
-            f"Review record is missing: {row['review_record_path']}",
-        )
-    try:
-        review = load_review_record(review_path)
-    except (OSError, ReviewRecordError) as error:
-        return _failed_row(
-            row, "invalid_review", f"Invalid review record: {error}"
-        )
-
-    mismatch = _identity_mismatch(
-        review, class_id, assignment_id, student_id, "Review record"
-    )
-    if mismatch is not None:
-        return _failed_row(row, "identity_mismatch", mismatch)
-
-    ratings = review["overall_standard_ratings"]
-    comments = [
-        comment
-        for standard_feedback in review["feedback"]["standard_feedback"]
-        for comment in standard_feedback["comments"]
-    ]
-    observations = [
-        observation
-        for unit in review["review_units"]
-        for observation in unit["standard_observations"]
-    ]
-    row.update(
-        {
-            "row_status": "ready",
-            "review_state": str(review["review_state"]),
-            "score_count": str(len(ratings)),
-            "total_score": _format_number(
-                sum(rating["rating"] for rating in ratings)
-            ),
-            "total_max_score": "",
-            "included_comment_count": str(
-                sum(comment["include_in_feedback"] for comment in comments)
-            ),
-            "selected_comment_count": str(len(comments)),
-            "tag_count": str(len(observations)),
-            "note_count": str(len(review["private_notes"])),
-        }
-    )
+    row["warnings"] = ";".join(dict.fromkeys(warnings))
     return row
-
-
-def _failed_row(
-    row: dict[str, str], status: str, message: str
-) -> dict[str, str]:
-    row["row_status"] = status
-    row["error"] = " ".join(message.split())
-    return row
-
-
-def _identity_mismatch(
-    record: dict[str, Any],
-    class_id: str,
-    assignment_id: str,
-    student_id: str,
-    record_name: str,
-) -> str | None:
-    expected_values = {
-        "class_id": class_id,
-        "assignment_id": assignment_id,
-        "student_id": student_id,
-    }
-    for field, expected in expected_values.items():
-        actual = record[field]
-        if actual != expected:
-            return (
-                f"{record_name} {field} is {actual!r}, expected {expected!r}."
-            )
-    return None
 
 
 def _write_csv(
-    path: Path, rows: list[dict[str, str]], *, overwrite: bool
+    path: Path,
+    rows: list[dict[str, str]],
+    *,
+    fieldnames: tuple[str, ...],
+    overwrite: bool,
 ) -> None:
     parent = path.parent
     try:
@@ -324,7 +301,7 @@ def _write_csv(
             temporary_path = Path(temporary_file.name)
             writer = csv.DictWriter(
                 temporary_file,
-                fieldnames=CSV_COLUMNS,
+                fieldnames=fieldnames,
                 lineterminator="\n",
             )
             writer.writeheader()
@@ -387,18 +364,11 @@ def _validate_identifier(value: str, field: str) -> None:
         raise ClassSummaryExportError(str(error)) from error
 
 
-def _relative_path(path: Path, workspace_root: Path) -> str:
-    try:
-        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
-    except (OSError, RuntimeError, ValueError) as error:
-        raise ClassSummaryExportError(
-            f"Could not resolve workspace-relative export path: {error}"
-        ) from error
+def _record_value(record: dict[str, Any] | None, field: str) -> str:
+    if record is None:
+        return ""
+    return str(record[field])
 
 
 def _csv_bool(value: bool) -> str:
     return "true" if value else "false"
-
-
-def _format_number(value: int | float) -> str:
-    return format(value, "g")

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -312,16 +312,22 @@ def print_exported_feedback_pdf(exported: ExportedFeedbackPdf) -> None:
 
 def print_exported_class_summary(exported: ExportedClassSummary) -> None:
     """Print a concise teacher-facing class summary export result."""
-    print("Exported class review summary:")
+    print("Exported assignment-local class summary:")
     print(f"Class: {exported.class_id}")
     print(f"Assignment: {exported.assignment_id}")
     print(f"Rows: {exported.row_count}")
-    print(f"Ready: {exported.ready_count}")
+    print(f"Valid reviews: {exported.ready_count}")
     print(f"Missing review: {exported.missing_review_count}")
     print(f"Invalid review: {exported.invalid_review_count}")
     print(f"Missing submission: {exported.missing_submission_count}")
     print(f"Invalid submission: {exported.invalid_submission_count}")
     print(f"Identity mismatch: {exported.identity_mismatch_count}")
+    print(
+        "Returned without full review: "
+        f"{exported.returned_without_full_review_count}"
+    )
+    print(f"Feedback PDF present: {exported.feedback_pdf_present_count}")
+    print(f"Feedback PDF stale: {exported.feedback_pdf_stale_count}")
     print(f"Overwrote existing: {format_bool(exported.overwrote_existing)}")
     print(f"Summary file: {exported.summary_relative_path}")
 
@@ -330,12 +336,18 @@ def print_exported_standards_summary(
     exported: ExportedStandardsSummary,
 ) -> None:
     """Print a concise teacher-facing standards summary export result."""
-    print("Exported standards summary:")
+    missing_reviews = exported.missing_review_count + exported.invalid_review_count
+    print("Exported assignment-local Focus Standard summary:")
     print(f"Class: {exported.class_id}")
     print(f"Assignment: {exported.assignment_id}")
-    print(f"Rows: {exported.row_count}")
     print(f"Standards: {exported.standard_count}")
+    print(f"Expected students: {exported.student_count}")
     print(f"Valid reviews: {exported.review_count}")
+    print(f"Missing reviews: {missing_reviews}")
+    print(
+        "Returned without full review: "
+        f"{exported.returned_without_full_review_count}"
+    )
     print(f"Missing review: {exported.missing_review_count}")
     print(f"Invalid review: {exported.invalid_review_count}")
     print(f"Missing submission: {exported.missing_submission_count}")

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -246,13 +246,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     export_class_summary_parser = subparsers.add_parser(
         "export-class-summary",
-        help="Export a class-level review summary CSV for one assignment.",
+        help="Export an assignment-local class summary CSV.",
         description=(
-            "Generate a teacher-facing CSV summary from existing submission "
-            "and review records for one class assignment. The export reports "
-            "review availability, review state, score totals, selected feedback "
-            "counts, tag counts, and note counts. It does not mutate canonical "
-            "records or evidence."
+            "Generate a teacher-facing assignment-local CSV summary from "
+            "existing submission and review records for one class assignment. "
+            "The export reports submission/review status, minimum-requirement "
+            "outcomes, Focus Standard ratings, and feedback export status. It "
+            "does not mutate canonical records or evidence."
         ),
     )
     _add_assignment_identity_arguments(export_class_summary_parser)
@@ -265,12 +265,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     export_standards_summary_parser = subparsers.add_parser(
         "export-standards-summary",
-        help="Export a standards-focused review summary CSV for one assignment.",
+        help="Export an assignment-local Focus Standard summary CSV.",
         description=(
-            "Generate a teacher-facing CSV summary of standards-linked review "
-            "tags and selected comments across one class assignment. The "
-            "export reads existing review records and does not mutate "
-            "canonical records, evidence, or source comment banks."
+            "Generate a teacher-facing assignment-local CSV summary of "
+            "teacher-entered overall Focus Standard ratings for one class "
+            "assignment. The export includes minimum-requirement outcomes and "
+            "feedback export status, and does not mutate canonical records or "
+            "evidence."
         ),
     )
     _add_assignment_identity_arguments(export_standards_summary_parser)

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -4524,8 +4524,8 @@ def _launch_assignment_review_actions(
 
         print("1. Select student/submission")
         print("2. Assemble routed submissions")
-        print("3. Export class review summary")
-        print("4. Export standards summary")
+        print("3. Export assignment-local class summary")
+        print("4. Export assignment-local Focus Standard summary")
         print("5. Refresh submission status")
         print("6. Back")
         print()

--- a/quillan/standards_summary_export.py
+++ b/quillan/standards_summary_export.py
@@ -1,57 +1,54 @@
-"""Teacher-facing standards-linked review summary CSV export."""
+"""Teacher-facing assignment-local Focus Standard summary CSV export."""
 
 from __future__ import annotations
 
 import csv
+import json
 import os
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Final
 
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
 from pds_core.standards import (
-    StandardDefinition,
     StandardsLibrary,
-    load_workspace_standards_library,
     find_standard_definition,
+    load_workspace_standards_library,
 )
 
-from quillan.review_record import ReviewRecordError, load_review_record
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
+from quillan.assignment_summary_context import (
+    LoadedStudentRecord,
+    discover_students,
+    feedback_status,
+    load_assignment,
+    load_student_record,
+    rating_values,
+    relative_path_for,
+    standard_column_keys,
 )
 
 CSV_COLUMNS: Final[tuple[str, ...]] = (
     "class_id",
     "assignment_id",
+    "standards_profile_id",
+    "focus_standard_order",
     "standard_id",
-    "code",
-    "short_name",
-    "standard_source",
-    "subject",
-    "course",
-    "domain",
-    "student_count",
-    "tag_student_count",
-    "comment_student_count",
-    "tag_count",
-    "positive_tag_count",
-    "developing_tag_count",
-    "negative_tag_count",
-    "neutral_tag_count",
-    "selected_comment_count",
-    "included_comment_count",
-    "excluded_comment_count",
-    "review_count",
-    "missing_review_count",
-    "invalid_review_count",
-    "missing_submission_count",
-    "invalid_submission_count",
-    "identity_mismatch_count",
-    "source",
+    "standard_column_key",
+    "standard_display_code",
+    "standard_display_name",
+    "students_expected",
+    "students_with_submissions",
+    "students_with_valid_reviews",
+    "students_reviewed_for_standard",
+    "students_returned_without_full_review",
+    "students_missing_rating",
+    "students_with_rating_included_in_feedback",
+    "feedback_pdf_present_count",
+    "feedback_pdf_stale_count",
+    "rating_counts_json",
+    "warnings",
 )
 
 
@@ -61,7 +58,7 @@ class StandardsSummaryExportError(Exception):
 
 @dataclass(frozen=True, slots=True)
 class ExportedStandardsSummary:
-    """Information about one generated assignment standards summary."""
+    """Information about one generated assignment Focus Standard summary."""
 
     class_id: str
     assignment_id: str
@@ -76,24 +73,9 @@ class ExportedStandardsSummary:
     missing_submission_count: int
     invalid_submission_count: int
     identity_mismatch_count: int
+    returned_without_full_review_count: int
     created_at: str
     overwrote_existing: bool
-
-
-@dataclass(slots=True)
-class _StandardCounts:
-    """Mutable aggregation state for one durable standard ID."""
-
-    tag_students: set[str] = field(default_factory=set)
-    comment_students: set[str] = field(default_factory=set)
-    tag_count: int = 0
-    positive_tag_count: int = 0
-    developing_tag_count: int = 0
-    negative_tag_count: int = 0
-    neutral_tag_count: int = 0
-    selected_comment_count: int = 0
-    included_comment_count: int = 0
-    excluded_comment_count: int = 0
 
 
 def standards_summary_export_path(
@@ -101,7 +83,7 @@ def standards_summary_export_path(
     class_id: str,
     assignment_id: str,
 ) -> Path:
-    """Return the canonical assignment-level standards summary CSV path."""
+    """Return the canonical assignment-local standards summary CSV path."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
     return (
@@ -123,22 +105,20 @@ def export_standards_summary(
     overwrite: bool = False,
     created_at: datetime | str | None = None,
 ) -> ExportedStandardsSummary:
-    """Export standards-linked schema version 2 review aggregates."""
+    """Export assignment-local Focus Standard rating aggregates."""
     normalized_created_at = _normalize_timestamp(created_at)
     try:
         resolved_root = Path(workspace_root).resolve(strict=False)
         output_path = standards_summary_export_path(
             resolved_root, class_id, assignment_id
         )
-    except (OSError, RuntimeError, StandardsSummaryExportError) as error:
+        assignment = load_assignment(resolved_root, class_id, assignment_id)
+        focus_standard_ids = list(assignment["focus_standard_ids"])
+        column_keys, key_warnings = standard_column_keys(focus_standard_ids)
+        values = rating_values(assignment)
+        students = discover_students(resolved_root, class_id, assignment_id)
+    except (OSError, RuntimeError, ValueError, StandardsSummaryExportError) as error:
         raise StandardsSummaryExportError(str(error)) from error
-
-    submissions_dir = output_path.parent.parent / "submissions"
-    if not submissions_dir.is_dir():
-        raise StandardsSummaryExportError(
-            "Assignment submissions directory does not exist: "
-            f"{submissions_dir}"
-        )
 
     overwrote_existing = output_path.exists()
     if overwrote_existing and not overwrite:
@@ -147,196 +127,168 @@ def export_standards_summary(
             "Use --overwrite to replace it."
         )
 
-    try:
-        student_dirs = sorted(
-            (path for path in submissions_dir.iterdir() if path.is_dir()),
-            key=lambda path: path.name,
-        )
-    except OSError as error:
-        raise StandardsSummaryExportError(
-            f"Could not discover student submission directories: {error}"
-        ) from error
-
-    aggregates: dict[str, _StandardCounts] = {}
-    status_counts = {
-        "review": 0,
-        "missing_review": 0,
-        "invalid_review": 0,
-        "missing_submission": 0,
-        "invalid_submission": 0,
-        "identity_mismatch": 0,
-    }
-    try:
-        standards_library = load_workspace_standards_library(resolved_root)
-    except OSError:
-        standards_library = StandardsLibrary(standards=(), profiles=())
-    for student_dir in student_dirs:
-        _inspect_student(
-            class_id,
-            assignment_id,
-            student_dir,
-            aggregates,
-            status_counts,
-        )
-
+    loaded_records = [
+        load_student_record(student, class_id, assignment_id) for student in students
+    ]
+    standards_library = _load_standards_library(resolved_root)
     rows = [
         _build_row(
+            resolved_root,
             class_id,
             assignment_id,
+            assignment,
             standard_id,
-            aggregates[standard_id],
-            status_counts,
-            find_standard_definition(standards_library, standard_id),
+            index,
+            column_keys[standard_id],
+            values,
+            loaded_records,
+            standards_library,
+            key_warnings,
         )
-        for standard_id in sorted(aggregates)
+        for index, standard_id in enumerate(focus_standard_ids, start=1)
     ]
     _write_csv(output_path, rows, overwrite=overwrite)
 
+    warning_counts = _warning_counts(loaded_records)
     return ExportedStandardsSummary(
         class_id=class_id,
         assignment_id=assignment_id,
         summary_path=output_path,
-        summary_relative_path=_relative_path(output_path, resolved_root),
+        summary_relative_path=relative_path_for(output_path, resolved_root),
         row_count=len(rows),
-        standard_count=len(aggregates),
-        student_count=len(student_dirs),
-        review_count=status_counts["review"],
-        missing_review_count=status_counts["missing_review"],
-        invalid_review_count=status_counts["invalid_review"],
-        missing_submission_count=status_counts["missing_submission"],
-        invalid_submission_count=status_counts["invalid_submission"],
-        identity_mismatch_count=status_counts["identity_mismatch"],
+        standard_count=len(rows),
+        student_count=len(students),
+        review_count=sum(record.review is not None for record in loaded_records),
+        missing_review_count=warning_counts["missing_review"],
+        invalid_review_count=warning_counts["invalid_review"],
+        missing_submission_count=warning_counts["missing_submission"],
+        invalid_submission_count=warning_counts["invalid_submission"],
+        identity_mismatch_count=warning_counts["identity_mismatch"],
+        returned_without_full_review_count=sum(
+            _returned_without_full_review(record.review)
+            for record in loaded_records
+        ),
         created_at=normalized_created_at,
         overwrote_existing=overwrote_existing,
     )
 
 
-def _inspect_student(
-    class_id: str,
-    assignment_id: str,
-    student_dir: Path,
-    aggregates: dict[str, _StandardCounts],
-    status_counts: dict[str, int],
-) -> None:
-    student_id = student_dir.name
-    manifest_path = student_dir / "submission.json"
-    review_path = student_dir / "review.json"
-
-    if not manifest_path.is_file():
-        status_counts["missing_submission"] += 1
-        return
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError):
-        status_counts["invalid_submission"] += 1
-        return
-    if _has_identity_mismatch(
-        manifest, class_id, assignment_id, student_id
-    ):
-        status_counts["identity_mismatch"] += 1
-        return
-
-    if not review_path.is_file():
-        status_counts["missing_review"] += 1
-        return
-    try:
-        review = load_review_record(review_path)
-    except (OSError, ReviewRecordError):
-        status_counts["invalid_review"] += 1
-        return
-    if _has_identity_mismatch(review, class_id, assignment_id, student_id):
-        status_counts["identity_mismatch"] += 1
-        return
-
-    status_counts["review"] += 1
-    for unit in review["review_units"]:
-        for observation in unit["standard_observations"]:
-            standard_id = observation["standard_id"]
-            counts = aggregates.setdefault(standard_id, _StandardCounts())
-            counts.tag_students.add(student_id)
-            counts.tag_count += 1
-            polarity = observation.get("module_details", {}).get("legacy_polarity")
-            if polarity in {"positive", "developing", "negative", "neutral"}:
-                polarity_field = f"{polarity}_tag_count"
-                setattr(counts, polarity_field, getattr(counts, polarity_field) + 1)
-
-    for rating in review["overall_standard_ratings"]:
-        standard_id = rating["standard_id"]
-        counts = aggregates.setdefault(standard_id, _StandardCounts())
-        counts.tag_students.add(student_id)
-
-    for standard_feedback in review["feedback"]["standard_feedback"]:
-        standard_id = standard_feedback["standard_id"]
-        comments = standard_feedback["comments"]
-        if not comments:
-            aggregates.setdefault(standard_id, _StandardCounts())
-            continue
-        counts = aggregates.setdefault(standard_id, _StandardCounts())
-        counts.comment_students.add(student_id)
-        counts.selected_comment_count += len(comments)
-        counts.included_comment_count += sum(
-            comment["include_in_feedback"] for comment in comments
-        )
-        counts.excluded_comment_count += sum(
-            not comment["include_in_feedback"] for comment in comments
-        )
-
-
 def _build_row(
+    workspace_root: Path,
     class_id: str,
     assignment_id: str,
+    assignment: dict[str, Any],
     standard_id: str,
-    counts: _StandardCounts,
-    status_counts: dict[str, int],
-    definition: StandardDefinition | None,
+    focus_order: int,
+    standard_column_key: str,
+    rating_scale_values: tuple[int, ...],
+    records: list[LoadedStudentRecord],
+    standards_library: StandardsLibrary,
+    key_warnings: tuple[str, ...],
 ) -> dict[str, str]:
+    warnings = list(key_warnings)
+    definition = find_standard_definition(standards_library, standard_id)
+    if definition is None:
+        warnings.append("standard_metadata_missing")
+
+    rating_counts = {str(value): 0 for value in rating_scale_values}
+    students_with_submissions = 0
+    students_with_valid_reviews = 0
+    students_reviewed_for_standard = 0
+    students_returned = 0
+    students_missing_rating = 0
+    students_included = 0
+    feedback_pdf_present = 0
+    feedback_pdf_stale = 0
+
+    for record in records:
+        if record.submission is not None:
+            students_with_submissions += 1
+        review = record.review
+        if review is None:
+            continue
+        students_with_valid_reviews += 1
+        pdf_path = record.student.student_dir / "exports" / "feedback.pdf"
+        _, pdf_status, _, _ = feedback_status(
+            workspace_root, review, "feedback_pdf", pdf_path
+        )
+        if pdf_status == "present":
+            feedback_pdf_present += 1
+        elif pdf_status == "stale":
+            feedback_pdf_stale += 1
+
+        if _returned_without_full_review(review):
+            students_returned += 1
+            continue
+
+        ratings_by_standard = {
+            rating["standard_id"]: rating
+            for rating in review["overall_standard_ratings"]
+        }
+        extra_ratings = set(ratings_by_standard) - set(assignment["focus_standard_ids"])
+        if extra_ratings:
+            warnings.append("rating_for_non_assignment_standard")
+
+        rating = ratings_by_standard.get(standard_id)
+        if rating is None:
+            students_missing_rating += 1
+            continue
+        students_reviewed_for_standard += 1
+        value = str(rating["rating"])
+        if value not in rating_counts:
+            warnings.append("unknown_rating_value")
+            rating_counts[value] = 0
+        rating_counts[value] += 1
+        if rating["include_in_feedback"]:
+            students_included += 1
+
     return {
         "class_id": class_id,
         "assignment_id": assignment_id,
+        "standards_profile_id": str(assignment["standards_profile_id"]),
+        "focus_standard_order": str(focus_order),
         "standard_id": standard_id,
-        "code": definition.code if definition is not None else "",
-        "short_name": definition.short_name if definition is not None else "",
-        "standard_source": definition.source if definition is not None else "",
-        "subject": definition.subject or "" if definition is not None else "",
-        "course": definition.course or "" if definition is not None else "",
-        "domain": definition.domain or "" if definition is not None else "",
-        "student_count": str(
-            len(counts.tag_students | counts.comment_students)
-        ),
-        "tag_student_count": str(len(counts.tag_students)),
-        "comment_student_count": str(len(counts.comment_students)),
-        "tag_count": str(counts.tag_count),
-        "positive_tag_count": str(counts.positive_tag_count),
-        "developing_tag_count": str(counts.developing_tag_count),
-        "negative_tag_count": str(counts.negative_tag_count),
-        "neutral_tag_count": str(counts.neutral_tag_count),
-        "selected_comment_count": str(counts.selected_comment_count),
-        "included_comment_count": str(counts.included_comment_count),
-        "excluded_comment_count": str(counts.excluded_comment_count),
-        "review_count": str(status_counts["review"]),
-        "missing_review_count": str(status_counts["missing_review"]),
-        "invalid_review_count": str(status_counts["invalid_review"]),
-        "missing_submission_count": str(status_counts["missing_submission"]),
-        "invalid_submission_count": str(status_counts["invalid_submission"]),
-        "identity_mismatch_count": str(status_counts["identity_mismatch"]),
-        "source": "review_record_v2",
+        "standard_column_key": standard_column_key,
+        "standard_display_code": definition.code if definition is not None else "",
+        "standard_display_name": definition.short_name if definition is not None else "",
+        "students_expected": str(len(records)),
+        "students_with_submissions": str(students_with_submissions),
+        "students_with_valid_reviews": str(students_with_valid_reviews),
+        "students_reviewed_for_standard": str(students_reviewed_for_standard),
+        "students_returned_without_full_review": str(students_returned),
+        "students_missing_rating": str(students_missing_rating),
+        "students_with_rating_included_in_feedback": str(students_included),
+        "feedback_pdf_present_count": str(feedback_pdf_present),
+        "feedback_pdf_stale_count": str(feedback_pdf_stale),
+        "rating_counts_json": json.dumps(rating_counts, sort_keys=True, separators=(",", ":")),
+        "warnings": ";".join(dict.fromkeys(warnings)),
     }
 
 
-def _has_identity_mismatch(
-    record: dict[str, Any],
-    class_id: str,
-    assignment_id: str,
-    student_id: str,
-) -> bool:
-    return any(
-        record[field] != expected
-        for field, expected in (
-            ("class_id", class_id),
-            ("assignment_id", assignment_id),
-            ("student_id", student_id),
+def _warning_counts(records: list[LoadedStudentRecord]) -> dict[str, int]:
+    return {
+        warning: sum(warning in record.warnings for record in records)
+        for warning in (
+            "missing_review",
+            "invalid_review",
+            "missing_submission",
+            "invalid_submission",
+            "identity_mismatch",
         )
-    )
+    }
+
+
+def _returned_without_full_review(review: dict[str, Any] | None) -> bool:
+    if review is None:
+        return False
+    return bool(review["minimum_requirement_outcome"]["returned_without_full_review"])
+
+
+def _load_standards_library(workspace_root: Path) -> StandardsLibrary:
+    try:
+        return load_workspace_standards_library(workspace_root)
+    except OSError:
+        return StandardsLibrary(standards=(), profiles=())
 
 
 def _write_csv(
@@ -430,12 +382,3 @@ def _validate_identifier(value: str, field: str) -> None:
         validate_identifier(value, field)
     except IdentifierValidationError as error:
         raise StandardsSummaryExportError(str(error)) from error
-
-
-def _relative_path(path: Path, workspace_root: Path) -> str:
-    try:
-        return path.resolve(strict=False).relative_to(workspace_root).as_posix()
-    except (OSError, RuntimeError, ValueError) as error:
-        raise StandardsSummaryExportError(
-            f"Could not resolve workspace-relative export path: {error}"
-        ) from error

--- a/tests/test_class_summary_export.py
+++ b/tests/test_class_summary_export.py
@@ -1,4 +1,4 @@
-"""Tests for teacher-facing class review summary CSV export."""
+"""Tests for teacher-facing assignment-local class summary CSV export."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from typing import Any
 import pytest
 
 from quillan.class_summary_export import (
-    CSV_COLUMNS,
+    BASE_CSV_COLUMNS,
     ClassSummaryExportError,
     ExportedClassSummary,
     class_summary_export_path,
@@ -26,6 +26,10 @@ from tests.test_review_tags import (
 )
 
 TIMESTAMP = "2026-06-23T12:30:00+00:00"
+STANDARD_A = "synthetic:W.A"
+STANDARD_B = "synthetic:W.B"
+STANDARD_A_KEY = "synthetic_W_A"
+STANDARD_B_KEY = "synthetic_W_B"
 
 
 def _student_dir(workspace: Path, student_id: str) -> Path:
@@ -43,6 +47,59 @@ def _student_dir(workspace: Path, student_id: str) -> Path:
 def _write_json(path: Path, value: Any) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def _write_assignment(workspace: Path) -> Path:
+    return _write_json(
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json",
+        {
+            "schema_version": "2",
+            "module": "quillan",
+            "record_type": "assignment",
+            "assignment_id": ASSIGNMENT_ID,
+            "title": "Synthetic Essay",
+            "class_ids": [CLASS_ID],
+            "writing_type": "argument",
+            "student_prompt": "Write a synthetic argument.",
+            "standards_profile_id": "synthetic_profile",
+            "focus_standard_ids": [STANDARD_A, STANDARD_B],
+            "review_unit": {
+                "type": "paragraph",
+                "singular_label": "paragraph",
+                "plural_label": "paragraphs",
+            },
+            "rating_scale": {
+                "scale_id": "synthetic_scale",
+                "levels": [
+                    {"value": 1, "label": "Starting", "description": "Early work."},
+                    {"value": 2, "label": "Growing", "description": "Developing work."},
+                    {"value": 3, "label": "Secure", "description": "Consistent work."},
+                ],
+            },
+            "basic_requirements": {"paragraphs_min": 1},
+            "minimum_requirement_policy": {
+                "allow_return_without_full_review": True
+            },
+        },
+    )
+
+
+def _write_roster(workspace: Path) -> Path:
+    path = workspace / "classes" / CLASS_ID / "roster.csv"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "class_id,student_id,last_name,first_name,period\n"
+        f"{CLASS_ID},00100,Rivera,Avery,3\n"
+        f"{CLASS_ID},00200,Patel,Mina,3\n"
+        f"{CLASS_ID},00900,Missing,Student,3\n",
+        encoding="utf-8",
+    )
     return path
 
 
@@ -73,113 +130,120 @@ def _read_rows(path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(file))
 
 
-def test_exports_sorted_ready_rows_with_stable_schema_and_totals(
+def test_exports_assignment_local_rows_with_focus_standard_ratings(
     tmp_path: Path,
 ) -> None:
+    assignment_path = _write_assignment(tmp_path)
+    roster_path = _write_roster(tmp_path)
     second_manifest, second_review_path, second_review = _write_records(
         tmp_path, "00200"
     )
     first_manifest, first_review_path, first_review = _write_records(
         tmp_path, "00100"
     )
-    first_review["overall_standard_ratings"].extend(
-        [
-            {
-                "standard_id": "synthetic:W.A",
-                "rating": 3,
-                "rationale": "Clear evidence.",
-                "include_in_feedback": True,
-                "updated_at": first_review["updated_at"],
-                "module_details": {},
-            },
-            {
-                "standard_id": "synthetic:W.B",
-                "rating": 3,
-                "rationale": None,
-                "include_in_feedback": False,
-                "updated_at": first_review["updated_at"],
-                "module_details": {},
-            },
-        ]
+    unrostered_manifest, unrostered_review_path, unrostered_review = _write_records(
+        tmp_path, "00300"
     )
-    first_review["review_units"].append(
+    first_review["minimum_requirement_outcome"] = {
+        "status": "met",
+        "returned_without_full_review": False,
+        "teacher_note": None,
+        "updated_at": first_review["updated_at"],
+    }
+    first_review["overall_standard_ratings"] = [
         {
-            "unit_id": "unit_0001",
-            "sequence": 1,
-            "label": "Paragraph 1",
-            "unit_type": "paragraph",
-            "standard_observations": [
+            "standard_id": STANDARD_A,
+            "rating": 3,
+            "rationale": "Uses evidence clearly.",
+            "include_in_feedback": True,
+            "updated_at": first_review["updated_at"],
+            "module_details": {},
+        },
+        {
+            "standard_id": STANDARD_B,
+            "rating": 9,
+            "rationale": "Unknown scale value.",
+            "include_in_feedback": False,
+            "updated_at": first_review["updated_at"],
+            "module_details": {},
+        },
+    ]
+    first_review["private_notes"].append(
+        {
+            "private_note_id": "note_0001",
+            "text": "Private note must not leak.",
+            "created_at": first_review["created_at"],
+            "updated_at": first_review["updated_at"],
+            "module_details": {},
+        }
+    )
+    first_review["feedback"]["standard_feedback"].append(
+        {
+            "standard_id": STANDARD_A,
+            "include_overall_rating": True,
+            "include_overall_rationale": True,
+            "included_observation_ids": [],
+            "comments": [
                 {
-                    "observation_id": "observation_0001",
-                    "standard_id": "synthetic:W.A",
-                    "applicable": True,
-                    "evidence_present": True,
-                    "rating": 3,
-                    "rationale": "Relevant evidence.",
+                    "feedback_comment_id": "feedback_comment_0001",
+                    "source": "custom",
+                    "text": "Feedback text must not leak.",
+                    "reusable_comment_id": None,
+                    "save_for_reuse": False,
                     "include_in_feedback": True,
-                    "updated_at": first_review["updated_at"],
+                    "created_at": first_review["created_at"],
                     "module_details": {},
                 }
             ],
             "module_details": {},
         }
     )
-    first_review["feedback"]["standard_feedback"].append(
-        {
-            "standard_id": "synthetic:W.A",
-            "include_overall_rating": True,
-            "include_overall_rationale": True,
-            "included_observation_ids": ["observation_0001"],
-            "comments": [
-                {
-                    "feedback_comment_id": "feedback_comment_0001",
-                    "source": "custom",
-                    "text": "Good evidence.",
-                    "reusable_comment_id": None,
-                    "save_for_reuse": False,
-                    "include_in_feedback": True,
-                    "created_at": first_review["created_at"],
-                    "module_details": {},
-                },
-                {
-                    "feedback_comment_id": "feedback_comment_0002",
-                    "source": "custom",
-                    "text": "Not for feedback.",
-                    "reusable_comment_id": None,
-                    "save_for_reuse": False,
-                    "include_in_feedback": False,
-                    "created_at": first_review["created_at"],
-                    "module_details": {},
-                },
-            ],
-            "module_details": {},
-        }
-    )
-    first_review["private_notes"].append(
-        {
-            "private_note_id": "note_0001",
-            "text": "Private note.",
-            "created_at": first_review["created_at"],
-            "updated_at": first_review["updated_at"],
-            "module_details": {},
-        }
-    )
+    pdf_path = _student_dir(tmp_path, "00100") / "exports" / "feedback.pdf"
+    md_path = _student_dir(tmp_path, "00100") / "exports" / "feedback.md"
+    pdf_path.parent.mkdir()
+    pdf_path.write_bytes(b"%PDF")
+    md_path.write_text("feedback markdown", encoding="utf-8")
+    first_review["exports"]["feedback_pdf"] = {
+        "path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            "00100/exports/feedback.pdf"
+        ),
+        "generated_at": TIMESTAMP,
+        "source_review_updated_at": first_review["updated_at"],
+        "module_details": {},
+    }
+    first_review["exports"]["feedback_markdown"] = {
+        "path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            "00100/exports/feedback.md"
+        ),
+        "generated_at": TIMESTAMP,
+        "source_review_updated_at": "2026-06-20T12:30:00+00:00",
+        "module_details": {},
+    }
     _write_json(first_review_path, first_review)
-    feedback_path = _student_dir(tmp_path, "00100") / "exports" / "feedback.md"
-    feedback_path.parent.mkdir()
-    feedback_path.write_text("existing feedback", encoding="utf-8")
-    evidence_path = tmp_path / "never-read-evidence.pdf"
-    comment_bank_path = tmp_path / "comment_banks" / "never-read.json"
-    evidence_path.write_bytes(b"evidence")
-    comment_bank_path.parent.mkdir()
-    comment_bank_path.write_text("comment bank", encoding="utf-8")
+    unrostered_review["overall_standard_ratings"] = [
+        {
+            "standard_id": "synthetic:outside",
+            "rating": 1,
+            "rationale": None,
+            "include_in_feedback": False,
+            "updated_at": unrostered_review["updated_at"],
+            "module_details": {},
+        }
+    ]
+    _write_json(unrostered_review_path, unrostered_review)
     originals = {
+        assignment_path: assignment_path.read_bytes(),
+        roster_path: roster_path.read_bytes(),
         first_manifest: first_manifest.read_bytes(),
         first_review_path: first_review_path.read_bytes(),
         second_manifest: second_manifest.read_bytes(),
         second_review_path: second_review_path.read_bytes(),
-        evidence_path: evidence_path.read_bytes(),
-        comment_bank_path: comment_bank_path.read_bytes(),
+        unrostered_manifest: unrostered_manifest.read_bytes(),
+        unrostered_review_path: unrostered_review_path.read_bytes(),
+        pdf_path: pdf_path.read_bytes(),
+        md_path: md_path.read_bytes(),
     }
 
     result = export_class_review_summary(
@@ -197,51 +261,75 @@ def test_exports_sorted_ready_rows_with_stable_schema_and_totals(
             f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
             "class_summary.csv"
         ),
-        row_count=2,
-        ready_count=2,
+        row_count=4,
+        ready_count=3,
         missing_review_count=0,
         invalid_review_count=0,
-        missing_submission_count=0,
+        missing_submission_count=1,
         invalid_submission_count=0,
         identity_mismatch_count=0,
+        returned_without_full_review_count=0,
+        feedback_pdf_present_count=1,
+        feedback_pdf_stale_count=0,
         created_at=TIMESTAMP,
         overwrote_existing=False,
     )
     with expected_path.open("r", encoding="utf-8", newline="") as file:
         reader = csv.DictReader(file)
-        assert tuple(reader.fieldnames or ()) == CSV_COLUMNS
+        fieldnames = tuple(reader.fieldnames or ())
         rows = list(reader)
-    assert [row["student_id"] for row in rows] == ["00100", "00200"]
+    assert fieldnames[: len(BASE_CSV_COLUMNS) - 1] == BASE_CSV_COLUMNS[:-1]
+    assert "score_count" not in fieldnames
+    assert "total_score" not in fieldnames
+    assert "tag_count" not in fieldnames
+    assert f"rating__{STANDARD_A_KEY}" in fieldnames
+    assert f"rating_label__{STANDARD_B_KEY}" in fieldnames
+    assert [row["student_id"] for row in rows] == ["00100", "00200", "00900", "00300"]
+
     first = rows[0]
-    assert first["row_status"] == "ready"
-    assert first["review_state"] == "ready_for_export"
+    assert first["student_display_name"] == "Avery Rivera"
+    assert first["roster_status"] == "rostered"
     assert first["submission_state"] == "unreviewed"
-    assert first["score_count"] == "2"
-    assert first["total_score"] == "6"
-    assert first["total_max_score"] == ""
-    assert first["included_comment_count"] == "1"
-    assert first["selected_comment_count"] == "2"
-    assert first["tag_count"] == "1"
-    assert first["note_count"] == "1"
-    assert first["feedback_export_exists"] == "true"
-    assert first["submission_manifest_path"].endswith(
-        "/submissions/00100/submission.json"
-    )
-    assert first["review_record_path"].endswith(
-        "/submissions/00100/review.json"
-    )
-    assert first["feedback_export_path"].endswith(
-        "/submissions/00100/exports/feedback.md"
-    )
-    assert first["error"] == ""
-    assert rows[1]["feedback_export_exists"] == "false"
+    assert first["submission_valid"] == "true"
+    assert first["review_state"] == "ready_for_export"
+    assert first["review_valid"] == "true"
+    assert first["minimum_requirement_status"] == "met"
+    assert first["returned_without_full_review"] == "false"
+    assert first["feedback_pdf_status"] == "present"
+    assert first["feedback_pdf_stale"] == "false"
+    assert first["feedback_markdown_status"] == "stale"
+    assert first["feedback_markdown_stale"] == "true"
+    assert first[f"rating__{STANDARD_A_KEY}"] == "3"
+    assert first[f"rating_label__{STANDARD_A_KEY}"] == "Secure"
+    assert first[f"rating_included_in_feedback__{STANDARD_A_KEY}"] == "true"
+    assert first[f"rating_missing__{STANDARD_A_KEY}"] == "false"
+    assert first[f"rating__{STANDARD_B_KEY}"] == "9"
+    assert first[f"rating_label__{STANDARD_B_KEY}"] == ""
+    assert "unknown_rating_value" in first["warnings"]
+
+    missing = rows[2]
+    assert missing["student_display_name"] == "Student Missing"
+    assert missing["submission_valid"] == "false"
+    assert missing[f"rating_missing__{STANDARD_A_KEY}"] == "true"
+    assert "missing_submission" in missing["warnings"]
+
+    unrostered = rows[3]
+    assert unrostered["roster_status"] == "unrostered_submission"
+    assert "unrostered_submission" in unrostered["warnings"]
+    assert "rating_for_non_assignment_standard" in unrostered["warnings"]
+    csv_text = expected_path.read_text(encoding="utf-8")
+    assert "Private note must not leak" not in csv_text
+    assert "Feedback text must not leak" not in csv_text
+    assert "feedback_comment_id" not in csv_text
+    assert "module_details" not in csv_text
     for path, original in originals.items():
         assert path.read_bytes() == original
 
 
-def test_status_rows_cover_missing_invalid_and_identity_mismatch(
+def test_status_rows_cover_missing_invalid_identity_and_returned(
     tmp_path: Path,
 ) -> None:
+    _write_assignment(tmp_path)
     _student_dir(tmp_path, "00100").mkdir(parents=True)
     _write_json(
         _student_dir(tmp_path, "00200") / "submission.json", {"invalid": True}
@@ -256,41 +344,42 @@ def test_status_rows_cover_missing_invalid_and_identity_mismatch(
     manifest, review = _records("other_student")
     _write_json(_student_dir(tmp_path, "00500") / "submission.json", manifest)
     _write_json(_student_dir(tmp_path, "00500") / "review.json", review)
+    manifest, review = _records("00600")
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": None,
+        "updated_at": review["updated_at"],
+    }
+    _write_json(_student_dir(tmp_path, "00600") / "submission.json", manifest)
+    _write_json(_student_dir(tmp_path, "00600") / "review.json", review)
 
     result = export_class_review_summary(
         tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
     )
     rows = _read_rows(result.summary_path)
 
-    assert [row["row_status"] for row in rows] == [
+    assert [";".join(row["warnings"].split(";")[:1]) for row in rows] == [
         "missing_submission",
         "invalid_submission",
         "missing_review",
         "invalid_review",
         "identity_mismatch",
+        "",
     ]
-    assert all(row["error"] for row in rows)
-    assert rows[0]["submission_state"] == ""
-    assert rows[2]["submission_state"] == "unreviewed"
-    assert all(row["review_state"] == "" for row in rows)
-    assert all(row["score_count"] == "" for row in rows)
+    assert rows[-1]["minimum_requirement_status"] == "returned_without_full_review"
+    assert rows[-1]["returned_without_full_review"] == "true"
     assert result.missing_submission_count == 1
     assert result.invalid_submission_count == 1
     assert result.missing_review_count == 1
     assert result.invalid_review_count == 1
     assert result.identity_mismatch_count == 1
+    assert result.returned_without_full_review_count == 1
 
 
-def test_empty_submissions_directory_writes_header_only(tmp_path: Path) -> None:
-    submissions = (
-        tmp_path
-        / "classes"
-        / CLASS_ID
-        / "assignments"
-        / ASSIGNMENT_ID
-        / "submissions"
-    )
-    submissions.mkdir(parents=True)
+def test_no_roster_and_no_submissions_writes_header_only(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
 
     result = export_class_review_summary(
         tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
@@ -298,21 +387,20 @@ def test_empty_submissions_directory_writes_header_only(tmp_path: Path) -> None:
 
     assert result.row_count == 0
     assert _read_rows(result.summary_path) == []
-    assert result.summary_path.read_text(encoding="utf-8").splitlines() == [
-        ",".join(CSV_COLUMNS)
-    ]
 
 
-def test_missing_submissions_directory_is_rejected(tmp_path: Path) -> None:
-    with pytest.raises(ClassSummaryExportError, match="does not exist"):
+def test_missing_assignment_config_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ClassSummaryExportError, match="assignment config"):
         export_class_review_summary(
             tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
         )
 
 
 def test_overwrite_policy_replaces_only_derived_csv(tmp_path: Path) -> None:
+    assignment_path = _write_assignment(tmp_path)
     manifest_path, review_path, _ = _write_records(tmp_path, "00100")
     originals = {
+        assignment_path: assignment_path.read_bytes(),
         manifest_path: manifest_path.read_bytes(),
         review_path: review_path.read_bytes(),
     }
@@ -335,7 +423,7 @@ def test_overwrite_policy_replaces_only_derived_csv(tmp_path: Path) -> None:
         created_at=TIMESTAMP,
     )
     assert second.overwrote_existing is True
-    assert _read_rows(second.summary_path)[0]["row_status"] == "ready"
+    assert _read_rows(second.summary_path)[0]["review_valid"] == "true"
     for path, original in originals.items():
         assert path.read_bytes() == original
 
@@ -362,15 +450,7 @@ def test_invalid_timestamp_is_rejected(
 
 
 def test_aware_datetime_is_normalized(tmp_path: Path) -> None:
-    submissions = (
-        tmp_path
-        / "classes"
-        / CLASS_ID
-        / "assignments"
-        / ASSIGNMENT_ID
-        / "submissions"
-    )
-    submissions.mkdir(parents=True)
+    _write_assignment(tmp_path)
     timestamp = datetime(2026, 6, 23, 12, 30, tzinfo=timezone.utc)
     result = export_class_review_summary(
         tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=timestamp

--- a/tests/test_cli_class_summary_export.py
+++ b/tests/test_cli_class_summary_export.py
@@ -10,7 +10,7 @@ import pytest
 from quillan.class_summary_export import class_summary_export_path
 from quillan.cli import main
 import quillan.cli_app.handlers.exports as cli_exports
-from tests.test_class_summary_export import _student_dir, _write_records
+from tests.test_class_summary_export import _student_dir, _write_assignment, _write_records
 from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID
 
 
@@ -19,6 +19,7 @@ def test_cli_exports_ready_and_non_ready_rows_and_prints_summary(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    _write_assignment(tmp_path)
     manifest_path, review_path, _ = _write_records(tmp_path, "00100")
     _student_dir(tmp_path, "00200").mkdir(parents=True)
     originals = {
@@ -30,16 +31,19 @@ def test_cli_exports_ready_and_non_ready_rows_and_prints_summary(
     assert main(["export-class-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
 
     output = capsys.readouterr().out
-    assert "Exported class review summary:" in output
+    assert "Exported assignment-local class summary:" in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
     assert "Rows: 2" in output
-    assert "Ready: 1" in output
+    assert "Valid reviews: 1" in output
     assert "Missing review: 0" in output
     assert "Invalid review: 0" in output
     assert "Missing submission: 1" in output
     assert "Invalid submission: 0" in output
     assert "Identity mismatch: 0" in output
+    assert "Returned without full review: 0" in output
+    assert "Feedback PDF present: 0" in output
+    assert "Feedback PDF stale: 0" in output
     assert "Overwrote existing: no" in output
     relative = (
         f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
@@ -51,10 +55,8 @@ def test_cli_exports_ready_and_non_ready_rows_and_prints_summary(
     )
     with summary_path.open("r", encoding="utf-8", newline="") as file:
         rows = list(csv.DictReader(file))
-    assert [row["row_status"] for row in rows] == [
-        "ready",
-        "missing_submission",
-    ]
+    assert [row["review_valid"] for row in rows] == ["true", "false"]
+    assert "missing_submission" in rows[1]["warnings"]
     for path, original in originals.items():
         assert path.read_bytes() == original
 
@@ -66,7 +68,7 @@ def test_cli_missing_submissions_directory_returns_one(
 ) -> None:
     monkeypatch.setattr(cli_exports, "resolve_workspace_root", lambda: tmp_path)
     assert main(["export-class-summary", CLASS_ID, ASSIGNMENT_ID]) == 1
-    assert "submissions directory does not exist" in capsys.readouterr().out
+    assert "assignment config" in capsys.readouterr().out
 
 
 def test_cli_overwrite_flag_controls_replacement(
@@ -74,6 +76,7 @@ def test_cli_overwrite_flag_controls_replacement(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    _write_assignment(tmp_path)
     manifest_path, review_path, _ = _write_records(tmp_path, "00100")
     originals = {
         manifest_path: manifest_path.read_bytes(),
@@ -94,6 +97,6 @@ def test_cli_overwrite_flag_controls_replacement(
     output = capsys.readouterr().out
     assert "Use --overwrite" in output
     assert "Overwrote existing: yes" in output
-    assert "row_status" in output_path.read_text(encoding="utf-8")
+    assert "review_valid" in output_path.read_text(encoding="utf-8")
     for path, original in originals.items():
         assert path.read_bytes() == original

--- a/tests/test_cli_standards_summary_export.py
+++ b/tests/test_cli_standards_summary_export.py
@@ -11,7 +11,8 @@ from quillan.cli import main
 import quillan.cli_app.handlers.exports as cli_exports
 from quillan.standards_summary_export import standards_summary_export_path
 from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID
-from tests.test_standards_summary_export import _tag, _write_review
+from tests.test_class_summary_export import STANDARD_A, _write_assignment
+from tests.test_standards_summary_export import _rating, _write_review
 
 
 def test_cli_exports_standards_rows_and_prints_summary(
@@ -19,24 +20,30 @@ def test_cli_exports_standards_rows_and_prints_summary(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    paths = _write_review(
+    assignment_path = _write_assignment(tmp_path)
+    manifest_path, review_path, _ = _write_review(
         tmp_path,
         "00100",
-        tags=[_tag("tag_1", "synthetic:W.A", "positive")],
-        comments=[],
+        ratings=[_rating(STANDARD_A, 3)],
     )
-    originals = {path: path.read_bytes() for path in paths}
+    originals = {
+        assignment_path: assignment_path.read_bytes(),
+        manifest_path: manifest_path.read_bytes(),
+        review_path: review_path.read_bytes(),
+    }
     monkeypatch.setattr(cli_exports, "resolve_workspace_root", lambda: tmp_path)
 
     assert main(["export-standards-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
 
     output = capsys.readouterr().out
-    assert "Exported standards summary:" in output
+    assert "Exported assignment-local Focus Standard summary:" in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
-    assert "Rows: 1" in output
-    assert "Standards: 1" in output
+    assert "Standards: 2" in output
+    assert "Expected students: 1" in output
     assert "Valid reviews: 1" in output
+    assert "Missing reviews: 0" in output
+    assert "Returned without full review: 0" in output
     assert "Missing review: 0" in output
     assert "Invalid review: 0" in output
     assert "Missing submission: 0" in output
@@ -51,7 +58,7 @@ def test_cli_exports_standards_rows_and_prints_summary(
     with standards_summary_export_path(
         tmp_path, CLASS_ID, ASSIGNMENT_ID
     ).open("r", encoding="utf-8", newline="") as file:
-        assert list(csv.DictReader(file))[0]["standard_id"] == "synthetic:W.A"
+        assert list(csv.DictReader(file))[0]["standard_id"] == STANDARD_A
     for path, original in originals.items():
         assert path.read_bytes() == original
 
@@ -64,13 +71,13 @@ def test_cli_handles_missing_directory_and_overwrite(
     monkeypatch.setattr(cli_exports, "resolve_workspace_root", lambda: tmp_path)
     command = ["export-standards-summary", CLASS_ID, ASSIGNMENT_ID]
     assert main(command) == 1
-    assert "submissions directory does not exist" in capsys.readouterr().out
+    assert "assignment config" in capsys.readouterr().out
 
+    _write_assignment(tmp_path)
     _write_review(
         tmp_path,
         "00100",
-        tags=[_tag("tag_1", "synthetic:W.A", "positive")],
-        comments=[],
+        ratings=[_rating(STANDARD_A, 3)],
     )
     output_path = standards_summary_export_path(
         tmp_path, CLASS_ID, ASSIGNMENT_ID
@@ -90,11 +97,11 @@ def test_cli_writes_header_only_when_no_standard_artifacts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _write_assignment(tmp_path)
     _write_review(
         tmp_path,
         "00100",
-        tags=[_tag("tag_1", None, "neutral")],
-        comments=[],
+        ratings=[],
     )
     monkeypatch.setattr(cli_exports, "resolve_workspace_root", lambda: tmp_path)
 
@@ -103,4 +110,6 @@ def test_cli_writes_header_only_when_no_standard_artifacts(
     with standards_summary_export_path(
         tmp_path, CLASS_ID, ASSIGNMENT_ID
     ).open("r", encoding="utf-8", newline="") as file:
-        assert list(csv.DictReader(file)) == []
+        rows = list(csv.DictReader(file))
+    assert len(rows) == 2
+    assert all(row["students_reviewed_for_standard"] == "0" for row in rows)

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -301,8 +301,8 @@ def test_assignment_review_actions_menu_includes_export_choices(
     output = capsys.readouterr().out
     assert "Assignment Review Actions" in output
     assert "2. Assemble routed submissions" in output
-    assert "3. Export class review summary" in output
-    assert "4. Export standards summary" in output
+    assert "3. Export assignment-local class summary" in output
+    assert "4. Export assignment-local Focus Standard summary" in output
 
 
 def test_selected_student_review_menu_includes_feedback_export(
@@ -444,7 +444,7 @@ def test_menu_export_class_summary_creates_summary_file(
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
-    assert "Exported class review summary:" in output
+    assert "Exported assignment-local class summary:" in output
     assert "Overwrote existing: no" in output
     assert summary_path.is_file()
 
@@ -475,7 +475,7 @@ def test_menu_export_standards_summary_creates_summary_file(
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
-    assert "Exported standards summary:" in output
+    assert "Exported assignment-local Focus Standard summary:" in output
     assert "Overwrote existing: no" in output
     assert summary_path.is_file()
 
@@ -671,7 +671,7 @@ def test_menu_export_class_summary_overwrites_existing_export(
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
-    assert "Exported class review summary:" in output
+    assert "Exported assignment-local class summary:" in output
     assert "Overwrote existing: yes" in output
     assert summary_path.read_text(encoding="utf-8") != "old content"
 
@@ -731,7 +731,7 @@ def test_menu_export_standards_summary_overwrites_existing_export(
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
-    assert "Exported standards summary:" in output
+    assert "Exported assignment-local Focus Standard summary:" in output
     assert "Overwrote existing: yes" in output
     assert summary_path.read_text(encoding="utf-8") != "old summary"
 

--- a/tests/test_standards_summary_export.py
+++ b/tests/test_standards_summary_export.py
@@ -1,8 +1,9 @@
-"""Tests for teacher-facing standards summary CSV export."""
+"""Tests for teacher-facing assignment-local Focus Standard summary CSV export."""
 
 from __future__ import annotations
 
 import csv
+import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -16,125 +17,68 @@ from quillan.standards_summary_export import (
     export_standards_summary,
     standards_summary_export_path,
 )
-from tests.test_class_summary_export import _records, _student_dir, _write_json
-from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID
-
-TIMESTAMP = "2026-06-23T13:00:00+00:00"
-
-
-def _tag(
-    tag_id: str, standard_id: str | None, polarity: str
-) -> dict[str, Any]:
-    tag = {
-        "tag_id": tag_id,
-        "label": f"{polarity} tag",
-        "polarity": polarity,
-        "created_at": TIMESTAMP,
-        "module_details": {},
-    }
-    if standard_id is not None:
-        tag["standard_id"] = standard_id
-    return tag
-
-
-def _comment(
-    comment_id: str, standard_id: str | None, included: bool
-) -> dict[str, Any]:
-    comment = {
-        "comment_record_id": comment_id,
-        "label": "Selected comment",
-        "text": "Snapshotted teacher-selected language.",
-        "source": "custom",
-        "include_in_feedback": included,
-        "created_at": TIMESTAMP,
-        "module_details": {},
-    }
-    if standard_id is not None:
-        comment.update(
-            {
-                "source": "comment_bank",
-                "bank_id": "general_writing",
-                "comment_id": f"source_{comment_id}",
-                "standard_id": standard_id,
-            }
-        )
-    return comment
+from tests.test_class_summary_export import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STANDARD_A,
+    STANDARD_A_KEY,
+    STANDARD_B,
+    STANDARD_B_KEY,
+    TIMESTAMP,
+    _records,
+    _student_dir,
+    _write_assignment,
+    _write_json,
+    _write_roster,
+)
 
 
 def _write_review(
     workspace: Path,
     student_id: str,
     *,
-    tags: list[dict[str, Any]],
-    comments: list[dict[str, Any]],
-) -> tuple[Path, Path]:
+    ratings: list[dict[str, Any]],
+    returned_without_full_review: bool = False,
+) -> tuple[Path, Path, dict[str, Any]]:
     manifest, review = _records(student_id)
-    observations = []
-    observation_ids_by_standard: dict[str, list[str]] = {}
-    for index, tag in enumerate(tags, start=1):
-        standard_id = tag.get("standard_id")
-        if standard_id is None:
-            continue
-        observation_id = f"observation_{index:04d}"
-        observations.append(
-            {
-                "observation_id": observation_id,
-                "standard_id": standard_id,
-                "applicable": True,
-                "evidence_present": True,
-                "rating": 1,
-                "rationale": tag["label"],
-                "include_in_feedback": True,
-                "updated_at": TIMESTAMP,
-                "module_details": {"legacy_polarity": tag["polarity"]},
-            }
-        )
-        observation_ids_by_standard.setdefault(standard_id, []).append(observation_id)
-    if observations:
-        review["review_units"] = [
-            {
-                "unit_id": f"unit_{index:04d}",
-                "sequence": index,
-                "label": f"Whole submission {index}",
-                "unit_type": "whole_submission",
-                "standard_observations": [observation],
-                "module_details": {},
-            }
-            for index, observation in enumerate(observations, start=1)
-        ]
-    comments_by_standard: dict[str, list[dict[str, Any]]] = {}
-    for index, comment in enumerate(comments, start=1):
-        standard_id = comment.get("standard_id")
-        if standard_id is None:
-            continue
-        comments_by_standard.setdefault(standard_id, []).append(
-            {
-                "feedback_comment_id": f"feedback_comment_{index:04d}",
-                "source": "custom",
-                "text": comment["text"],
-                "reusable_comment_id": None,
-                "save_for_reuse": False,
-                "include_in_feedback": comment["include_in_feedback"],
-                "created_at": TIMESTAMP,
-                "module_details": {},
-            }
-        )
-    review["feedback"]["standard_feedback"] = [
-        {
-            "standard_id": standard_id,
-            "include_overall_rating": False,
-            "include_overall_rationale": False,
-            "included_observation_ids": observation_ids_by_standard.get(standard_id, []),
-            "comments": standard_comments,
-            "module_details": {},
+    if returned_without_full_review:
+        review["review_state"] = "returned_without_full_review"
+        review["minimum_requirement_outcome"] = {
+            "status": "returned_without_full_review",
+            "returned_without_full_review": True,
+            "teacher_note": None,
+            "updated_at": review["updated_at"],
         }
-        for standard_id, standard_comments in sorted(comments_by_standard.items())
-    ]
+    else:
+        review["minimum_requirement_outcome"] = {
+            "status": "met",
+            "returned_without_full_review": False,
+            "teacher_note": None,
+            "updated_at": review["updated_at"],
+        }
+    review["overall_standard_ratings"] = ratings
     student_dir = _student_dir(workspace, student_id)
     return (
         _write_json(student_dir / "submission.json", manifest),
         _write_json(student_dir / "review.json", review),
+        review,
     )
+
+
+def _rating(
+    standard_id: str,
+    value: int,
+    *,
+    include_in_feedback: bool = True,
+) -> dict[str, Any]:
+    return {
+        "standard_id": standard_id,
+        "rating": value,
+        "rationale": "Teacher-entered rating.",
+        "include_in_feedback": include_in_feedback,
+        "updated_at": TIMESTAMP,
+        "module_details": {"debug": "must not leak"},
+    }
 
 
 def _read_rows(path: Path) -> list[dict[str, str]]:
@@ -142,44 +86,75 @@ def _read_rows(path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(file))
 
 
-def test_aggregates_standards_in_sorted_stable_rows_without_mutation(
+def test_focus_standard_rows_follow_assignment_order_and_count_ratings(
     tmp_path: Path,
 ) -> None:
-    first_paths = _write_review(
+    assignment_path = _write_assignment(tmp_path)
+    roster_path = _write_roster(tmp_path)
+    first_manifest, first_review_path, first_review = _write_review(
         tmp_path,
         "00100",
-        tags=[
-            _tag("tag_1", "synthetic:W.Z", "positive"),
-            _tag("tag_2", "synthetic:W.A", "developing"),
-            _tag("tag_3", "synthetic:W.A", "negative"),
-            _tag("tag_4", None, "neutral"),
-        ],
-        comments=[
-            _comment("comment_1", "synthetic:W.A", True),
-            _comment("comment_2", "synthetic:W.A", False),
-            _comment("comment_3", None, True),
+        ratings=[
+            _rating(STANDARD_A, 3),
+            _rating(STANDARD_B, 2, include_in_feedback=False),
         ],
     )
-    second_paths = _write_review(
+    second_manifest, second_review_path, _ = _write_review(
         tmp_path,
         "00200",
-        tags=[
-            _tag("tag_1", "synthetic:W.A", "neutral"),
-            _tag("tag_2", "synthetic:W.A", "positive"),
-        ],
-        comments=[
-            _comment("comment_1", "synthetic:W.A", True),
-            _comment("comment_2", "synthetic:W.Z", False),
-        ],
+        ratings=[_rating(STANDARD_A, 2)],
     )
-    evidence = tmp_path / "evidence.pdf"
-    evidence.write_bytes(b"never read")
-    bank = tmp_path / "comment_banks" / "bank.json"
-    bank.parent.mkdir()
-    bank.write_text("{not json", encoding="utf-8")
+    returned_manifest, returned_review_path, _ = _write_review(
+        tmp_path,
+        "00300",
+        ratings=[],
+        returned_without_full_review=True,
+    )
+    outside_manifest, outside_review_path, outside_review = _write_review(
+        tmp_path,
+        "00400",
+        ratings=[_rating("synthetic:outside", 1)],
+    )
+    pdf_path = _student_dir(tmp_path, "00100") / "exports" / "feedback.pdf"
+    stale_pdf_path = _student_dir(tmp_path, "00200") / "exports" / "feedback.pdf"
+    pdf_path.parent.mkdir()
+    stale_pdf_path.parent.mkdir()
+    pdf_path.write_bytes(b"%PDF")
+    stale_pdf_path.write_bytes(b"%PDF")
+    first_review["exports"]["feedback_pdf"] = {
+        "path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            "00100/exports/feedback.pdf"
+        ),
+        "generated_at": TIMESTAMP,
+        "source_review_updated_at": first_review["updated_at"],
+        "module_details": {},
+    }
+    _write_json(first_review_path, first_review)
+    stale_review = json.loads(second_review_path.read_text(encoding="utf-8"))
+    stale_review["exports"]["feedback_pdf"] = {
+        "path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            "00200/exports/feedback.pdf"
+        ),
+        "generated_at": TIMESTAMP,
+        "source_review_updated_at": "2026-06-20T12:30:00+00:00",
+        "module_details": {},
+    }
+    _write_json(second_review_path, stale_review)
     originals = {
-        path: path.read_bytes()
-        for path in (*first_paths, *second_paths, evidence, bank)
+        assignment_path: assignment_path.read_bytes(),
+        roster_path: roster_path.read_bytes(),
+        first_manifest: first_manifest.read_bytes(),
+        first_review_path: first_review_path.read_bytes(),
+        second_manifest: second_manifest.read_bytes(),
+        second_review_path: second_review_path.read_bytes(),
+        returned_manifest: returned_manifest.read_bytes(),
+        returned_review_path: returned_review_path.read_bytes(),
+        outside_manifest: outside_manifest.read_bytes(),
+        outside_review_path: outside_review_path.read_bytes(),
+        pdf_path: pdf_path.read_bytes(),
+        stale_pdf_path: stale_pdf_path.read_bytes(),
     }
 
     result = export_standards_summary(
@@ -199,13 +174,14 @@ def test_aggregates_standards_in_sorted_stable_rows_without_mutation(
         ),
         row_count=2,
         standard_count=2,
-        student_count=2,
-        review_count=2,
+        student_count=5,
+        review_count=4,
         missing_review_count=0,
         invalid_review_count=0,
-        missing_submission_count=0,
+        missing_submission_count=1,
         invalid_submission_count=0,
         identity_mismatch_count=0,
+        returned_without_full_review_count=1,
         created_at=TIMESTAMP,
         overwrote_existing=False,
     )
@@ -213,35 +189,46 @@ def test_aggregates_standards_in_sorted_stable_rows_without_mutation(
         reader = csv.DictReader(file)
         assert tuple(reader.fieldnames or ()) == CSV_COLUMNS
         rows = list(reader)
-    assert [row["standard_id"] for row in rows] == ["synthetic:W.A", "synthetic:W.Z"]
+    assert [row["standard_id"] for row in rows] == [STANDARD_A, STANDARD_B]
+    assert [row["standard_column_key"] for row in rows] == [
+        STANDARD_A_KEY,
+        STANDARD_B_KEY,
+    ]
+    assert "tag_count" not in rows[0]
+    assert "positive_tag_count" not in rows[0]
+
     first = rows[0]
-    assert first["student_count"] == "2"
-    assert first["tag_student_count"] == "2"
-    assert first["comment_student_count"] == "2"
-    assert first["tag_count"] == "4"
-    assert first["positive_tag_count"] == "1"
-    assert first["developing_tag_count"] == "1"
-    assert first["negative_tag_count"] == "1"
-    assert first["neutral_tag_count"] == "1"
-    assert first["selected_comment_count"] == "3"
-    assert first["included_comment_count"] == "2"
-    assert first["excluded_comment_count"] == "1"
-    assert first["review_count"] == "2"
-    assert first["source"] == "review_record_v2"
-    assert rows[1]["student_count"] == "2"
-    assert rows[1]["tag_student_count"] == "1"
-    assert rows[1]["comment_student_count"] == "1"
+    assert first["standards_profile_id"] == "synthetic_profile"
+    assert first["focus_standard_order"] == "1"
+    assert first["students_expected"] == "5"
+    assert first["students_with_submissions"] == "4"
+    assert first["students_with_valid_reviews"] == "4"
+    assert first["students_reviewed_for_standard"] == "2"
+    assert first["students_returned_without_full_review"] == "1"
+    assert first["students_missing_rating"] == "1"
+    assert first["students_with_rating_included_in_feedback"] == "2"
+    assert first["feedback_pdf_present_count"] == "1"
+    assert first["feedback_pdf_stale_count"] == "1"
+    assert json.loads(first["rating_counts_json"]) == {"1": 0, "2": 1, "3": 1}
+    assert "rating_for_non_assignment_standard" in first["warnings"]
+    assert "standard_metadata_missing" in first["warnings"]
+
+    second = rows[1]
+    assert second["students_reviewed_for_standard"] == "1"
+    assert second["students_missing_rating"] == "2"
+    assert second["students_with_rating_included_in_feedback"] == "0"
+    assert json.loads(second["rating_counts_json"]) == {"1": 0, "2": 1, "3": 0}
+    csv_text = expected_path.read_text(encoding="utf-8")
+    assert "Teacher-entered rating" not in csv_text
+    assert "module_details" not in csv_text
+    assert "synthetic:outside" not in csv_text
     for path, original in originals.items():
         assert path.read_bytes() == original
 
 
 def test_non_ready_counts_repeat_on_rows_and_do_not_abort(tmp_path: Path) -> None:
-    _write_review(
-        tmp_path,
-        "00100",
-        tags=[_tag("tag_1", "synthetic:W.A", "positive")],
-        comments=[],
-    )
+    _write_assignment(tmp_path)
+    _write_review(tmp_path, "00100", ratings=[_rating(STANDARD_A, 3)])
     _student_dir(tmp_path, "00200").mkdir(parents=True)
     manifest, _ = _records("00300")
     _write_json(_student_dir(tmp_path, "00300") / "submission.json", manifest)
@@ -268,60 +255,45 @@ def test_non_ready_counts_repeat_on_rows_and_do_not_abort(tmp_path: Path) -> Non
     assert result.invalid_submission_count == 1
     assert result.identity_mismatch_count == 1
     row = _read_rows(result.summary_path)[0]
-    assert row["missing_submission_count"] == "1"
-    assert row["missing_review_count"] == "1"
-    assert row["invalid_review_count"] == "1"
-    assert row["invalid_submission_count"] == "1"
-    assert row["identity_mismatch_count"] == "1"
+    assert row["students_with_valid_reviews"] == "1"
+    assert row["students_with_submissions"] == "3"
 
 
-def test_no_linked_artifacts_writes_header_only(tmp_path: Path) -> None:
-    _write_review(
-        tmp_path,
-        "00100",
-        tags=[_tag("tag_1", None, "neutral")],
-        comments=[_comment("comment_1", None, True)],
-    )
-
-    result = export_standards_summary(
-        tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
-    )
-
-    assert result.row_count == result.standard_count == 0
-    assert result.review_count == 1
-    assert _read_rows(result.summary_path) == []
-    assert result.summary_path.read_text(encoding="utf-8").splitlines() == [
-        ",".join(CSV_COLUMNS)
-    ]
-
-
-def test_no_valid_reviews_writes_header_only_with_counts(tmp_path: Path) -> None:
+def test_no_valid_reviews_writes_focus_standard_rows_with_counts(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
     _student_dir(tmp_path, "00100").mkdir(parents=True)
 
     result = export_standards_summary(
         tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
     )
 
-    assert result.row_count == result.review_count == 0
+    assert result.row_count == result.standard_count == 2
+    assert result.review_count == 0
     assert result.missing_submission_count == 1
-    assert _read_rows(result.summary_path) == []
+    rows = _read_rows(result.summary_path)
+    assert [row["standard_id"] for row in rows] == [STANDARD_A, STANDARD_B]
+    assert all(row["students_reviewed_for_standard"] == "0" for row in rows)
 
 
-def test_missing_submissions_directory_is_rejected(tmp_path: Path) -> None:
-    with pytest.raises(StandardsSummaryExportError, match="does not exist"):
+def test_missing_assignment_config_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(StandardsSummaryExportError, match="assignment config"):
         export_standards_summary(
             tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
         )
 
 
 def test_overwrite_replaces_only_the_derived_csv(tmp_path: Path) -> None:
-    paths = _write_review(
+    assignment_path = _write_assignment(tmp_path)
+    manifest_path, review_path, _ = _write_review(
         tmp_path,
         "00100",
-        tags=[_tag("tag_1", "synthetic:W.A", "positive")],
-        comments=[],
+        ratings=[_rating(STANDARD_A, 3)],
     )
-    originals = {path: path.read_bytes() for path in paths}
+    originals = {
+        assignment_path: assignment_path.read_bytes(),
+        manifest_path: manifest_path.read_bytes(),
+        review_path: review_path.read_bytes(),
+    }
     first = export_standards_summary(
         tmp_path, CLASS_ID, ASSIGNMENT_ID, created_at=TIMESTAMP
     )
@@ -341,7 +313,7 @@ def test_overwrite_replaces_only_the_derived_csv(tmp_path: Path) -> None:
         created_at=TIMESTAMP,
     )
     assert second.overwrote_existing is True
-    assert _read_rows(second.summary_path)[0]["standard_id"] == "synthetic:W.A"
+    assert _read_rows(second.summary_path)[0]["standard_id"] == STANDARD_A
     for path, original in originals.items():
         assert path.read_bytes() == original
 

--- a/tests/test_v070_smoke.py
+++ b/tests/test_v070_smoke.py
@@ -318,13 +318,12 @@ def test_v070_synthetic_teacher_review_and_export_workflow(
     assert len(class_rows) == 1
     class_row = class_rows[0]
     assert class_row["student_id"] == STUDENT_ID
-    assert class_row["row_status"] == "ready"
-    assert class_row["score_count"] == "0"
-    assert class_row["selected_comment_count"] == "0"
-    assert class_row["included_comment_count"] == "0"
-    assert class_row["tag_count"] == "0"
-    assert class_row["note_count"] == "1"
-    assert class_row["feedback_export_exists"] == "true"
+    assert class_row["review_valid"] == "true"
+    assert class_row["review_state"] == "not_started"
+    assert class_row["feedback_pdf_status"] == "missing"
+    assert class_row["feedback_markdown_status"] == "unknown"
+    assert class_row["warnings"] == "feedback_markdown_metadata_missing"
+    assert "Private note" not in class_summary.summary_path.read_text(encoding="utf-8")
     for path, original in canonical_before_exports.items():
         assert path.read_bytes() == original
 
@@ -335,6 +334,8 @@ def test_v070_synthetic_teacher_review_and_export_workflow(
         created_at=EXPORTED_AT,
     )
     standards_rows = _read_csv_rows(standards_summary.summary_path)
-    assert standards_rows == []
+    assert len(standards_rows) == 1
+    assert standards_rows[0]["standard_id"] == STANDARD_ID
+    assert standards_rows[0]["students_reviewed_for_standard"] == "0"
     for path, original in canonical_before_exports.items():
         assert path.read_bytes() == original

--- a/tests/test_v080_end_to_end_smoke.py
+++ b/tests/test_v080_end_to_end_smoke.py
@@ -373,11 +373,11 @@ def test_v080_scan_review_export_end_to_end_smoke(
     assert "not_started" in class_summary_text
 
     standards_summary_text = standards_summary_path.read_text(encoding="utf-8")
-    assert "student_count" in standards_summary_text
-    assert STANDARD_ID not in standards_summary_text
+    assert "students_expected" in standards_summary_text
+    assert STANDARD_ID in standards_summary_text
 
     output = capsys.readouterr().out
     assert "Routed Quillan response page." in output
     assert "Exported student feedback:" in output
-    assert "Exported class review summary:" in output
-    assert "Exported standards summary:" in output
+    assert "Exported assignment-local class summary:" in output
+    assert "Exported assignment-local Focus Standard summary:" in output


### PR DESCRIPTION
## Summary

Implements assignment-local v2 class and Focus Standard summary exports for Quillan’s standards-based review workflow.

The summaries now report one class and one assignment using v2 review records, Focus Standard ratings, minimum-requirement outcomes, returned-without-full-review status, feedback export status, and assignment-local warnings.

## Changes

* Rebuilds `class_summary.csv` around v2 assignment-local reporting fields:

  * roster-aware student rows;
  * minimum-requirement outcomes;
  * returned-without-full-review status;
  * Focus Standard rating columns;
  * rating labels resolved through the assignment rating scale;
  * feedback PDF/Markdown status;
  * warnings.
* Rebuilds `standards_summary.csv` as one row per configured assignment Focus Standard.
* Adds rating distributions from `overall_standard_ratings`.
* Adds missing-rating counts.
* Adds returned-without-full-review counts.
* Adds feedback PDF coverage.
* Adds shared read-only summary helpers in `quillan/assignment_summary_context.py`.
* Updates CLI descriptions and output to remove legacy score/tag wording.
* Updates menu labels to use assignment-local summary language.
* Updates README and CLI contract documentation.
* Reworks exporter, CLI, menu, smoke, privacy, and read-only tests for the new schema.

## Behavior

The new reports are assignment-local only. They summarize one class and one assignment.

They do not calculate grades, percentages, mastery labels, longitudinal progress, cross-assignment performance, or cross-module results.

Missing ratings remain missing. Returned-without-full-review records are counted separately and are not treated as low ratings.

## Verification

Full test suite:

* `.\.venv\Scripts\python.exe -m pytest`

Result:

* `1026 passed`

Changed-file Ruff:

* `.\.venv\Scripts\ruff.exe check <changed files>`

Result:

* `All checks passed`

## Notes

This PR does not implement cross-assignment reports, longitudinal reports, marking-period reports, gradebook export, parent/admin reporting, Quillan + ScoreForm combined reporting, assignment results manifest, PDF summaries, email delivery, LMS upload, AI analysis, OCR, handwriting recognition, or parsing student writing.

Closes #231
