### PR TITLE
Show student names in review screens

### DIFF
--- a/quillan/assignment_summary_context.py
+++ b/quillan/assignment_summary_context.py
@@ -205,7 +205,7 @@ def feedback_status(
         if not file_path.is_file():
             warnings.append(f"{field}_file_missing")
             return relative_path, "missing", "false", tuple(warnings)
-        if metadata["source_review_updated_at"] != review["updated_at"]:
+        if review is not None and metadata["source_review_updated_at"] != review["updated_at"]:
             warnings.append(f"{field}_stale")
             return relative_path, "stale", "true", tuple(warnings)
         return relative_path, "present", "false", tuple(warnings)

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -575,9 +575,11 @@ def _prompt_review_unit() -> dict[str, str]:
 
 
 def _default_rating_scale() -> dict[str, Any]:
+    levels = _DEFAULT_RATING_SCALE["levels"]
+    assert isinstance(levels, list)
     return {
         "scale_id": _DEFAULT_RATING_SCALE["scale_id"],
-        "levels": [dict(level) for level in _DEFAULT_RATING_SCALE["levels"]],
+        "levels": [dict(level) for level in levels],
     }
 
 

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -8,7 +8,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from pds_core.classes import load_class_roster
 from pds_core.rosters import RosterError, student_display_name
@@ -683,20 +683,23 @@ def _render_pdf_to_path(path: Path, feedback: _StudentFeedback) -> None:
             spaceAfter=5,
         )
     )
+    title_style = cast(ParagraphStyle, styles["FeedbackTitle"])
+    section_style = cast(ParagraphStyle, styles["FeedbackSection"])
+    body_style = cast(ParagraphStyle, styles["FeedbackBody"])
     story: list[Any] = []
     title = "Returned for Revision" if feedback.returned_work else "Student Feedback"
-    story.append(Paragraph(title, styles["FeedbackTitle"]))
-    story.append(_metadata_table(feedback, styles["FeedbackBody"]))
+    story.append(Paragraph(title, title_style))
+    story.append(_metadata_table(feedback, body_style))
     story.append(Spacer(1, 0.08 * inch))
     if feedback.returned_work is not None:
-        _append_returned_work_pdf(story, styles, feedback)
+        _append_returned_work_pdf(story, section_style, body_style, feedback)
     else:
-        _append_standard_feedback_pdf(story, styles, feedback)
+        _append_standard_feedback_pdf(story, section_style, body_style, feedback)
     story.append(Spacer(1, 0.12 * inch))
     story.append(
         Paragraph(
             "Quillan student feedback export",
-            styles["FeedbackBody"],
+            body_style,
         )
     )
 
@@ -746,9 +749,12 @@ def _metadata_table(feedback: _StudentFeedback, style: ParagraphStyle) -> Table:
 
 
 def _append_standard_feedback_pdf(
-    story: list[Any], styles: dict[str, ParagraphStyle], feedback: _StudentFeedback
+    story: list[Any],
+    section_style: ParagraphStyle,
+    body_style: ParagraphStyle,
+    feedback: _StudentFeedback,
 ) -> None:
-    story.append(Paragraph("Focus Standard Ratings", styles["FeedbackSection"]))
+    story.append(Paragraph("Focus Standard Ratings", section_style))
     if feedback.ratings:
         for rating in feedback.ratings:
             value = _format_number(rating["rating"])
@@ -759,34 +765,34 @@ def _append_standard_feedback_pdf(
                     "<b>"
                     f"{_escape_pdf_text(rating['standard_id'])}</b>: "
                     f"{_escape_pdf_text(value + label_suffix)}",
-                    styles["FeedbackBody"],
+                    body_style,
                 )
             )
             if rating.get("rationale"):
                 story.append(
                     Paragraph(
                         f"Rationale: {_escape_pdf_text(rating['rationale'])}",
-                        styles["FeedbackBody"],
+                        body_style,
                     )
                 )
     else:
-        story.append(Paragraph("No Focus Standard ratings selected.", styles["FeedbackBody"]))
+        story.append(Paragraph("No Focus Standard ratings selected.", body_style))
 
-    story.append(Paragraph("Feedback Comments", styles["FeedbackSection"]))
+    story.append(Paragraph("Feedback Comments", section_style))
     if feedback.comments:
         for comment in feedback.comments:
             prefix = f"{comment.get('standard_id')}: " if comment.get("standard_id") else ""
             story.append(
                 Paragraph(
                     f"{_escape_pdf_text(prefix)}{_escape_pdf_text(comment['text'])}",
-                    styles["FeedbackBody"],
+                    body_style,
                 )
             )
     else:
-        story.append(Paragraph("No feedback comments selected.", styles["FeedbackBody"]))
+        story.append(Paragraph("No feedback comments selected.", body_style))
 
     if feedback.observations:
