### PR TITLE
Offer to open generated printable packets

### DIFF
--- a/quillan/generated_output_opening.py
+++ b/quillan/generated_output_opening.py
@@ -1,0 +1,148 @@
+"""Safely open generated Quillan outputs from the active PDS workspace."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pds_core.local_open import LocalOpenError, open_local_path
+
+
+class GeneratedOutputOpeningError(Exception):
+    """Raised when generated output cannot be opened safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class OpenedGeneratedOutput:
+    """Information about a generated output path opened for the teacher."""
+
+    path: Path
+    relative_path: str
+
+
+def resolve_generated_output_path(
+    workspace_root: str | Path,
+    output_path: str | Path,
+) -> Path:
+    """Resolve a generated output path that stays in the PDS workspace."""
+    raw_output_path = str(output_path)
+    stripped_output_path = raw_output_path.strip()
+
+    if not stripped_output_path:
+        raise GeneratedOutputOpeningError("Generated output path must not be empty.")
+    if stripped_output_path.lower().startswith(
+        ("http://", "https://", "file://")
+    ):
+        raise GeneratedOutputOpeningError(
+            "Generated output path must be a local path, not a URL."
+        )
+
+    try:
+        resolved_workspace_root = _resolve_workspace_root(workspace_root)
+        candidate = Path(raw_output_path)
+        if candidate.is_absolute():
+            resolved_output_path = candidate.resolve(strict=False)
+        else:
+            resolved_output_path = (
+                resolved_workspace_root / candidate
+            ).resolve(strict=False)
+        resolved_output_path.relative_to(resolved_workspace_root)
+    except (OSError, RuntimeError, ValueError) as error:
+        raise GeneratedOutputOpeningError(
+            "Generated output path must remain inside the PDS workspace."
+        ) from error
+
+    return resolved_output_path
+
+
+def open_generated_output_file(
+    workspace_root: str | Path,
+    output_path: str | Path,
+) -> OpenedGeneratedOutput:
+    """Open one existing generated file inside the active PDS workspace."""
+    resolved_workspace_root = _resolve_workspace_root(workspace_root)
+    resolved_output_path = resolve_generated_output_path(
+        resolved_workspace_root,
+        output_path,
+    )
+
+    if not resolved_output_path.exists():
+        raise GeneratedOutputOpeningError(
+            f"Generated output file does not exist: "
+            f"{resolved_output_path.relative_to(resolved_workspace_root).as_posix()}"
+        )
+    if not resolved_output_path.is_file():
+        raise GeneratedOutputOpeningError(
+            "Generated output path must identify a file."
+        )
+
+    try:
+        opened_path = open_local_path(resolved_output_path)
+    except LocalOpenError as error:
+        raise GeneratedOutputOpeningError(
+            f"Could not open generated output file: {error}"
+        ) from error
+
+    return OpenedGeneratedOutput(
+        path=opened_path.resolve(strict=False),
+        relative_path=resolved_output_path.relative_to(
+            resolved_workspace_root
+        ).as_posix(),
+    )
+
+
+def open_generated_output_folder(
+    workspace_root: str | Path,
+    output_path: str | Path,
+) -> OpenedGeneratedOutput:
+    """Open the containing folder for an existing generated file."""
+    resolved_workspace_root = _resolve_workspace_root(workspace_root)
+    resolved_output_path = resolve_generated_output_path(
+        resolved_workspace_root,
+        output_path,
+    )
+
+    if not resolved_output_path.exists():
+        raise GeneratedOutputOpeningError(
+            f"Generated output file does not exist: "
+            f"{resolved_output_path.relative_to(resolved_workspace_root).as_posix()}"
+        )
+    if not resolved_output_path.is_file():
+        raise GeneratedOutputOpeningError(
+            "Generated output path must identify a file."
+        )
+
+    containing_folder = resolved_output_path.parent
+    if not containing_folder.exists():
+        raise GeneratedOutputOpeningError(
+            f"Generated output folder does not exist: "
+            f"{containing_folder.relative_to(resolved_workspace_root).as_posix()}"
+        )
+    if not containing_folder.is_dir():
+        raise GeneratedOutputOpeningError(
+            "Generated output folder path must identify a directory."
+        )
+
+    try:
+        opened_path = open_local_path(containing_folder)
+    except LocalOpenError as error:
+        raise GeneratedOutputOpeningError(
+            f"Could not open generated output folder: {error}"
+        ) from error
+
+    return OpenedGeneratedOutput(
+        path=opened_path.resolve(strict=False),
+        relative_path=containing_folder.relative_to(
+            resolved_workspace_root
+        ).as_posix(),
+    )
+
+
+def _resolve_workspace_root(workspace_root: str | Path) -> Path:
+    """Resolve the workspace root with a Quillan-owned error boundary."""
+    try:
+        return Path(workspace_root).resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        raise GeneratedOutputOpeningError(
+            f"Could not resolve the PDS workspace root: {error}"
+        ) from error

