### PR TITLE
Warn before assignment creation without standards profiles

### DIFF
--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -388,6 +388,81 @@ def _prompt_standards_selection(
     return selected_profile.profile_id, selected_standards
 
 
+def _confirm_standards_profile_prerequisite(workspace_root: Path) -> bool:
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        navigation_hint,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
+
+    _print_assignment_section_header("Create Writing Assignment")
+    print("Assignment creation requires an existing PDS Core standards profile.")
+    print()
+
+    try:
+        library = load_standards_for_selection(workspace_root)
+    except (OSError, StandardsReadError, StandardsValidationError) as error:
+        print(
+            "Quillan could not load the PDS Core standards library for this "
+            "workspace."
+        )
+        print()
+        print(
+            "Create or repair standards/profile data in PDS Core, then return "
+            "to Quillan."
+        )
+        print()
+        print(f"Error: {error}")
+        print()
+        print_navigation_options()
+        print()
+        selection = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(selection)
+        if selection == "" or navigation is NavigationChoice.BACK:
+            return False
+        print(f"Invalid selection. {navigation_hint()}")
+        return False
+
+    profiles = list_profiles_for_selection(library)
+    if not profiles:
+        print("No standards profiles were found in this workspace.")
+        print()
+        print(
+            "Create or import standards and standards profiles in PDS Core, "
+            "then return to Quillan to create the assignment."
+        )
+        print()
+        print_navigation_options()
+        print()
+        selection = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(selection)
+        if selection == "" or navigation is NavigationChoice.BACK:
+            return False
+        print(f"Invalid selection. {navigation_hint()}")
+        return False
+
+    print(
+        "Quillan uses a standards profile to let you choose Focus Standards "
+        "for this assignment. Standards and standards profiles are created in "
+        "PDS Core, not in Quillan."
+    )
+    print()
+    print(f"Standards profiles found: {len(profiles)}")
+    print()
+    print("1. Continue")
+    print_navigation_options()
+    print()
+    selection = input("Select an option: ").strip()
+    navigation = parse_navigation_choice(selection)
+    if selection == "1":
+        return True
+    if selection == "" or navigation is NavigationChoice.BACK:
+        return False
+    print(f"Invalid selection. {navigation_hint()}")
+    return False
+
+
 def _prompt_focus_standards(
     standards: Sequence[StandardSelectionItem],
 ) -> list[str] | None:
@@ -414,6 +489,8 @@ def prompt_create_assignment() -> int:
     """Prompt for and write one validated writing assignment config."""
     workspace_root = _workspace_root()
     if workspace_root is None:
+        return 1
+    if not _confirm_standards_profile_prerequisite(workspace_root):
         return 1
     _print_assignment_section_header("Select Assignment Class")
     class_folder = _prompt_class_folder(workspace_root)

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -21,6 +21,7 @@ from quillan.assignments import (
     load_assignment_config,
     validate_assignment_config,
 )
+from quillan.menu_navigation import QuitQuillan, ReturnToMainMenu
 
 STANDARD_ID = "njsls-ela:W.AW.11-12.1"
 SECOND_STANDARD_ID = "njsls-ela:L.KL.11-12.2"
@@ -117,6 +118,25 @@ def _write_standards_library(workspace_root: Path) -> None:
                     title="Synthetic ELA 11-12",
                 ),
             ),
+        ),
+    )
+
+
+def _write_standards_library_without_profiles(workspace_root: Path) -> None:
+    write_workspace_standards_library(
+        workspace_root,
+        StandardsLibrary(
+            standards=(
+                StandardDefinition(
+                    standard_id=STANDARD_ID,
+                    code="W.AW.11-12.1",
+                    source="NJSLS",
+                    short_name="Argument Writing",
+                    description="Write arguments supported by evidence.",
+                    available_modules=("quillan",),
+                ),
+            ),
+            profiles=(),
         ),
     )
 
