### PR TITLE
Support multi-class assignment creation

### DIFF
--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -123,7 +123,6 @@ def build_assignment_config(
     *,
     assignment_id: str,
     title: str,
-    class_id: str,
     writing_type: str,
     student_prompt: str,
     standards_profile_id: str,
@@ -132,15 +131,26 @@ def build_assignment_config(
     rating_scale: Mapping[str, Any],
     basic_requirements: Mapping[str, Any],
     minimum_requirement_policy: Mapping[str, Any],
+    class_ids: Sequence[str] | None = None,
+    class_id: str | None = None,
 ) -> dict[str, Any]:
     """Build and validate a v2 assignment config."""
+    if class_ids is None:
+        if class_id is None:
+            raise ValueError("class_ids is required.")
+        selected_class_ids = [class_id]
+    elif class_id is not None:
+        raise ValueError("Pass either class_ids or class_id, not both.")
+    else:
+        selected_class_ids = list(class_ids)
+
     assignment: dict[str, Any] = {
         "schema_version": "2",
         "module": "quillan",
         "record_type": "assignment",
         "assignment_id": assignment_id,
         "title": title,
-        "class_ids": [class_id],
+        "class_ids": selected_class_ids,
         "writing_type": writing_type,
         "student_prompt": student_prompt,
         "standards_profile_id": standards_profile_id,
@@ -164,9 +174,9 @@ def write_assignment_config(
     """Write a validated assignment config to its canonical shared path."""
     assignment_data = dict(assignment)
     validate_assignment_config(assignment_data)
-    if assignment_data["class_ids"] != [class_id]:
+    if class_id not in assignment_data["class_ids"]:
         raise AssignmentConfigError(
-            "Assignment class_ids must match the selected class_id."
+            "Assignment class_ids must include the selected class_id."
         )
     assignment_id = str(assignment_data["assignment_id"])
     path = assignment_config_path(workspace_root, class_id, assignment_id)
@@ -285,21 +295,95 @@ def _prompt_class_folder(workspace_root: Path) -> ClassFolder | None:
     return None
 
 
+def _parse_class_folder_selection(
+    selection: str,
+    folders: Sequence[ClassFolder],
+) -> tuple[ClassFolder, ...]:
+    """Parse comma-separated class numbers and class IDs in teacher-entered order."""
+    selected_folders: list[ClassFolder] = []
+    seen_class_ids: set[str] = set()
+    tokens = parse_comma_separated_values(selection)
+    if not tokens:
+        raise ValueError("At least one class selection is required.")
+
+    by_class_id = {folder.class_id: folder for folder in folders}
+    for token in tokens:
+        if token.isdigit():
+            index = int(token)
+            if not 1 <= index <= len(folders):
+                raise ValueError(f"Class selection not found: {token}")
+            folder = folders[index - 1]
+        else:
+            if token not in by_class_id:
+                raise ValueError(f"Class not found: {token}")
+            folder = by_class_id[token]
+        if folder.class_id in seen_class_ids:
+            raise ValueError(f"Duplicate class selection: {token}")
+        seen_class_ids.add(folder.class_id)
+        selected_folders.append(folder)
+    return tuple(selected_folders)
+
+
+def _prompt_assignment_class_folders(workspace_root: Path) -> tuple[ClassFolder, ...] | None:
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        parse_navigation_choice,
+        print_navigation_options,
+    )
+
+    folders = _available_class_folders(workspace_root)
+    if not folders:
+        print("No class rosters found. Create a class roster first.")
+        return None
+
+    print("Available classes:")
+    for index, folder in enumerate(folders, start=1):
+        print(f"{index}. {folder.class_id}")
+    print()
+    print("Select class(es) for assignment.")
+    print(
+        "Enter one number, multiple numbers separated by commas, "
+        "or exact class_id values."
+    )
+    print()
+    print("Examples:")
+    print("  1")
+    print("  1,3")
+    print("  english10_p2,english10_p4")
+    print()
+    print_navigation_options()
+    print()
+    selection = input("Select class(es) for assignment: ").strip()
+    navigation = parse_navigation_choice(selection)
+    if selection == "" or navigation is NavigationChoice.BACK:
+        return None
+    try:
+        return _parse_class_folder_selection(selection, folders)
+    except ValueError as error:
+        print(f"Error: {error}")
+        return None
+
+
 def _print_assignment_section_header(
     title: str,
     *,
     class_id: str | None = None,
+    class_ids: Sequence[str] | None = None,
     assignment_id: str | None = None,
 ) -> None:
     from quillan.menu import clear_screen, print_menu_header
 
     clear_screen()
     print_menu_header(title)
+    if class_ids is not None:
+        class_label = ", ".join(class_ids)
+        label = "Class" if len(class_ids) == 1 else "Classes"
+        print(f"{label}: {class_label}")
     if class_id is not None:
         print(f"Class: {class_id}")
     if assignment_id is not None:
         print(f"Assignment ID: {assignment_id}")
-    if class_id is not None or assignment_id is not None:
+    if class_ids is not None or class_id is not None or assignment_id is not None:
         print()
 
 
@@ -505,15 +589,16 @@ def prompt_create_assignment() -> int:
         return 1
     if not _confirm_standards_profile_prerequisite(workspace_root):
         return 1
-    _print_assignment_section_header("Select Assignment Class")
-    class_folder = _prompt_class_folder(workspace_root)
-    if class_folder is None:
+    _print_assignment_section_header("Select Assignment Classes")
+    class_folders = _prompt_assignment_class_folders(workspace_root)
+    if class_folders is None:
         return 1
+    class_ids = [folder.class_id for folder in class_folders]
 
     try:
         _print_assignment_section_header(
             "Assignment Identity",
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
         )
         title = _required_input("Assignment title: ", "assignment title")
         suggested_id = suggest_assignment_id(title)
@@ -527,14 +612,14 @@ def prompt_create_assignment() -> int:
 
         _print_assignment_section_header(
             "Writing Prompt",
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
             assignment_id=assignment_id,
         )
         writing_type = _prompt_writing_type()
         student_prompt = _prompt_student_prompt()
         _print_assignment_section_header(
             "Standards Profile",
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
             assignment_id=assignment_id,
         )
         standards_selection = _prompt_standards_selection(workspace_root)
@@ -543,25 +628,25 @@ def prompt_create_assignment() -> int:
         standards_profile_id, focus_standard_ids = standards_selection
         _print_assignment_section_header(
             "Review Unit Setup",
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
             assignment_id=assignment_id,
         )
         review_unit = _prompt_review_unit()
         _print_assignment_section_header(
             "Rating Scale Setup",
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
             assignment_id=assignment_id,
         )
         rating_scale = _prompt_rating_scale()
         _print_assignment_section_header(
             "Basic Requirements",
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
             assignment_id=assignment_id,
         )
         basic_requirements = _prompt_basic_requirements()
         _print_assignment_section_header(
             "Minimum Requirement Policy",
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
             assignment_id=assignment_id,
         )
         minimum_requirement_policy = _prompt_minimum_requirement_policy()
@@ -569,7 +654,7 @@ def prompt_create_assignment() -> int:
         assignment = build_assignment_config(
             assignment_id=assignment_id,
             title=title,
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
             writing_type=writing_type,
             student_prompt=student_prompt,
             standards_profile_id=standards_profile_id,
@@ -583,46 +668,70 @@ def prompt_create_assignment() -> int:
         print(f"Error: {error}")
         return 1
 
-    output_path = assignment_config_path(
-        workspace_root,
-        class_folder.class_id,
-        assignment_id,
-    )
+    output_paths = [
+        assignment_config_path(workspace_root, class_id, assignment_id)
+        for class_id in class_ids
+    ]
     _print_assignment_section_header(
         "Review Assignment Before Saving",
-        class_id=class_folder.class_id,
+        class_ids=class_ids,
         assignment_id=assignment_id,
     )
-    print(format_assignment_summary(assignment, output_path, workspace_root))
+    print(format_assignment_summary(assignment, output_paths[0], workspace_root))
+    print()
+    class_count = len(class_ids)
+    class_word = "class" if class_count == 1 else "classes"
+    print(f"This assignment will be saved for {class_count} {class_word}:")
+    for class_id, output_path in zip(class_ids, output_paths, strict=True):
+        print(f"- {class_id}: {output_path}")
     if not _prompt_yes_no("Save this assignment? [Y/n]: ", default=True):
         print("Canceled: assignment was not saved.")
         return 0
 
     overwrite = False
-    if output_path.exists():
+    existing_paths = [
+        (class_id, output_path)
+        for class_id, output_path in zip(class_ids, output_paths, strict=True)
+        if output_path.exists()
+    ]
+    if existing_paths:
         _print_assignment_section_header(
             "Confirm Assignment Overwrite",
-            class_id=class_folder.class_id,
+            class_ids=class_ids,
             assignment_id=assignment_id,
         )
-        print(f"Assignment config already exists: {output_path}")
-        confirmation = input("Type OVERWRITE to replace it: ").strip()
+        print("Assignment config already exists in one or more selected classes:")
+        print()
+        for class_id, output_path in existing_paths:
+            print(f"- {class_id}: {output_path}")
+        print()
+        confirmation = input(
+            "Type OVERWRITE to replace existing assignment configs: "
+        ).strip()
         if confirmation != "OVERWRITE":
-            print("Canceled: existing assignment was not changed.")
+            print("Canceled: existing assignments were not changed.")
             return 1
         overwrite = True
 
     try:
-        saved_path = write_assignment_config(
-            workspace_root,
-            class_folder.class_id,
-            assignment,
-            overwrite=overwrite,
-        )
+        saved_paths = [
+            write_assignment_config(
+                workspace_root,
+                class_id,
+                assignment,
+                overwrite=overwrite,
+            )
+            for class_id in class_ids
+        ]
     except (AssignmentConfigError, OSError, FileExistsError) as error:
         print(f"Error: {error}")
         return 1
-    print(f"Saved assignment: {saved_path}")
+    if len(saved_paths) == 1:
+        print(f"Saved assignment: {saved_paths[0]}")
+    else:
+        print(f"Saved assignment for {len(saved_paths)} classes:")
+        for class_id, saved_path in zip(class_ids, saved_paths, strict=True):
+            print(f"- {class_id}: {saved_path}")
     return 0
 
 

--- a/quillan/assignments.py
+++ b/quillan/assignments.py
@@ -159,8 +159,12 @@ def _validate_class_ids(class_ids: Any) -> None:
     if not class_ids:
         raise AssignmentConfigError("Field 'class_ids' must not be empty.")
 
+    seen_class_ids: set[str] = set()
     for class_id in class_ids:
         _validate_identifier(class_id, "class_id")
+        if class_id in seen_class_ids:
+            raise AssignmentConfigError(f"Duplicate class_id: {class_id}.")
+        seen_class_ids.add(class_id)
 
 
 def _validate_focus_standard_ids(focus_standard_ids: Any) -> None:

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -31,11 +31,13 @@ def _assignment(
     *,
     assignment_id: str = "literary_analysis_essay",
     class_id: str = "english_12_p3",
+    class_ids: list[str] | None = None,
 ) -> dict[str, object]:
     return workflows.build_assignment_config(
         assignment_id=assignment_id,
         title="Literary Analysis Essay",
-        class_id=class_id,
+        class_ids=class_ids,
+        class_id=None if class_ids is not None else class_id,
         writing_type="literary_analysis",
         student_prompt="Analyze how the author develops a central idea.",
         standards_profile_id="synthetic_ela_11_12",
@@ -181,6 +183,13 @@ def test_build_assignment_config_has_required_v2_fields_and_validates() -> None:
     validate_assignment_config(assignment)
 
 
+def test_build_assignment_config_accepts_multiple_class_ids() -> None:
+    assignment = _assignment(class_ids=["english_12_p3", "english_12_p4"])
+
+    assert assignment["class_ids"] == ["english_12_p3", "english_12_p4"]
+    validate_assignment_config(assignment)
+
+
 def test_write_assignment_config_uses_canonical_path(tmp_path: Path) -> None:
     assignment = _assignment()
 
@@ -202,6 +211,28 @@ def test_write_assignment_config_uses_canonical_path(tmp_path: Path) -> None:
     assert path.read_text(encoding="utf-8").endswith("\n")
 
 
+def test_write_assignment_config_allows_included_multi_class_path(
+    tmp_path: Path,
+) -> None:
+    assignment = _assignment(class_ids=["english_12_p3", "english_12_p4"])
+
+    path = workflows.write_assignment_config(
+        tmp_path,
+        "english_12_p4",
+        assignment,
+    )
+
+    assert path == (
+        tmp_path
+        / "classes"
+        / "english_12_p4"
+        / "assignments"
+        / "literary_analysis_essay"
+        / "assignment.json"
+    )
+    assert load_assignment_config(path) == assignment
+
+
 def test_write_assignment_config_rejects_class_path_mismatch(
     tmp_path: Path,
 ) -> None:
@@ -215,6 +246,43 @@ def test_write_assignment_config_rejects_class_path_mismatch(
         )
 
     assert not list(tmp_path.rglob("assignment.json"))
+
+
+def test_parse_class_folder_selection_accepts_numbers_and_class_ids(
+    tmp_path: Path,
+) -> None:
+    _write_roster(tmp_path, "english10_p2")
+    _write_roster(tmp_path, "english10_p3")
+    _write_roster(tmp_path, "english10_p4")
+    folders = workflows._available_class_folders(tmp_path)
+
+    cases = [
+        ("1", ("english10_p2",)),
+        ("1,3", ("english10_p2", "english10_p4")),
+        ("1, 3", ("english10_p2", "english10_p4")),
+        ("english10_p2", ("english10_p2",)),
+        ("english10_p2,english10_p4", ("english10_p2", "english10_p4")),
+        ("1,english10_p4", ("english10_p2", "english10_p4")),
+    ]
+    for selection, expected in cases:
+        parsed = workflows._parse_class_folder_selection(selection, folders)
+        assert tuple(folder.class_id for folder in parsed) == expected
+
+
+@pytest.mark.parametrize(
+    "selection",
+    ["", "0", "99", "1,99", "missing_class", "1,1", "english10_p2,1"],
+)
+def test_parse_class_folder_selection_rejects_invalid_and_duplicate_values(
+    tmp_path: Path,
+    selection: str,
+) -> None:
+    _write_roster(tmp_path, "english10_p2")
+    _write_roster(tmp_path, "english10_p3")
+    folders = workflows._available_class_folders(tmp_path)
+
+    with pytest.raises(ValueError):
+        workflows._parse_class_folder_selection(selection, folders)
 
 
 def test_assignment_parsing_helpers() -> None:
@@ -333,7 +401,7 @@ def test_prompt_create_assignment_writes_valid_v2_config(
         output
     )
     assert "Standards profiles found: 1" in output
-    assert "Select Assignment Class" in output
+    assert "Select Assignment Classes" in output
     assert "Assignment Identity" in output
     assert "Writing Prompt" in output
     assert "Examples: literary_analysis, argument, research_paper, reflection" in output
@@ -348,6 +416,65 @@ def test_prompt_create_assignment_writes_valid_v2_config(
     assert "Review Assignment Before Saving" in output
     assert "Saved assignment:" in output
     assert "Focus standard IDs (2)" in output
+
+
+def test_prompt_create_assignment_writes_same_config_for_multiple_classes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path, "english_12_p3")
+    _write_roster(tmp_path, "english_12_p4")
+    _write_standards_library(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "1",
+            "1,2",
+            "Argument Essay",
+            "",
+            "argument",
+            "Write an argument.",
+            "1",
+            "1",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ],
+    )
+
+    assert workflows.prompt_create_assignment() == 0
+    first_path = (
+        tmp_path
+        / "classes"
+        / "english_12_p3"
+        / "assignments"
+        / "argument_essay"
+        / "assignment.json"
+    )
+    second_path = (
+        tmp_path
+        / "classes"
+        / "english_12_p4"
+        / "assignments"
+        / "argument_essay"
+        / "assignment.json"
+    )
+    first_assignment = load_assignment_config(first_path)
+    second_assignment = load_assignment_config(second_path)
+    assert first_assignment == second_assignment
+    assert first_assignment["class_ids"] == ["english_12_p3", "english_12_p4"]
+    output = capsys.readouterr().out
+    assert "Classes: english_12_p3, english_12_p4" in output
+    assert "This assignment will be saved for 2 classes:" in output
+    assert "Saved assignment for 2 classes:" in output
 
 
 def test_prompt_create_assignment_prerequisite_back_stops_before_class_selection(
@@ -365,7 +492,7 @@ def test_prompt_create_assignment_prerequisite_back_stops_before_class_selection
     assert "Assignment creation requires an existing PDS Core standards profile." in (
         output
     )
-    assert "Select Assignment Class" not in output
+    assert "Select Assignment Classes" not in output
     assert "Assignment title:" not in prompts
 
 
@@ -406,7 +533,7 @@ def test_prompt_create_assignment_no_profiles_stops_before_assignment_entry(
     assert "No standards profiles were found in this workspace." in output
     assert "Create or import standards and standards profiles in PDS Core" in output
     assert "1. Continue" not in output
-    assert "Select Assignment Class" not in output
+    assert "Select Assignment Classes" not in output
     assert "Assignment title:" not in prompts
     assert "Writing type:" not in prompts
     assert "Student-facing assignment prompt:" not in prompts
@@ -434,7 +561,7 @@ def test_prompt_create_assignment_standards_load_failure_stops_before_entry(
     assert "Create or repair standards/profile data in PDS Core" in output
     assert "Error:" in output
     assert "1. Continue" not in output
-    assert "Select Assignment Class" not in output
+    assert "Select Assignment Classes" not in output
     assert "Assignment title:" not in prompts
     assert "Writing type:" not in prompts
     assert "Student-facing assignment prompt:" not in prompts
@@ -611,7 +738,63 @@ def test_prompt_create_assignment_does_not_overwrite_without_confirmation(
 
     assert workflows.prompt_create_assignment() == 1
     assert original_path.read_bytes() == original_bytes
-    assert "existing assignment was not changed" in capsys.readouterr().out
+    assert "existing assignments were not changed" in capsys.readouterr().out
+
+
+def test_prompt_create_assignment_preflights_all_overwrite_conflicts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path, "english_12_p3")
+    _write_roster(tmp_path, "english_12_p4")
+    _write_standards_library(tmp_path)
+    original_path = workflows.write_assignment_config(
+        tmp_path,
+        "english_12_p3",
+        _assignment(assignment_id="argument_essay"),
+    )
+    original_bytes = original_path.read_bytes()
+    second_path = (
+        tmp_path
+        / "classes"
+        / "english_12_p4"
+        / "assignments"
+        / "argument_essay"
+        / "assignment.json"
+    )
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "1",
+            "1,2",
+            "Argument Essay",
+            "",
+            "argument",
+            "Write a new argument.",
+            "1",
+            "1",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "nope",
+        ],
+    )
+
+    assert workflows.prompt_create_assignment() == 1
+    assert original_path.read_bytes() == original_bytes
+    assert not second_path.exists()
+    output = capsys.readouterr().out
+    assert "Assignment config already exists in one or more selected classes" in output
+    assert "english_12_p3" in output
+    assert "existing assignments were not changed" in output
 
 
 def test_prompt_create_assignment_overwrites_with_explicit_confirmation(

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -102,6 +102,27 @@ def test_validate_assignment_config_keeps_writing_type_compatibility() -> None:
     validate_assignment_config(assignment)
 
 
+def test_validate_assignment_config_accepts_multiple_unique_class_ids() -> None:
+    assignment = _valid_assignment_config()
+    assignment["class_ids"] = [
+        "english12_period3_synthetic",
+        "english12_period4_synthetic",
+    ]
+
+    validate_assignment_config(assignment)
+
+
+def test_validate_assignment_config_rejects_duplicate_class_ids(tmp_path: Path) -> None:
+    assignment = _valid_assignment_config()
+    assignment["class_ids"] = [
+        "english12_period3_synthetic",
+        "english12_period3_synthetic",
+    ]
+
+    with pytest.raises(AssignmentConfigError, match="Duplicate class_id"):
+        load_assignment_config(_write_assignment(tmp_path, assignment))
+
+
 def test_optional_metadata_fields_do_not_break_validation(tmp_path: Path) -> None:
     assignment = _valid_assignment_config()
     assignment["created_at"] = "2026-07-02T00:00:00+00:00"


### PR DESCRIPTION
## Summary

- Add multi-class support to the create-assignment workflow.
- Allow class selection by:
  - one visible number
  - multiple comma-separated numbers
  - exact `class_id`
  - mixed number and `class_id` input
- Reject invalid and duplicate class selections.
- Build one assignment config with all selected `class_ids`.
- Write identical class-local assignment copies to every selected class.
- Preserve current class-local storage under:
  - `classes/<class_id>/assignments/<assignment_id>/assignment.json`
- Update `write_assignment_config(...)` so multi-class configs can be written to any selected class path.
- Preflight overwrite conflicts across all selected class targets before writing anything.
- Show selected classes and destination paths during review/save.
- Preserve single-class assignment creation.
- Preserve class-first assignment discovery and view/validate compatibility.
- Update assignment validation to reject duplicate `class_ids`.

## Validation

- Ran `.\run_tests.ps1`
- Pytest: `1102 passed`
- Ruff: passed
- Mypy: no issues found in 155 source files
- Script diff whitespace check: passed
- Ran `git diff --check`
- Diff check: passed
- Manual/workflow smoke coverage verified:
  - single-class creation
  - multi-class creation
  - overwrite decline/preflight behavior
  - class-first view/validate compatibility

Closes #191