### PR TITLE
Fix review completion status consistency

### DIFF
--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -97,7 +97,11 @@ from quillan.review_record_paths import (
     review_record_path,
     write_review_record,
 )
-from quillan.review_status_display import feedback_export_status, review_status_label
+from quillan.review_status_display import (
+    feedback_export_status,
+    review_progress_status,
+    review_status_label,
+)
 from quillan.review_snapshot import current_review_details_text
 from quillan.review_targets import (
     ReviewTargetError,
@@ -2201,11 +2205,17 @@ def _print_review_observation_status(
         print("Observations: 0")
         print("Included for feedback: 0")
         print("Review record state: not_started")
+        print("Observations complete: no")
         return
+    status = review_progress_status(record)
     print(f"Review units: {_count_record_items(record, 'review_units')}")
     print(f"Observations: {_count_review_unit_observations(record)}")
     print(f"Included for feedback: {_count_included_review_unit_observations(record)}")
-    print(f"Review record state: {record['review_state']}")
+    print(f"Review record state: {status.review_state}")
+    if status.is_returned_without_full_review:
+        print(f"Observations: {status.observations_status_label}")
+    else:
+        print(f"Observations complete: {_format_yes_no(status.observations_complete)}")
 
 
 def _count_included_review_unit_observations(record: dict[str, Any]) -> int:
@@ -2342,6 +2352,7 @@ def _print_review_summary(
         except (OSError, ReviewRecordError):
             pass
     print(f"Review: {review_status_label(record)}")
+    _print_review_phase_statuses(record)
     print(f"Feedback export: {feedback_export_status(workspace_root, record)}")
 
     _print_review_record_summary(
@@ -2400,6 +2411,18 @@ def _print_review_record_summary(
 def _count_record_items(record: dict[str, Any], field: str) -> int:
     value = record.get(field)
     return len(value) if isinstance(value, list) else 0
+
+
+def _print_review_phase_statuses(record: dict[str, Any] | None) -> None:
+    status = review_progress_status(record)
+    if status.is_returned_without_full_review:
+        print(f"Observations: {status.observations_status_label}")
+        print(f"Ratings: {status.ratings_status_label}")
+        print(f"Feedback composition: {status.feedback_status_label}")
+        return
+    print(f"Observations complete: {_format_yes_no(status.observations_complete)}")
+    print(f"Ratings complete: {_format_yes_no(status.ratings_complete)}")
+    print(f"Feedback composed: {_format_yes_no(status.feedback_composed)}")
 
 
 def _count_review_unit_observations(record: dict[str, Any]) -> int:
@@ -2910,19 +2933,21 @@ def _print_feedback_composer_status(
         return
     included_comments = sum(summary.included_comment_count for summary in summaries)
     records = sum(1 for summary in summaries if summary.has_feedback_record)
-    print(f"Review record state: {record['review_state']}")
+    status = review_progress_status(record)
+    print(f"Review record state: {status.review_state}")
     print(f"Focus Standards configured: {len(assignment['focus_standard_ids'])}")
     print(f"Standards with feedback records: {records}")
     print(f"Included comments: {included_comments}")
-    print(
-        "Ratings complete: "
-        f"{_format_yes_no(record['review_state'] in {'ratings_complete', 'feedback_composed'})}"
-    )
-    if record["review_state"] == "returned_without_full_review":
+    if status.is_returned_without_full_review:
+        print(f"Ratings: {status.ratings_status_label}")
+        print(f"Feedback composition: {status.feedback_status_label}")
         print(
             "This submission was returned without full standards review. "
             "Change the minimum-requirements outcome before composing feedback."
         )
+    else:
+        print(f"Ratings complete: {_format_yes_no(status.ratings_complete)}")
+        print(f"Feedback composed: {_format_yes_no(status.feedback_composed)}")
 
 
 def _menu_configure_standard_feedback_options(
@@ -3193,7 +3218,7 @@ def _menu_mark_feedback_composed(
     print(f"Focus Standards: {focus_standard_count}")
     print(f"Standards with feedback records: {len(feedback_records)}")
     print(f"Included comments: {included_comments}")
-    if record["review_state"] != "ratings_complete":
+    if not review_progress_status(record).ratings_complete:
         print("Warning: ratings are not marked complete.")
     if len(ratings) < focus_standard_count:
         print("Warning: some Focus Standards do not have overall ratings.")
@@ -3232,7 +3257,14 @@ def _print_overall_rating_status(
     print(f"Focus Standards configured: {len(focus_standard_ids)}")
     print(f"Ratings recorded: {len(rated)}")
     print(f"Missing ratings: {max(len(focus_standard_ids) - len(rated), 0)}")
-    print(f"Current review state: {record['review_state'] if record else 'not_started'}")
+    status = review_progress_status(record)
+    print(f"Current review state: {status.review_state}")
+    if status.is_returned_without_full_review:
+        print(f"Observations: {status.observations_status_label}")
+        print(f"Ratings: {status.ratings_status_label}")
+    else:
+        print(f"Observations complete: {_format_yes_no(status.observations_complete)}")
+        print(f"Ratings complete: {_format_yes_no(status.ratings_complete)}")
 
 
 def _print_overall_rating_warnings(record: dict[str, Any] | None) -> None:
@@ -3251,7 +3283,7 @@ def _print_overall_rating_warnings(record: dict[str, Any] | None) -> None:
     observation_count = _count_review_unit_observations(record)
     if observation_count == 0:
         print("Warning: no observations recorded.")
-    if record["review_state"] != "observations_complete":
+    if not review_progress_status(record).observations_complete:
         print("Warning: observations are not marked complete.")
 
 
@@ -4396,14 +4428,11 @@ def _menu_export_student_feedback(
     except (ReviewRecordError, OSError):
         record = None
     if record is not None:
-        print(f"Current review state: {record['review_state']}")
-        if record["review_state"] == "returned_without_full_review":
+        status = review_progress_status(record)
+        print(f"Current review state: {status.review_state}")
+        if status.is_returned_without_full_review:
             print("This will export returned-work feedback.")
-        elif record["review_state"] not in {
-            "feedback_composed",
-            "ready_for_export",
-            "exported",
-        }:
+        elif not status.feedback_composed:
             print("Warning: feedback is not marked composed yet.")
         print()
     print("1. Export PDF feedback")

--- a/quillan/review_snapshot.py
+++ b/quillan/review_snapshot.py
@@ -7,7 +7,12 @@ from typing import Any
 
 from quillan.review_record import ReviewRecordError, load_review_record
 from quillan.review_record_paths import review_record_path
-from quillan.review_status_display import feedback_export_status, review_status_label
+from quillan.review_status_display import (
+    feedback_export_status,
+    review_progress_status,
+    review_status_label,
+)
+
 
 def current_review_details_text(
     workspace_root: str | Path,
@@ -37,6 +42,7 @@ def current_review_details_text(
 
     lines.append("Review record: exists")
     lines.append(f"Review: {review_status_label(record)}")
+    _append_review_phase_statuses(lines, record)
     lines.append(
         f"Feedback export: {feedback_export_status(workspace_root, record)}"
     )
@@ -102,6 +108,20 @@ def _append_requirement_checks(lines: list[str], record: dict[str, Any]) -> None
         if note := _non_empty(check.get("teacher_note")):
             lines.append(f"  Note: {note}")
     lines.append("")
+
+
+def _append_review_phase_statuses(lines: list[str], record: dict[str, Any]) -> None:
+    status = review_progress_status(record)
+    if status.is_returned_without_full_review:
+        lines.append(f"Observations: {status.observations_status_label}")
+        lines.append(f"Ratings: {status.ratings_status_label}")
+        lines.append(f"Feedback composition: {status.feedback_status_label}")
+        return
+    lines.append(
+        f"Observations complete: {'yes' if status.observations_complete else 'no'}"
+    )
+    lines.append(f"Ratings complete: {'yes' if status.ratings_complete else 'no'}")
+    lines.append(f"Feedback composed: {'yes' if status.feedback_composed else 'no'}")
 
 
 def _append_review_units(lines: list[str], record: dict[str, Any]) -> None:

--- a/quillan/review_status_display.py
+++ b/quillan/review_status_display.py
@@ -2,8 +2,30 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+OBSERVATIONS_COMPLETE_STATES = {
+    "observations_complete",
+    "ratings_complete",
+    "feedback_composed",
+    "ready_for_export",
+    "exported",
+}
+
+RATINGS_COMPLETE_STATES = {
+    "ratings_complete",
+    "feedback_composed",
+    "ready_for_export",
+    "exported",
+}
+
+FEEDBACK_COMPOSED_STATES = {
+    "feedback_composed",
+    "ready_for_export",
+    "exported",
+}
 
 REVIEW_STATE_LABELS = {
     "not_started": "not started",
@@ -18,12 +40,78 @@ REVIEW_STATE_LABELS = {
 }
 
 
+@dataclass(frozen=True, slots=True)
+class ReviewProgressStatus:
+    """Authoritative teacher-review progress derived from review_state."""
+
+    review_state: str
+    review_state_label: str
+    is_returned_without_full_review: bool
+    observations_complete: bool
+    ratings_complete: bool
+    feedback_composed: bool
+    ready_for_export: bool
+    exported: bool
+    observations_status_label: str
+    ratings_status_label: str
+    feedback_status_label: str
+
+
 def review_status_label(record: dict[str, Any] | None) -> str:
     """Return the teacher-facing review workflow label."""
     if record is None:
         return REVIEW_STATE_LABELS["not_started"]
     state = str(record.get("review_state", "not_started"))
     return REVIEW_STATE_LABELS.get(state, state.replace("_", " "))
+
+
+def review_progress_status(record: dict[str, Any] | None) -> ReviewProgressStatus:
+    """Return centralized review-phase completion status for menus and gates."""
+    state = (
+        "not_started"
+        if record is None
+        else str(record.get("review_state", "not_started"))
+    )
+    returned = state == "returned_without_full_review"
+    observations_complete = state in OBSERVATIONS_COMPLETE_STATES
+    ratings_complete = state in RATINGS_COMPLETE_STATES
+    feedback_composed = state in FEEDBACK_COMPOSED_STATES
+    exported = state == "exported" or _export_metadata_exists(record)
+
+    if returned:
+        observations_label = "not applicable - returned without full standards review"
+        ratings_label = "not applicable - returned without full standards review"
+        feedback_label = "not applicable - returned without full standards review"
+    else:
+        observations_label = "complete" if observations_complete else "incomplete"
+        ratings_label = "complete" if ratings_complete else "incomplete"
+        feedback_label = "composed" if feedback_composed else "not composed"
+
+    return ReviewProgressStatus(
+        review_state=state,
+        review_state_label=review_status_label(record),
+        is_returned_without_full_review=returned,
+        observations_complete=observations_complete,
+        ratings_complete=ratings_complete,
+        feedback_composed=feedback_composed,
+        ready_for_export=state in {"ready_for_export", "exported"} or exported,
+        exported=exported,
+        observations_status_label=observations_label,
+        ratings_status_label=ratings_label,
+        feedback_status_label=feedback_label,
+    )
+
+
+def _export_metadata_exists(record: dict[str, Any] | None) -> bool:
+    if record is None:
+        return False
+    exports = record.get("exports")
+    if not isinstance(exports, dict):
+        return False
+    return any(
+        isinstance(exports.get(key), dict)
+        for key in ("feedback_pdf", "feedback_markdown")
+    )
 
 
 def feedback_export_status(

--- a/tests/test_review_snapshot.py
+++ b/tests/test_review_snapshot.py
@@ -119,6 +119,9 @@ def test_current_review_details_formats_saved_artifacts(tmp_path: Path) -> None:
     assert text.startswith(
         "Review record: exists\n"
         "Review: feedback composed\n"
+        "Observations complete: yes\n"
+        "Ratings complete: yes\n"
+        "Feedback composed: yes\n"
         "Feedback export: not exported"
     )
     assert "Quillan" not in text
@@ -162,3 +165,30 @@ def test_current_review_details_formats_empty_sections(tmp_path: Path) -> None:
     assert "No overall standard ratings recorded." in text
     assert "No feedback composed." in text
     assert "No private notes recorded." in text
+
+
+def test_current_review_details_formats_returned_phases_as_not_applicable(
+    tmp_path: Path,
+) -> None:
+    review = _review()
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Missing required work.",
+        "updated_at": TIMESTAMP,
+    }
+    path = review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    write_review_record(path, review)
+
+    text = current_review_details_text(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+
+    assert "Review: returned without full standards review" in text
+    assert (
+        "Observations: not applicable - returned without full standards review"
+    ) in text
+    assert "Ratings: not applicable - returned without full standards review" in text
+    assert (
+        "Feedback composition: not applicable - returned without full standards review"
+    ) in text
+    assert "Observations complete: no" not in text

--- a/tests/test_review_status_display.py
+++ b/tests/test_review_status_display.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from quillan.review_status_display import feedback_export_status, review_status_label
+from quillan.review_status_display import (
+    feedback_export_status,
+    review_progress_status,
+    review_status_label,
+)
 
 
 @pytest.mark.parametrize(
@@ -23,6 +27,68 @@ from quillan.review_status_display import feedback_export_status, review_status_
 )
 def test_review_status_label(state: str, label: str) -> None:
     assert review_status_label({"review_state": state}) == label
+
+
+@pytest.mark.parametrize(
+    ("state", "observations", "ratings", "feedback"),
+    [
+        ("not_started", False, False, False),
+        ("requirements_checked", False, False, False),
+        ("observations_in_progress", False, False, False),
+        ("observations_complete", True, False, False),
+        ("ratings_complete", True, True, False),
+        ("feedback_composed", True, True, True),
+        ("ready_for_export", True, True, True),
+        ("exported", True, True, True),
+    ],
+)
+def test_review_progress_status_treats_later_states_as_complete(
+    state: str,
+    observations: bool,
+    ratings: bool,
+    feedback: bool,
+) -> None:
+    status = review_progress_status({"review_state": state})
+
+    assert status.observations_complete is observations
+    assert status.ratings_complete is ratings
+    assert status.feedback_composed is feedback
+
+
+def test_review_progress_status_treats_returned_work_as_not_applicable() -> None:
+    status = review_progress_status({"review_state": "returned_without_full_review"})
+
+    assert status.is_returned_without_full_review is True
+    assert status.observations_complete is False
+    assert status.ratings_complete is False
+    assert status.feedback_composed is False
+    assert status.observations_status_label == (
+        "not applicable - returned without full standards review"
+    )
+    assert status.ratings_status_label == (
+        "not applicable - returned without full standards review"
+    )
+    assert status.feedback_status_label == (
+        "not applicable - returned without full standards review"
+    )
+
+
+def test_review_progress_status_exported_uses_export_metadata() -> None:
+    status = review_progress_status(
+        {
+            "review_state": "returned_without_full_review",
+            "exports": {
+                "feedback_pdf": {
+                    "path": "feedback.pdf",
+                    "generated_at": "2026-07-08T17:35:00+00:00",
+                }
+            },
+        }
+    )
+
+    assert status.review_state == "returned_without_full_review"
+    assert status.exported is True
+    assert status.is_returned_without_full_review is True
 
 
 def test_feedback_export_status_uses_latest_metadata_timestamp(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Centralize review-completion status display with `review_progress_status()`.
- Treat later review states as satisfying earlier workflow phases:
  - `ratings_complete` satisfies observations completion.
  - `feedback_composed`, `ready_for_export`, and `exported` satisfy observations and ratings completion.
  - `ready_for_export` and `exported` satisfy feedback composition.
- Update review menus to use the centralized progress helper instead of local `review_state` checks.
- Update Current Review Details to show the same observations, ratings, and feedback phase status logic used by review menus.
- Display observations, ratings, and feedback composition as not applicable for records returned without full standards review.
- Preserve the separation between review workflow status and feedback export status.
- Remove duplicate phase-status output from the nested review-record summary.
- Add regression coverage for review-progress display across the review-state progression and returned-without-full-review path.

## Validation

- `.\.venv\Scripts\ruff.exe check ...` passed.
- `.\.venv\Scripts\python.exe -m pytest` passed: `1048 passed`.

Closes #257