### PR TITLE
Improve student feedback standard display

### DIFF
--- a/docs/feedback_export_contract.md
+++ b/docs/feedback_export_contract.md
@@ -226,7 +226,7 @@ Canonical pds-core workspace path:
 standards/library.json
 ```
 
-When available, the standards library may be used to resolve student-facing display labels for Focus Standards.
+When available, the standards library must be used to resolve student-facing display information for Focus Standards.
 
 The export may use:
 
@@ -236,16 +236,19 @@ The export may use:
 * subject;
 * course;
 * domain; and
-* description, if appropriate for student-facing display.
+* description.
 
 Durable references remain the pds-core `standard_id` values stored in Quillan records.
 
 Rules:
 
 * Quillan does not own, mutate, import, retire, reactivate, or authoritatively redefine standards during feedback export.
-* If a standard definition cannot be resolved, the export may fall back to the durable `standard_id`.
+* When the standards library provides a non-empty description for a Focus Standard, the student feedback export must display that full description under the standard heading.
+* The export must not summarize, rewrite, simplify, abbreviate, paraphrase, or omit an available description based on presentation judgment.
+* If a standard definition cannot be resolved, or its display metadata is empty, the export must fall back safely to the durable `standard_id`.
 * Missing display metadata must not block export when the teacher has already completed review data.
-* Missing display metadata must not cause Quillan to invent standard labels.
+* Missing display metadata must not cause Quillan to invent standard titles or descriptions.
+* The durable `standard_id` remains the stored reference in canonical assignment and review records; resolved display information is export-only presentation data.
 
 ## Teacher-Controlled Source Rules
 
@@ -382,6 +385,7 @@ assignment.json.focus_standard_ids
 Each Focus Standard section may include:
 
 * standard display code or title, when resolved from pds-core;
+* the full standard description, when the resolved record provides one;
 * durable `standard_id`, when useful;
 * overall Focus Standard rating, when selected for feedback;
 * rating label from the assignment rating scale;
@@ -405,6 +409,7 @@ Your evidence is relevant and usually well chosen. To improve, make sure each qu
 Rules:
 
 * Focus Standard sections should be student-readable.
+* A resolved non-empty standard description is required display content, not optional formatting polish.
 * Internal IDs such as `observation_id`, `unit_id`, `feedback_comment_id`, and `requirement_check_id` should not appear in ordinary student-facing output.
 * Durable `standard_id` may appear if needed for clarity, but teacher-facing display fields should be preferred when available.
 * A section should not imply that missing feedback equals failure.

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -12,11 +12,17 @@ from typing import Any, cast
 
 from pds_core.classes import load_class_roster
 from pds_core.rosters import RosterError, student_display_name
+from pds_core.standards import StandardsValidationError, find_standard_definition
+from pds_core.standards_selection import (
+    load_standards_for_selection,
+    resolve_standard_selection,
+)
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import inch
 from reportlab.platypus import (
+    HRFlowable,
     Paragraph,
     SimpleDocTemplate,
     Spacer,
@@ -103,7 +109,24 @@ class _StudentFeedback:
     ratings: list[dict[str, Any]]
     comments: list[dict[str, Any]]
     observations: list[dict[str, Any]]
+    standard_sections: list[_FocusStandardFeedbackSection]
     returned_work: dict[str, Any] | None
+
+
+@dataclass(frozen=True, slots=True)
+class _StandardDisplay:
+    standard_id: str
+    code: str | None
+    short_name: str | None
+    description: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _FocusStandardFeedbackSection:
+    display: _StandardDisplay
+    rating: dict[str, Any] | None
+    comments: list[dict[str, Any]]
+    observations: list[dict[str, Any]]
 
 
 def feedback_export_path(
@@ -372,6 +395,7 @@ def _assemble_student_feedback(context: dict[str, Any]) -> _StudentFeedback:
         comments = _included_feedback_comments(review)
         observations = _included_review_unit_observations(review)
         returned_work = None
+    ratings_with_labels = _with_rating_labels(ratings, assignment)
     return _StudentFeedback(
         class_id=class_id,
         assignment_id=assignment_id,
@@ -380,11 +404,78 @@ def _assemble_student_feedback(context: dict[str, Any]) -> _StudentFeedback:
         assignment_title=_assignment_title(assignment, assignment_id),
         class_display=class_id,
         created_at=context["created_at"],
-        ratings=_with_rating_labels(ratings, assignment),
+        ratings=ratings_with_labels,
         comments=comments,
         observations=observations,
+        standard_sections=_focus_standard_sections(
+            context["workspace_root"],
+            assignment,
+            ratings_with_labels,
+            comments,
+            observations,
+        ),
         returned_work=returned_work,
     )
+
+
+def _focus_standard_sections(
+    workspace_root: Path,
+    assignment: dict[str, Any] | None,
+    ratings: list[dict[str, Any]],
+    comments: list[dict[str, Any]],
+    observations: list[dict[str, Any]],
+) -> list[_FocusStandardFeedbackSection]:
+    ordered_ids = list(assignment.get("focus_standard_ids", [])) if assignment else []
+    selected_ids = [
+        str(item["standard_id"])
+        for items in (ratings, comments, observations)
+        for item in items
+    ]
+    for standard_id in selected_ids:
+        if standard_id not in ordered_ids:
+            ordered_ids.append(standard_id)
+    displays = _standard_display_map(workspace_root, ordered_ids)
+    ratings_by_id = {str(item["standard_id"]): item for item in ratings}
+    return [
+        _FocusStandardFeedbackSection(
+            display=displays[standard_id],
+            rating=ratings_by_id.get(standard_id),
+            comments=[item for item in comments if item["standard_id"] == standard_id],
+            observations=[
+                item for item in observations if item["standard_id"] == standard_id
+            ],
+        )
+        for standard_id in ordered_ids
+        if standard_id in selected_ids
+    ]
+
+
+def _standard_display_map(
+    workspace_root: Path, standard_ids: list[str]
+) -> dict[str, _StandardDisplay]:
+    fallback = {
+        standard_id: _StandardDisplay(standard_id, None, None, None)
+        for standard_id in standard_ids
+    }
+    try:
+        library = load_standards_for_selection(workspace_root)
+    except (OSError, StandardsValidationError, ValueError):
+        return fallback
+    for standard_id in standard_ids:
+        try:
+            item = resolve_standard_selection(library, standard_id)
+        except (StandardsValidationError, ValueError):
+            continue
+        definition = find_standard_definition(library, standard_id)
+        fallback[standard_id] = _StandardDisplay(
+            standard_id=standard_id,
+            code=_non_empty(item.code),
+            short_name=_non_empty(item.short_name),
+            description=(
+                _non_empty(definition.description) if definition is not None else None
+            ),
+        )
+    return fallback
 
 
 def _render_feedback_markdown(feedback: _StudentFeedback) -> str:
@@ -402,9 +493,7 @@ def _render_feedback_markdown(feedback: _StudentFeedback) -> str:
         assignment_id=feedback.assignment_id,
         student_id=feedback.student_id,
         created_at=feedback.created_at,
-        ratings=feedback.ratings,
-        comments=feedback.comments,
-        observations=feedback.observations,
+        standard_sections=feedback.standard_sections,
     )
 
 
@@ -414,9 +503,7 @@ def _render_markdown(
     assignment_id: str,
     student_id: str,
     created_at: str,
-    ratings: list[dict[str, Any]],
-    comments: list[dict[str, Any]],
-    observations: list[dict[str, Any]],
+    standard_sections: list[_FocusStandardFeedbackSection],
 ) -> str:
     lines = [
         "# Feedback",
@@ -426,39 +513,51 @@ def _render_markdown(
         f"Student: {_plain_text(student_id)}",
         f"Generated: {_plain_text(created_at)}",
         "",
-        "## Standards Ratings",
+        "---",
+        "",
+        "## Focus Standard Feedback",
         "",
     ]
-    if ratings:
-        for rating in ratings:
-            rendered = (
-                f"- {_plain_text(rating['standard_id'])}: "
-                f"{_format_number(rating['rating'])}"
+    if not standard_sections:
+        lines.append("No Focus Standard feedback selected.")
+    for index, section in enumerate(standard_sections):
+        if index:
+            lines.extend(["", "---", ""])
+        lines.extend([f"### {_plain_text(_standard_heading(section.display))}", ""])
+        if section.display.description:
+            lines.extend(
+                ["Standard:", _plain_text(section.display.description), ""]
             )
-            if rating.get("rationale"):
-                rendered += f" - {_plain_text(rating['rationale'])}"
-            lines.append(rendered)
-    else:
-        lines.append("No standards ratings recorded.")
-
-    lines.extend(["", "## Feedback Comments", ""])
-    if comments:
-        lines.extend(f"- {_plain_text(comment['text'])}" for comment in comments)
-    else:
-        lines.append("No feedback comments selected.")
-    lines.extend(["", "## Review Unit Observations", ""])
-    if observations:
-        for observation in observations:
-            rendered = f"- {_plain_text(observation['standard_id'])}"
-            if observation.get("unit_label"):
-                rendered += f" ({_plain_text(observation['unit_label'])})"
-            if observation.get("rationale"):
-                rendered += f": {_plain_text(observation['rationale'])}"
-            lines.append(rendered)
-    else:
-        lines.append("No review-unit observations selected.")
+        if section.rating:
+            value = _format_number(section.rating["rating"])
+            label = section.rating.get("rating_label")
+            label_suffix = f" ({_plain_text(label)})" if label else ""
+            lines.extend([f"Rating: {value}{label_suffix}", ""])
+            if section.rating.get("rationale"):
+                lines.extend(
+                    ["Rationale:", _plain_text(section.rating["rationale"]), ""]
+                )
+        if section.comments:
+            lines.append("Feedback:")
+            lines.extend(f"- {_plain_text(item['text'])}" for item in section.comments)
+            lines.append("")
+        if section.observations:
+            lines.append("Review-unit observations:")
+            for observation in section.observations:
+                unit = observation.get("unit_label") or "Review unit"
+                rationale = _non_empty(observation.get("rationale"))
+                rendered = f"- {_plain_text(unit)}"
+                if rationale:
+                    rendered += f": {_plain_text(rationale)}"
+                lines.append(rendered)
     lines.append("")
     return "\n".join(lines)
+
+
+def _standard_heading(display: _StandardDisplay) -> str:
+    if display.code and display.short_name:
+        return f"{display.code} — {display.short_name}"
+    return display.code or display.standard_id
 
 
 def _render_returned_work_markdown(
@@ -754,59 +853,56 @@ def _append_standard_feedback_pdf(
     body_style: ParagraphStyle,
     feedback: _StudentFeedback,
 ) -> None:
-    story.append(Paragraph("Focus Standard Ratings", section_style))
-    if feedback.ratings:
-        for rating in feedback.ratings:
-            value = _format_number(rating["rating"])
-            label = rating.get("rating_label")
+    story.append(Paragraph("Focus Standard Feedback", section_style))
+    if not feedback.standard_sections:
+        story.append(Paragraph("No Focus Standard feedback selected.", body_style))
+    for index, section in enumerate(feedback.standard_sections):
+        if index:
+            story.append(Spacer(1, 0.08 * inch))
+            story.append(HRFlowable(width="100%", thickness=0.5, color=colors.grey))
+            story.append(Spacer(1, 0.04 * inch))
+        story.append(
+            Paragraph(
+                f"<b>{_escape_pdf_text(_standard_heading(section.display))}</b>",
+                section_style,
+            )
+        )
+        if section.display.description:
+            story.append(Paragraph("<b>Standard:</b>", body_style))
+            story.append(
+                Paragraph(_escape_pdf_text(section.display.description), body_style)
+            )
+        if section.rating:
+            value = _format_number(section.rating["rating"])
+            label = section.rating.get("rating_label")
             label_suffix = f" ({_plain_text(label)})" if label else ""
             story.append(
                 Paragraph(
-                    "<b>"
-                    f"{_escape_pdf_text(rating['standard_id'])}</b>: "
-                    f"{_escape_pdf_text(value + label_suffix)}",
+                    f"<b>Rating:</b> {_escape_pdf_text(value + label_suffix)}",
                     body_style,
                 )
             )
-            if rating.get("rationale"):
+            if section.rating.get("rationale"):
                 story.append(
                     Paragraph(
-                        f"Rationale: {_escape_pdf_text(rating['rationale'])}",
+                        f"<b>Rationale:</b> "
+                        f"{_escape_pdf_text(section.rating['rationale'])}",
                         body_style,
                     )
                 )
-    else:
-        story.append(Paragraph("No Focus Standard ratings selected.", body_style))
-
-    story.append(Paragraph("Feedback Comments", section_style))
-    if feedback.comments:
-        for comment in feedback.comments:
-            prefix = f"{comment.get('standard_id')}: " if comment.get("standard_id") else ""
+        if section.comments:
+            story.append(Paragraph("<b>Feedback:</b>", body_style))
+        for comment in section.comments:
             story.append(
-                Paragraph(
-                    f"{_escape_pdf_text(prefix)}{_escape_pdf_text(comment['text'])}",
-                    body_style,
-                )
+                Paragraph(f"• {_escape_pdf_text(comment['text'])}", body_style)
             )
-    else:
-        story.append(Paragraph("No feedback comments selected.", body_style))
-
-    if feedback.observations:
-        story.append(Paragraph("Review Unit Observations", section_style))
-        for observation in feedback.observations:
-            evidence = observation.get("evidence_present")
-            evidence_text = ""
-            if evidence is True:
-                evidence_text = " Evidence present: yes."
-            elif evidence is False:
-                evidence_text = " Evidence present: no."
+        if section.observations:
+            story.append(Paragraph("<b>Review-unit observations:</b>", body_style))
+        for observation in section.observations:
             unit = observation.get("unit_label") or "Review unit"
-            text = (
-                f"{unit} - {observation['standard_id']}."
-                f"{evidence_text}"
-            )
+            text = f"• {_plain_text(unit)}"
             if observation.get("rationale"):
-                text += f" {_plain_text(observation['rationale'])}"
+                text += f": {_plain_text(observation['rationale'])}"
             story.append(Paragraph(_escape_pdf_text(text), body_style))
 
 

--- a/tests/test_cli_feedback_export.py
+++ b/tests/test_cli_feedback_export.py
@@ -87,7 +87,9 @@ def test_cli_exports_feedback_and_prints_summary(
     ).read_text(encoding="utf-8")
     assert "Existing selected language." in content
     assert "Excluded comment." not in content
-    assert "- synthetic:W.A: 3 - Uses evidence." in content
+    assert "### synthetic:W.A" in content
+    assert "Rating: 3" in content
+    assert "Rationale:\nUses evidence." in content
     assert review_path.read_bytes() == review_before
 
 

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -8,6 +8,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from pds_core.standards import (
+    StandardDefinition,
+    StandardsLibrary,
+    StandardsProfile,
+    write_workspace_standards_library,
+)
 
 from quillan.feedback_export import (
     ExportedFeedback,
@@ -27,6 +33,10 @@ from tests.test_review_tags import (
 )
 
 TIMESTAMP = "2026-06-23T12:30:00+00:00"
+STANDARD_DESCRIPTION = (
+    "Cite a range of thorough textual evidence and make relevant connections "
+    "to support analysis."
+)
 
 
 def _write_assignment(root: Path) -> None:
@@ -65,6 +75,30 @@ def _write_assignment(root: Path) -> None:
     }
     (assignment_dir / "assignment.json").write_text(
         json.dumps(assignment), encoding="utf-8"
+    )
+
+
+def _write_standards_library(root: Path) -> None:
+    write_workspace_standards_library(
+        root,
+        StandardsLibrary(
+            standards=(
+                StandardDefinition(
+                    standard_id="synthetic:W.A",
+                    code="RL.CR.9-10.1",
+                    source="Synthetic standards",
+                    short_name="Cite Textual Evidence",
+                    description=STANDARD_DESCRIPTION,
+                    available_modules=("quillan",),
+                ),
+            ),
+            profiles=(
+                StandardsProfile(
+                    profile_id="synthetic_profile",
+                    standards=("synthetic:W.A",),
+                ),
+            ),
+        ),
     )
 
 
@@ -202,9 +236,9 @@ def test_exports_ordered_student_content_without_mutating_sources(
     assert f"Assignment: {ASSIGNMENT_ID}" in content
     assert f"Student: {STUDENT_ID}" in content
     assert f"Generated: {TIMESTAMP}" in content
-    assert content.index("- synthetic:W.A: 3 - Uses evidence.") < content.index(
-        "- synthetic:W.B: 4"
-    )
+    assert content.index("### synthetic:W.A") < content.index("### synthetic:W.B")
+    assert "Rating: 3" in content
+    assert "Rationale:\nUses evidence." in content
     assert content.index(
         "- First student comment. With a second line."
     ) < content.index("- Second student comment.")
@@ -230,8 +264,63 @@ def test_empty_scores_and_comments_have_clear_messages(tmp_path: Path) -> None:
     )
 
     content = result.feedback_path.read_text(encoding="utf-8")
-    assert "No standards ratings recorded." in content
-    assert "No feedback comments selected." in content
+    assert "No Focus Standard feedback selected." in content
+
+
+def test_groups_feedback_under_resolved_standard_with_full_description(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_assignment(tmp_path)
+    _write_standards_library(tmp_path)
+    review = _review("feedback_composed")
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "synthetic:W.A",
+            "rating": 1,
+            "rationale": "Teacher rationale unchanged.",
+            "include_in_feedback": True,
+            "updated_at": review["updated_at"],
+            "module_details": {},
+        }
+    ]
+    review["feedback"]["standard_feedback"] = [
+        {
+            "standard_id": "synthetic:W.A",
+            "include_overall_rating": True,
+            "include_overall_rationale": True,
+            "included_observation_ids": [],
+            "comments": [
+                {
+                    "feedback_comment_id": "feedback_comment_0001",
+                    "source": "custom",
+                    "text": "Student comment unchanged.",
+                    "reusable_comment_id": None,
+                    "save_for_reuse": False,
+                    "include_in_feedback": True,
+                    "created_at": review["created_at"],
+                    "module_details": {},
+                }
+            ],
+            "module_details": {},
+        }
+    ]
+    _write_review(tmp_path, review)
+
+    result = export_student_feedback(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+    content = result.feedback_path.read_text(encoding="utf-8")
+
+    heading = "### RL.CR.9-10.1 — Cite Textual Evidence"
+    assert heading in content
+    assert STANDARD_DESCRIPTION in content
+    assert "Rating: 1 (Developing)" in content
+    assert content.index(heading) < content.index(STANDARD_DESCRIPTION)
+    assert content.index(STANDARD_DESCRIPTION) < content.index("Rating: 1 (Developing)")
+    assert content.index("Rating: 1 (Developing)") < content.index("Feedback:")
+    assert "synthetic:W.A" not in content
+    assert "\n---\n" in content
 
 
 def test_exports_returned_work_notice_without_standards_ratings(
@@ -581,7 +670,8 @@ def test_export_respects_composed_feedback_options_and_selected_observations(
     )
     text = result.feedback_path.read_text(encoding="utf-8")
 
-    assert "- synthetic:W.A: 3" in text
+    assert "### synthetic:W.A" in text
+    assert "Rating: 3" in text
     assert "Hidden rationale." not in text
     assert "Reusable snapshot text." in text
     assert "Excluded custom text." not in text

--- a/tests/test_feedback_pdf_export.py
+++ b/tests/test_feedback_pdf_export.py
@@ -18,7 +18,12 @@ from quillan.feedback_export import (
     feedback_pdf_export_path,
 )
 from quillan.review_record_paths import review_record_path
-from tests.test_feedback_export import TIMESTAMP, _write_assignment
+from tests.test_feedback_export import (
+    STANDARD_DESCRIPTION,
+    TIMESTAMP,
+    _write_assignment,
+    _write_standards_library,
+)
 from tests.test_review_scores import _write_manifest, _write_review
 from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID, _review
 
@@ -192,6 +197,7 @@ def test_normal_pdf_export_creates_student_facing_pdf_and_metadata(
         "reusable_comment_id",
         "comment_set_id",
         "observation_id",
+        "unit_id",
         "review.json",
         "private_reusable_comment",
         "private_set",
@@ -214,6 +220,28 @@ def test_normal_pdf_export_creates_student_facing_pdf_and_metadata(
         "module_details": {},
     }
     assert review_after["exports"]["feedback_markdown"] is None
+
+
+def test_pdf_uses_resolved_standard_heading_and_full_description(tmp_path: Path) -> None:
+    _write_roster(tmp_path)
+    _write_manifest(tmp_path)
+    _write_assignment_with_rating_labels(tmp_path)
+    _write_standards_library(tmp_path)
+    _write_review(tmp_path, _feedback_ready_review())
+
+    result = export_student_feedback_pdf(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+    text = _pdf_text(result.feedback_pdf_path)
+
+    assert "RL.CR.9-10.1" in text
+    assert "Cite Textual Evidence" in text
+    assert STANDARD_DESCRIPTION in text
+    assert text.index("RL.CR.9-10.1") < text.index(STANDARD_DESCRIPTION)
+    assert text.index(STANDARD_DESCRIPTION) < text.index("Rating:")
+    assert text.index("Rating:") < text.index("Feedback:")
+    assert text.index("Feedback:") < text.index("Review-unit observations:")
+    assert "synthetic:W.A" not in text
 
 
 def test_pdf_export_falls_back_to_student_id_without_roster(tmp_path: Path) -> None:

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -370,7 +370,9 @@ def test_menu_export_student_feedback_creates_feedback_file(
     assert feedback_path.is_file()
 
     feedback_text = feedback_path.read_text(encoding="utf-8")
-    assert "- njsls-ela:W.1: 3 - Good work." in feedback_text
+    assert "### njsls-ela:W.1" in feedback_text
+    assert "Rating: 3" in feedback_text
+    assert "Rationale:\nGood work." in feedback_text
     assert "- Good work." in feedback_text
     assert "This should not appear in student feedback." not in feedback_text
     assert manifest_path.read_bytes() == manifest_before

--- a/tests/test_v070_smoke.py
+++ b/tests/test_v070_smoke.py
@@ -294,8 +294,7 @@ def test_v070_synthetic_teacher_review_and_export_workflow(
         submission_path.parent / "exports" / "feedback.md"
     )
     feedback_text = feedback.feedback_path.read_text(encoding="utf-8")
-    assert "No standards ratings recorded." in feedback_text
-    assert "No feedback comments selected." in feedback_text
+    assert "No Focus Standard feedback selected." in feedback_text
     for private_value in (
         "Private synthetic teacher note.",
         comment_text,

--- a/tests/test_v080_end_to_end_smoke.py
+++ b/tests/test_v080_end_to_end_smoke.py
@@ -366,7 +366,7 @@ def test_v080_scan_review_export_end_to_end_smoke(
     feedback_text = feedback_path.read_text(encoding="utf-8")
     assert f"Assignment: {ASSIGNMENT_ID}" in feedback_text
     assert "Teacher Notes" not in feedback_text
-    assert "No standards ratings recorded." in feedback_text
+    assert "No Focus Standard feedback selected." in feedback_text
 
     class_summary_text = class_summary_path.read_text(encoding="utf-8")
     assert STUDENT_ID in class_summary_text


### PR DESCRIPTION
## Summary

* Improve student-facing feedback export readability for Focus Standard feedback.
* Group ratings, rationales, comments, and selected review-unit observations by Focus Standard.
* Resolve and display student-friendly Focus Standard metadata:

  * standard code
  * short name/title
  * complete standards-library description
* Preserve assignment Focus Standard order.
* Display full standard descriptions whenever available from the standards library.
* Fall back safely to durable `standard_id` when standards metadata is missing or invalid.
* Add Markdown horizontal rules for clearer section separation.
* Add PDF dividers for clearer visual separation.
* Preserve teacher-entered ratings, rationales, comments, and observation text unchanged.
* Keep private notes, internal IDs, provenance, and unselected content hidden.
* Preserve returned-work export behavior.
* Update `docs/feedback_export_contract.md` to document the student-facing standard display contract.

## Validation

* Ran `.\.venv\Scripts\python.exe -m pytest tests\test_feedback_export.py tests\test_feedback_pdf_export.py -q`
* Targeted pytest: `30 passed`
* Ran `.\run_tests.ps1`
* Full pytest: `1158 passed`
* Ran `.\.venv\Scripts\python.exe -m ruff check .`
* Ruff: passed
* Ran `.\.venv\Scripts\python.exe -m mypy .`
* Mypy: no issues found in 157 source files
* Ran `git diff --check`
* Diff check: passed
* Markdown smoke/test coverage confirmed:

  * resolved standard headings
  * exact full standards-library descriptions
  * rating display
  * Focus Standard grouping
  * section dividers
  * safe metadata fallback
* PDF extraction coverage confirmed:

  * same standard ordering and grouping
  * resolved headings
  * full descriptions
  * rating/rationale/comment/observation ordering
  * hidden private/internal fields
* Returned-work behavior remains unchanged.

Closes #261
