### PR TITLE
Write class metadata during roster creation

### DIFF
--- a/quillan/roster_workflows.py
+++ b/quillan/roster_workflows.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import re
 import unicodedata
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 
+from pds_core.class_metadata import (
+    ClassMetadata,
+    ClassMetadataError,
+    class_metadata_path,
+    create_class_metadata,
+    load_class_metadata_for_class,
+    write_class_metadata_for_class,
+)
 from pds_core.classes import (
     ClassFolder,
     list_class_folders,
@@ -27,6 +36,12 @@ from pds_core.rosters import (
     replace_student_record,
 )
 from pds_core.routes import class_roster_path
+from pds_core.school_years import (
+    SchoolYearStateError,
+    SchoolYearValidationError,
+    get_active_school_year,
+    validate_school_year,
+)
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
 _REQUIRED_STUDENT_FIELDS = ("student_id", "last_name", "first_name", "period")
@@ -48,8 +63,32 @@ def shared_roster_period(roster: Roster) -> str | None:
     return next(iter(unique_periods)) if len(unique_periods) == 1 else None
 
 
-def format_roster_for_display(roster: Roster, roster_path: str | Path) -> str:
+def _metadata_school_year_label(
+    metadata: ClassMetadata | None,
+    metadata_error: Exception | None,
+) -> str:
+    if metadata is not None:
+        return metadata.school_year
+    if metadata_error is not None:
+        return "metadata error"
+    return "not set"
+
+
+def format_roster_for_display(
+    roster: Roster,
+    roster_path: str | Path,
+    *,
+    metadata: ClassMetadata | None = None,
+    metadata_path: str | Path | None = None,
+    metadata_error: Exception | None = None,
+) -> str:
     """Return a readable roster summary including all roster columns."""
+    roster_display_path = Path(roster_path)
+    metadata_display_path = (
+        roster_display_path.with_name("class.json")
+        if metadata_path is None
+        else Path(metadata_path)
+    )
     columns = tuple(
         column for column in roster.columns if column != "class_id"
     )
@@ -72,11 +111,19 @@ def format_roster_for_display(roster: Roster, roster_path: str | Path) -> str:
     }
     lines = [
         f"Class ID: {roster.class_id}",
-        f"Roster path: {Path(roster_path)}",
+        f"School year: {_metadata_school_year_label(metadata, metadata_error)}",
+        f"Roster path: {roster_display_path}",
+        f"Class metadata path: {metadata_display_path}",
         f"Student count: {len(roster.students)}",
-        "",
-        "  ".join(column.ljust(widths[column]) for column in columns),
     ]
+    if metadata_error is not None:
+        lines.append(f"Metadata error: {metadata_error}")
+    lines.extend(
+        [
+            "",
+            "  ".join(column.ljust(widths[column]) for column in columns),
+        ]
+    )
     lines.extend(
         "  ".join(row.get(column, "").ljust(widths[column]) for column in columns)
         for row in rows
@@ -108,12 +155,23 @@ def create_class_roster(
     class_id: str,
     students: Sequence[Mapping[str, str]],
     *,
+    school_year: str,
     overwrite: bool = False,
-) -> tuple[Roster, Path]:
-    """Create and write a validated roster at its canonical shared path."""
+) -> tuple[Roster, Path, ClassMetadata, Path]:
+    """Create and write validated roster and metadata artifacts."""
     roster = create_roster(class_id, students)
+    metadata = create_class_metadata(
+        class_id,
+        school_year,
+        created_at=datetime.now(timezone.utc),
+    )
     path = write_class_roster(workspace_root, roster, overwrite=overwrite)
-    return roster, path
+    metadata_path = write_class_metadata_for_class(
+        workspace_root,
+        metadata,
+        overwrite=overwrite,
+    )
+    return roster, path, metadata, metadata_path
 
 
 def validate_roster_file(path: str | Path) -> Roster:
@@ -153,6 +211,42 @@ def _workspace_root() -> Path | None:
 
 def _available_class_folders(workspace_root: Path) -> tuple[ClassFolder, ...]:
     return list_class_folders(workspace_root, require_roster=True)