-        story.append(Paragraph("Review Unit Observations", styles["FeedbackSection"]))
+        story.append(Paragraph("Review Unit Observations", section_style))
         for observation in feedback.observations:
             evidence = observation.get("evidence_present")
             evidence_text = ""
@@ -801,49 +807,52 @@ def _append_standard_feedback_pdf(
             )
             if observation.get("rationale"):
                 text += f" {_plain_text(observation['rationale'])}"
-            story.append(Paragraph(_escape_pdf_text(text), styles["FeedbackBody"]))
+            story.append(Paragraph(_escape_pdf_text(text), body_style))
 
 
 def _append_returned_work_pdf(
-    story: list[Any], styles: dict[str, ParagraphStyle], feedback: _StudentFeedback
+    story: list[Any],
+    section_style: ParagraphStyle,
+    body_style: ParagraphStyle,
+    feedback: _StudentFeedback,
 ) -> None:
     assert feedback.returned_work is not None
     story.append(
         Paragraph(
             "This submission was returned without full standards review because "
             "minimum requirements were not met.",
-            styles["FeedbackBody"],
+            body_style,
         )
     )
-    story.append(Paragraph("Minimum Requirements Not Met", styles["FeedbackSection"]))
+    story.append(Paragraph("Minimum Requirements Not Met", section_style))
     for requirement in feedback.returned_work["unmet_requirements"]:
         story.append(
             Paragraph(
                 f"<b>{_escape_pdf_text(requirement['label'])}</b>",
-                styles["FeedbackBody"],
+                body_style,
             )
         )
         story.append(
             Paragraph(
                 f"Expected: {_escape_pdf_text(requirement['expected'])}",
-                styles["FeedbackBody"],
+                body_style,
             )
         )
         if note := _non_empty(requirement.get("teacher_note")):
             story.append(
-                Paragraph(f"Teacher note: {_escape_pdf_text(note)}", styles["FeedbackBody"])
+                Paragraph(f"Teacher note: {_escape_pdf_text(note)}", body_style)
             )
-    story.append(Paragraph("Return Note", styles["FeedbackSection"]))
+    story.append(Paragraph("Return Note", section_style))
     story.append(
         Paragraph(
             _escape_pdf_text(feedback.returned_work["outcome"]["teacher_note"]),
-            styles["FeedbackBody"],
+            body_style,
         )
     )
     story.append(
         Paragraph(
             "No full Focus Standard ratings were completed for this submission.",
-            styles["FeedbackBody"],
+            body_style,
         )
     )
 

--- a/quillan/focus_standard_comments.py
+++ b/quillan/focus_standard_comments.py
@@ -238,6 +238,7 @@ def lookup_comments(
 ) -> tuple[ReusableFocusStandardComment, ...]:
     """Find active, student-facing reusable comments compatible with an assignment."""
     matches: list[ReusableFocusStandardComment] = []
