### PR TITLE
Update scan post-route menu after assembly

### DIFF
--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from pds_core.scan_routes import scans_inbox_dir
+from quillan.assignment_submission_assembly import assemble_assignment_submissions
+from quillan.cli_app.output import (
+    print_assignment_submission_assembly,
+    print_assignment_submission_status,
+)
+from quillan.intake_assembly import IntakeAssemblyTarget
 from quillan.menu_navigation import (
     NavigationChoice,
     QuitQuillan,
@@ -16,10 +23,36 @@ from quillan.menu_navigation import (
     parse_navigation_choice,
     print_navigation_options,
 )
+from quillan.submission_status import list_assignment_submission_status
 
 WorkspaceShowHandler = Callable[[], int]
 WorkspaceSetHandler = Callable[[str], int]
 WorkspaceActionHandler = Callable[[], int]
+
+
+@dataclass(frozen=True, slots=True)
+class PostRouteTargetStatus:
+    """Status summary used to render scan post-route actions."""
+
+    class_id: str
+    assignment_id: str
+    has_manifests: bool
+    has_routed_evidence: bool
+    has_unassembled_routed_files: bool
+    students_with_manifests: int
+    students_with_routed_evidence: int
+    unassembled_routed_file_count: int
+    status_error: str | None = None
+
+    @property
+    def ready_for_review(self) -> bool:
+        return self.has_manifests and not self.has_unassembled_routed_files
+
+    @property
+    def needs_assembly(self) -> bool:
+        return self.has_routed_evidence and (
+            not self.has_manifests or self.has_unassembled_routed_files
+        )
 
 
 def clear_screen() -> None:
@@ -108,11 +141,246 @@ def _normalize_menu_path(raw_path: str) -> Path | None:
     return Path(stripped)
 
 
+def _post_route_target_status(
+    workspace_root: Path,
+    target: IntakeAssemblyTarget,
+) -> PostRouteTargetStatus:
+    try:
+        status = list_assignment_submission_status(
+            workspace_root,
+            target.class_id,
+            target.assignment_id,
+        )
+    except Exception as error:
+        return PostRouteTargetStatus(
+            class_id=target.class_id,
+            assignment_id=target.assignment_id,
+            has_manifests=False,
+            has_routed_evidence=False,
+            has_unassembled_routed_files=False,
+            students_with_manifests=0,
+            students_with_routed_evidence=0,
+            unassembled_routed_file_count=0,
+            status_error=str(error),
+        )
+    return PostRouteTargetStatus(
+        class_id=target.class_id,
+        assignment_id=target.assignment_id,
+        has_manifests=bool(status.students_with_manifests),
+        has_routed_evidence=bool(status.students_with_routed_evidence),
+        has_unassembled_routed_files=bool(status.unassembled_routed_files),
+        students_with_manifests=len(status.students_with_manifests),
+        students_with_routed_evidence=len(status.students_with_routed_evidence),
+        unassembled_routed_file_count=len(status.unassembled_routed_files),
+    )
+
+
+def _post_route_status_label(status: PostRouteTargetStatus) -> str:
+    if status.status_error is not None:
+        return "status unavailable"
+    if status.ready_for_review:
+        return "ready for review"
+    if status.has_manifests and status.has_unassembled_routed_files:
+        return "partly assembled"
+    if status.needs_assembly:
+        return "needs assembly"
+    if status.has_manifests:
+        return "assembled"
+    return "no routed evidence found"
+
+
+def _assemble_post_route_target(
+    workspace_root: Path,
+    target: IntakeAssemblyTarget,
+) -> None:
+    result = assemble_assignment_submissions(
+        workspace_root,
+        target.class_id,
+        target.assignment_id,
+    )
+    print_assignment_submission_assembly(result, workspace_root)
+
+
+def _view_post_route_submission_status(
+    workspace_root: Path,
+    target: IntakeAssemblyTarget,
+) -> None:
+    try:
+        status = list_assignment_submission_status(
+            workspace_root,
+            target.class_id,
+            target.assignment_id,
+        )
+    except Exception as error:
+        print("Submission status could not be loaded.")
+        print(f"Error: {error}")
+        return
+    print_assignment_submission_status(status, workspace_root)
+
+
+def _launch_post_route_review(
+    workspace_root: Path,
+    target: IntakeAssemblyTarget,
+) -> None:
+    from quillan.review_menu import launch_assignment_review_actions
+
+    launch_assignment_review_actions(
+        workspace_root,
+        target.class_id,
+        target.assignment_id,
+    )
+
+
+def _handle_single_post_route_target(
+    workspace_root: Path,
+    target: IntakeAssemblyTarget,
+    status: PostRouteTargetStatus,
+) -> bool:
+    if status.status_error is not None:
+        print("Submission status could not be loaded.")
+        print(f"Error: {status.status_error}")
+        print()
+        print("1. Try assembling submissions")
+        print("2. Return to Scan Intake")
+        print_navigation_options()
+        choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
+        if choice == "" or choice == "2" or navigation is NavigationChoice.BACK:
+            return False
+        if choice == "1":
+            _assemble_post_route_target(workspace_root, target)
+            return True
+        print(f"Invalid selection. {navigation_hint()}")
+        return True
+
+    if status.has_manifests and status.has_unassembled_routed_files:
+        print(
+            "Some submission records have been assembled, but routed evidence "
+            "still needs assembly."
+        )
+        print()
+        print("1. Assemble remaining submissions")
+        print("2. View submission status")
+        print("3. Review student work")
+        print_navigation_options()
+        choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
+        if choice == "" or navigation is NavigationChoice.BACK:
+            return False
+        if choice == "1":
+            _assemble_post_route_target(workspace_root, target)
+            return True
+        if choice == "2":
+            _view_post_route_submission_status(workspace_root, target)
+            return True
+        if choice == "3":
+            _launch_post_route_review(workspace_root, target)
+            return True
+        print(f"Invalid selection. {navigation_hint()}")
+        return True
+
+    if status.ready_for_review:
+        print("Submission records have been assembled for this assignment.")
+        print("The assignment is ready for review.")
+        print()
+        print("1. View submission status")
+        print("2. Review student work")
+        print("3. Reassemble submissions")
+        print_navigation_options()
+        choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
+        if choice == "" or navigation is NavigationChoice.BACK:
+            return False
+        if choice == "1":
+            _view_post_route_submission_status(workspace_root, target)
+            return True
+        if choice == "2":
+            _launch_post_route_review(workspace_root, target)
+            return True
+        if choice == "3":
+            _assemble_post_route_target(workspace_root, target)
+            return True
+        print(f"Invalid selection. {navigation_hint()}")
+        return True
+
+    print("Submission records are required before review.")
+    print()
+    print("1. Assemble submissions now")
+    print("2. View submission status")
+    print_navigation_options()
+    choice = input("Select an option: ").strip()
+    navigation = parse_navigation_choice(choice)
+    if choice == "" or navigation is NavigationChoice.BACK:
+        return False
+    if choice == "1":
+        _assemble_post_route_target(workspace_root, target)
+        return True
+    if choice == "2":
+        _view_post_route_submission_status(workspace_root, target)
+        return True
+    print(f"Invalid selection. {navigation_hint()}")
+    return True
+
+
+def handle_scan_post_route_menu(
+    workspace_root: Path,
+    targets: Sequence[IntakeAssemblyTarget],
+) -> None:
+    """Show status-aware follow-up actions after scan intake routes evidence."""
+    if not targets:
+        return
+
+    while True:
+        statuses = [
+            _post_route_target_status(workspace_root, target)
+            for target in targets
+        ]
+        print()
+        print("Scan routed successfully.")
+        print("Routed evidence was filed for:")
+        for index, (target, status) in enumerate(
+            zip(targets, statuses, strict=True),
+            start=1,
+        ):
+            label = ""
+            if len(targets) > 1:
+                label = f" - {_post_route_status_label(status)}"
+            print(
+                f"{index}. Class: {target.class_id}; "
+                f"Assignment: {target.assignment_id}{label}"
+            )
+        print()
+
+        if len(targets) == 1:
+            should_redraw = _handle_single_post_route_target(
+                workspace_root,
+                targets[0],
+                statuses[0],
+            )
+            if not should_redraw:
+                return
+            continue
+
+        print("Select a target to view status-aware actions.")
+        print_navigation_options()
+        choice = input("Select target: ").strip()
+        navigation = parse_navigation_choice(choice)
+        if choice == "" or navigation is NavigationChoice.BACK:
+            return
+        if choice.isdigit() and 1 <= int(choice) <= len(targets):
+            index = int(choice) - 1
+            _ = _handle_single_post_route_target(
+                workspace_root,
+                targets[index],
+                statuses[index],
+            )
+            continue
+        print(f"Invalid selection. {navigation_hint()}")
+
+
 def launch_scan_intake_workflow() -> None:
     """Route scans from the shared inbox, with a power-user path fallback."""
-    from quillan.assignment_submission_assembly import assemble_assignment_submissions
     from quillan.cli_app.handlers import routing
-    from quillan.cli_app.output import print_assignment_submission_assembly
     from quillan.intake_assembly import assembly_targets_from_intake_summary
     from quillan.scan_intake_summary import ScanIntakeSummary
 
@@ -127,68 +395,10 @@ def launch_scan_intake_workflow() -> None:
         return
     inbox = scans_inbox_dir(workspace_root)
     inbox.mkdir(parents=True, exist_ok=True)
-    exit_to_main = False
 
     def post_route(summary: ScanIntakeSummary) -> None:
-        nonlocal exit_to_main
         targets = assembly_targets_from_intake_summary(summary)
-        if not targets:
-            return
-        while True:
-            print()
-            print("Scan routed successfully.")
-            print("Routed evidence was filed for:")
-            for index, target in enumerate(targets, start=1):
-                print(
-                    f"{index}. Class: {target.class_id}; "
-                    f"Assignment: {target.assignment_id}"
-                )
-            print()
-            print("Submission records are required before review.")
-            if len(targets) == 1:
-                print("1. Assemble submissions now")
-                print("2. View submission status")
-                print_navigation_options()
-                choice = input("Select an option: ").strip()
-                navigation = parse_navigation_choice(choice)
-                if navigation is NavigationChoice.BACK:
-                    return
-                if choice == "1":
-                    target = targets[0]
-                    result = assemble_assignment_submissions(
-                        workspace_root, target.class_id, target.assignment_id
-                    )
-                    print_assignment_submission_assembly(result, workspace_root)
-                    continue
-                if choice == "2":
-                    from quillan.submission_status import list_assignment_submission_status
-                    from quillan.cli_app.output import print_assignment_submission_status
-
-                    target = targets[0]
-                    print_assignment_submission_status(
-                        list_assignment_submission_status(
-                            workspace_root, target.class_id, target.assignment_id
-                        ),
-                        workspace_root,
-                    )
-                    continue
-                print(f"Invalid selection. {navigation_hint()}")
-                continue
-            print_navigation_options()
-            choice = input("Select target: ").strip()
-            navigation = parse_navigation_choice(choice)
-            if choice == "" or navigation is NavigationChoice.BACK:
-                return
-            if choice.isdigit() and 1 <= int(choice) <= len(targets):
-                target = targets[int(choice) - 1]
-                result = assemble_assignment_submissions(
-                    workspace_root, target.class_id, target.assignment_id
-                )
-                print_assignment_submission_assembly(result, workspace_root)
-            else:
-                print(
-                    f"Invalid selection. {navigation_hint()}"
-                )
+        handle_scan_post_route_menu(workspace_root, targets)
 
     while True:
         clear_screen()
@@ -252,8 +462,6 @@ def launch_scan_intake_workflow() -> None:
         )
         print()
         pause_for_user()
