### PR TITLE
Offer class selection for roster validation

### DIFF
--- a/quillan/roster_workflows.py
+++ b/quillan/roster_workflows.py
@@ -549,22 +549,13 @@ def _normalize_path_input(value: str) -> str:
     return stripped
 
 
-def prompt_validate_roster() -> int:
-    """Validate an explicit roster CSV without rewriting it."""
-    from quillan.menu import print_menu_header
-
-    print_menu_header("Validate Class Roster")
-    roster_path = _normalize_path_input(input("Roster CSV path: "))
-    if not roster_path:
-        print("Error: roster CSV path is required.")
-        return 1
-    try:
-        roster = validate_roster_file(roster_path)
-    except RosterError as error:
-        print_roster_validation_error(error)
-        return 1
+def _print_roster_validation_summary(
+    roster: Roster,
+    roster_path: str | Path,
+) -> None:
     print("Roster file is valid.")
     print(f"Class ID: {roster.class_id}")
+    print(f"Roster path: {Path(roster_path)}")
     print(f"Student count: {len(roster.students)}")
     print("First students:")
     for student in roster.students[:5]:
@@ -572,6 +563,70 @@ def prompt_validate_roster() -> int:
             f"  {student.student_id}: "
             f"{student.last_name}, {student.first_name}"
         )
+
+
+def prompt_validate_roster() -> int:
+    """Validate a selected canonical class roster or an explicit CSV path."""
+    from quillan.menu import print_menu_header
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
+
+    print_menu_header("Validate Class Roster")
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return 1
+    folders = _available_class_folders(workspace_root)
+    if folders:
+        print("Available classes:")
+        for index, folder in enumerate(folders, start=1):
+            print(f"{index}. {folder.class_id}")
+    else:
+        print("No class rosters found.")
+        print("Create a class roster first, or choose a custom roster CSV path.")
+    print("C. Custom roster CSV path")
+    print_navigation_options()
+    print()
+
+    selection = input("Select class to validate: ").strip()
+    navigation = parse_navigation_choice(selection)
+    if selection == "" or navigation is NavigationChoice.BACK:
+        return 1
+
+    selected_folder: ClassFolder | None = None
+    if selection.isdigit() and 1 <= int(selection) <= len(folders):
+        selected_folder = folders[int(selection) - 1]
+    else:
+        selected_folder = next(
+            (folder for folder in folders if folder.class_id == selection),
+            None,
+        )
+
+    if selected_folder is not None:
+        try:
+            roster = load_class_roster(workspace_root, selected_folder.class_id)
+        except RosterError as error:
+            print_roster_validation_error(error)
+            return 1
+        _print_roster_validation_summary(roster, selected_folder.roster_path)
+        return 0
+
+    if selection.casefold() != "c":
+        print(f"Error: Class not found: {selection}")
+        return 1
+
+    roster_path = _normalize_path_input(input("Roster CSV path, or B/M/Q: "))
+    navigation = parse_navigation_choice(roster_path)
+    if roster_path == "" or navigation is NavigationChoice.BACK:
+        return 1
+    try:
+        roster = validate_roster_file(roster_path)
+    except RosterError as error:
+        print_roster_validation_error(error)
+        return 1
+    _print_roster_validation_summary(roster, roster_path)
     return 0
 
 

--- a/tests/test_roster_workflows.py
+++ b/tests/test_roster_workflows.py
@@ -407,31 +407,110 @@ def test_edit_save_requires_confirmation_then_writes(
     assert saved.students[0].extra_fields["preferred_name"] == "Ari"
 
 
-def test_validate_roster_summary_and_structured_error(
+@pytest.mark.parametrize("selection", ["1", "synthetic_class"])
+def test_validate_selected_class_roster(
+    selection: str,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     valid_path = write_class_roster(tmp_path, _roster())
-    _inputs(monkeypatch, [str(valid_path)])
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, [selection])
     assert workflows.prompt_validate_roster() == 0
     valid_output = capsys.readouterr().out
+    assert "Available classes:" in valid_output
     assert "Roster file is valid." in valid_output
+    assert "Class ID: synthetic_class" in valid_output
+    assert f"Roster path: {valid_path}" in valid_output
     assert "Student count: 2" in valid_output
     assert "0012" in valid_output
 
+
+def test_validate_custom_roster_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    valid_path = write_class_roster(tmp_path / "external", _roster())
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: workspace)
+    prompts = _inputs(monkeypatch, ["c", str(valid_path)])
+
+    assert workflows.prompt_validate_roster() == 0
+    output = capsys.readouterr().out
+    assert "No class rosters found." in output
+    assert "C. Custom roster CSV path" in output
+    assert f"Roster path: {valid_path}" in output
+    assert any("Roster CSV path, or B/M/Q:" in prompt for prompt in prompts)
+
+
+def test_validate_selected_class_prints_structured_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    roster_path = tmp_path / "classes" / "synthetic_class" / "roster.csv"
+    roster_path.parent.mkdir(parents=True)
+    roster_path.write_text(
+        "class_id,student_id,last_name,first_name,period\n"
+        "synthetic_class,0001,Example,,3\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1"])
+
+    assert workflows.prompt_validate_roster() == 1
+    invalid_output = capsys.readouterr().out
+    assert "[blank_required_value]" in invalid_output
+    assert "row 2" in invalid_output
+    assert "column first_name" in invalid_output
+    assert "Traceback" not in invalid_output
+
+
+def test_validate_custom_roster_prints_structured_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     invalid_path = tmp_path / "invalid.csv"
     invalid_path.write_text(
         "class_id,student_id,last_name,first_name,period\n"
         "synthetic_class,0001,Example,,3\n",
         encoding="utf-8",
     )
-    _inputs(monkeypatch, [str(invalid_path)])
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["c", str(invalid_path)])
     assert workflows.prompt_validate_roster() == 1
     invalid_output = capsys.readouterr().out
     assert "[blank_required_value]" in invalid_output
     assert "row 2" in invalid_output
     assert "column first_name" in invalid_output
+
+
+@pytest.mark.parametrize(
+    ("selection", "expected"),
+    [
+        ("b", None),
+        ("m", ReturnToMainMenu),
+        ("q", QuitQuillan),
+    ],
+)
+def test_validate_roster_selection_navigation(
+    selection: str,
+    expected: type[Exception] | None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, [selection])
+
+    if expected is None:
+        assert workflows.prompt_validate_roster() == 1
+    else:
+        with pytest.raises(expected):
+            workflows.prompt_validate_roster()
 
 
 def test_shared_validation_rejects_duplicate_student_id() -> None:


### PR DESCRIPTION
## Summary

- Update `Roster Management → Validate class roster` to list canonical class rosters first.
- Allow validation by visible number or exact `class_id`.
- Preserve `C. Custom roster CSV path` for advanced/manual validation.
- Support shared `B/M/Q` navigation.
- Handle empty workspaces without crashing.
- Preserve structured roster validation errors for invalid rosters.
- Print concise validation context:
  - class ID
  - roster path
  - student count
  - first students
- Add focused tests for class selection, exact `class_id` selection, custom path validation, invalid rosters, empty workspaces, and navigation.

## Validation

- Ran `.\run_tests.ps1`
- Pytest: `1072 passed`
- Ruff: passed
- Mypy: passed, 155 files
- Ran `git diff --check`
- Diff check: passed
- Prompt-level smoke coverage passed for:
  - class selection
  - custom roster paths
  - invalid rosters
  - empty workspaces
  - `B/M/Q` navigation

Closes #254