+
+
+def _load_optional_class_metadata(
+    workspace_root: Path,
+    class_id: str,
+) -> tuple[ClassMetadata | None, Exception | None]:
+    metadata_path = class_metadata_path(workspace_root, class_id)
+    if not metadata_path.is_file():
+        return None, None
+    try:
+        return load_class_metadata_for_class(workspace_root, class_id), None
+    except ClassMetadataError as error:
+        return None, error
+
+
+def _prompt_school_year(workspace_root: Path) -> str | None:
+    try:
+        active_school_year = get_active_school_year(workspace_root)
+    except SchoolYearStateError as error:
+        print(f"Warning: could not read active school year: {error}")
+        active_school_year = None
+
+    if active_school_year is not None:
+        print(f"Active school year: {active_school_year}")
+        use_active = input("Use this school year for the class roster? [Y/n]: ")
+        if use_active.strip().casefold() not in {"n", "no"}:
+            return active_school_year
+    else:
+        print("No active school year is open for this workspace.")
+
+    entered = input("School year for this roster (YYYY-YYYY): ").strip()
+    try:
+        return validate_school_year(entered)
+    except SchoolYearValidationError as error:
+        print(f"Error: {error}")
+        return None
 
 
 def _prompt_class_folder(
@@ -298,11 +392,13 @@ def _print_roster_action_header(title: str) -> None:
 def _print_roster_edit_dashboard(
     roster: Roster,
     *,
+    school_year_label: str,
     dirty: bool,
     last_status: str | None = None,
 ) -> None:
     _print_roster_action_header("Edit Class Roster")
     print(f"Class ID: {roster.class_id}")
+    print(f"School year: {school_year_label}")
     print(f"Student count: {len(roster.students)}")
     print(f"Unsaved changes: {'yes' if dirty else 'no'}")
     if last_status is not None:
@@ -347,14 +443,26 @@ def prompt_create_roster() -> int:
     workspace_root = _workspace_root()
     if workspace_root is None:
         return 1
+    school_year = _prompt_school_year(workspace_root)
+    if school_year is None:
+        return 1
     output_path = class_roster_path(workspace_root, class_id)
+    output_metadata_path = class_metadata_path(workspace_root, class_id)
     overwrite = False
-    if output_path.exists():
-        print(f"Roster already exists for class '{class_id}':")
-        print(output_path)
-        confirmation = input("Type OVERWRITE to replace it: ").strip()
+    if output_path.exists() or output_metadata_path.exists():
+        if output_path.exists():
+            print(f"Roster already exists for class '{class_id}':")
+            print(output_path)
+        if output_metadata_path.exists():
+            if output_path.exists():
+                print()
+            print("Class metadata already exists:")
+            print(output_metadata_path)
+        confirmation = input(
+            "Type OVERWRITE to replace the roster and class metadata: "
+        ).strip()
         if confirmation != "OVERWRITE":
-            print("Canceled: existing roster was not changed.")
+            print("Canceled: existing roster and class metadata were not changed.")
             return 1
         overwrite = True
 
@@ -383,17 +491,19 @@ def prompt_create_roster() -> int:
         print(f"  Staged: {student_id} - {last_name}, {first_name}")
 
     try:
-        roster, saved_path = create_class_roster(
+        roster, saved_path, _metadata, saved_metadata_path = create_class_roster(
             workspace_root,
             class_id,
             students,
+            school_year=school_year,
             overwrite=overwrite,
         )
-    except RosterError as error:
+    except (RosterError, ClassMetadataError, SchoolYearValidationError) as error:
         print_roster_validation_error(error)
         return 1
     print(f"Created roster with {len(roster.students)} students:")
     print(saved_path)
+    print(f"Created class metadata: {saved_metadata_path}")
     return 0
 
 
@@ -413,8 +523,20 @@ def prompt_view_roster() -> int:
     except RosterError as error:
         print_roster_validation_error(error)
         return 1
+    metadata, metadata_error = _load_optional_class_metadata(
+        workspace_root,
+        folder.class_id,
+    )
     print()
-    print(format_roster_for_display(roster, folder.roster_path))
+    print(
+        format_roster_for_display(
+            roster,
+            folder.roster_path,
+            metadata=metadata,
+            metadata_path=folder.metadata_path,
+            metadata_error=metadata_error,
+        )
+    )
     return 0
 
 
@@ -432,6 +554,10 @@ def prompt_edit_class_roster() -> int:
     except RosterError as error:
         print_roster_validation_error(error)
         return 1
+    metadata, metadata_error = _load_optional_class_metadata(
+        workspace_root,
+        folder.class_id,
+    )
 
     dirty = False
     last_status: str | None = None
@@ -458,6 +584,7 @@ def prompt_edit_class_roster() -> int:
     while True:
         _print_roster_edit_dashboard(
             staged_roster,
+            school_year_label=_metadata_school_year_label(metadata, metadata_error),
             dirty=dirty,
             last_status=last_status,
         )
@@ -495,7 +622,15 @@ def prompt_edit_class_roster() -> int:
                     last_status = "student removal canceled"
             elif choice == "4":
                 _print_roster_action_header("Current Roster")
-                print(format_roster_for_display(staged_roster, folder.roster_path))
+                print(
+                    format_roster_for_display(
+                        staged_roster,
+                        folder.roster_path,
+                        metadata=metadata,
+                        metadata_path=folder.metadata_path,
+                        metadata_error=metadata_error,
+                    )
+                )
                 if dirty:
                     print("\nUnsaved staged changes are shown above.")
                 print()
@@ -552,9 +687,17 @@ def _normalize_path_input(value: str) -> str:
 def _print_roster_validation_summary(
     roster: Roster,
     roster_path: str | Path,
+    *,
+    metadata: ClassMetadata | None = None,
+    metadata_error: Exception | None = None,
+    include_metadata: bool = False,
 ) -> None:
     print("Roster file is valid.")
     print(f"Class ID: {roster.class_id}")
+    if include_metadata:
+        print(f"School year: {_metadata_school_year_label(metadata, metadata_error)}")
+        if metadata_error is not None:
+            print(f"Metadata error: {metadata_error}")
     print(f"Roster path: {Path(roster_path)}")
     print(f"Student count: {len(roster.students)}")
     print("First students:")
@@ -610,7 +753,17 @@ def prompt_validate_roster() -> int:
         except RosterError as error:
             print_roster_validation_error(error)
             return 1
-        _print_roster_validation_summary(roster, selected_folder.roster_path)
+        metadata, metadata_error = _load_optional_class_metadata(
+            workspace_root,
+            selected_folder.class_id,
+        )
+        _print_roster_validation_summary(
+            roster,
+            selected_folder.roster_path,
+            metadata=metadata,
+            metadata_error=metadata_error,
+            include_metadata=True,
+        )
         return 0
 
     if selection.casefold() != "c":

--- a/tests/test_roster_workflows.py
+++ b/tests/test_roster_workflows.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import datetime, timezone
 from pathlib import Path
 
+from pds_core.class_metadata import (
+    create_class_metadata,
+    load_class_metadata_for_class,
+    write_class_metadata_for_class,
+)
 from pds_core.classes import load_class_roster, write_class_roster
 from pds_core.rosters import (
     Roster,
@@ -15,6 +21,7 @@ from pds_core.rosters import (
     remove_student_record,
     replace_student_record,
 )
+from pds_core.school_years import open_school_year
 import pytest
 
 from quillan.menu_navigation import QuitQuillan, ReturnToMainMenu
@@ -66,7 +73,7 @@ def _inputs(
 def test_create_class_roster_uses_canonical_path_and_preserves_zero_id(
     tmp_path: Path,
 ) -> None:
-    roster, path = workflows.create_class_roster(
+    roster, path, metadata, metadata_path = workflows.create_class_roster(
         tmp_path,
         "english_12_p3",
         [
@@ -77,11 +84,18 @@ def test_create_class_roster_uses_canonical_path_and_preserves_zero_id(
                 "period": "3",
             }
         ],
+        school_year="2026-2027",
     )
 
     assert path == tmp_path / "classes" / "english_12_p3" / "roster.csv"
+    assert metadata_path == tmp_path / "classes" / "english_12_p3" / "class.json"
+    assert metadata.school_year == "2026-2027"
     assert roster.students[0].student_id == "0007"
     assert load_class_roster(tmp_path, "english_12_p3").students[0].student_id == "0007"
+    assert load_class_metadata_for_class(
+        tmp_path,
+        "english_12_p3",
+    ).school_year == "2026-2027"
 
 
 def test_prompt_create_roster_writes_canonical_roster_and_preserves_zero_id(
@@ -94,6 +108,7 @@ def test_prompt_create_roster_writes_canonical_roster_and_preserves_zero_id(
         [
             "English 10 Period 2",
             "",
+            "2026-2027",
             "2",
             "0008",
             "Synthetic",
@@ -106,7 +121,9 @@ def test_prompt_create_roster_writes_canonical_roster_and_preserves_zero_id(
 
     class_id = "english_10_period_2"
     roster_path = tmp_path / "classes" / class_id / "roster.csv"
+    metadata_path = tmp_path / "classes" / class_id / "class.json"
     assert roster_path.is_file()
+    assert metadata_path.is_file()
 
     roster = load_class_roster(tmp_path, class_id)
     assert roster.class_id == class_id
@@ -115,6 +132,94 @@ def test_prompt_create_roster_writes_canonical_roster_and_preserves_zero_id(
     assert roster.students[0].last_name == "Synthetic"
     assert roster.students[0].first_name == "Riley"
     assert roster.students[0].period == "2"
+    assert load_class_metadata_for_class(tmp_path, class_id).school_year == "2026-2027"
+
+
+def test_prompt_create_roster_accepts_active_school_year(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    open_school_year(
+        tmp_path,
+        "2026-2027",
+        opened_at=datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "English 10 Period 2",
+            "",
+            "",
+            "2",
+            "0008",
+            "Synthetic",
+            "Riley",
+            "",
+        ],
+    )
+
+    assert workflows.prompt_create_roster() == 0
+
+    assert load_class_metadata_for_class(
+        tmp_path,
+        "english_10_period_2",
+    ).school_year == "2026-2027"
+
+
+def test_prompt_create_roster_can_override_active_school_year(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    open_school_year(
+        tmp_path,
+        "2026-2027",
+        opened_at=datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "English 10 Period 2",
+            "",
+            "n",
+            "2027-2028",
+            "2",
+            "0008",
+            "Synthetic",
+            "Riley",
+            "",
+        ],
+    )
+
+    assert workflows.prompt_create_roster() == 0
+
+    assert load_class_metadata_for_class(
+        tmp_path,
+        "english_10_period_2",
+    ).school_year == "2027-2028"
+
+
+@pytest.mark.parametrize("school_year", ["2026", "2026-26", "2026-2028"])
+def test_prompt_create_roster_rejects_invalid_school_year_without_writing(
+    school_year: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "English 10 Period 2",
+            "",
+            school_year,
+        ],
+    )
+
+    assert workflows.prompt_create_roster() == 1
+    class_dir = tmp_path / "classes" / "english_10_period_2"
+    assert not (class_dir / "roster.csv").exists()
+    assert not (class_dir / "class.json").exists()
 
 
 def test_prompt_create_roster_does_not_overwrite_without_confirmation(
@@ -129,6 +234,7 @@ def test_prompt_create_roster_does_not_overwrite_without_confirmation(
         [
             "Synthetic Class",
             "",
+            "2026-2027",
             "no",
         ],
     )
@@ -137,12 +243,47 @@ def test_prompt_create_roster_does_not_overwrite_without_confirmation(
     assert load_class_roster(tmp_path, "synthetic_class") == original
 
 
+def test_prompt_create_roster_decline_overwrite_preserves_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_class_roster(tmp_path, _roster())
+    metadata = create_class_metadata(
+        "synthetic_class",
+        "2026-2027",
+        created_at=datetime.now(timezone.utc),
+    )
+    write_class_metadata_for_class(tmp_path, metadata)
+    original_roster = load_class_roster(tmp_path, "synthetic_class")
+    original_metadata = (tmp_path / "classes" / "synthetic_class" / "class.json").read_text(
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(
+        monkeypatch,
+        [
+            "Synthetic Class",
+            "",
+            "2027-2028",
+            "no",
+        ],
+    )
+
+    assert workflows.prompt_create_roster() == 1
+    assert load_class_roster(tmp_path, "synthetic_class") == original_roster
+    assert (
+        tmp_path / "classes" / "synthetic_class" / "class.json"
+    ).read_text(encoding="utf-8") == original_metadata
+
+
 def test_format_roster_includes_required_and_optional_columns() -> None:
     output = workflows.format_roster_for_display(
         _roster(),
         Path("classes/synthetic_class/roster.csv"),
     )
 
+    assert "School year: not set" in output
+    assert "Class metadata path: classes\\synthetic_class\\class.json" in output
     assert "Student count: 2" in output
     assert "student_id" in output
     assert "last_name" in output
@@ -151,6 +292,37 @@ def test_format_roster_includes_required_and_optional_columns() -> None:
     assert "preferred_name" in output
     assert "notes" in output
     assert "0012" in output
+
+
+def test_format_roster_includes_metadata_school_year() -> None:
+    metadata = create_class_metadata(
+        "synthetic_class",
+        "2026-2027",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    output = workflows.format_roster_for_display(
+        _roster(),
+        Path("classes/synthetic_class/roster.csv"),
+        metadata=metadata,
+        metadata_path=Path("classes/synthetic_class/class.json"),
+    )
+
+    assert "School year: 2026-2027" in output
+    assert "Class metadata path:" in output
+
+
+def test_format_roster_shows_metadata_error_concisely() -> None:
+    output = workflows.format_roster_for_display(
+        _roster(),
+        Path("classes/synthetic_class/roster.csv"),
+        metadata_path=Path("classes/synthetic_class/class.json"),
+        metadata_error=ValueError("bad metadata"),
+    )
+
+    assert "School year: metadata error" in output
+    assert "Metadata error: bad metadata" in output
+    assert "Traceback" not in output
 
 
 def test_add_and_edit_student_preserve_optional_schema_and_values() -> None:
@@ -381,6 +553,14 @@ def test_edit_save_requires_confirmation_then_writes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     write_class_roster(tmp_path, _roster())
+    metadata = create_class_metadata(
+        "synthetic_class",
+        "2026-2027",
+        created_at=datetime.now(timezone.utc),
+    )
+    write_class_metadata_for_class(tmp_path, metadata)
+    metadata_path = tmp_path / "classes" / "synthetic_class" / "class.json"
+    original_metadata = metadata_path.read_text(encoding="utf-8")
     monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
     _inputs(
         monkeypatch,
@@ -405,6 +585,7 @@ def test_edit_save_requires_confirmation_then_writes(
     assert saved.students[0].period == "4"
     assert saved.students[0].student_id == "0012"
     assert saved.students[0].extra_fields["preferred_name"] == "Ari"
+    assert metadata_path.read_text(encoding="utf-8") == original_metadata
 
 
 @pytest.mark.parametrize("selection", ["1", "synthetic_class"])
@@ -422,9 +603,32 @@ def test_validate_selected_class_roster(
     assert "Available classes:" in valid_output
     assert "Roster file is valid." in valid_output
     assert "Class ID: synthetic_class" in valid_output
+    assert "School year: not set" in valid_output
     assert f"Roster path: {valid_path}" in valid_output
     assert "Student count: 2" in valid_output
     assert "0012" in valid_output
+
+
+def test_validate_selected_class_roster_reports_metadata_school_year(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_class_roster(tmp_path, _roster())
+    metadata = create_class_metadata(
+        "synthetic_class",
+        "2026-2027",
+        created_at=datetime.now(timezone.utc),
+    )
+    write_class_metadata_for_class(tmp_path, metadata)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1"])
+
+    assert workflows.prompt_validate_roster() == 0
+
+    output = capsys.readouterr().out
+    assert "Roster file is valid." in output
+    assert "School year: 2026-2027" in output
 
 
 def test_validate_custom_roster_path(
@@ -442,6 +646,7 @@ def test_validate_custom_roster_path(
     output = capsys.readouterr().out
     assert "No class rosters found." in output
     assert "C. Custom roster CSV path" in output
+    assert "School year:" not in output
     assert f"Roster path: {valid_path}" in output
     assert any("Roster CSV path, or B/M/Q:" in prompt for prompt in prompts)
 


### PR DESCRIPTION
## Summary

- Add Quillan support for pds-core class metadata during roster workflows.
- Update roster creation to write both:
  - `classes/<class_id>/roster.csv`
  - `classes/<class_id>/class.json`
- Prompt for school year during roster creation using pds-core validation.
- Use active workspace school year as the default when available.
- Allow manual school-year entry when no active school year exists or when the teacher overrides the active year.
- Display school-year metadata in roster views.
- Display the canonical `class.json` path in roster views.
- Show concise metadata errors without blocking valid roster display.
- Report metadata status during canonical roster validation.
- Keep custom CSV validation roster-only.
- Preserve existing legacy roster behavior when `class.json` is missing.
- Preserve class metadata unchanged during roster edit workflows.
- Add tests for active year, manual year, override behavior, invalid year rejection, metadata writes, overwrite protection, display, validation, custom path behavior, legacy rosters, invalid metadata display, and edit preservation.

## Compatibility

- No `school_year` column is added to `roster.csv`.
- Existing rosters without `class.json` still view correctly.
- Existing rosters without `class.json` still validate correctly.
- Existing rosters without `class.json` still edit correctly.
- Custom roster CSV validation does not require metadata.
- Metadata is created through pds-core helpers, not Quillan-specific JSON handling.

## Validation

- Ran `.\run_tests.ps1`
- Pytest: `1111 passed`
- Ruff: passed
- Mypy: no issues found in 155 source files
- Script diff whitespace check: passed
- Ran `git diff --check`
- Diff check: passed
- Only Git CRLF normalization warnings were reported
- Manual/workflow smoke coverage verified:
  - active school year path
  - no active school year/manual entry path
  - invalid school year rejection
  - legacy roster display without `class.json`
  - invalid metadata display
  - canonical validation metadata reporting
  - custom path validation remains roster-only
  - edit workflow preserves metadata unchanged

Closes #194