-        if exit_to_main:
-            return
 
 
 def launch_review_student_work_menu() -> None:

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -204,6 +204,19 @@ def _run_review_selection_workflow() -> int:
     )
 
 
+def launch_assignment_review_actions(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> int:
+    """Launch review actions for a known class assignment."""
+    return _launch_assignment_review_actions(
+        workspace_root,
+        class_id,
+        assignment_id,
+    )
+
+
 def _workspace_root() -> Path | None:
     try:
         return resolve_workspace_root()

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -17,8 +17,11 @@ from qrcode.image.pil import PilImage
 
 from quillan.cli import main
 import quillan.cli_app.handlers.routing as cli_routing
+from quillan.intake_assembly import IntakeAssemblyTarget
+from quillan.menu import handle_scan_post_route_menu
 from quillan.payloads import build_response_payload
 from quillan.pdf_pages import PdfPageImage
+from quillan.submission_status import AssignmentSubmissionStatus
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
@@ -184,6 +187,226 @@ def _routed_pngs(workspace: Path) -> list[Path]:
             / "scans"
         ).glob("response_*.png")
     )
+
+
+def _post_route_target() -> IntakeAssemblyTarget:
+    return IntakeAssemblyTarget(CLASS_ID, ASSIGNMENT_ID, 1)
+
+
+def _assignment_status(
+    *,
+    manifests: tuple[str, ...] = (),
+    routed: tuple[str, ...] = (STUDENT_ID,),
+    unassembled: tuple[Path, ...] = (),
+) -> AssignmentSubmissionStatus:
+    return AssignmentSubmissionStatus(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        students_with_manifests=manifests,
+        students_with_routed_evidence=routed,
+        students_without_manifests=tuple(
+            student_id for student_id in routed if student_id not in manifests
+        ),
+        unassembled_routed_files=unassembled,
+        skipped_routed_files=(),
+        student_statuses=(),
+    )
+
+
+def test_post_route_menu_pre_assembly_wording(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(),
+    )
+    _menu_input(monkeypatch, ["b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    output = capsys.readouterr().out
+    assert "Submission records are required before review." in output
+    assert "Assemble submissions now" in output
+    assert "View submission status" in output
+
+
+def test_post_route_menu_recomputes_status_after_assembly(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statuses = iter(
+        [
+            _assignment_status(),
+            _assignment_status(
+                manifests=(STUDENT_ID,),
+                routed=(STUDENT_ID,),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: next(statuses),
+    )
+    monkeypatch.setattr(
+        "quillan.menu.assemble_assignment_submissions",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "quillan.menu.print_assignment_submission_assembly",
+        lambda *_args, **_kwargs: print("Assembly complete."),
+    )
+    _menu_input(monkeypatch, ["1", "b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    output = capsys.readouterr().out
+    after_assembly = output.split("Assembly complete.", maxsplit=1)[1]
+    assert "Submission records have been assembled" in after_assembly
+    assert "ready for review" in after_assembly
+    assert "Submission records are required before review." not in after_assembly
+    assert "Assemble submissions now" not in after_assembly
+    assert "Reassemble submissions" in after_assembly
+
+
+def test_post_route_menu_ready_state_offers_review(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reviewed_targets: list[tuple[Path, str, str]] = []
+
+    def fake_launch_review(root: Path, class_id: str, assignment_id: str) -> int:
+        reviewed_targets.append((root, class_id, assignment_id))
+        return 0
+
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(
+            manifests=(STUDENT_ID,),
+            routed=(STUDENT_ID,),
+        ),
+    )
+    monkeypatch.setattr(
+        "quillan.review_menu.launch_assignment_review_actions",
+        fake_launch_review,
+    )
+    _menu_input(monkeypatch, ["2", "b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    output = capsys.readouterr().out
+    assert "Review student work" in output
+    assert reviewed_targets == [(workspace, CLASS_ID, ASSIGNMENT_ID)]
+
+
+def test_post_route_menu_partial_state_wording(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(
+            manifests=(STUDENT_ID,),
+            routed=(STUDENT_ID, SECOND_STUDENT_ID),
+            unassembled=(workspace / "unassembled.png",),
+        ),
+    )
+    _menu_input(monkeypatch, ["b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    output = capsys.readouterr().out
+    assert "Some submission records have been assembled" in output
+    assert "routed evidence still needs assembly" in output
+    assert "Assemble remaining submissions" in output
+    assert "Review student work" in output
+
+
+def test_post_route_menu_view_status_uses_existing_status_output(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(),
+    )
+    _menu_input(monkeypatch, ["2", "b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    output = capsys.readouterr().out
+    assert f"Submission status for assignment {ASSIGNMENT_ID}" in output
+    assert "Students with routed evidence: 1" in output
+
+
+def test_post_route_menu_status_error_falls_back_safely(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_status_error(*_args: object, **_kwargs: object) -> None:
+        raise ValueError("synthetic status failure")
+
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        raise_status_error,
+    )
+    _menu_input(monkeypatch, ["b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    output = capsys.readouterr().out
+    assert "Submission status could not be loaded." in output
+    assert "Error: synthetic status failure" in output
+    assert "Try assembling submissions" in output
+    assert "Return to Scan Intake" in output
+    assert "Traceback" not in output
+
+
+def test_post_route_multi_target_lists_status_labels(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    second_target = IntakeAssemblyTarget("english12_p4_synthetic", ASSIGNMENT_ID, 1)
+
+    def status_for_target(
+        _workspace: Path,
+        class_id: str,
+        _assignment_id: str,
+    ) -> AssignmentSubmissionStatus:
+        if class_id == CLASS_ID:
+            return _assignment_status()
+        return AssignmentSubmissionStatus(
+            class_id=class_id,
+            assignment_id=ASSIGNMENT_ID,
+            students_with_manifests=(STUDENT_ID,),
+            students_with_routed_evidence=(STUDENT_ID,),
+            students_without_manifests=(),
+            unassembled_routed_files=(),
+            skipped_routed_files=(),
+            student_statuses=(),
+        )
+
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        status_for_target,
+    )
+    _menu_input(monkeypatch, ["b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target(), second_target])
+
+    output = capsys.readouterr().out
+    assert f"Class: {CLASS_ID}; Assignment: {ASSIGNMENT_ID} - needs assembly" in output
+    assert (
+        "Class: english12_p4_synthetic; "
+        f"Assignment: {ASSIGNMENT_ID} - ready for review"
+    ) in output
 
 
 def test_review_student_work_exposes_scan_intake_option(


### PR DESCRIPTION
## Summary

* Add a status-aware Scan Intake post-route menu.
* Extract post-route menu handling into `handle_scan_post_route_menu(...)`.
* Add `PostRouteTargetStatus` to summarize current submission/assembly state.
* Reload submission status after each post-route action, including after assembly.
* Preserve pre-assembly wording:

  * `Submission records are required before review.`
  * `Assemble submissions now`
* Update post-assembly wording to show assembled/ready status.
* Offer `Review student work` once manifests exist and the assignment is ready.
* Label post-assembly assembly action as `Reassemble submissions`.
* Label partial assembly action as `Assemble remaining submissions`.
* Show clear fallback wording when submission status cannot be loaded.
* Add a narrow public `launch_assignment_review_actions(...)` adapter in `review_menu.py`.
* Add focused tests for:

  * pre-assembly menu wording
  * ready-for-review wording
  * partial assembly wording
  * status-load error fallback
  * view-status action
  * review action
  * multi-target labels

## Behavior

* Before manifests exist, the menu still tells the teacher that submission records are required before review.
* After manifests exist, the menu now says submissions are assembled/ready and no longer repeats the stale required-step wording.
* When routed evidence remains unassembled, the menu clearly identifies the partial state.
* Status load errors show a clear fallback menu without traceback.
* B/M/Q navigation continues to flow through existing navigation helpers.

## Validation

* Ran `.\run_tests.ps1`
* Pytest: `1134 passed`
* Ruff: passed
* Mypy: no issues found in 157 source files
* Script diff whitespace check: passed
* Ran `git diff --check`
* Diff check: passed
* Only Git LF-to-CRLF warnings were reported
* Manual smoke coverage was exercised through direct post-route menu tests using the same menu loop after assembly.
* Confirmed the menu redraw changes to ready-for-review wording and no longer repeats the stale required-step text after assembly.

Closes #198
