### PR TITLE
Keep observation entry in review unit loop

### DIFF
--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -2723,7 +2723,6 @@ def _menu_review_unit_observations(
             _menu_record_review_unit_observation(
                 workspace_root, class_id, assignment_id, student_id, assignment
             )
-            input("Press Enter to continue...")
         elif choice == "3":
             _menu_mark_observations_complete(
                 workspace_root, class_id, assignment_id, student_id
@@ -2796,28 +2795,49 @@ def _menu_record_review_unit_observation(
     student_id: str,
     assignment: dict[str, Any],
 ) -> None:
-    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
-    if record is None or not record.get("review_units"):
+    while True:
+        record = _current_review_record(
+            workspace_root, class_id, assignment_id, student_id
+        )
+        if record is None or not record.get("review_units"):
+            _print_observation_entry_header(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                step="Review unit selection",
+            )
+            print("Define review units before recording observations.")
+            input("Press Enter to continue...")
+            return
         _print_observation_entry_header(
             workspace_root,
             class_id,
             assignment_id,
             student_id,
-            step="Review unit selection",
+            step="Select review unit",
         )
-        print("Define review units before recording observations.")
-        return
-    _print_observation_entry_header(
-        workspace_root,
-        class_id,
-        assignment_id,
-        student_id,
-        step="Select review unit",
-    )
-    unit = _prompt_review_unit(record["review_units"])
-    if unit is None:
-        print("Observation entry canceled.")
-        return
+        unit = _prompt_review_unit(record["review_units"])
+        if unit is None:
+            return
+        _record_review_unit_observation(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            assignment,
+            unit,
+        )
+
+
+def _record_review_unit_observation(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+    unit: dict[str, Any],
+) -> None:
     _print_observation_entry_header(
         workspace_root,
         class_id,
@@ -2919,8 +2939,10 @@ def _menu_record_review_unit_observation(
         )
     except ReviewObservationError as error:
         print(f"Error: could not update observation: {error}")
+        input("Press Enter to continue...")
         return
     print_updated_review_unit_observation(updated)
+    input("Press Enter to continue...")
 
 
 def _menu_mark_observations_complete(

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -466,6 +466,7 @@ def test_review_menu_records_applicable_focus_standard_observation(
             "Clear evidence.",
             "1",
             "",
+            "B",
             "4",
             "12",
             "6",
@@ -482,6 +483,8 @@ def test_review_menu_records_applicable_focus_standard_observation(
     assert "Step: Save confirmation" in output
     assert "Updated Focus Standard observation:" in output
     assert "Action: created" in output
+    assert output.count("Step: Select review unit") == 2
+    assert "1. Paragraph 1 (1 observations)" in output
     assert "Rating:" not in output
     review = json.loads(
         review_record_path(
@@ -497,6 +500,83 @@ def test_review_menu_records_applicable_focus_standard_observation(
     assert observation["include_in_feedback"] is True
     assert review["overall_standard_ratings"] == []
     assert review["feedback"]["standard_feedback"] == []
+
+
+def test_observation_entry_records_multiple_units_without_parent_menu(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review = _review_record()
+    review["review_units"] = [
+        {
+            "unit_id": f"paragraph_{sequence}",
+            "sequence": sequence,
+            "label": f"Paragraph {sequence}",
+            "unit_type": "paragraph",
+            "standard_observations": [],
+            "module_details": {},
+        }
+        for sequence in (1, 2)
+    ]
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    assignment = {
+        "focus_standard_ids": ["njsls-ela:W.1"],
+    }
+    _menu_input(
+        monkeypatch,
+        [
+            "1", "1", "1", "", "", "Good evidence", "1", "",
+            "2", "1", "1", "", "", "Needs explanation", "1", "",
+            "B",
+        ],
+    )
+
+    review_menu._menu_record_review_unit_observation(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, assignment
+    )
+
+    output = capsys.readouterr().out
+    assert output.count("Step: Select review unit") == 3
+    assert "1. Paragraph 1 (1 observations)" in output
+    assert "2. Paragraph 2 (1 observations)" in output
+    updated = json.loads(review_path.read_text(encoding="utf-8"))
+    assert [len(unit["standard_observations"]) for unit in updated["review_units"]] == [
+        1,
+        1,
+    ]
+
+
+def test_observation_entry_back_before_save_does_not_write(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review = _review_record()
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [],
+            "module_details": {},
+        }
+    ]
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    before = review_path.read_bytes()
+    _menu_input(monkeypatch, ["1", "1", "1", "", "", "Unsaved", "2", "B"])
+
+    review_menu._menu_record_review_unit_observation(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        {"focus_standard_ids": ["njsls-ela:W.1"]},
+    )
+
+    assert review_path.read_bytes() == before
 
 
 def test_review_menu_marks_observations_complete(


### PR DESCRIPTION
## Summary

* Keep teachers inside the review-unit Focus Standard observation-entry flow after saving.
* Return to the refreshed review-unit list after each saved observation.
* Update review-unit observation counts after each save.
* Allow repeated observation entry across multiple review units without returning to the parent submenu.
* Preserve `B. Back` behavior from the review-unit list as the exit path to the parent observations submenu.
* Remove the extra parent-level pause after exiting observation entry.
* Return to unit selection without saving when backing out or canceling during observation entry.
* Preserve existing mutation behavior in `set_review_unit_observation(...)`.
* Preserve update-without-duplication behavior for existing unit-standard observations.
* Add tests for repeated entry, refreshed counts, and cancellation without writes.

## Validation

* Ran `.\run_tests.ps1`
* Pytest: `1142 passed`
* Ruff: passed
* Mypy: no issues found in 157 source files
* Ran `git diff --check`
* Diff check: passed
* Only Git line-ending warnings were reported
* Automated menu smoke test recorded observations for two review units consecutively without visiting the parent menu.
* Cancel-before-save test confirmed the review file remained byte-for-byte unchanged.
* Existing observation update regression tests passed, confirming edits do not create duplicate observations.

Closes #255
