### PR TITLE
Add global menu navigation shortcuts

### DIFF
--- a/quillan/assignment_picker.py
+++ b/quillan/assignment_picker.py
@@ -9,6 +9,12 @@ from pds_core.classes import list_class_folders
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.storage import assignment_config_path
+from quillan.menu_navigation import (
+    NavigationChoice,
+    navigation_hint,
+    parse_navigation_choice,
+    print_navigation_options,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,11 +37,12 @@ def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
     print("Available classes:")
     for index, folder in enumerate(folders, start=1):
         print(f"{index}. {folder.class_id}")
-    print("B. Back")
+    print_navigation_options()
     print()
     while True:
         selection = input("Select class: ").strip()
-        if selection == "" or selection.casefold() == "b":
+        navigation = parse_navigation_choice(selection)
+        if selection == "" or navigation is NavigationChoice.BACK:
             print("Class selection canceled.")
             return None
         if selection.isdigit() and 1 <= int(selection) <= len(folders):
@@ -47,7 +54,7 @@ def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
         if class_matches:
             class_id = class_matches[0].class_id
             break
-        print("Invalid class selection. Please choose a listed class or Back.")
+        print(f"Invalid class selection. {navigation_hint()}")
 
     assignments = available_assignments(workspace_root, class_id)
     if not assignments:
@@ -60,11 +67,12 @@ def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
         if assignment.title:
             label += f" - {assignment.title}"
         print(f"{index}. {label}")
-    print("B. Back")
+    print_navigation_options()
     print()
     while True:
         selection = input("Select assignment: ").strip()
-        if selection == "" or selection.casefold() == "b":
+        navigation = parse_navigation_choice(selection)
+        if selection == "" or navigation is NavigationChoice.BACK:
             print("Assignment selection canceled.")
             return None
         if selection.isdigit() and 1 <= int(selection) <= len(assignments):
@@ -74,7 +82,7 @@ def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
         ]
         if assignment_matches:
             return assignment_matches[0]