--- a/quillan/printable_response_workflows.py
+++ b/quillan/printable_response_workflows.py
@@ -12,6 +12,11 @@ from pds_core.routes import class_assignments_dir
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.generated_output_opening import (
+    GeneratedOutputOpeningError,
+    open_generated_output_file,
+    open_generated_output_folder,
+)
 from quillan.printable_response import (
     PRINTABLE_RESPONSE_FILENAME,
     generate_printable_responses_for_roster,
@@ -101,6 +106,56 @@ def _workspace_root() -> Path | None:
     except WorkspaceRootError as error:
         print(f"Error: {error}")
         return None
+
+
+def _prompt_open_generated_packet(
+    workspace_root: Path,
+    generated_path: Path,
+) -> None:
+    from quillan.menu_navigation import (
+        NavigationChoice,
+        parse_navigation_choice,
+    )
+
+    print()
+    print("What would you like to do next?")
+    print("1. Open generated packet")
+    print("2. Open containing folder")
+    print("3. Return to Printable Response Pages")
+    selection = input("Select an option: ").strip()
+    navigation = parse_navigation_choice(selection)
+    if (
+        selection == ""
+        or selection == "3"
+        or navigation is NavigationChoice.BACK
+    ):
+        return
+
+    if selection == "1":
+        try:
+            opened = open_generated_output_file(workspace_root, generated_path)
+        except GeneratedOutputOpeningError as error:
+            print(f"Error: could not open generated packet: {error}")
+            print("Generated packet remains saved at:")
+            print(generated_path)
+            return
+        print("Opened generated packet:")
+        print(opened.path)
+        return
+
+    if selection == "2":
+        try:
+            opened = open_generated_output_folder(workspace_root, generated_path)
+        except GeneratedOutputOpeningError as error:
+            print(f"Error: could not open containing folder: {error}")
+            print("Generated packet remains saved at:")
+            print(generated_path)
+            return
+        print("Opened containing folder:")
+        print(opened.path)
+        return
+
+    print("Returning to Printable Response Pages.")
 
 
 def _prompt_class_selection(workspace_root: Path) -> ClassFolder | None:
@@ -246,6 +301,7 @@ def prompt_generate_class_packet() -> int:
     print(f"Class: {class_folder.class_id}")
     print(f"Assignment: {assignment_label}")
     print(f"Pages per student: {pages_per_student}")
+    _prompt_open_generated_packet(workspace_root, generated_path)
     return 0
 
 

--- a/tests/test_generated_output_opening.py
+++ b/tests/test_generated_output_opening.py
@@ -1,0 +1,149 @@
+"""Tests for safely opening generated Quillan outputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import quillan.generated_output_opening as opening
+from quillan.generated_output_opening import (
+    GeneratedOutputOpeningError,
+    OpenedGeneratedOutput,
+)
+
+
+def _generated_pdf(workspace_root: Path) -> Path:
+    output_path = (
+        workspace_root
+        / "classes"
+        / "english10_p2"
+        / "assignments"
+        / "essay_01"
+        / "templates"
+        / "printable_response_pages.pdf"
+    )
+    output_path.parent.mkdir(parents=True)
+    output_path.write_bytes(b"%PDF synthetic")
+    return output_path
+
+
+def test_open_generated_output_file_opens_valid_file_inside_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_path = _generated_pdf(tmp_path)
+    calls: list[Path] = []
+
+    def open_local_path(path: str | Path) -> Path:
+        calls.append(Path(path))
+        return Path(path)
+
+    monkeypatch.setattr(opening, "open_local_path", open_local_path)
+
+    opened = opening.open_generated_output_file(tmp_path, output_path)
+
+    assert calls == [output_path]
+    assert opened == OpenedGeneratedOutput(
+        path=output_path,
+        relative_path=(
+            "classes/english10_p2/assignments/essay_01/templates/"
+            "printable_response_pages.pdf"
+        ),
+    )
+
+
+def test_open_generated_output_folder_opens_valid_containing_folder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_path = _generated_pdf(tmp_path)
+    calls: list[Path] = []
+
+    def open_local_path(path: str | Path) -> Path:
+        calls.append(Path(path))
+        return Path(path)
+
+    monkeypatch.setattr(opening, "open_local_path", open_local_path)
+
+    opened = opening.open_generated_output_folder(tmp_path, output_path)
+
+    assert calls == [output_path.parent]
+    assert opened == OpenedGeneratedOutput(
+        path=output_path.parent,
+        relative_path="classes/english10_p2/assignments/essay_01/templates",
+    )
+
+
+def test_open_generated_output_accepts_workspace_relative_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_path = _generated_pdf(tmp_path)
+    relative_path = output_path.relative_to(tmp_path)
+    calls: list[Path] = []
+
+    def open_local_path(path: str | Path) -> Path:
+        calls.append(Path(path))
+        return Path(path)
+
+    monkeypatch.setattr(opening, "open_local_path", open_local_path)
+
+    opened = opening.open_generated_output_file(tmp_path, relative_path)
+
+    assert calls == [output_path]
+    assert opened.path == output_path
+
+
+def test_open_generated_output_file_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(GeneratedOutputOpeningError, match="does not exist"):
+        opening.open_generated_output_file(tmp_path, "missing.pdf")
+
+
+def test_open_generated_output_file_rejects_directory(tmp_path: Path) -> None:
+    output_path = tmp_path / "classes"
+    output_path.mkdir()
+
+    with pytest.raises(GeneratedOutputOpeningError, match="must identify a file"):
+        opening.open_generated_output_file(tmp_path, output_path)
+
+
+def test_open_generated_output_folder_rejects_missing_output(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(GeneratedOutputOpeningError, match="does not exist"):
+        opening.open_generated_output_folder(tmp_path, "missing.pdf")
+
+
+def test_open_generated_output_rejects_outside_workspace(tmp_path: Path) -> None:
+    outside_path = tmp_path.parent / "outside.pdf"
+    outside_path.write_bytes(b"%PDF outside")
+
+    with pytest.raises(GeneratedOutputOpeningError, match="inside"):
+        opening.open_generated_output_file(tmp_path, outside_path)
+
+
+@pytest.mark.parametrize(
+    "output_path",
+    [
+        "http://example.test/packet.pdf",
+        "https://example.test/packet.pdf",
+        "file:///tmp/packet.pdf",
+    ],
+)
+def test_open_generated_output_rejects_url_like_paths(
+    tmp_path: Path,
+    output_path: str,
+) -> None:
+    with pytest.raises(GeneratedOutputOpeningError, match="not a URL"):
+        opening.open_generated_output_file(tmp_path, output_path)
+
+
+def test_open_generated_output_rejects_parent_traversal_outside_workspace(
+    tmp_path: Path,
+) -> None:
+    outside_path = tmp_path.parent / "outside.pdf"
+    outside_path.write_bytes(b"%PDF outside")
+
+    with pytest.raises(GeneratedOutputOpeningError, match="inside"):
+        opening.open_generated_output_file(tmp_path, "../outside.pdf")

--- a/tests/test_printable_response_workflows.py
+++ b/tests/test_printable_response_workflows.py
@@ -11,6 +11,10 @@ from pds_core.rosters import create_roster
 from pypdf import PdfReader
 import pytest
 
+from quillan.generated_output_opening import (
+    GeneratedOutputOpeningError,
+    OpenedGeneratedOutput,
+)
 import quillan.printable_response_workflows as workflows
 
 
@@ -137,7 +141,7 @@ def test_generate_class_packet_happy_path(
     roster_bytes = roster_path.read_bytes()
     assignment_bytes = assignment_path.read_bytes()
     monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(monkeypatch, ["1", "1", "2"])
+    _inputs(monkeypatch, ["1", "1", "2", "3"])
 
     assert workflows.prompt_generate_class_packet() == 0
 
@@ -163,6 +167,7 @@ def test_generate_class_packet_happy_path(
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
     assert "Pages per student: 2" in output
+    assert "What would you like to do next?" in output
 
 
 def test_generate_class_packet_accepts_exact_ids_and_blank_page_default(
@@ -172,7 +177,7 @@ def test_generate_class_packet_accepts_exact_ids_and_blank_page_default(
     _write_roster(tmp_path)
     _write_assignment(tmp_path)
     monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(monkeypatch, [CLASS_ID, ASSIGNMENT_ID, ""])
+    _inputs(monkeypatch, [CLASS_ID, ASSIGNMENT_ID, "", ""])
 
     assert workflows.prompt_generate_class_packet() == 0
     output_path = workflows.expected_printable_packet_path(
@@ -181,6 +186,132 @@ def test_generate_class_packet_accepts_exact_ids_and_blank_page_default(
         ASSIGNMENT_ID,
     )
     assert len(PdfReader(str(output_path)).pages) == 2
+
+
+def test_generate_class_packet_can_open_generated_packet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1", "1", "1"])
+    calls: list[tuple[Path, Path]] = []
+
+    def open_file(
+        workspace_root: str | Path,
+        output_path: str | Path,
+    ) -> OpenedGeneratedOutput:
+        calls.append((Path(workspace_root), Path(output_path)))
+        return OpenedGeneratedOutput(Path(output_path), "synthetic.pdf")
+
+    monkeypatch.setattr(workflows, "open_generated_output_file", open_file)
+
+    assert workflows.prompt_generate_class_packet() == 0
+    output_path = workflows.expected_printable_packet_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+    )
+    assert calls == [(tmp_path, output_path)]
+    output = capsys.readouterr().out
+    assert "Opened generated packet:" in output
+    assert str(output_path) in output
+
+
+def test_generate_class_packet_can_open_containing_folder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1", "1", "2"])
+    calls: list[tuple[Path, Path]] = []
+
+    def open_folder(
+        workspace_root: str | Path,
+        output_path: str | Path,
+    ) -> OpenedGeneratedOutput:
+        calls.append((Path(workspace_root), Path(output_path)))
+        return OpenedGeneratedOutput(Path(output_path).parent, "templates")
+
+    monkeypatch.setattr(workflows, "open_generated_output_folder", open_folder)
+
+    assert workflows.prompt_generate_class_packet() == 0
+    output_path = workflows.expected_printable_packet_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+    )
+    assert calls == [(tmp_path, output_path)]
+    output = capsys.readouterr().out
+    assert "Opened containing folder:" in output
+    assert str(output_path.parent) in output
+
+
+@pytest.mark.parametrize("selection", ["3", ""])
+def test_generate_class_packet_declines_opening(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1", "1", selection])
+    calls: list[Path] = []
+
+    def open_file(
+        _workspace_root: str | Path,
+        output_path: str | Path,
+    ) -> OpenedGeneratedOutput:
+        calls.append(Path(output_path))
+        return OpenedGeneratedOutput(Path(output_path), "synthetic.pdf")
+
+    monkeypatch.setattr(workflows, "open_generated_output_file", open_file)
+
+    assert workflows.prompt_generate_class_packet() == 0
+    assert calls == []
+    assert workflows.expected_printable_packet_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+    ).is_file()
+
+
+def test_generate_class_packet_opening_failure_preserves_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["1", "1", "1", "1"])
+
+    def fail_to_open(
+        _workspace_root: str | Path,
+        _output_path: str | Path,
+    ) -> OpenedGeneratedOutput:
+        raise GeneratedOutputOpeningError("viewer failed")
+
+    monkeypatch.setattr(workflows, "open_generated_output_file", fail_to_open)
+
+    assert workflows.prompt_generate_class_packet() == 0
+    output_path = workflows.expected_printable_packet_path(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+    )
+    assert output_path.is_file()
+    output = capsys.readouterr().out
+    assert "Error: could not open generated packet: viewer failed" in output
+    assert "Generated packet remains saved at:" in output
+    assert str(output_path) in output
+    assert "Traceback" not in output
 
 
 def test_generate_class_packet_requires_roster(
@@ -299,7 +430,7 @@ def test_generate_class_packet_overwrites_after_exact_confirmation(
     output_path.parent.mkdir(parents=True)
     output_path.write_bytes(b"old")
     monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(monkeypatch, ["1", "1", "1", "OVERWRITE"])
+    _inputs(monkeypatch, ["1", "1", "1", "OVERWRITE", "3"])
 
     assert workflows.prompt_generate_class_packet() == 0
     assert output_path.read_bytes().startswith(b"%PDF")


### PR DESCRIPTION
## Summary

* Add safe generated-output opening support for printable response packets.
* Add `generated_output_opening.py` for workspace-contained generated-output opening.
* Use `pds_core.local_open.open_local_path` instead of duplicating platform-specific open logic.
* After successful packet generation, prompt the teacher to:

  * open the generated PDF
  * open the containing folder
  * return without opening
* Keep generated packets from opening automatically.
* Validate generated-output paths before opening:

  * path exists
  * PDF target is a file
  * folder target is a directory
  * target remains inside the resolved workspace
  * URL-like paths are rejected
* Show clear success/failure messages for optional open actions.
* Preserve generation success even if the optional open action fails.
* Add safety and workflow tests for generated-output opening and post-generation menu behavior.

## Validation

* Ran `.\.venv\Scripts\python.exe -m pytest tests/test_generated_output_opening.py tests/test_printable_response_workflows.py`
* Targeted pytest: `34 passed`
* Ran `.\.venv\Scripts\python.exe -m ruff check .`
* Ruff: passed
* Ran `.\.venv\Scripts\python.exe -m mypy .`
* Mypy: passed
* Ran `.\run_tests.ps1`
* Full pytest: `1127 passed`
* Full Ruff: passed
* Full mypy: passed
* Script diff whitespace check: passed
* Ran `git diff --check`
* Diff check: passed
* Only Git CRLF normalization warnings were reported
* Automated tests monkeypatch the opener, so no real external PDF viewer or File Explorer window is launched during tests.
* Workflow tests verify menu choices, safety checks, success messages, and failure handling.

Closes #196