@@ -229,6 +249,7 @@ def test_prompt_create_assignment_writes_valid_v2_config(
         monkeypatch,
         [
             "1",
+            "1",
             "Literary Analysis Essay",
             "",
             "literary analysis",
@@ -282,6 +303,10 @@ def test_prompt_create_assignment_writes_valid_v2_config(
     assert "focus_standards" not in assignment
     assert "rubric_id" not in assignment
     output = capsys.readouterr().out
+    assert "Assignment creation requires an existing PDS Core standards profile." in (
+        output
+    )
+    assert "Standards profiles found: 1" in output
     assert "Select Assignment Class" in output
     assert "Assignment Identity" in output
     assert "Writing Prompt" in output
@@ -296,6 +321,97 @@ def test_prompt_create_assignment_writes_valid_v2_config(
     assert "Focus standard IDs (2)" in output
 
 
+def test_prompt_create_assignment_prerequisite_back_stops_before_class_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_standards_library(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    prompts = _inputs(monkeypatch, ["b"])
+
+    assert workflows.prompt_create_assignment() == 1
+    output = capsys.readouterr().out
+    assert "Assignment creation requires an existing PDS Core standards profile." in (
+        output
+    )
+    assert "Select Assignment Class" not in output
+    assert "Assignment title:" not in prompts
+
+
+@pytest.mark.parametrize(
+    ("selection", "expected_exception"),
+    [("m", ReturnToMainMenu), ("q", QuitQuillan)],
+)
+def test_prompt_create_assignment_prerequisite_uses_shared_global_navigation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+    expected_exception: type[Exception],
+) -> None:
+    _write_roster(tmp_path)
+    _write_standards_library(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, [selection])
+
+    with pytest.raises(expected_exception):
+        workflows.prompt_create_assignment()
+
+
+def test_prompt_create_assignment_no_profiles_stops_before_assignment_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_standards_library_without_profiles(tmp_path)
+    original_files = {
+        path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()
+    }
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    prompts = _inputs(monkeypatch, ["b"])
+
+    assert workflows.prompt_create_assignment() == 1
+    output = capsys.readouterr().out
+    assert "No standards profiles were found in this workspace." in output
+    assert "Create or import standards and standards profiles in PDS Core" in output
+    assert "1. Continue" not in output
+    assert "Select Assignment Class" not in output
+    assert "Assignment title:" not in prompts
+    assert "Writing type:" not in prompts
+    assert "Student-facing assignment prompt:" not in prompts
+    assert not list(tmp_path.rglob("assignment.json"))
+    assert {
+        path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()
+    } == original_files
+
+
+def test_prompt_create_assignment_standards_load_failure_stops_before_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    standards_path = tmp_path / "standards" / "library.json"
+    standards_path.parent.mkdir()
+    standards_path.write_text("{not valid json", encoding="utf-8")
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    prompts = _inputs(monkeypatch, ["b"])
+
+    assert workflows.prompt_create_assignment() == 1
+    output = capsys.readouterr().out
+    assert "could not load the PDS Core standards library" in output
+    assert "Create or repair standards/profile data in PDS Core" in output
+    assert "Error:" in output
+    assert "1. Continue" not in output
+    assert "Select Assignment Class" not in output
+    assert "Assignment title:" not in prompts
+    assert "Writing type:" not in prompts
+    assert "Student-facing assignment prompt:" not in prompts
+    assert not list(tmp_path.rglob("assignment.json"))
+
+
 def test_prompt_create_assignment_default_rating_scale_has_four_unique_levels(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -306,6 +422,7 @@ def test_prompt_create_assignment_default_rating_scale_has_four_unique_levels(
     _inputs(
         monkeypatch,
         [
+            "1",
             "1",
             "Argument Essay",
             "",
@@ -355,6 +472,7 @@ def test_prompt_create_assignment_writes_declined_minimum_requirement_policy(
         monkeypatch,
         [
             "1",
+            "1",
             "Argument Essay",
             "",
             "argument",
@@ -399,6 +517,7 @@ def test_prompt_create_assignment_final_cancel_does_not_write(
         monkeypatch,
         [
             "1",
+            "1",
             "Argument Essay",
             "",
             "argument",
@@ -441,6 +560,7 @@ def test_prompt_create_assignment_does_not_overwrite_without_confirmation(
         monkeypatch,
         [
             "1",
+            "1",
             "Argument Essay",
             "",
             "argument",
@@ -481,6 +601,7 @@ def test_prompt_create_assignment_overwrites_with_explicit_confirmation(
         monkeypatch,
         [
             "1",
+            "1",
             "Argument Essay",
             "",
             "argument",
@@ -518,10 +639,12 @@ def test_prompt_create_assignment_invalid_input_fails_without_traceback(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     _write_roster(tmp_path)
+    _write_standards_library(tmp_path)
     monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
     _inputs(
         monkeypatch,
         [
+            "1",
             "1",
             "Argument Essay",
             "bad id",


### PR DESCRIPTION
## Summary

- Add an early standards-profile prerequisite check before assignment creation begins.
- Show the prerequisite notice before class selection, assignment title, assignment ID, writing type, or student prompt entry.
- Explain that standards and standards profiles are created/imported in PDS Core, not Quillan.
- If standards profiles exist, allow the teacher to choose `1. Continue`.
- If no standards profiles exist, stop early and direct the teacher to PDS Core.
- If the standards library cannot be loaded, stop early with a clear teacher-facing error.
- Preserve shared `B/M/Q` navigation behavior.
- Do not create, edit, launch, or write standards/profile data from Quillan.
- Add focused tests for Continue, Back, Main Menu, Quit, no profiles, load failure, and no standards writes.

## Validation

- Ran `.\.venv\Scripts\python.exe -m pytest tests\test_assignment_workflows.py`
- Targeted pytest: `20 passed`
- Ran `.\run_tests.ps1`
- Full pytest: `1077 passed`
- Ruff: passed
- Mypy: no issues found in 155 source files
- Script whitespace check: passed
- Ran `git diff --check`
- Diff check: passed
- Smoke/focused workflow coverage verified:
  - prerequisite notice appears before class/title/prompt entry
  - Continue proceeds to class selection
  - no-profile and load-failure cases stop early
  - `B/M/Q` use shared navigation behavior
  - standards/profile data is not written by Quillan

Closes #189