### PR TITLE
Normalize assignment writing type input

### DIFF
--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -84,6 +84,19 @@ def suggest_assignment_id(title: str) -> str:
     return suggestion.strip("_-").lower()
 
 
+def normalize_writing_type(value: str) -> str:
+    """Normalize teacher-friendly writing type input to lowercase snake case."""
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+    writing_type = re.sub(r"[^a-z0-9]+", "_", ascii_value.strip().lower())
+    writing_type = re.sub(r"_+", "_", writing_type).strip("_")
+    if not writing_type:
+        raise ValueError("writing type is required.")
+    if re.fullmatch(r"[a-z][a-z0-9_]*", writing_type) is None:
+        raise ValueError("writing type must start with a letter after normalization.")
+    return writing_type
+
+
 def parse_comma_separated_values(value: str) -> list[str]:
     """Return trimmed, nonblank values from comma-separated teacher input."""
     return [item.strip() for item in value.split(",") if item.strip()]
@@ -517,7 +530,7 @@ def prompt_create_assignment() -> int:
             class_id=class_folder.class_id,
             assignment_id=assignment_id,
         )
-        writing_type = _required_input("Writing type: ", "writing type")
+        writing_type = _prompt_writing_type()
         student_prompt = _prompt_student_prompt()
         _print_assignment_section_header(
             "Standards Profile",
@@ -625,6 +638,18 @@ def _prompt_student_prompt() -> str:
         "Student-facing assignment prompt: ",
         "student-facing assignment prompt",
     )
+
+
+def _prompt_writing_type() -> str:
+    print("Writing type:")
+    print("Examples: literary_analysis, argument, research_paper, reflection")
+    print("You may type spaces; Quillan will store lowercase snake_case.")
+    print()
+    raw = _required_input("Writing type: ", "writing type")
+    normalized = normalize_writing_type(raw)
+    if normalized != raw.strip():
+        print(f"Stored writing type: {normalized}")
+    return normalized
 
 
 def _default_review_unit() -> dict[str, str]:

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -237,6 +237,31 @@ def test_assignment_parsing_helpers() -> None:
         workflows.parse_optional_nonnegative_int("many", "paragraphs_min")
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("literary analysis", "literary_analysis"),
+        ("Literary Analysis", "literary_analysis"),
+        ("  literary analysis  ", "literary_analysis"),
+        ("research-paper", "research_paper"),
+        ("research_paper", "research_paper"),
+        ("short response", "short_response"),
+        ("compare/contrast", "compare_contrast"),
+    ],
+)
+def test_normalize_writing_type_accepts_teacher_friendly_input(
+    value: str,
+    expected: str,
+) -> None:
+    assert workflows.normalize_writing_type(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", " !?! ", "123 response"])
+def test_normalize_writing_type_rejects_unusable_input(value: str) -> None:
+    with pytest.raises(ValueError, match="writing type"):
+        workflows.normalize_writing_type(value)
+
+
 def test_prompt_create_assignment_writes_valid_v2_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -279,6 +304,7 @@ def test_prompt_create_assignment_writes_valid_v2_config(
     )
     assignment = load_assignment_config(path)
     assert assignment["schema_version"] == "2"
+    assert assignment["writing_type"] == "literary_analysis"
     assert assignment["student_prompt"] == (
         "Analyze how the author develops a central idea."
     )
@@ -310,6 +336,9 @@ def test_prompt_create_assignment_writes_valid_v2_config(
     assert "Select Assignment Class" in output
     assert "Assignment Identity" in output
     assert "Writing Prompt" in output
+    assert "Examples: literary_analysis, argument, research_paper, reflection" in output
+    assert "Quillan will store lowercase snake_case" in output
+    assert "Stored writing type: literary_analysis" in output
     assert "Standards Profile" in output
     assert "Focus Standard Selection" in output
     assert "Review Unit Setup" in output

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -95,6 +95,13 @@ def test_validate_assignment_config_accepts_example_assignment() -> None:
     validate_assignment_config(json.loads(path.read_text(encoding="utf-8")))
 
 
+def test_validate_assignment_config_keeps_writing_type_compatibility() -> None:
+    assignment = _valid_assignment_config()
+    assignment["writing_type"] = "literary analysis"
+
+    validate_assignment_config(assignment)
+
+
 def test_optional_metadata_fields_do_not_break_validation(tmp_path: Path) -> None:
     assignment = _valid_assignment_config()
     assignment["created_at"] = "2026-07-02T00:00:00+00:00"


### PR DESCRIPTION
## Summary

- Add writing-type normalization for the create-assignment workflow.
- Show writing-type examples in the prompt:
  - `literary_analysis`
  - `argument`
  - `research_paper`
  - `reflection`
- Explain that teachers may type spaces and Quillan will store lowercase snake case.
- Normalize teacher input before saving:
  - `literary analysis` → `literary_analysis`
  - `Literary Analysis` → `literary_analysis`
  - punctuation-separated values → snake case
- Preserve existing snake-case values.
- Print `Stored writing type: ...` when normalization changes the teacher’s input.
- Preserve compatibility for existing assignment configs with any non-empty `writing_type`.
- Add tests for normalization, prompt copy, confirmation output, saved JSON, and validation compatibility.

## Validation

- Ran `.\.venv\Scripts\python.exe -m pytest tests/test_assignment_workflows.py tests/test_assignments.py`
- Targeted pytest: `91 passed`
- Ran `.\run_tests.ps1`
- Full pytest: `1088 passed`
- Ruff: passed
- Mypy: passed
- Script diff whitespace check: passed
- Ran `git diff --check`
- Diff check: passed
- Manual/workflow smoke coverage confirmed:
  - entering `literary analysis` saves `"writing_type": "literary_analysis"`
  - workflow prints `Stored writing type: literary_analysis`
  - existing non-empty writing types with spaces remain valid

Closes #192