### PR TITLE
Keep overall rating entry in focus standard loop

### DIFF
--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -3019,7 +3019,6 @@ def _menu_overall_focus_standard_ratings(
             _menu_record_overall_focus_standard_rating(
                 workspace_root, class_id, assignment_id, student_id, assignment
             )
-            input("Press Enter to continue...")
         elif choice == "3":
             _menu_mark_overall_ratings_complete(
                 workspace_root, class_id, assignment_id, student_id, assignment
@@ -3582,32 +3581,58 @@ def _menu_record_overall_focus_standard_rating(
     student_id: str,
     assignment: dict[str, Any],
 ) -> None:
-    record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
-    if record is not None and record["review_state"] == "returned_without_full_review":
+    while True:
+        record = _current_review_record(
+            workspace_root, class_id, assignment_id, student_id
+        )
+        if (
+            record is not None
+            and record["review_state"] == "returned_without_full_review"
+        ):
+            _print_rating_entry_header(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                step="Unavailable",
+            )
+            _print_overall_rating_warnings(record)
+            input("Press Enter to continue...")
+            return
         _print_rating_entry_header(
             workspace_root,
             class_id,
             assignment_id,
             student_id,
-            step="Unavailable",
+            step="Select Focus Standard",
         )
-        _print_overall_rating_warnings(record)
-        return
-    _print_rating_entry_header(
-        workspace_root,
-        class_id,
-        assignment_id,
-        student_id,
-        step="Select Focus Standard",
-    )
-    standard_id = _prompt_focus_standard_with_rating_status(
-        workspace_root,
-        assignment["focus_standard_ids"],
-        record,
-    )
-    if standard_id is None:
-        print("Overall rating entry canceled.")
-        return
+        standard_id = _prompt_focus_standard_with_rating_status(
+            workspace_root,
+            assignment["focus_standard_ids"],
+            record,
+        )
+        if standard_id is None:
+            return
+        _record_overall_focus_standard_rating(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+            assignment,
+            standard_id,
+            record,
+        )
+
+
+def _record_overall_focus_standard_rating(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    assignment: dict[str, Any],
+    standard_id: str,
+    record: dict[str, Any] | None,
+) -> None:
     current_rating = _overall_rating_for_standard(record, standard_id)
     try:
         summaries = summarize_focus_standard_observations(
@@ -3615,6 +3640,7 @@ def _menu_record_overall_focus_standard_rating(
         )
     except ReviewRatingError as error:
         print(f"Error: could not summarize observations: {error}")
+        input("Press Enter to continue...")
         return
     summary = next(item for item in summaries if item.standard_id == standard_id)
     _print_rating_entry_header(
@@ -3698,8 +3724,10 @@ def _menu_record_overall_focus_standard_rating(
         )
     except ReviewRatingError as error:
         print(f"Error: could not update overall rating: {error}")
+        input("Press Enter to continue...")
         return
     print_updated_overall_standard_rating(updated)
+    input("Press Enter to continue...")
 
 
 def _menu_mark_overall_ratings_complete(

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -678,6 +678,7 @@ def test_review_menu_records_and_completes_overall_focus_standard_rating(
             "",
             "1",
             "",
+            "B",
             "3",
             "1",
             "",
@@ -717,6 +718,132 @@ def test_review_menu_records_and_completes_overall_focus_standard_rating(
     ]
     for legacy_field in ("scores", "tags", "comments", "notes"):
         assert legacy_field not in review
+
+
+def test_overall_rating_entry_loops_and_updates_without_duplicates(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assignment_path = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment = json.loads(assignment_path.read_text(encoding="utf-8"))
+    assignment["focus_standard_ids"] = ["njsls-ela:W.1", "njsls-ela:W.2"]
+    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
+
+    review = _review_record()
+    review["review_state"] = "observations_complete"
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [],
+            "module_details": {},
+        }
+    ]
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    _menu_input(
+        monkeypatch,
+        [
+            "1",
+            "1",
+            "First rationale",
+            "",
+            "1",
+            "",
+            "1",
+            "1",
+            "Updated rationale",
+            "n",
+            "1",
+            "",
+            "2",
+            "1",
+            "Second rationale",
+            "",
+            "1",
+            "",
+            "B",
+        ],
+    )
+
+    review_menu._menu_record_overall_focus_standard_rating(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, assignment
+    )
+
+    output = capsys.readouterr().out
+    assert output.count("Updated overall Focus Standard rating:") == 3
+    assert "(current rating: 1)" in output
+    assert "(not rated)" in output
+    updated = json.loads(review_path.read_text(encoding="utf-8"))
+    assert len(updated["overall_standard_ratings"]) == 2
+    ratings = {
+        item["standard_id"]: item for item in updated["overall_standard_ratings"]
+    }
+    assert ratings["njsls-ela:W.1"]["rationale"] == "Updated rationale"
+    assert ratings["njsls-ela:W.1"]["include_in_feedback"] is False
+    assert ratings["njsls-ela:W.2"]["rationale"] == "Second rationale"
+
+
+def test_overall_rating_entry_cancellations_do_not_write(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review = _review_record()
+    review["review_state"] = "observations_complete"
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [],
+            "module_details": {},
+        }
+    ]
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    before = review_path.read_bytes()
+    assignment = json.loads(
+        (
+            workspace
+            / "classes"
+            / CLASS_ID
+            / "assignments"
+            / ASSIGNMENT_ID
+            / "assignment.json"
+        ).read_text(encoding="utf-8")
+    )
+    _menu_input(
+        monkeypatch,
+        ["1", "", "1", "1", "Unsaved rationale", "", "2", "B"],
+    )
+
+    review_menu._menu_record_overall_focus_standard_rating(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, assignment
+    )
+
+    assert review_path.read_bytes() == before
+
+
+def test_overall_rating_parent_menu_has_no_pause_after_entry_back(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["2", "B", "4"])
+
+    review_menu._menu_overall_focus_standard_ratings(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
 
 
 def test_review_menu_blocks_observations_for_returned_without_full_review(


### PR DESCRIPTION
## Summary

* Keep teachers inside the overall Focus Standard rating-entry flow after saving.
* Return to the refreshed Focus Standard list after each saved rating.
* Allow multiple Focus Standards to be rated in one session without returning to the parent submenu.
* Refresh current-rating status after each save.
* Preserve `B. Back` behavior from the Focus Standard list as the exit path to the parent ratings submenu.
* Remove the extra parent-level pause after exiting rating entry.
* Return to the Focus Standard list without saving when backing out or canceling during rating entry.
* Preserve existing mutation behavior in `set_overall_standard_rating(...)`.
* Preserve update-without-duplication behavior for existing Focus Standard ratings.
* Add regression tests for:

  * repeated rating entry
  * refreshed rating statuses
  * cancellation without writes
  * rating updates without duplication
  * parent pause behavior

## Validation

* Ran `.\.venv\Scripts\python.exe -m pytest tests\test_menu_review_student_work.py -q`
* Targeted pytest: `24 passed`
* Ran `.\run_tests.ps1`
* Full pytest: `1145 passed`
* Ruff: passed
* Mypy: no issues found in 157 source files
* Ran `git diff --check`
* Diff check: passed
* Smoke simulation confirmed:

  * repeated rating entry works without visiting the parent submenu
  * current-rating displays refresh after save
  * cancel/back paths do not write changes
  * editing an existing Focus Standard rating does not duplicate it
  * no extra parent pause remains

Closes #256