-        print("Invalid assignment selection. Please choose a listed assignment or Back.")
+        print(f"Invalid assignment selection. {navigation_hint()}")
 
 
 def available_assignments(

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -243,6 +243,12 @@ def _available_class_folders(workspace_root: Path) -> tuple[ClassFolder, ...]:
 
 
 def _prompt_class_folder(workspace_root: Path) -> ClassFolder | None:
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
+
     folders = _available_class_folders(workspace_root)
     if not folders:
         print("No class rosters found. Create a class roster first.")
@@ -251,8 +257,12 @@ def _prompt_class_folder(workspace_root: Path) -> ClassFolder | None:
     print("Available classes:")
     for index, folder in enumerate(folders, start=1):
         print(f"{index}. {folder.class_id}")
+    print_navigation_options()
     print()
     selection = input("Select class for assignment: ").strip()
+    navigation = parse_navigation_choice(selection)
+    if selection == "" or navigation is NavigationChoice.BACK:
+        return None
     if selection.isdigit() and 1 <= int(selection) <= len(folders):
         return folders[int(selection) - 1]
     for folder in folders:
@@ -646,6 +656,12 @@ def prompt_view_validate_assignment() -> int:
 def launch_assignment_menu() -> int:
     """Launch the teacher-facing assignment management submenu."""
     from quillan.menu import clear_screen, pause_for_user, print_menu_header
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        navigation_hint,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
 
     try:
         while True:
@@ -654,12 +670,13 @@ def launch_assignment_menu() -> int:
             print("1. Create writing assignment")
             print("2. View/validate assignment")
             print("3. Printable Response Pages")
-            print("4. Back")
+            print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(choice)
             print()
 
-            if choice == "4":
+            if choice == "4" or navigation is NavigationChoice.BACK:
                 return 0
             workflows = {
                 "1": prompt_create_assignment,
@@ -673,7 +690,7 @@ def launch_assignment_menu() -> int:
 
                 launch_printable_response_menu()
             elif workflow is None:
-                print("Invalid selection. Please enter a number from 1 to 4.")
+                print(f"Invalid selection. {navigation_hint()}")
             else:
                 clear_screen()
                 workflow()

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -8,6 +8,14 @@ from collections.abc import Callable
 from pathlib import Path
 
 from pds_core.scan_routes import scans_inbox_dir
+from quillan.menu_navigation import (
+    NavigationChoice,
+    QuitQuillan,
+    ReturnToMainMenu,
+    navigation_hint,
+    parse_navigation_choice,
+    print_navigation_options,
+)
 
 WorkspaceShowHandler = Callable[[], int]
 WorkspaceSetHandler = Callable[[str], int]
@@ -140,9 +148,11 @@ def launch_scan_intake_workflow() -> None:
             if len(targets) == 1:
                 print("1. Assemble submissions now")
                 print("2. View submission status")
-                print("3. Return to Scan Intake")
-                print("4. Back to Main Menu")
+                print_navigation_options()
                 choice = input("Select an option: ").strip()
+                navigation = parse_navigation_choice(choice)
+                if navigation is NavigationChoice.BACK:
+                    return
                 if choice == "1":
                     target = targets[0]
                     result = assemble_assignment_submissions(
@@ -162,15 +172,12 @@ def launch_scan_intake_workflow() -> None:
                         workspace_root,
                     )
                     continue
-                if choice == "4":
-                    exit_to_main = True
-                return
-            print(
-                "Choose a numbered target to assemble it, or B to return "
-                "to Scan Intake."
-            )
+                print(f"Invalid selection. {navigation_hint()}")
+                continue
+            print_navigation_options()
             choice = input("Select target: ").strip()
-            if choice == "" or choice.casefold() == "b":
+            navigation = parse_navigation_choice(choice)
+            if choice == "" or navigation is NavigationChoice.BACK:
                 return
             if choice.isdigit() and 1 <= int(choice) <= len(targets):
                 target = targets[int(choice) - 1]
@@ -180,8 +187,7 @@ def launch_scan_intake_workflow() -> None:
                 print_assignment_submission_assembly(result, workspace_root)
             else:
                 print(
-                    "Invalid selection. Please choose a routed assignment "
-                    "or Back."
+                    f"Invalid selection. {navigation_hint()}"
                 )
 
     while True:
@@ -206,10 +212,11 @@ def launch_scan_intake_workflow() -> None:
             print(f"\nPlace scanned PDFs or images in:\n{inbox}")
         print("C. Choose custom file/folder path")
         print("R. Refresh")
-        print("B. Back")
+        print_navigation_options()
         print()
         selection = input("Select scan: ").strip()
-        if selection.casefold() == "b":
+        navigation = parse_navigation_choice(selection)
+        if navigation is NavigationChoice.BACK:
             return
         if selection == "":
             print("Scan intake canceled. No scan files were routed.")
@@ -234,7 +241,7 @@ def launch_scan_intake_workflow() -> None:
             # Preserve pasted-path convenience for experienced users of earlier menus.
             source_path = _normalize_menu_path(selection)
             if source_path is None:
-                print("Invalid selection. Please choose a scan, C, R, or B.")
+                print(f"Invalid selection. {navigation_hint()}")
                 pause_for_user()
                 continue
         print()
@@ -277,10 +284,11 @@ def launch_workspace_menu(
         print("2. Set workspace folder")
         print("3. Validate/create current workspace")
         print("4. Reset saved workspace preference")
-        print("5. Back")
+        print_navigation_options()
         print()
 
         choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
         print()
 
         if choice == "1":
@@ -314,10 +322,10 @@ def launch_workspace_menu(
             workspace_reset()
             print()
             pause_for_user()
-        elif choice == "5":
+        elif choice == "5" or navigation is NavigationChoice.BACK:
             return
         else:
-            print("Invalid selection. Please enter a number from 1 to 5.")
+            print(f"Invalid selection. {navigation_hint()}")
             print()
             pause_for_user()
 
@@ -338,10 +346,13 @@ def launch_menu(
             print("3. Roster Management")
             print("4. Workspace Settings")
             print("5. Help")
-            print("6. Exit")
+            print("Q. Quit")
             print()
 
             choice = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(
+                choice, allow_back=False, allow_main_menu=False
+            )
             print()
 
             if choice == "1":
@@ -362,13 +373,23 @@ def launch_menu(
                 print_menu_help()
                 print()
                 pause_for_user()
-            elif choice == "6":
+            elif choice == "6" or navigation is NavigationChoice.QUIT:
                 print("Goodbye.")
                 return 0
             else:
-                print("Invalid selection. Please enter a number from 1 to 6.")
+                print("Invalid selection. Please choose a listed option or Q.")
                 print()
                 pause_for_user()
+    except ReturnToMainMenu:
+        return launch_menu(
+            workspace_show,
+            workspace_set,
+            workspace_validate,
+            workspace_reset,
+        )
+    except QuitQuillan:
+        print("Goodbye.")
+        return 0
     except KeyboardInterrupt:
         print("\nExiting Quillan.")
         return 0

--- a/quillan/menu_navigation.py
+++ b/quillan/menu_navigation.py
@@ -1,0 +1,73 @@
+"""Shared navigation primitives for teacher-facing interactive menus."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class NavigationChoice(Enum):
+    """A recognized controlled-prompt navigation command."""
+
+    BACK = "b"
+    MAIN_MENU = "m"
+    QUIT = "q"
+    ALL = "a"
+
+
+class ReturnToMainMenu(Exception):
+    """Unwind the current workflow and redraw Quillan's main menu."""
+
+
+class QuitQuillan(Exception):
+    """Unwind the current workflow and exit Quillan cleanly."""
+
+
+def parse_navigation_choice(
+    value: str,
+    *,
+    allow_back: bool = True,
+    allow_main_menu: bool = True,
+    allow_quit: bool = True,
+    allow_all: bool = False,
+) -> NavigationChoice | None:
+    """Parse a letter command from a controlled prompt and raise global signals."""
+    normalized = value.strip().casefold()
+    choice = {
+        "b": NavigationChoice.BACK,
+        "m": NavigationChoice.MAIN_MENU,
+        "q": NavigationChoice.QUIT,
+        "a": NavigationChoice.ALL,
+    }.get(normalized)
+    if choice is NavigationChoice.BACK and allow_back:
+        return choice
+    if choice is NavigationChoice.MAIN_MENU and allow_main_menu:
+        raise ReturnToMainMenu
+    if choice is NavigationChoice.QUIT and allow_quit:
+        raise QuitQuillan
+    if choice is NavigationChoice.ALL and allow_all:
+        return choice
+    return None
+
+
+def print_navigation_options(
+    *,
+    back: bool = True,
+    main_menu: bool = True,
+    quit: bool = True,
+    all_items: bool = False,
+) -> None:
+    """Print the standard commands supported by a controlled prompt."""
+    if all_items:
+        print("A. All")
+    if back:
+        print("B. Back")
+    if main_menu:
+        print("M. Main Menu")
+    if quit:
+        print("Q. Quit")
+
+
+def navigation_hint(*, all_items: bool = False) -> str:
+    """Return a concise invalid-selection hint for the standard commands."""
+    commands = "A, B, M, or Q" if all_items else "B, M, or Q"
+    return f"Please choose a listed option, {commands}."

--- a/quillan/printable_response_workflows.py
+++ b/quillan/printable_response_workflows.py
@@ -104,6 +104,12 @@ def _workspace_root() -> Path | None:
 
 
 def _prompt_class_selection(workspace_root: Path) -> ClassFolder | None:
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
+
     folders = list_class_folders(workspace_root, require_roster=True)
     if not folders:
         print("No class rosters found. Create a class roster first.")
@@ -112,8 +118,12 @@ def _prompt_class_selection(workspace_root: Path) -> ClassFolder | None:
     print("Available classes:")
     for index, folder in enumerate(folders, start=1):
         print(f"{index}. {folder.class_id}")
+    print_navigation_options()
     print()
     selection = input("Select class roster: ").strip()
+    navigation = parse_navigation_choice(selection)
+    if selection == "" or navigation is NavigationChoice.BACK:
+        return None
     if selection.isdigit() and 1 <= int(selection) <= len(folders):
         return folders[int(selection) - 1]
     for folder in folders:
@@ -135,6 +145,12 @@ def _prompt_assignment_selection(
     workspace_root: Path,
     class_id: str,
 ) -> AssignmentChoice | None:
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
+
     choices = discover_assignment_configs(workspace_root, class_id)
     if not choices:
         print("No assignment configs found for this class. Create an assignment first.")
@@ -143,8 +159,12 @@ def _prompt_assignment_selection(
     print("Available assignments:")
     for index, choice in enumerate(choices, start=1):
         print(f"{index}. {_format_assignment_choice(choice)}")
+    print_navigation_options()
     print()
     selection = input("Select assignment: ").strip()
+    navigation = parse_navigation_choice(selection)
+    if selection == "" or navigation is NavigationChoice.BACK:
+        return None
     selected: AssignmentChoice | None = None
     if selection.isdigit() and 1 <= int(selection) <= len(choices):
         selected = choices[int(selection) - 1]
@@ -232,24 +252,31 @@ def prompt_generate_class_packet() -> int:
 def launch_printable_response_menu() -> int:
     """Launch the teacher-facing printable response pages submenu."""
     from quillan.menu import clear_screen, pause_for_user, print_menu_header
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        navigation_hint,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
 
     try:
         while True:
             clear_screen()
             print_menu_header("Printable Response Pages")
             print("1. Generate class packet")
-            print("2. Back")
+            print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(choice)
             print()
 
-            if choice == "2":
+            if choice == "2" or navigation is NavigationChoice.BACK:
                 return 0
             if choice == "1":
                 clear_screen()
                 prompt_generate_class_packet()
             else:
-                print("Invalid selection. Please enter a number from 1 to 2.")
+                print(f"Invalid selection. {navigation_hint()}")
             print()
             pause_for_user()
     except KeyboardInterrupt:

--- a/quillan/review_materials_menu.py
+++ b/quillan/review_materials_menu.py
@@ -6,6 +6,12 @@ from __future__ import annotations
 def launch_review_materials_menu() -> int:
     """Launch an informational placeholder for removed legacy review materials."""
     from quillan.menu import clear_screen, pause_for_user, print_menu_header
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        navigation_hint,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
 
     try:
         while True:
@@ -22,15 +28,16 @@ def launch_review_materials_menu() -> int:
                 "a later release."
             )
             print()
-            print("1. Back")
+            print_navigation_options()
             print()
 
             choice = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(choice)
             print()
 
-            if choice in {"", "1"}:
+            if choice in {"", "1"} or navigation is NavigationChoice.BACK:
                 return 0
-            print("Invalid selection. Please enter 1 to go back.")
+            print(f"Invalid selection. {navigation_hint()}")
             print()
             pause_for_user()
     except KeyboardInterrupt:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -138,6 +138,12 @@ from quillan.submission_status import (
     StudentSubmissionStatus,
     list_assignment_submission_status,
 )
+from quillan.menu_navigation import (
+    NavigationChoice,
+    navigation_hint,
+    parse_navigation_choice,
+    print_navigation_options,
+)
 
 _BACK = object()
 
@@ -152,12 +158,13 @@ def launch_review_student_work_menu() -> int:
             print_menu_header("Review Student Work")
             print("1. Assignment Review Actions")
             print("2. Scan Intake / Route Paper Responses")
-            print("3. Back")
+            print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(choice)
             print()
 
-            if choice in {"", "3"}:
+            if choice in {"", "3"} or navigation is NavigationChoice.BACK:
                 return 0
             if choice == "1":
                 clear_screen()
@@ -169,7 +176,7 @@ def launch_review_student_work_menu() -> int:
 
                 launch_scan_intake_workflow()
             else:
-                print("Invalid selection. Please enter a number from 1 to 3.")
+                print(f"Invalid selection. {navigation_hint()}")
                 print()
                 pause_for_user()
     except KeyboardInterrupt:
@@ -213,12 +220,13 @@ def _prompt_class_id(workspace_root: Path) -> str | None:
     print("Available classes:")
     for index, folder in enumerate(folders, start=1):
         print(f"{index}. {folder.class_id}")
-    print("B. Back")
+    print_navigation_options()
     print()
 
     while True:
         selection = input("Select class: ").strip()
-        if selection == "" or selection.casefold() == "b":
+        navigation = parse_navigation_choice(selection)
+        if selection == "" or navigation is NavigationChoice.BACK:
             print("Review selection canceled.")
             return None
         if selection.isdigit() and 1 <= int(selection) <= len(folders):
@@ -245,12 +253,13 @@ def _prompt_assignment(
         if assignment.title:
             label += f" - {assignment.title}"
         print(f"{index}. {label}")
-    print("B. Back")
+    print_navigation_options()
     print()
 
     while True:
         selection = input("Select assignment: ").strip()
-        if selection == "" or selection.casefold() == "b":
+        navigation = parse_navigation_choice(selection)
+        if selection == "" or navigation is NavigationChoice.BACK:
             print("Assignment selection canceled.")
             return None
         if selection.isdigit() and 1 <= int(selection) <= len(assignments):
@@ -326,12 +335,13 @@ def _prompt_student_id(
             f"{index}. {student_id}: "
             f"{_student_status_label(status_by_student.get(student_id))}"
         )
-    print("B. Back")
+    print_navigation_options()
     print()
 
     while True:
         selection = input("Select student/submission: ").strip()
-        if selection == "" or selection.casefold() == "b":
+        navigation = parse_navigation_choice(selection)
+        if selection == "" or navigation is NavigationChoice.BACK:
             print("Student selection canceled.")
             return None
         if selection.isdigit() and 1 <= int(selection) <= len(student_ids):
@@ -410,11 +420,12 @@ def _launch_selected_student_review(
             print()
             print("1. View routed evidence status")
             print("2. Refresh summary")
-            print("3. Back")
+            print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(choice)
             print()
-            if choice in {"", "3"}:
+            if choice in {"", "3"} or navigation is NavigationChoice.BACK:
                 return 0
             if choice in {"1", "2"}:
                 continue
@@ -434,11 +445,12 @@ def _launch_selected_student_review(
             print("1. Assemble this assignment now")
             print("2. View routed evidence status")
             print("3. Refresh summary")
-            print("4. Back")
+            print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(choice)
             print()
-            if choice in {"", "4"}:
+            if choice in {"", "4"} or navigation is NavigationChoice.BACK:
                 return 0
             if choice == "1":
                 _assemble_assignment(workspace_root, class_id, assignment_id)
@@ -460,13 +472,14 @@ def _launch_selected_student_review(
         print("9. Update review workflow state")
         print("10. Export student feedback")
         print("11. Refresh summary")
-        print("12. Back")
+        print_navigation_options()
         print()
 
         choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
         print()
 
-        if choice in {"", "12"}:
+        if choice in {"", "12"} or navigation is NavigationChoice.BACK:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -1419,7 +1432,7 @@ def _confirm_comment_selection(
         print("1. Add comment")
         print("2. Change include-in-feedback setting")
         print("3. Change target")
-        print("4. Back")
+        print_navigation_options()
         print()
         selection = input("Select an option: ").strip()
         if selection == "1":
@@ -2626,21 +2639,21 @@ def _choose_submission_evidence_page(
             f"{index}. Page {page.page_number} - {page.page_state} - "
             f"{page.evidence_id}"
         )
-    print("A. Open all selected pages")
-    print("B. Back")
+    print_navigation_options(all_items=True)
     print()
 
     choice = input("Select page: ").strip()
+    navigation = parse_navigation_choice(choice, allow_all=True)
     print()
-    if choice.lower() == "b" or choice == "":
+    if navigation is NavigationChoice.BACK or choice == "":
         return _BACK
-    if choice.lower() == "a":
+    if navigation is NavigationChoice.ALL:
         return None
     if choice.isdecimal():
         index = int(choice)
         if 1 <= index <= len(pages):
             return pages[index - 1].page_number
-    print("Invalid selection. Please choose a listed page, A, or B.")
+    print(f"Invalid selection. {navigation_hint(all_items=True)}")
     return _BACK
 
 
@@ -2670,11 +2683,12 @@ def _menu_review_unit_observations(
         print("1. Define/replace review units")
         print("2. Record/update Focus Standard observation")
         print("3. Mark observations complete")
-        print("4. Back")
+        print_navigation_options()
         print()
         choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
         print()
-        if choice in {"", "4"}:
+        if choice in {"", "4"} or navigation is NavigationChoice.BACK:
             return
         if choice == "1":
             _menu_define_review_units(
@@ -2946,8 +2960,9 @@ def _menu_overall_focus_standard_ratings(
         print("4. Back")
         print()
         choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
         print()
-        if choice in {"", "4"}:
+        if choice in {"", "4"} or navigation is NavigationChoice.BACK:
             return
         if choice == "1":
             _menu_view_focus_standard_observation_summary(
@@ -2997,11 +3012,12 @@ def _menu_compose_focus_standard_feedback(
         print("2. Add custom Focus Standard comment")
         print("3. Select reusable Focus Standard comment")
         print("4. Mark feedback composed")
-        print("5. Back")
+        print_navigation_options()
         print()
         choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
         print()
-        if choice in {"", "5"}:
+        if choice in {"", "5"} or navigation is NavigationChoice.BACK:
             return
         if choice == "1":
             _menu_configure_standard_feedback_options(
@@ -4056,10 +4072,11 @@ def _menu_review_minimum_requirements(
         print("1. Record/update requirement check")
         print("2. Finalize minimum-requirements outcome")
         print("3. Export returned-work feedback")
-        print("4. Back")
+        print_navigation_options()
         print()
         selection = input("Select an option: ").strip()
-        if selection in {"", "4"} or selection.casefold() == "b":
+        navigation = parse_navigation_choice(selection)
+        if selection in {"", "4"} or navigation is NavigationChoice.BACK:
             return
         if selection == "1":
             _menu_record_requirement_checks(
@@ -4506,7 +4523,7 @@ def _menu_manage_submission_pages(
     print("1. Exclude page from review")
     print("2. Restore excluded page")
     print("3. Mark page as needs rescan")
-    print("4. Back")
+    print_navigation_options()
     print()
     choice = input("Select an option: ").strip()
     if choice in {"", "4"}:
@@ -4775,6 +4792,9 @@ def _menu_export_student_feedback(
     print("4. Back")
     print()
     export_choice = input("Select an option: ").strip()
+    navigation = parse_navigation_choice(export_choice)
+    if navigation is NavigationChoice.BACK:
+        return
     if export_choice not in {"1", "2", "3"}:
         print("Export canceled.")
         return
@@ -4804,9 +4824,13 @@ def _menu_export_student_feedback(
         print()
         print("1. Keep existing export and cancel")
         print("2. Overwrite existing export")
-        print("3. Back")
+        print_navigation_options()
         print()
         selection = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(selection)
+        if navigation is NavigationChoice.BACK:
+            print("Export canceled.")
+            return
         if selection == "2":
             overwrite = True
         else:
@@ -4930,13 +4954,14 @@ def _launch_assignment_review_actions(
         print("3. Export assignment-local class summary")
         print("4. Export assignment-local Focus Standard summary")
         print("5. Refresh submission status")
-        print("6. Back")
+        print_navigation_options()
         print()
 
         choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
         print()
 
-        if choice in {"", "6"}:
+        if choice in {"", "6"} or navigation is NavigationChoice.BACK:
             return 0
         elif choice == "1":
             student_id = _prompt_student_id(

--- a/quillan/roster_workflows.py
+++ b/quillan/roster_workflows.py
@@ -168,8 +168,18 @@ def _prompt_class_folder(
     print("Available classes:")
     for index, folder in enumerate(folders, start=1):
         print(f"{index}. {folder.class_id}")
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
+
+    print_navigation_options()
     print()
     selection = input(f"Select class to {action}: ").strip()
+    navigation = parse_navigation_choice(selection)
+    if selection == "" or navigation is NavigationChoice.BACK:
+        return None
     if selection.isdigit() and 1 <= int(selection) <= len(folders):
         return folders[int(selection) - 1]
     for folder in folders:
@@ -303,7 +313,9 @@ def _print_roster_edit_dashboard(
     print("3. Remove student from active roster")
     print("4. View current roster")
     print("5. Save changes")
-    print("6. Cancel without saving")
+    from quillan.menu_navigation import print_navigation_options
+
+    print_navigation_options()
     print()
 
 
@@ -423,6 +435,26 @@ def prompt_edit_class_roster() -> int:
 
     dirty = False
     last_status: str | None = None
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        QuitQuillan,
+        ReturnToMainMenu,
+        parse_navigation_choice,
+    )
+
+    def confirm_dirty_navigation(error: Exception) -> None:
+        if not dirty:
+            raise error
+        destination = (
+            "Main Menu" if isinstance(error, ReturnToMainMenu) else "quit Quillan"
+        )
+        _print_roster_action_header("Discard Roster Changes")
+        print("Unsaved roster changes will be discarded.")
+        print()
+        confirmation = input(f"Type DISCARD to {destination}: ").strip()
+        if confirmation == "DISCARD":
+            raise error
+
     while True:
         _print_roster_edit_dashboard(
             staged_roster,
@@ -434,6 +466,14 @@ def prompt_edit_class_roster() -> int:
         print()
 
         try:
+            try:
+                navigation = parse_navigation_choice(choice)
+            except (ReturnToMainMenu, QuitQuillan) as error:
+                confirm_dirty_navigation(error)
+                last_status = "discard not confirmed"
+                continue
+            if navigation is NavigationChoice.BACK:
+                choice = "6"
             if choice == "1":
                 _print_roster_action_header("Add Student")
                 staged_roster = prompt_add_student_to_roster(staged_roster)
@@ -538,6 +578,12 @@ def prompt_validate_roster() -> int:
 def launch_roster_menu() -> int:
     """Launch the teacher-facing roster management submenu."""
     from quillan.menu import clear_screen, pause_for_user, print_menu_header
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        navigation_hint,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
 
     try:
         while True:
@@ -547,12 +593,13 @@ def launch_roster_menu() -> int:
             print("2. View class roster")
             print("3. Edit class roster")
             print("4. Validate class roster")
-            print("5. Back")
+            print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(choice)
             print()
 
-            if choice == "5":
+            if choice == "5" or navigation is NavigationChoice.BACK:
                 return 0
             workflows = {
                 "1": prompt_create_roster,
@@ -562,7 +609,7 @@ def launch_roster_menu() -> int:
             }
             workflow = workflows.get(choice)
             if workflow is None:
-                print("Invalid selection. Please enter a number from 1 to 5.")
+                print(f"Invalid selection. {navigation_hint()}")
             else:
                 clear_screen()
                 workflow()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,11 +74,34 @@ def test_cli_without_command_displays_menu_options_and_exits(
     assert "3. Roster Management" in output
     assert "4. Workspace Settings" in output
     assert "5. Help" in output
-    assert "6. Exit" in output
+    assert "Q. Quit" in output
+    assert "6. Exit" not in output
     assert "Printable Response Pages" not in output
     assert "Scan Intake / Route Paper Responses" not in output
     assert "Review Materials" not in output
     assert "Goodbye." in output
+
+
+def test_nested_menu_main_and_quit_shortcuts_unwind_globally(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["1", "m", "q"])
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert output.count("1. Assignment Management") == 2
+    assert "Goodbye." in output
+
+
+def test_nested_menu_quit_shortcut_exits_cleanly(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["1", "q"])
+
+    assert main(["menu"]) == 0
+    assert "Goodbye." in capsys.readouterr().out
 
 
 def test_cli_validates_assignment_config(
@@ -387,7 +410,8 @@ def test_menu_dispatch_displays_options_and_exits(
     assert "3. Roster Management" in output
     assert "4. Workspace Settings" in output
     assert "5. Help" in output
-    assert "6. Exit" in output
+    assert "Q. Quit" in output
+    assert "6. Exit" not in output
     assert "Printable Response Pages" not in output
     assert "Scan Intake / Route Paper Responses" not in output
     assert "Review Materials" not in output

--- a/tests/test_menu_navigation.py
+++ b/tests/test_menu_navigation.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from quillan.menu_navigation import (
+    NavigationChoice,
+    QuitQuillan,
+    ReturnToMainMenu,
+    parse_navigation_choice,
+)
+
+
+@pytest.mark.parametrize("value", ["b", "B"])
+def test_parse_navigation_choice_back_is_case_insensitive(value: str) -> None:
+    assert parse_navigation_choice(value) is NavigationChoice.BACK
+
+
+@pytest.mark.parametrize("value", ["m", "M"])
+def test_parse_navigation_choice_unwinds_to_main_menu(value: str) -> None:
+    with pytest.raises(ReturnToMainMenu):
+        parse_navigation_choice(value)
+
+
+@pytest.mark.parametrize("value", ["q", "Q"])
+def test_parse_navigation_choice_quits(value: str) -> None:
+    with pytest.raises(QuitQuillan):
+        parse_navigation_choice(value)
+
+
+@pytest.mark.parametrize("value", ["a", "A"])
+def test_all_is_available_only_when_explicitly_enabled(value: str) -> None:
+    assert parse_navigation_choice(value) is None
+    assert (
+        parse_navigation_choice(value, allow_all=True)
+        is NavigationChoice.ALL
+    )

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -196,7 +196,9 @@ def test_review_menu_selected_student_excludes_legacy_review_entry_actions(
     assert "9. Update review workflow state" in output
     assert "10. Export student feedback" in output
     assert "11. Refresh summary" in output
-    assert "12. Back" in output
+    assert "B. Back" in output
+    assert "M. Main Menu" in output
+    assert "Q. Quit" in output
     assert "Add structured tag" not in output
     assert "Select reusable comment" not in output
     assert "Set criterion score" not in output

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -302,7 +302,9 @@ def test_main_menu_shows_and_opens_review_student_work(
     assert "Review Student Work" in output
     assert "1. Assignment Review Actions" in output
     assert "2. Scan Intake / Route Paper Responses" in output
-    assert "3. Back" in output
+    assert "B. Back" in output
+    assert "M. Main Menu" in output
+    assert "Q. Quit" in output
     assert "Manage Review Materials" not in output
     assert "Goodbye." in output
 
@@ -870,7 +872,7 @@ def test_review_menu_multi_page_open_submission_selects_one_page(
     assert "Open Submission Evidence" in output
     assert "1. Page 1 - present - evidence_001" in output
     assert "2. Page 2 - present - evidence_002" in output
-    assert "A. Open all selected pages" in output
+    assert "A. All" in output
 
 
 def test_review_menu_multi_page_open_submission_opens_all_pages(
@@ -1215,6 +1217,6 @@ def test_review_menu_no_classes_and_invalid_selection_back_out_safely(
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "Invalid selection. Please enter a number from 1 to 3." in output
+    assert "Invalid selection. Please choose a listed option, B, M, or Q." in output
     assert "No classes found in the current workspace." in output
     assert "Goodbye." in output

--- a/tests/test_review_materials_menu.py
+++ b/tests/test_review_materials_menu.py
@@ -51,7 +51,7 @@ def test_main_menu_excludes_review_materials_and_exits_cleanly(
     assert "2. Review Student Work" in output
     assert "4. Workspace Settings" in output
     assert "5. Help" in output
-    assert "6. Exit" in output
+    assert "Q. Quit" in output
     assert "Review Materials" not in output
     assert "Goodbye." in output
 
@@ -68,7 +68,9 @@ def test_review_student_work_menu_excludes_review_materials(
     assert "Review Student Work" in output
     assert "1. Assignment Review Actions" in output
     assert "2. Scan Intake / Route Paper Responses" in output
-    assert "3. Back" in output
+    assert "B. Back" in output
+    assert "M. Main Menu" in output
+    assert "Q. Quit" in output
     assert "Manage Review Materials" not in output
     assert "Comment Banks" not in output
     assert "Tag Banks" not in output
@@ -86,11 +88,11 @@ def test_direct_review_materials_menu_is_disabled(
     output = capsys.readouterr().out
     assert "Review Materials" in output
     assert "Legacy generic comment-bank, tag-bank, and rubric workflows" in output
-    assert "1. Back" in output
+    assert "B. Back" in output
     assert "Comment Banks" not in output
     assert "Tag Banks" not in output
     assert "Starter Materials" not in output
-    assert "Invalid selection. Please enter 1 to go back." in output
+    assert "Invalid selection. Please choose a listed option, B, M, or Q." in output
 
 
 def test_review_materials_menu_has_no_workspace_side_effects(

--- a/tests/test_roster_workflows.py
+++ b/tests/test_roster_workflows.py
@@ -17,6 +17,7 @@ from pds_core.rosters import (
 )
 import pytest
 
+from quillan.menu_navigation import QuitQuillan, ReturnToMainMenu
 import quillan.roster_workflows as workflows
 
 
@@ -312,6 +313,50 @@ def test_edit_cancel_discard_does_not_write_staged_changes(
     assert "Discard Roster Changes" in output
     saved = load_class_roster(tmp_path, "synthetic_class")
     assert saved == original
+
+
+@pytest.mark.parametrize(
+    ("command", "error_type", "destination"),
+    [
+        ("m", ReturnToMainMenu, "Main Menu"),
+        ("q", QuitQuillan, "quit Quillan"),
+    ],
+)
+def test_dirty_edit_global_navigation_requires_discard_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    command: str,
+    error_type: type[Exception],
+    destination: str,
+) -> None:
+    write_class_roster(tmp_path, _roster())
+    original = load_class_roster(tmp_path, "synthetic_class")
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    prompts = _inputs(
+        monkeypatch,
+        [
+            "1",
+            "1",
+            "0099",
+            "Person",
+            "Taylor",
+            "3",
+            "Tay",
+            "",
+            command,
+            "KEEP",
+            command,
+            "DISCARD",
+        ],
+    )
+
+    with pytest.raises(error_type):
+        workflows.prompt_edit_class_roster()
+    output = capsys.readouterr().out
+    assert output.count("Unsaved roster changes will be discarded.") == 2
+    assert f"Type DISCARD to {destination}: " in prompts
+    assert load_class_roster(tmp_path, "synthetic_class") == original
 
 
 def test_edit_view_current_roster_is_explicit_action(


### PR DESCRIPTION
## Summary

- Add shared global navigation primitives for Quillan interactive menus.
- Standardize displayed menu navigation around:
  - `B. Back`
  - `M. Main Menu`
  - `Q. Quit`
  - `A. All` only where an all-selection action exists.
- Update main menu to use `Q. Quit` instead of a numbered exit option.
- Add `M. Main Menu` and `Q. Quit` support across nested assignment, roster, review, printable response, workspace, scan-intake, and selection menus.
- Preserve local `B. Back` behavior for one-level navigation.
- Keep `A. All` limited to applicable evidence-page selection.
- Preserve free-text fields so `B`, `M`, `Q`, and `A` are not treated as navigation unless explicitly listed.
- Require explicit `DISCARD` confirmation before leaving dirty roster-edit workflows with `M` or `Q`.
- Keep legacy numeric navigation accepted where needed for compatibility, while no longer displaying it as the primary UI.
- Add regression coverage for case-insensitive navigation, global unwind behavior, `A. All`, and dirty-roster safety.

## Validation

- Ruff passed.
- `git diff --check` passed.
- Full pytest suite passed: `1062 passed`.
- Manual smoke coverage included:
  - main menu
  - assignment menu
  - printable response menu
  - review/student workflow
  - scan intake
  - Open All
  - dirty roster discard
  - nested `M` / `Q` flows

Closes #203