+    files: tuple[FocusStandardCommentSetFile, ...]
     if comment_set_id is not None:
         files = (
             FocusStandardCommentSetFile(

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -138,6 +138,7 @@ from quillan.submission_status import (
     StudentSubmissionStatus,
     list_assignment_submission_status,
 )
+from quillan.student_display import student_display_lookup, student_review_label
 from quillan.menu_navigation import (
     NavigationChoice,
     navigation_hint,
@@ -329,10 +330,11 @@ def _prompt_student_id(
         student_status.student_id: student_status
         for student_status in status.student_statuses
     }
+    student_labels = student_display_lookup(workspace_root, class_id)
     print("Select student/submission:")
     for index, student_id in enumerate(student_ids, start=1):
         print(
-            f"{index}. {student_id}: "
+            f"{index}. {student_labels.get(student_id, student_id)}: "
             f"{_student_status_label(status_by_student.get(student_id))}"
         )
     print_navigation_options()
@@ -603,7 +605,13 @@ def _print_review_action_header(
     print_menu_header(title)
     print(f"Class: {class_id}")
     print(f"Assignment: {assignment_id}")
-    print(f"Student: {student_id}")
+    try:
+        workspace_root = resolve_workspace_root()
+    except WorkspaceRootError:
+        student_label = student_id
+    else:
+        student_label = student_review_label(workspace_root, class_id, student_id)
+    print(f"Student: {student_label}")
     print()
 
 
@@ -2383,7 +2391,10 @@ def _print_review_summary(
     print()
     print(f"Class: {class_id}")
     print(f"Assignment: {assignment_id}")
-    print(f"Student: {student_id}")
+    print(
+        f"Student: "
+        f"{student_review_label(workspace_root, class_id, student_id)}"
+    )
 
     status = _load_submission_status(workspace_root, class_id, assignment_id)
     student_status = None
@@ -2724,7 +2735,7 @@ def _menu_define_review_units(
     existing_units = existing.get("review_units", []) if existing is not None else []
     print(f"Assignment review unit type: {unit_type}")
     print(f"Focus Standards: {len(assignment['focus_standard_ids'])}")
-    if existing_units:
+    if existing is not None and existing_units:
         existing_observations = _count_review_unit_observations(existing)
         print(
             f"Existing review units: {len(existing_units)}; "
@@ -3212,7 +3223,7 @@ def _menu_add_custom_focus_standard_feedback_comment(
     reusable_label = None
     reusable_text = None
     purpose = "general"
-    rating_values = None
+    rating_values: list[int | float] | None = None
     if save_for_reuse:
         _print_feedback_action_header(
             "Save Reusable Focus Standard Comment",
@@ -3811,7 +3822,12 @@ def _feedback_record_for_standard(
     standard_id: str,
 ) -> dict[str, Any] | None:
     feedback = record.get("feedback", {})
-    standard_feedback = feedback.get("standard_feedback") if isinstance(feedback, dict) else []
+    raw_standard_feedback = (
+        feedback.get("standard_feedback") if isinstance(feedback, dict) else None
+    )
+    standard_feedback = (
+        raw_standard_feedback if isinstance(raw_standard_feedback, list) else []
+    )
     for item in standard_feedback:
         if isinstance(item, dict) and item.get("standard_id") == standard_id:
             return item

--- a/quillan/student_display.py
+++ b/quillan/student_display.py
@@ -1,0 +1,39 @@
+"""Resilient teacher-facing student labels."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.classes import load_class_roster
+from pds_core.rosters import RosterError, student_display_name, student_lookup
+
+
+def student_display_lookup(
+    workspace_root: str | Path,
+    class_id: str,
+) -> dict[str, str]:
+    """Return name-and-ID labels, or an empty mapping when a roster is unavailable."""
+    try:
+        roster = load_class_roster(workspace_root, class_id)
+        students = student_lookup(roster)
+    except (RosterError, OSError, ValueError, TypeError):
+        return {}
+
+    labels: dict[str, str] = {}
+    for student_id, student in students.items():
+        try:
+            name = student_display_name(student).strip()
+        except (RosterError, AttributeError, TypeError, ValueError):
+            continue
+        if name:
+            labels[student_id] = f"{name} ({student_id})"
+    return labels
+
+
+def student_review_label(
+    workspace_root: str | Path,
+    class_id: str,
+    student_id: str,
+) -> str:
+    """Return a teacher-friendly label with a safe ID-only fallback."""
+    return student_display_lookup(workspace_root, class_id).get(student_id, student_id)

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -334,13 +334,19 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
     assert f"1. {CLASS_ID}" in output
     assert f"1. {ASSIGNMENT_ID} - Synthetic Essay" in output
     assert f"Submission status for assignment {ASSIGNMENT_ID}" in output
-    assert f"1. {STUDENT_ID}: unreviewed; manifest exists; evidence files=1" in output
-    assert f"2. {SECOND_STUDENT_ID}: no manifest; no routed evidence" in output
+    assert (
+        f"1. Avery Rivera ({STUDENT_ID}): "
+        "unreviewed; manifest exists; evidence files=1"
+    ) in output
+    assert (
+        f"2. Mina Patel ({SECOND_STUDENT_ID}): "
+        "no manifest; no routed evidence"
+    ) in output
     assert "Selected Student Review" in output
     assert "Current review summary" in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
-    assert f"Student: {STUDENT_ID}" in output
+    assert f"Student: Avery Rivera ({STUDENT_ID})" in output
     assert "Submission: assembled" in output
     assert "Evidence files: 1" in output
     assert "Review record: not started" in output
@@ -754,6 +760,7 @@ def test_review_menu_views_current_review_details_read_only(
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
     assert "Current Review Details" in output
+    assert f"Student: Avery Rivera ({STUDENT_ID})" in output
     assert "Paragraph 2 (paragraph)" in output
     assert (
         "njsls-ela:W.1: applicable; evidence present: yes; "
@@ -947,7 +954,7 @@ def test_review_menu_reports_missing_openable_evidence(
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert f"Student: {SECOND_STUDENT_ID}" in output
+    assert f"Student: Mina Patel ({SECOND_STUDENT_ID})" in output
     assert "Submission: not assembled" in output
     assert "No routed evidence has been found for this student yet." in output
     assert "1. Assemble this assignment now" not in output

--- a/tests/test_review_feedback.py
+++ b/tests/test_review_feedback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -33,11 +33,13 @@ from tests.test_review_ratings import (
 
 
 def _read_review(root: Path) -> dict[str, Any]:
-    return json.loads(
+    data = json.loads(
         review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
             encoding="utf-8"
         )
     )
+    assert isinstance(data, dict)
+    return cast(dict[str, Any], data)
 
 
 def _fresh_review() -> dict[str, Any]:
@@ -54,7 +56,7 @@ def _write_fresh_workspace(root: Path) -> None:
 def _write_comment_set(root: Path) -> None:
     path = focus_standard_comment_set_path(root, "synthetic_argument_focus_comments")
     path.parent.mkdir(parents=True)
-    data = {
+    data: dict[str, Any] = {
         "schema_version": "1",
         "module": "quillan",
         "record_type": "focus_standard_comment_set",

--- a/tests/test_review_observations.py
+++ b/tests/test_review_observations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -113,11 +113,13 @@ def _write_workspace(root: Path) -> None:
 
 
 def _read_review(root: Path) -> dict[str, Any]:
-    return json.loads(
+    data = json.loads(
         review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
             encoding="utf-8"
         )
     )
+    assert isinstance(data, dict)
+    return cast(dict[str, Any], data)
 
 
 def test_setting_review_units_creates_v2_record_with_assignment_unit_type(

--- a/tests/test_review_ratings.py
+++ b/tests/test_review_ratings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -231,11 +231,13 @@ def _review_record() -> dict[str, Any]:
 
 
 def _read_review(root: Path) -> dict[str, Any]:
-    return json.loads(
+    data = json.loads(
         review_record_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
             encoding="utf-8"
         )
     )
+    assert isinstance(data, dict)
+    return cast(dict[str, Any], data)
 
 
 def test_set_overall_rating_creates_record_and_preserves_review_data(

--- a/tests/test_standards_summary_export.py
+++ b/tests/test_standards_summary_export.py
@@ -18,8 +18,6 @@ from quillan.standards_summary_export import (
     standards_summary_export_path,
 )
 from tests.test_class_summary_export import (
-    ASSIGNMENT_ID,
-    CLASS_ID,
     STANDARD_A,
     STANDARD_A_KEY,
     STANDARD_B,
@@ -31,6 +29,9 @@ from tests.test_class_summary_export import (
     _write_json,
     _write_roster,
 )
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
 
 
 def _write_review(

--- a/tests/test_student_display.py
+++ b/tests/test_student_display.py
@@ -1,0 +1,57 @@
+"""Tests for resilient teacher-facing student labels."""
+
+from pathlib import Path
+
+from pds_core.rosters import RosterError
+import pytest
+
+import quillan.student_display as student_display
+
+
+def test_student_review_label_uses_core_display_name(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    student = object()
+    roster = object()
+    monkeypatch.setattr(student_display, "load_class_roster", lambda *_: roster)
+    monkeypatch.setattr(
+        student_display, "student_lookup", lambda value: {"10002": student}
+    )
+    monkeypatch.setattr(
+        student_display, "student_display_name", lambda value: "Eli Brooks"
+    )
+
+    assert (
+        student_display.student_review_label(tmp_path, "english10", "10002")
+        == "Eli Brooks (10002)"
+    )
+
+
+def test_student_review_label_falls_back_when_roster_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        student_display,
+        "load_class_roster",
+        lambda *_: (_ for _ in ()).throw(RosterError("missing")),
+    )
+
+    assert (
+        student_display.student_review_label(tmp_path, "english10", "10002")
+        == "10002"
+    )
+
+
+def test_student_review_label_falls_back_for_missing_roster_row(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(student_display, "load_class_roster", lambda *_: object())
+    monkeypatch.setattr(student_display, "student_lookup", lambda _: {})
+
+    assert (
+        student_display.student_review_label(tmp_path, "english10", "19999")
+        == "19999"
+    )


### PR DESCRIPTION
## Summary

- Display student names plus IDs in review-related teacher-facing screens.
- Update Select Student/Submission so entries use the format `Student Name (student_id): status`.
- Update Selected Student Review and shared review action headers to show `Student: Name (ID)` when roster metadata is available.
- Preserve safe ID-only fallback when roster data is missing, invalid, or does not contain the submission student.
- Preserve student IDs as the durable internal identity for paths, records, manifests, routing, and exports.
- Use pds-core preferred-name behavior through existing roster display helpers.
- Add/update focused tests for name-plus-ID display, preferred-name behavior, and fallback behavior.
- Clean up strict typing issues so the full validation script passes.

## Validation

- Ran `.\run_tests.ps1`
- Pytest: `1065 passed`
- Ruff: passed
- Mypy: no issues in 155 files
- Ran `git diff --check`
- Diff check: passed
- Confirmed student identity display remains `Name (ID)`, with preferred-name support and ID-only fallback for missing or invalid roster data.

Closes #200