### PR TITLE
Fix review and export status display

### DIFF
--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -308,6 +308,10 @@ def print_exported_feedback_pdf(exported: ExportedFeedbackPdf) -> None:
     print(f"PDF file: {exported.feedback_pdf_relative_path}")
     if exported.feedback_markdown_relative_path is not None:
         print(f"Markdown file: {exported.feedback_markdown_relative_path}")
+        export_formats = "PDF + Markdown"
+    else:
+        export_formats = "PDF"
+    print(f"Feedback export: {export_formats} exported {exported.created_at}")
 
 
 def print_exported_class_summary(exported: ExportedClassSummary) -> None:

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -887,6 +887,11 @@ def _update_export_metadata(
             "source_review_updated_at": context["review"]["updated_at"],
             "module_details": {},
         }
+    # Returned work remains a distinct terminal workflow state under the v2
+    # contract, even when its return feedback has been exported.
+    if review["review_state"] != "returned_without_full_review":
+        review["review_state"] = "exported"
+    review["updated_at"] = created_at
     try:
         validate_review_record(review)
         write_review_record(context["record_path"], review, overwrite=True)

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -45,7 +46,6 @@ from quillan.cli_app.output import (
     print_updated_review_unit_observation,
     print_updated_review_units,
     print_updated_review_score,
-    print_updated_submission_review_state,
 )
 from quillan.comment_banks import CommentBankError, load_comment_bank
 from quillan.feedback_export import (
@@ -85,11 +85,19 @@ from quillan.review_feedback import (
     summarize_standard_feedback,
 )
 from quillan.review_record import (
+    ALLOWED_REVIEW_STATES,
     ALLOWED_TAG_POLARITIES,
     ReviewRecordError,
+    build_empty_review_record,
     load_review_record,
+    validate_review_record,
 )
-from quillan.review_record_paths import review_record_path
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    review_record_path,
+    write_review_record,
+)
+from quillan.review_status_display import feedback_export_status, review_status_label
 from quillan.review_snapshot import current_review_details_text
 from quillan.review_targets import (
     ReviewTargetError,
@@ -110,11 +118,7 @@ from quillan.submission_review_opening import (
     open_student_submission_for_review,
     selected_submission_evidence_pages,
 )
-from quillan.submission_manifest import (
-    ALLOWED_SUBMISSION_STATES,
-    SubmissionManifestError,
-    load_submission_manifest,
-)
+from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
 from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
@@ -124,10 +128,6 @@ from quillan.submission_page_management import (
     exclude_submission_page,
     mark_submission_page_needs_rescan,
     restore_excluded_submission_page,
-)
-from quillan.submission_review_state import (
-    SubmissionReviewStateError,
-    update_submission_review_state,
 )
 from quillan.submission_status import (
     AssignmentSubmissionStatus,
@@ -453,7 +453,7 @@ def _launch_selected_student_review(
         print("6. Compose Focus Standard feedback")
         print("7. Manage submission pages")
         print("8. Add teacher note")
-        print("9. Update submission review state")
+        print("9. Update review workflow state")
         print("10. Export student feedback")
         print("11. Refresh summary")
         print("12. Back")
@@ -2005,27 +2005,47 @@ def _menu_update_submission_review_state(
     _print_review_action_header(
         "Update Review State", class_id, assignment_id, student_id
     )
-    print("Use this to mark where this student's submission is in your review workflow.")
-    print("This is not a grade.")
+    print("Use this to update the teacher-review workflow. This is not a grade.")
     print()
-    current_state = _current_submission_state(
-        workspace_root, class_id, assignment_id, student_id
-    )
+    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
+    if not path.exists():
+        timestamp = datetime.now(timezone.utc).isoformat()
+        record = build_empty_review_record(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            created_at=timestamp,
+        )
+    else:
+        try:
+            record = load_review_record(path)
+        except (OSError, ReviewRecordError) as error:
+            print(f"Error: could not load review record: {error}")
+            return
+    current_state = str(record["review_state"])
     print(f"Current state: {current_state}")
     print()
-    states = ("unreviewed", "in_progress", "needs_rescan", "reviewed")
+    states = (
+        "not_started",
+        "requirements_checked",
+        "returned_without_full_review",
+        "observations_in_progress",
+        "observations_complete",
+        "ratings_complete",
+        "feedback_composed",
+        "ready_for_export",
+        "exported",
+    )
     descriptions = {
-        "unreviewed": "Review has not started yet.",
-        "in_progress": "Review is underway.",
-        "needs_rescan": "The submission needs a corrected scan or page.",
-        "reviewed": "Review is complete.",
+        state: review_status_label({"review_state": state}).capitalize()
+        for state in states
     }
     for index, state_opt in enumerate(states, start=1):
         print(f"{index}. {state_opt} - {descriptions[state_opt]}")
     print("B. Back")
     print()
 
-    selection = input("Select submission review state: ").strip()
+    selection = input("Select review workflow state: ").strip()
     if not selection or selection.casefold() == "b":
         print("Update review state canceled.")
         return
@@ -2037,10 +2057,10 @@ def _menu_update_submission_review_state(
     else:
         selected_state = selection
 
-    if selected_state not in ALLOWED_SUBMISSION_STATES:
+    if selected_state not in ALLOWED_REVIEW_STATES:
         print(
             "Update review state canceled. Invalid state selection. "
-            f"Allowed values: {', '.join(sorted(ALLOWED_SUBMISSION_STATES))}."
+            f"Allowed values: {', '.join(states)}."
         )
         return
 
@@ -2055,18 +2075,16 @@ def _menu_update_submission_review_state(
         return
 
     try:
-        updated = update_submission_review_state(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-            selected_state,
-        )
-    except SubmissionReviewStateError as error:
-        print(f"Error: could not update submission review state: {error}")
+        updated_record = dict(record)
+        updated_record["review_state"] = selected_state
+        updated_record["updated_at"] = datetime.now(timezone.utc).isoformat()
+        validate_review_record(updated_record)
+        write_review_record(path, updated_record, overwrite=True)
+    except (ReviewRecordError, ReviewRecordPathError, OSError) as error:
+        print(f"Error: could not update review workflow state: {error}")
         return
 
-    print_updated_submission_review_state(updated)
+    print(f"Review: {review_status_label(updated_record)}")
 
 
 def _prompt_yes_no_default_no(prompt: str) -> bool:
@@ -2306,18 +2324,25 @@ def _print_review_summary(
     if student_status is None:
         print("Submission: not assembled")
         print("Evidence files: 0")
-        print("Review state: not_started")
     elif student_status.manifest_path is None:
         print("Submission: not assembled")
         print("Evidence files: routed but not assembled")
-        print("Review state: not_started")
     else:
         print("Submission: assembled")
         print(
             "Evidence files: "
             f"{sum(page.evidence_count for page in student_status.pages)}"
         )
-        print(f"Review state: {student_status.submission_state}")
+
+    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
+    record = None
+    if path.exists():
+        try:
+            record = load_review_record(path)
+        except (OSError, ReviewRecordError):
+            pass
+    print(f"Review: {review_status_label(record)}")
+    print(f"Feedback export: {feedback_export_status(workspace_root, record)}")
 
     _print_review_record_summary(
         workspace_root,
@@ -2358,7 +2383,6 @@ def _print_review_record_summary(
         return
 
     print("Review record: exists")
-    print(f"Review record state: {record['review_state']}")
     print(f"Private notes: {_count_record_items(record, 'private_notes')}")
     print(f"Review units: {_count_record_items(record, 'review_units')}")
     print(f"Review-unit observations: {_count_review_unit_observations(record)}")

--- a/quillan/review_snapshot.py
+++ b/quillan/review_snapshot.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from quillan.review_record import ReviewRecordError, load_review_record
 from quillan.review_record_paths import review_record_path
+from quillan.review_status_display import feedback_export_status, review_status_label
 
 def current_review_details_text(
     workspace_root: str | Path,
@@ -35,7 +36,10 @@ def current_review_details_text(
         return "\n".join(lines)
 
     lines.append("Review record: exists")
-    lines.append(f"Review state: {record['review_state']}")
+    lines.append(f"Review: {review_status_label(record)}")
+    lines.append(
+        f"Feedback export: {feedback_export_status(workspace_root, record)}"
+    )
     lines.append("")
     _append_requirement_checks(lines, record)
     _append_review_units(lines, record)

--- a/quillan/review_status_display.py
+++ b/quillan/review_status_display.py
@@ -1,0 +1,59 @@
+"""Teacher-facing display helpers for submission, review, and export status."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+REVIEW_STATE_LABELS = {
+    "not_started": "not started",
+    "requirements_checked": "requirements checked",
+    "returned_without_full_review": "returned without full standards review",
+    "observations_in_progress": "observations in progress",
+    "observations_complete": "observations complete",
+    "ratings_complete": "ratings complete",
+    "feedback_composed": "feedback composed",
+    "ready_for_export": "ready for export",
+    "exported": "exported",
+}
+
+
+def review_status_label(record: dict[str, Any] | None) -> str:
+    """Return the teacher-facing review workflow label."""
+    if record is None:
+        return REVIEW_STATE_LABELS["not_started"]
+    state = str(record.get("review_state", "not_started"))
+    return REVIEW_STATE_LABELS.get(state, state.replace("_", " "))
+
+
+def feedback_export_status(
+    workspace_root: str | Path,
+    record: dict[str, Any] | None,
+) -> str:
+    """Derive a teacher-facing export status from review export metadata."""
+    if record is None:
+        return "not exported"
+    exports = record.get("exports")
+    if not isinstance(exports, dict):
+        return "not exported"
+
+    present: list[tuple[str, str]] = []
+    for key, label in (
+        ("feedback_pdf", "PDF"),
+        ("feedback_markdown", "Markdown"),
+    ):
+        metadata = exports.get(key)
+        if not isinstance(metadata, dict):
+            continue
+        relative_path = metadata.get("path")
+        if not isinstance(relative_path, str) or not (
+            Path(workspace_root) / Path(relative_path)
+        ).is_file():
+            return "metadata exists, but export file is missing"
+        present.append((label, str(metadata.get("generated_at", ""))))
+
+    if not present:
+        return "not exported"
+    latest = max(timestamp for _, timestamp in present)
+    labels = " + ".join(label for label, _ in present)
+    return f"{labels} exported {latest}".rstrip()

--- a/tests/test_feedback_pdf_export.py
+++ b/tests/test_feedback_pdf_export.py
@@ -203,6 +203,7 @@ def test_normal_pdf_export_creates_student_facing_pdf_and_metadata(
 
     review_after = json.loads(review_path.read_text(encoding="utf-8"))
     metadata = review_after["exports"]["feedback_pdf"]
+    assert review_after["review_state"] == "exported"
     assert metadata == {
         "path": (
             f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -193,7 +193,7 @@ def test_review_menu_selected_student_excludes_legacy_review_entry_actions(
     assert "6. Compose Focus Standard feedback" in output
     assert "7. Manage submission pages" in output
     assert "8. Add teacher note" in output
-    assert "9. Update submission review state" in output
+    assert "9. Update review workflow state" in output
     assert "10. Export student feedback" in output
     assert "11. Refresh summary" in output
     assert "12. Back" in output
@@ -309,14 +309,14 @@ def test_review_menu_blank_note_cancels_without_review_record(
     assert manifest_path.read_bytes() == manifest_before
 
 
-def test_review_menu_updates_submission_review_state(
+def test_review_menu_updates_review_workflow_state(
     workspace: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _menu_input(
         monkeypatch,
         _enter_selected_student()
-        + ["9", "in_progress", "1"]
+        + ["9", "4", "1"]
         + _exit_after_selected_student_action_to_main(),
     )
 
@@ -329,4 +329,10 @@ def test_review_menu_updates_submission_review_state(
         STUDENT_ID,
     )
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    assert manifest["submission_state"] == "in_progress"
+    assert manifest["submission_state"] == "unreviewed"
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert review["review_state"] == "observations_in_progress"

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -325,7 +325,7 @@ def test_review_summary_includes_existing_review_record_counts(
 
     output = capsys.readouterr().out
     assert "Review record: exists" in output
-    assert "Review record state: feedback_composed" in output
+    assert "Review: feedback composed" in output
     assert "Private notes: 1" in output
     assert "Review-unit observations: 0" in output
     assert review_path.read_bytes() == review_before
@@ -939,7 +939,7 @@ def test_review_menu_adds_teacher_note_to_review_record(
     assert review["review_state"] == "not_started"
 
 
-def test_review_menu_updates_submission_review_state(
+def test_review_menu_updates_review_workflow_state(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -954,7 +954,7 @@ def test_review_menu_updates_submission_review_state(
             "1",
             "1",
             "9",
-            "in_progress",
+            "4",
             "1",
             "",
             "12",
@@ -974,7 +974,13 @@ def test_review_menu_updates_submission_review_state(
         STUDENT_ID,
     )
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    assert manifest["submission_state"] == "in_progress"
+    assert manifest["submission_state"] == "unreviewed"
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert review["review_state"] == "observations_in_progress"
 
 
 def test_review_menu_adds_custom_focus_standard_feedback_comment(

--- a/tests/test_review_snapshot.py
+++ b/tests/test_review_snapshot.py
@@ -116,7 +116,11 @@ def test_current_review_details_formats_saved_artifacts(tmp_path: Path) -> None:
 
     text = current_review_details_text(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
 
-    assert text.startswith("Review record: exists\nReview state: feedback_composed")
+    assert text.startswith(
+        "Review record: exists\n"
+        "Review: feedback composed\n"
+        "Feedback export: not exported"
+    )
     assert "Quillan" not in text
     assert "Current Review Details" not in text
     assert "Review record: exists" in text

--- a/tests/test_review_status_display.py
+++ b/tests/test_review_status_display.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quillan.review_status_display import feedback_export_status, review_status_label
+
+
+@pytest.mark.parametrize(
+    ("state", "label"),
+    [
+        ("not_started", "not started"),
+        ("requirements_checked", "requirements checked"),
+        ("returned_without_full_review", "returned without full standards review"),
+        ("observations_in_progress", "observations in progress"),
+        ("observations_complete", "observations complete"),
+        ("ratings_complete", "ratings complete"),
+        ("feedback_composed", "feedback composed"),
+        ("ready_for_export", "ready for export"),
+        ("exported", "exported"),
+    ],
+)
+def test_review_status_label(state: str, label: str) -> None:
+    assert review_status_label({"review_state": state}) == label
+
+
+def test_feedback_export_status_uses_latest_metadata_timestamp(tmp_path: Path) -> None:
+    pdf = tmp_path / "feedback.pdf"
+    markdown = tmp_path / "feedback.md"
+    pdf.write_bytes(b"pdf")
+    markdown.write_text("feedback", encoding="utf-8")
+    record = {
+        "exports": {
+            "feedback_pdf": {
+                "path": "feedback.pdf",
+                "generated_at": "2026-07-08T17:30:00+00:00",
+            },
+            "feedback_markdown": {
+                "path": "feedback.md",
+                "generated_at": "2026-07-08T17:35:00+00:00",
+            },
+        }
+    }
+
+    assert feedback_export_status(tmp_path, record) == (
+        "PDF + Markdown exported 2026-07-08T17:35:00+00:00"
+    )
+
+
+def test_feedback_export_status_warns_when_metadata_file_is_missing(
+    tmp_path: Path,
+) -> None:
+    record = {
+        "exports": {
+            "feedback_pdf": {
+                "path": "missing.pdf",
+                "generated_at": "2026-07-08T17:35:00+00:00",
+            },
+            "feedback_markdown": None,
+        }
+    }
+
+    assert feedback_export_status(tmp_path, record) == (
+        "metadata exists, but export file is missing"
+    )


### PR DESCRIPTION
## Summary

* Separate teacher-facing submission, review, and feedback export status displays.
* Update review workflow state handling so it uses `review.json.review_state`.
* Derive feedback export status from export metadata.
* Detect missing export files when export metadata exists.
* Set full-review records to `exported` after successful feedback export.
* Preserve `returned_without_full_review` as the review state for returned work while still displaying export status separately.
* Add status-display and export-state tests.

## Validation

* 1,037 tests passed.
* Ruff passed.
* `git diff --check` passed.
