### PR TITLE
Refresh scan post-route action screens

### DIFF
--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -71,6 +71,12 @@ def pause_for_user() -> None:
     input("Press Enter to continue...")
 
 
+def _pause_for_post_route_menu() -> None:
+    """Wait after a post-route action before redrawing the action menu."""
+    print("Press Enter to return to the post-route menu...")
+    input()
+
+
 def print_menu_header(title: str | None = None) -> None:
     """Print the Quillan identity and an optional section title."""
     print("\033[32mQuillan\033[0m")
@@ -218,6 +224,17 @@ def _view_post_route_submission_status(
     print_assignment_submission_status(status, workspace_root)
 
 
+def _print_post_route_action_header(
+    title: str,
+    target: IntakeAssemblyTarget | PostRouteTargetStatus,
+) -> None:
+    clear_screen()
+    print_menu_header(title)
+    print(f"Class: {target.class_id}")
+    print(f"Assignment: {target.assignment_id}")
+    print()
+
+
 def _launch_post_route_review(
     workspace_root: Path,
     target: IntakeAssemblyTarget,
@@ -248,7 +265,10 @@ def _handle_single_post_route_target(
         if choice == "" or choice == "2" or navigation is NavigationChoice.BACK:
             return False
         if choice == "1":
+            _print_post_route_action_header("Assemble Submissions", target)
             _assemble_post_route_target(workspace_root, target)
+            print()
+            _pause_for_post_route_menu()
             return True
         print(f"Invalid selection. {navigation_hint()}")
         return True
@@ -268,12 +288,19 @@ def _handle_single_post_route_target(
         if choice == "" or navigation is NavigationChoice.BACK:
             return False
         if choice == "1":
+            _print_post_route_action_header("Assemble Submissions", target)
             _assemble_post_route_target(workspace_root, target)
+            print()
+            _pause_for_post_route_menu()
             return True
         if choice == "2":
+            _print_post_route_action_header("Submission Status", target)
             _view_post_route_submission_status(workspace_root, target)
+            print()
+            _pause_for_post_route_menu()
             return True
         if choice == "3":
+            _print_post_route_action_header("Review Student Work", target)
             _launch_post_route_review(workspace_root, target)
             return True
         print(f"Invalid selection. {navigation_hint()}")
@@ -292,13 +319,20 @@ def _handle_single_post_route_target(
         if choice == "" or navigation is NavigationChoice.BACK:
             return False
         if choice == "1":
+            _print_post_route_action_header("Submission Status", target)
             _view_post_route_submission_status(workspace_root, target)
+            print()
+            _pause_for_post_route_menu()
             return True
         if choice == "2":
+            _print_post_route_action_header("Review Student Work", target)
             _launch_post_route_review(workspace_root, target)
             return True
         if choice == "3":
+            _print_post_route_action_header("Assemble Submissions", target)
             _assemble_post_route_target(workspace_root, target)
+            print()
+            _pause_for_post_route_menu()
             return True
         print(f"Invalid selection. {navigation_hint()}")
         return True
@@ -313,10 +347,16 @@ def _handle_single_post_route_target(
     if choice == "" or navigation is NavigationChoice.BACK:
         return False
     if choice == "1":
+        _print_post_route_action_header("Assemble Submissions", target)
         _assemble_post_route_target(workspace_root, target)
+        print()
+        _pause_for_post_route_menu()
         return True
     if choice == "2":
+        _print_post_route_action_header("Submission Status", target)
         _view_post_route_submission_status(workspace_root, target)
+        print()
+        _pause_for_post_route_menu()
         return True
     print(f"Invalid selection. {navigation_hint()}")
     return True
@@ -330,12 +370,15 @@ def handle_scan_post_route_menu(
     if not targets:
         return
 
+    should_clear_menu = False
     while True:
+        if should_clear_menu:
+            clear_screen()
+        print_menu_header("Scan Intake / Route Paper Responses")
         statuses = [
             _post_route_target_status(workspace_root, target)
             for target in targets
         ]
-        print()
         print("Scan routed successfully.")
         print("Routed evidence was filed for:")
         for index, (target, status) in enumerate(
@@ -359,6 +402,7 @@ def handle_scan_post_route_menu(
             )
             if not should_redraw:
                 return
+            should_clear_menu = True
             continue
 
         print("Select a target to view status-aware actions.")
@@ -374,6 +418,7 @@ def handle_scan_post_route_menu(
                 targets[index],
                 statuses[index],
             )
+            should_clear_menu = True
             continue
         print(f"Invalid selection. {navigation_hint()}")
 

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -19,6 +19,7 @@ from quillan.cli import main
 import quillan.cli_app.handlers.routing as cli_routing
 from quillan.intake_assembly import IntakeAssemblyTarget
 from quillan.menu import handle_scan_post_route_menu
+from quillan.menu_navigation import QuitQuillan, ReturnToMainMenu
 from quillan.payloads import build_response_payload
 from quillan.pdf_pages import PdfPageImage
 from quillan.submission_status import AssignmentSubmissionStatus
@@ -227,6 +228,7 @@ def test_post_route_menu_pre_assembly_wording(
     handle_scan_post_route_menu(workspace, [_post_route_target()])
 
     output = capsys.readouterr().out
+    assert "Scan Intake / Route Paper Responses" in output
     assert "Submission records are required before review." in output
     assert "Assemble submissions now" in output
     assert "View submission status" in output
@@ -258,11 +260,21 @@ def test_post_route_menu_recomputes_status_after_assembly(
         "quillan.menu.print_assignment_submission_assembly",
         lambda *_args, **_kwargs: print("Assembly complete."),
     )
-    _menu_input(monkeypatch, ["1", "b"])
+    clear_calls: list[str] = []
+    monkeypatch.setattr(
+        "quillan.menu.clear_screen",
+        lambda: clear_calls.append("clear"),
+    )
+    _menu_input(monkeypatch, ["1", "", "b"])
 
     handle_scan_post_route_menu(workspace, [_post_route_target()])
 
     output = capsys.readouterr().out
+    assert clear_calls == ["clear", "clear"]
+    assert "Assemble Submissions" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert "Press Enter to return to the post-route menu..." in output
     after_assembly = output.split("Assembly complete.", maxsplit=1)[1]
     assert "Submission records have been assembled" in after_assembly
     assert "ready for review" in after_assembly
@@ -335,13 +347,179 @@ def test_post_route_menu_view_status_uses_existing_status_output(
         "quillan.menu.list_assignment_submission_status",
         lambda *_args, **_kwargs: _assignment_status(),
     )
-    _menu_input(monkeypatch, ["2", "b"])
+    clear_calls: list[str] = []
+    monkeypatch.setattr(
+        "quillan.menu.clear_screen",
+        lambda: clear_calls.append("clear"),
+    )
+    _menu_input(monkeypatch, ["2", "", "b"])
 
     handle_scan_post_route_menu(workspace, [_post_route_target()])
 
     output = capsys.readouterr().out
-    assert f"Submission status for assignment {ASSIGNMENT_ID}" in output
+    assert clear_calls == ["clear", "clear"]
+    assert "Submission Status" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert "Press Enter to return to the post-route menu..." in output
+    status_heading_index = output.index("Submission Status")
+    status_report_index = output.index(
+        f"Submission status for assignment {ASSIGNMENT_ID}"
+    )
+    assert status_heading_index < status_report_index
     assert "Students with routed evidence: 1" in output
+    after_status = output.split(
+        "Press Enter to return to the post-route menu...",
+        maxsplit=1,
+    )[1]
+    assert "Scan Intake / Route Paper Responses" in after_status
+    assert "Submission records are required before review." in after_status
+
+
+def test_post_route_ready_state_reassemble_uses_clean_action_screen(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(
+            manifests=(STUDENT_ID,),
+            routed=(STUDENT_ID,),
+        ),
+    )
+    monkeypatch.setattr(
+        "quillan.menu.assemble_assignment_submissions",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "quillan.menu.print_assignment_submission_assembly",
+        lambda *_args, **_kwargs: print("Reassembly complete."),
+    )
+    clear_calls: list[str] = []
+    monkeypatch.setattr(
+        "quillan.menu.clear_screen",
+        lambda: clear_calls.append("clear"),
+    )
+    _menu_input(monkeypatch, ["3", "", "b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    output = capsys.readouterr().out
+    assert clear_calls == ["clear", "clear"]
+    assert "Assemble Submissions" in output
+    assert "Reassembly complete." in output
+    assert "Press Enter to return to the post-route menu..." in output
+
+
+def test_post_route_partial_state_assemble_remaining_uses_clean_action_screen(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(
+            manifests=(STUDENT_ID,),
+            routed=(STUDENT_ID, SECOND_STUDENT_ID),
+            unassembled=(workspace / "unassembled.png",),
+        ),
+    )
+    monkeypatch.setattr(
+        "quillan.menu.assemble_assignment_submissions",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "quillan.menu.print_assignment_submission_assembly",
+        lambda *_args, **_kwargs: print("Remaining submissions assembled."),
+    )
+    clear_calls: list[str] = []
+    monkeypatch.setattr(
+        "quillan.menu.clear_screen",
+        lambda: clear_calls.append("clear"),
+    )
+    _menu_input(monkeypatch, ["1", "", "b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    output = capsys.readouterr().out
+    assert clear_calls == ["clear", "clear"]
+    assert "Assemble Submissions" in output
+    assert "Remaining submissions assembled." in output
+    assert "Some submission records have been assembled" in output
+
+
+def test_post_route_review_action_clears_before_launching_review(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    def fake_clear_screen() -> None:
+        events.append("clear")
+
+    def fake_launch_review(_root: Path, _class_id: str, _assignment_id: str) -> int:
+        events.append("review")
+        return 0
+
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(
+            manifests=(STUDENT_ID,),
+            routed=(STUDENT_ID,),
+        ),
+    )
+    monkeypatch.setattr("quillan.menu.clear_screen", fake_clear_screen)
+    monkeypatch.setattr(
+        "quillan.review_menu.launch_assignment_review_actions",
+        fake_launch_review,
+    )
+    _menu_input(monkeypatch, ["2", "b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+    assert events == ["clear", "review", "clear"]
+
+
+def test_post_route_menu_back_returns(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(),
+    )
+    _menu_input(monkeypatch, ["b"])
+
+    handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+
+def test_post_route_menu_main_menu_navigation_is_unchanged(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(),
+    )
+    _menu_input(monkeypatch, ["m"])
+
+    with pytest.raises(ReturnToMainMenu):
+        handle_scan_post_route_menu(workspace, [_post_route_target()])
+
+
+def test_post_route_menu_quit_navigation_is_unchanged(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "quillan.menu.list_assignment_submission_status",
+        lambda *_args, **_kwargs: _assignment_status(),
+    )
+    _menu_input(monkeypatch, ["q"])
+
+    with pytest.raises(QuitQuillan):
+        handle_scan_post_route_menu(workspace, [_post_route_target()])
 
 
 def test_post_route_menu_status_error_falls_back_safely(


### PR DESCRIPTION
## Summary

* Refresh Scan Intake post-route screens so action output no longer accumulates under the routing transcript.
* Redraw post-route menus under `Quillan / Scan Intake / Route Paper Responses`.
* Clear before status, assembly, reassembly, partial assembly, and review actions.
* Add clean action headings with class and assignment context.
* Pause after status and assembly output with `Press Enter to return to the post-route menu...`.
* Redraw the post-route menu cleanly after status and assembly actions.
* Reload submission status after assembly.
* Preserve #198 status-aware wording after assembly.
* Preserve `B`, `M`, and `Q` navigation behavior.
* Expand focused scan-intake menu tests for the redraw behavior.

## Validation

* Ran `.\.venv\Scripts\python.exe -m pytest tests\test_menu_scan_intake.py`
* Targeted pytest: `20 passed`
* Ran `.\run_tests.ps1`
* Full pytest: `1140 passed`
* Ruff: passed
* Mypy: no issues found in 157 source files
* Script diff whitespace check: passed
* Ran `git diff --check`
* Diff check: passed
* Only Git LF-to-CRLF working-copy warnings were reported for the edited files
* Interactive paths from the manual plan are covered by focused monkeypatched input/output tests:

  * status screen clearing
  * assembly screen clearing
  * reassembly screen clearing
  * partial assembly screen clearing
  * review launch clearing
  * post-action menu redraw
  * `B/M/Q` navigation

Closes #199
