### PR TITLE
Improve reusable comment text workflow

### DIFF
--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from pds_core.classes import list_class_folders, load_class_roster
 from pds_core.rosters import RosterError
@@ -2126,13 +2126,23 @@ def _menu_update_submission_review_state(
 
 
 def _prompt_yes_no_default_no(prompt: str) -> bool:
-    response = input(f"{prompt} (y/N): ").strip().casefold()
-    return response in {"y", "yes"}
+    while True:
+        response = input(f"{prompt} (y/N): ").strip().casefold()
+        if response in {"y", "yes"}:
+            return True
+        if response in {"", "n", "no"}:
+            return False
+        print("Invalid response. Enter y or n, or press Enter for the default.")
 
 
 def _prompt_yes_no_default_yes(prompt: str) -> bool:
-    response = input(f"{prompt} (Y/n): ").strip().casefold()
-    return response not in {"n", "no"}
+    while True:
+        response = input(f"{prompt} (Y/n): ").strip().casefold()
+        if response in {"", "y", "yes"}:
+            return True
+        if response in {"n", "no"}:
+            return False
+        print("Invalid response. Enter y or n, or press Enter for the default.")
 
 
 def _format_yes_no(value: bool) -> str:
@@ -3282,7 +3292,11 @@ def _menu_add_custom_focus_standard_feedback_comment(
         )
         print(f"Reusable comment label: {reusable_label}")
         print()
-        reusable_text = input("Reusable comment text:\n").strip() or text
+        reusable_text_result = _prompt_reusable_comment_text(text)
+        if reusable_text_result is _BACK:
+            print("Custom feedback comment canceled.")
+            return
+        reusable_text = cast(str, reusable_text_result)
         _print_feedback_action_header(
             "Save Reusable Focus Standard Comment",
             student_id,
@@ -3307,11 +3321,15 @@ def _menu_add_custom_focus_standard_feedback_comment(
         standard_id=standard_id,
     )
     print("Save this Focus Standard feedback comment?")
-    print(f"Comment: {_preview_text(text)}")
+    print("Student feedback comment:")
+    print(_preview_text(text))
     print(f"Include in feedback: {_format_yes_no(include_in_feedback)}")
     print(f"Save for reuse: {_format_yes_no(save_for_reuse)}")
     if reusable_label is not None:
         print(f"Reusable label: {reusable_label}")
+        print("Reusable text:")
+        print(_preview_text(cast(str, reusable_text)))
+        print(f"Reusable purpose: {purpose}")
     print()
     print("1. Save comment")
     print("2. Back")
@@ -4032,6 +4050,36 @@ def _prompt_reusable_comment_purpose() -> str:
     if selection in purposes:
         return selection
     return "general"
+
+
+def _prompt_reusable_comment_text(default_text: str) -> str | object:
+    while True:
+        print(
+            "Privacy reminder: remove student-specific details before saving "
+            "reusable Focus Standard comments."
+        )
+        print()
+        print("Reusable comment text currently defaults to:")
+        print(default_text)
+        print()
+        print("Use this text as the reusable comment?")
+        print("1. Use as-is")
+        print("2. Edit reusable text")
+        print("3. Back")
+        print()
+        selection = input("Select an option: ").strip()
+        if selection == "1":
+            return default_text
+        if selection == "2":
+            revised_text = input(
+                "Reusable comment text "
+                "(press Enter to keep the current/default text):\n"
+            ).strip()
+            return revised_text or default_text
+        if selection == "3":
+            return _BACK
+        print("Invalid response. Select 1, 2, or 3.")
+        print()
 
 
 def _current_overall_rating(record: dict[str, Any], standard_id: str) -> int | None:

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -1307,6 +1307,114 @@ def test_review_menu_adds_custom_focus_standard_feedback_comment(
     assert not {"comments", "scores", "tags", "notes"} & review.keys()
 
 
+def test_review_menu_saves_default_custom_comment_text_for_reuse(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review = _review_record()
+    review["feedback"]["standard_feedback"] = []
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        [
+            "2", "1", "1", "1", "1", "1", "6", "2", "1",
+            "Student-specific feedback text.",
+            "1", "",  # Reject invalid default-yes input, then accept its default.
+            "1", "y",  # Reject invalid default-no input, then choose yes.
+            "General feedback", "1", "", "1",
+            "", "5", "12", "6", "", "3", "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert output.count(
+        "Invalid response. Enter y or n, or press Enter for the default."
+    ) >= 2
+    assert "Reusable comment text currently defaults to:" in output
+    assert "Student-specific feedback text." in output
+    assert "Student feedback comment:" in output
+    assert "Reusable label: General feedback" in output
+    assert "Reusable text:" in output
+
+    saved_review = json.loads(review_path.read_text(encoding="utf-8"))
+    comment = saved_review["feedback"]["standard_feedback"][0]["comments"][0]
+    assert comment["text"] == "Student-specific feedback text."
+    comment_set_paths = list(
+        (workspace / "shared" / "focus_standard_comments").glob("*.json")
+    )
+    assert len(comment_set_paths) == 1
+    comment_set = json.loads(comment_set_paths[0].read_text(encoding="utf-8"))
+    assert comment_set["comments"][0]["text"] == "Student-specific feedback text."
+
+
+def test_review_menu_keeps_revised_reusable_text_separate(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review = _review_record()
+    review["feedback"]["standard_feedback"] = []
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+
+    _menu_input(
+        monkeypatch,
+        [
+            "2", "1", "1", "1", "1", "1", "6", "2", "1",
+            "Avery, revise paragraph 2.", "", "y", "General revision", "2",
+            "Revise the relevant paragraph.", "", "1",
+            "", "5", "12", "6", "", "3", "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    output = capsys.readouterr().out
+    assert "Privacy reminder:" in output
+    assert "Reusable text:" in output
+    assert "Revise the relevant paragraph." in output
+    saved_review = json.loads(review_path.read_text(encoding="utf-8"))
+    assert saved_review["feedback"]["standard_feedback"][0]["comments"][0][
+        "text"
+    ] == "Avery, revise paragraph 2."
+    comment_set_path = next(
+        (workspace / "shared" / "focus_standard_comments").glob("*.json")
+    )
+    comment_set = json.loads(comment_set_path.read_text(encoding="utf-8"))
+    assert comment_set["comments"][0]["text"] == "Revise the relevant paragraph."
+
+
+@pytest.mark.parametrize("back_at_text_step", [True, False])
+def test_review_menu_back_while_saving_reusable_comment_writes_nothing(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    back_at_text_step: bool,
+) -> None:
+    review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review = _review_record()
+    review["feedback"]["standard_feedback"] = []
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    original_review = review_path.read_bytes()
+    reusable_steps = ["Cancelable feedback.", "", "y", "Cancelable label"]
+    reusable_steps.extend(["3"] if back_at_text_step else ["1", "", "2"])
+
+    _menu_input(
+        monkeypatch,
+        [
+            "2", "1", "1", "1", "1", "1", "6", "2", "1",
+            *reusable_steps,
+            "", "5", "12", "6", "", "3", "6",
+        ],
+    )
+
+    assert main(["menu"]) == 0
+    assert review_path.read_bytes() == original_review
+    assert not (workspace / "shared" / "focus_standard_comments").exists()
+
+
 def test_review_menu_selects_reusable_focus_standard_feedback_comment(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Summary

* Improve the custom Focus Standard comment reuse workflow.
* Show the original student feedback text as the default reusable-comment text.
* Offer explicit reusable-text actions:

  * `Use as-is`
  * `Edit reusable text`
  * `Back`
* Keep the privacy reminder visible beside the reusable-text decision.
* Allow teachers to generalize or remove student-specific details without retyping the entire comment.
* Expand final confirmation to distinguish:

  * the student feedback comment
  * the reusable comment label
  * the reusable comment text
* Reject invalid yes/no input such as `1` and reprompt with clear guidance.
* Preserve blank-input defaults for default-yes and default-no prompts.
* Keep the student feedback comment and revised reusable comment as separate records.
* Ensure backing out from reusable-text selection or final confirmation writes no records.
* Preserve existing schemas and persistence contracts.

## Validation

* Ran `.\run_tests.ps1`
* Pytest: `1149 passed`
* Ruff: passed
* Mypy: no issues found in 157 source files
* Embedded diff whitespace check: passed
* Ran `git diff --check`
* Diff check: passed
* Automated menu smoke tests confirmed:

  * default reusable text uses the original feedback comment
  * edited reusable text remains separate from student feedback text
  * invalid yes/no input is rejected and reprompted
  * blank responses retain their documented defaults
  * backing out during reusable-text selection writes nothing
  * backing out during final confirmation writes nothing
* No schema or persistence-contract changes were made.

Closes #259
