### PR TITLE
Clarify reusable comment purpose taxonomy

### DIFF
--- a/docs/focus_standard_comment_contract.md
+++ b/docs/focus_standard_comment_contract.md
@@ -477,7 +477,9 @@ Example:
 
 ### `purpose`
 
-`purpose` organizes comments by feedback function.
+`purpose` is a stable, broad feedback-function enum for teacher-facing
+organization. It describes the feedback move, not the assignment's writing
+type or genre.
 
 Allowed values are:
 
@@ -499,7 +501,14 @@ Example:
 ```
 
 Purpose is teacher-facing organization only. It must not imply automatic
-scoring or automatic comment selection.
+scoring and is not required for automatic comment selection. `general` is the
+appropriate value when none of the stable categories fits. For example, a
+creative-writing comment about character or dialogue may use `general` plus
+optional teacher tags rather than forcing genre vocabulary into `purpose`.
+
+Writing-type compatibility remains represented by `writing_types`, including
+creative writing, narrative writing, poetry, multimedia writing, and
+teacher-defined assignment types.
 
 ### `student_facing`
 
@@ -557,6 +566,22 @@ Rules:
 * must be an object;
 * may be empty;
 * consumers must not require unknown keys inside `module_details`.
+
+Quillan may store optional teacher-facing, writing-type-specific organization
+tags under `module_details.teacher_tags`:
+
+```json
+"module_details": {
+  "teacher_tags": ["character", "dialogue"]
+}
+```
+
+When present, `teacher_tags` must be an array of unique, non-empty lowercase
+snake-case strings. Quillan normalizes teacher input such as `Scene
+Development` to `scene_development`. Tags are optional; consumers must tolerate
+their absence, and existing schema version `1` comments with empty
+`module_details` remain valid. Consumers must not require teacher tags for
+lookup or automatic selection.
 
 ## Source and Provenance
 
@@ -672,6 +697,13 @@ Optional lookup filters may include:
 * course or class context if future contracts define that metadata;
 * usage recency; and
 * usage count.
+
+Teacher tags are display and organization metadata, not durable lookup keys.
+Lookup must not require them. Stable matching remains based on the comment
+set's `standards_profile_id` and durable comment/assignment fields such as
+`writing_type`, `standard_id`, optional `rating_value`, `active`, and
+`student_facing` status. `purpose` may support an explicit future teacher
+filter, but is not required for automatic comment selection.
 
 A typical feedback-composition workflow should use the current assignment and
 review context:

--- a/quillan/focus_standard_comments.py
+++ b/quillan/focus_standard_comments.py
@@ -292,6 +292,7 @@ def append_saved_comment(
     purpose: str,
     rating_values: list[int | float] | None,
     source: dict[str, Any],
+    teacher_tags: list[str] | None = None,
     created_at: datetime | str | None = None,
     comment_set_id: str | None = None,
     comment_id: str | None = None,
@@ -311,6 +312,7 @@ def append_saved_comment(
     normalized_label = _normalize_required_string(label, "label")
     normalized_text = _normalize_required_string(text, "text")
     normalized_purpose = _validate_allowed(purpose, "purpose", ALLOWED_PURPOSES)
+    normalized_teacher_tags = normalize_teacher_tags(teacher_tags)
     normalized_rating_values = _normalize_unique_numbers(
         rating_values or [], "rating_values"
     )
@@ -351,7 +353,11 @@ def append_saved_comment(
         "updated_at": normalized_created_at,
         "source": copy.deepcopy(source),
         "usage": {"times_used": 0, "last_used_at": None},
-        "module_details": {},
+        "module_details": (
+            {"teacher_tags": normalized_teacher_tags}
+            if normalized_teacher_tags
+            else {}
+        ),
     }
     comment_set["comments"].append(comment)
     if not comment_set["writing_types"]:
@@ -471,6 +477,34 @@ def suggest_identifier(label: str) -> str:
     return suggestion or "focus_standard_comment"
 
 
+def normalize_teacher_tags(teacher_tags: list[str] | None) -> list[str]:
+    """Normalize optional teacher-facing tags to unique lowercase snake-case."""
+    if teacher_tags is None:
+        return []
+    if not isinstance(teacher_tags, list):
+        raise FocusStandardCommentError("teacher_tags must be a list.")
+    normalized_tags: list[str] = []
+    seen: set[str] = set()
+    for index, value in enumerate(teacher_tags):
+        tag = _normalize_teacher_tag(value, f"teacher_tags[{index}]")
+        if tag not in seen:
+            seen.add(tag)
+            normalized_tags.append(tag)
+    return normalized_tags
+
+
+def _normalize_teacher_tag(value: Any, field: str) -> str:
+    text = _validate_non_empty_string(value, field)
+    normalized = unicodedata.normalize("NFKD", text)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    tag = re.sub(r"[^A-Za-z0-9]+", "_", ascii_text.strip()).strip("_").lower()
+    if not tag:
+        raise FocusStandardCommentError(
+            f"Field '{field}' must contain letters or numbers."
+        )
+    return tag
+
+
 def _comment_sets_dir(workspace_root: str | Path) -> Path:
     return Path(workspace_root) / "shared" / "focus_standard_comments"
 
@@ -518,7 +552,18 @@ def _validate_comment(
         )
     _validate_source(comment["source"], f"{context}.source")
     _validate_usage(comment["usage"], f"{context}.usage")
-    _validate_object(comment["module_details"], f"{context}.module_details")
+    module_details = comment["module_details"]
+    _validate_object(module_details, f"{context}.module_details")
+    if "teacher_tags" in module_details:
+        teacher_tags = _validate_unique_strings(
+            module_details["teacher_tags"],
+            f"{context}.module_details.teacher_tags",
+        )
+        if normalize_teacher_tags(teacher_tags) != teacher_tags:
+            raise FocusStandardCommentError(
+                f"Field '{context}.module_details.teacher_tags' must contain "
+                "lowercase snake-case values."
+            )
 
 
 def _validate_source(value: Any, context: str) -> None:

--- a/quillan/review_feedback.py
+++ b/quillan/review_feedback.py
@@ -228,6 +228,7 @@ def add_custom_feedback_comment(
     reusable_label: str | None = None,
     reusable_text: str | None = None,
     purpose: str = "general",
+    teacher_tags: list[str] | None = None,
     rating_values: list[int | float] | None = None,
 ) -> AddedFeedbackComment:
     """Add one teacher-authored feedback comment under a Focus Standard."""
@@ -275,6 +276,7 @@ def add_custom_feedback_comment(
             label=reusable_label_text,
             text=reusable_comment_text,
             purpose=purpose,
+            teacher_tags=teacher_tags,
             rating_values=rating_values_to_save,
             source=_saved_comment_source(
                 context,

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -55,7 +55,11 @@ from quillan.feedback_export import (
     feedback_export_path,
     feedback_pdf_export_path,
 )
-from quillan.focus_standard_comments import FocusStandardCommentError, lookup_comments
+from quillan.focus_standard_comments import (
+    FocusStandardCommentError,
+    lookup_comments,
+    normalize_teacher_tags,
+)
 from quillan.standards_summary_export import (
     StandardsSummaryExportError,
     export_standards_summary,
@@ -3267,6 +3271,7 @@ def _menu_add_custom_focus_standard_feedback_comment(
     reusable_label = None
     reusable_text = None
     purpose = "general"
+    teacher_tags: list[str] = []
     rating_values: list[int | float] | None = None
     if save_for_reuse:
         _print_feedback_action_header(
@@ -3307,6 +3312,7 @@ def _menu_add_custom_focus_standard_feedback_comment(
         print(f"Reusable comment text: {_preview_text(reusable_text)}")
         print()
         purpose = _prompt_reusable_comment_purpose()
+        teacher_tags = _prompt_reusable_comment_teacher_tags()
         rating = _current_overall_rating(record, standard_id)
         if rating is not None and _prompt_yes_no_default_yes(
             f"Tag reusable comment with current rating {rating}?"
@@ -3330,6 +3336,8 @@ def _menu_add_custom_focus_standard_feedback_comment(
         print("Reusable text:")
         print(_preview_text(cast(str, reusable_text)))
         print(f"Reusable purpose: {purpose}")
+        if teacher_tags:
+            print(f"Teacher tags: {', '.join(teacher_tags)}")
     print()
     print("1. Save comment")
     print("2. Back")
@@ -3350,6 +3358,7 @@ def _menu_add_custom_focus_standard_feedback_comment(
             reusable_label=reusable_label,
             reusable_text=reusable_text,
             purpose=purpose,
+            teacher_tags=teacher_tags,
             rating_values=rating_values,
         )
     except ReviewFeedbackError as error:
@@ -4030,26 +4039,59 @@ def _print_existing_standard_feedback_comments(
 
 def _prompt_reusable_comment_purpose() -> str:
     purposes = [
-        "praise",
-        "next_step",
-        "clarification",
-        "evidence",
-        "reasoning",
-        "organization",
-        "style",
-        "conventions",
-        "revision",
-        "general",
+        ("praise", "identifies something the student is doing well"),
+        ("next_step", "suggests what the student should do next"),
+        ("clarification", "asks for clearer explanation or wording"),
+        ("evidence", "addresses textual support, examples, or details"),
+        ("reasoning", "addresses explanation, logic, or development"),
+        ("organization", "addresses structure, sequence, or arrangement"),
+        ("style", "addresses voice, tone, diction, or sentence craft"),
+        ("conventions", "addresses grammar, mechanics, or formatting"),
+        ("revision", "addresses broader revision work"),
+        ("general", "use when no category fits"),
     ]
-    print("Reusable comment purpose:")
-    for index, purpose in enumerate(purposes, start=1):
-        print(f"{index}. {purpose}")
-    selection = input("Select purpose (default general): ").strip()
-    if selection.isdigit() and 1 <= int(selection) <= len(purposes):
-        return purposes[int(selection) - 1]
-    if selection in purposes:
-        return selection
-    return "general"
+    purpose_names = [purpose for purpose, _description in purposes]
+    print("Reusable comment purpose")
+    print()
+    print("Purpose is broad teacher-facing organization metadata.")
+    print("It describes the feedback move, not the assignment genre.")
+    print("It is not used for automatic scoring or automatic comment selection.")
+    print('Use "general" when none of the categories fit.')
+    print()
+    print(
+        "For creative or narrative writing, ideas such as character, dialogue, "
+        "pacing, or imagery belong in optional teacher tags."
+    )
+    print()
+    for index, (purpose, description) in enumerate(purposes, start=1):
+        print(f"{index}. {purpose} - {description}")
+    while True:
+        selection = input("Select purpose (default general): ").strip()
+        if not selection:
+            return "general"
+        if selection.isdigit() and 1 <= int(selection) <= len(purposes):
+            return purposes[int(selection) - 1][0]
+        if selection in purpose_names:
+            return selection
+        print(
+            "Invalid purpose selection. Choose a listed number, type a listed "
+            "purpose, or press Enter for general."
+        )
+
+
+def _prompt_reusable_comment_teacher_tags() -> list[str]:
+    print()
+    print("Optional teacher tags")
+    print()
+    print("Use tags for writing-type-specific organization.")
+    print("Examples for creative writing: character, dialogue, pacing, imagery.")
+    print("Leave blank for none.")
+    raw_tags = input("Teacher tags, comma-separated: ").strip()
+    if not raw_tags:
+        return []
+    return normalize_teacher_tags(
+        [raw_tag for raw_tag in raw_tags.split(",") if raw_tag.strip()]
+    )
 
 
 def _prompt_reusable_comment_text(default_text: str) -> str | object:

--- a/tests/test_focus_standard_comments.py
+++ b/tests/test_focus_standard_comments.py
@@ -186,3 +186,43 @@ def test_saving_reusable_comment_creates_default_set_with_teacher_text(
     assert saved.comment_set_id == "synthetic_profile_argument_focus_comments"
     assert loaded["comments"][0]["source"]["type"] == "teacher_saved_from_feedback"
     assert loaded["comments"][0]["text"] == "Teacher-approved reusable text."
+
+
+def test_teacher_tags_are_normalized_without_affecting_lookup(tmp_path: Path) -> None:
+    saved = append_saved_comment(
+        tmp_path,
+        standards_profile_id="synthetic_profile",
+        writing_type="narrative",
+        standard_id="njsls-ela:W.3",
+        label="Develop the scene",
+        text="Develop the scene through dialogue and sensory details.",
+        purpose="general",
+        teacher_tags=["Character", "Scene Development", "dialogue", "character"],
+        rating_values=[],
+        source={
+            "type": "manual",
+            "class_id": None,
+            "assignment_id": None,
+            "student_id": None,
+            "review_path": None,
+            "feedback_comment_id": None,
+            "saved_at": TIMESTAMP,
+        },
+        created_at=TIMESTAMP,
+    )
+
+    loaded = load_comment_set(saved.path)
+    assert loaded["comments"][0]["module_details"] == {
+        "teacher_tags": ["character", "scene_development", "dialogue"]
+    }
+    matches = lookup_comments(
+        tmp_path,
+        standards_profile_id="synthetic_profile",
+        writing_type="narrative",
+        standard_id="njsls-ela:W.3",
+    )
+    assert [match.comment_id for match in matches] == [saved.comment_id]
+
+
+def test_existing_comment_without_teacher_tags_remains_valid() -> None:
+    validate_comment_set(_comment_set())

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -1324,7 +1324,7 @@ def test_review_menu_saves_default_custom_comment_text_for_reuse(
             "Student-specific feedback text.",
             "1", "",  # Reject invalid default-yes input, then accept its default.
             "1", "y",  # Reject invalid default-no input, then choose yes.
-            "General feedback", "1", "", "1",
+            "General feedback", "1", "", "", "1",
             "", "5", "12", "6", "", "3", "6",
         ],
     )
@@ -1349,6 +1349,8 @@ def test_review_menu_saves_default_custom_comment_text_for_reuse(
     assert len(comment_set_paths) == 1
     comment_set = json.loads(comment_set_paths[0].read_text(encoding="utf-8"))
     assert comment_set["comments"][0]["text"] == "Student-specific feedback text."
+    assert comment_set["comments"][0]["purpose"] == "general"
+    assert comment_set["comments"][0]["module_details"] == {}
 
 
 def test_review_menu_keeps_revised_reusable_text_separate(
@@ -1366,7 +1368,8 @@ def test_review_menu_keeps_revised_reusable_text_separate(
         [
             "2", "1", "1", "1", "1", "1", "6", "2", "1",
             "Avery, revise paragraph 2.", "", "y", "General revision", "2",
-            "Revise the relevant paragraph.", "", "1",
+            "Revise the relevant paragraph.", "",
+            "Character, Scene Development, dialogue", "1",
             "", "5", "12", "6", "", "3", "6",
         ],
     )
@@ -1385,6 +1388,12 @@ def test_review_menu_keeps_revised_reusable_text_separate(
     )
     comment_set = json.loads(comment_set_path.read_text(encoding="utf-8"))
     assert comment_set["comments"][0]["text"] == "Revise the relevant paragraph."
+    assert comment_set["comments"][0]["purpose"] == "general"
+    assert comment_set["comments"][0]["module_details"]["teacher_tags"] == [
+        "character",
+        "scene_development",
+        "dialogue",
+    ]
 
 
 @pytest.mark.parametrize("back_at_text_step", [True, False])
@@ -1399,7 +1408,7 @@ def test_review_menu_back_while_saving_reusable_comment_writes_nothing(
     review_path.write_text(json.dumps(review), encoding="utf-8")
     original_review = review_path.read_bytes()
     reusable_steps = ["Cancelable feedback.", "", "y", "Cancelable label"]
-    reusable_steps.extend(["3"] if back_at_text_step else ["1", "", "2"])
+    reusable_steps.extend(["3"] if back_at_text_step else ["1", "", "", "2"])
 
     _menu_input(
         monkeypatch,
@@ -1413,6 +1422,45 @@ def test_review_menu_back_while_saving_reusable_comment_writes_nothing(
     assert main(["menu"]) == 0
     assert review_path.read_bytes() == original_review
     assert not (workspace / "shared" / "focus_standard_comments").exists()
+
+
+@pytest.mark.parametrize(
+    ("responses", "expected"),
+    [
+        ([""], "general"),
+        (["2"], "next_step"),
+        (["revision"], "revision"),
+        (["character", "10"], "general"),
+    ],
+)
+def test_reusable_comment_purpose_prompt_handles_input_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    responses: list[str],
+    expected: str,
+) -> None:
+    _menu_input(monkeypatch, responses)
+
+    purpose = review_menu._prompt_reusable_comment_purpose()
+
+    output = capsys.readouterr().out
+    assert purpose == expected
+    assert "broad teacher-facing organization metadata" in output
+    assert "not the assignment genre" in output
+    assert "not used for automatic scoring or automatic comment selection" in output
+    assert 'Use "general" when none of the categories fit.' in output
+    if responses[0] == "character":
+        assert "Invalid purpose selection" in output
+
+
+def test_reusable_comment_teacher_tags_normalize_and_deduplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(monkeypatch, ["Character, Scene Development, dialogue, character"])
+
+    tags = review_menu._prompt_reusable_comment_teacher_tags()
+
+    assert tags == ["character", "scene_development", "dialogue"]
 
 
 def test_review_menu_selects_reusable_focus_standard_feedback_comment(

--- a/tests/test_review_feedback.py
+++ b/tests/test_review_feedback.py
@@ -282,6 +282,7 @@ def test_custom_comment_can_be_saved_for_reuse_with_approved_text(
         reusable_label="General claim next step",
         reusable_text="Reusable teacher-approved text.",
         purpose="next_step",
+        teacher_tags=["Claim Development", "voice"],
         created_at=FIRST_TIMESTAMP,
     )
 
@@ -289,6 +290,10 @@ def test_custom_comment_can_be_saved_for_reuse_with_approved_text(
     saved = load_comment_set(result.saved_reusable_comment.path)
     assert saved["comments"][0]["text"] == "Reusable teacher-approved text."
     assert saved["comments"][0]["rating_values"] == [2]
+    assert saved["comments"][0]["module_details"]["teacher_tags"] == [
+        "claim_development",
+        "voice",
+    ]
     assert _read_review(tmp_path)["feedback"]["standard_feedback"][0]["comments"][0][
         "text"
     ] == "Student-specific custom text."


### PR DESCRIPTION
## Summary

* Clarify the reusable Focus Standard comment `purpose` workflow.
* Keep `purpose` as a stable broad feedback-function enum.
* Add optional teacher-facing tags for writing-type-specific organization.
* Explain in the purpose UI that purpose is broad metadata, not a genre taxonomy.
* Explicitly account for creative and narrative writing use cases.
* Add descriptions for each purpose option.
* Reject invalid purpose values and reprompt instead of silently defaulting to `general`.
* Preserve blank-input default to `general`.
* Add optional comma-separated teacher tags.
* Normalize teacher tags to lowercase snake-case.
* Store optional tags under `module_details.teacher_tags`.
* Preserve existing schema version `1` comment compatibility for comments without tags.
* Keep reusable comment lookup based on stable fields; lookup does not depend on tags.
* Update the reusable Focus Standard comment contract.
* Add menu, persistence, validation, normalization, and lookup coverage.

## Validation

* Ran `.\run_tests.ps1`
* Pytest: `1156 passed`
* Ruff: passed
* Mypy: no issues found in 157 source files
* Built-in whitespace check: passed
* Ran `git diff --check`
* Diff check: passed
* Targeted pytest: `56 passed`
* Targeted Ruff: passed
* Targeted mypy: passed
* Manual prompt smoke test confirmed:

  * invalid purpose `character` is rejected and reprompted
  * subsequent valid purpose `style` is accepted
  * `Character, Scene Development, dialogue` normalizes to `["character", "scene_development", "dialogue"]`
  * blank purpose saves `general`
  * optional tags persist correctly
  * lookup behavior remains tag-independent

Closes #260
