### PR TITLE
Add student performance summary export

### DIFF
--- a/docs/assignment_reporting_contract.md
+++ b/docs/assignment_reporting_contract.md
@@ -38,8 +38,8 @@ Those broader questions belong to a future Paper Data Suite reporting module.
 ## Status
 
 This is the active assignment-level reporting contract for the v0.8.6
-standards-based workflow redesign. Runtime exports support assignment-local
-class summary CSVs and Focus Standard summary CSVs from schema version `2`
+standards-based workflow redesign. Runtime exports support compact student
+performance, comprehensive class, and Focus Standard summary CSVs from schema version `2`
 review records. Some optional future formats, such as PDFs or assignment
 results manifests, may remain contract guidance, but the active reporting
 workflow is no longer the legacy schema version `1` tag/comment/score summary
@@ -68,9 +68,26 @@ Assignment-level reports are derived artifacts generated from canonical Quillan 
 
 Quillan owns three target assignment-local reporting artifacts.
 
-### Assignment-Level Class Summary
+### Student Performance Summary
 
-A teacher-facing summary of review progress, requirement status, feedback export status, and overall Focus Standard ratings for one class and one assignment.
+The ordinary teacher-facing student-by-standard report. It answers which
+rating each student received on each assignment Focus Standard without
+including internal record paths or routine workflow diagnostics.
+
+```text
+classes/<class_id>/assignments/<assignment_id>/exports/student_performance_summary.csv
+```
+
+It contains student identity, review status, minimum-requirement status,
+actionable flags, and one compact rating cell per Focus Standard in assignment
+order. Missing and returned ratings remain missing; they are never converted
+to zero or the lowest rating.
+
+### Comprehensive Class Summary
+
+An audit/troubleshooting summary of record validity and paths, review progress,
+requirement status, feedback export status, and detailed Focus Standard fields.
+`class_summary.csv` remains its backward-compatible path.
 
 Suggested paths:
 
@@ -79,7 +96,7 @@ classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
 classes/<class_id>/assignments/<assignment_id>/exports/class_summary.pdf
 ```
 
-### Assignment-Level Focus Standard Summary
+### Standards Summary
 
 A teacher-facing summary of Focus Standard performance for one class and one assignment.
 

--- a/quillan/class_summary_export.py
+++ b/quillan/class_summary_export.py
@@ -1,4 +1,4 @@
-"""Teacher-facing assignment-local class summary CSV export."""
+"""Comprehensive assignment-local class summary CSV for audit/troubleshooting."""
 
 from __future__ import annotations
 
@@ -79,7 +79,7 @@ def class_summary_export_path(
     class_id: str,
     assignment_id: str,
 ) -> Path:
-    """Return the canonical assignment-local class summary CSV path."""
+    """Return the compatibility path for the comprehensive class summary."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
     return (

--- a/quillan/cli_app/handlers/exports.py
+++ b/quillan/cli_app/handlers/exports.py
@@ -14,6 +14,7 @@ from quillan.cli_app.output import (
     print_exported_class_summary,
     print_exported_feedback,
     print_exported_feedback_pdf,
+    print_exported_student_performance_summary,
     print_exported_standards_summary,
 )
 from quillan.feedback_export import (
@@ -24,6 +25,10 @@ from quillan.feedback_export import (
 from quillan.standards_summary_export import (
     StandardsSummaryExportError,
     export_standards_summary,
+)
+from quillan.student_performance_summary_export import (
+    StudentPerformanceSummaryExportError,
+    export_student_performance_summary,
 )
 
 
@@ -69,7 +74,7 @@ def handle_export_feedback(args: argparse.Namespace) -> int:
 
 
 def handle_export_class_summary(args: argparse.Namespace) -> int:
-    """Export one teacher-facing assignment class summary CSV."""
+    """Export one comprehensive assignment class summary CSV."""
     try:
         workspace_root = resolve_workspace_root()
         exported = export_class_review_summary(
@@ -83,6 +88,20 @@ def handle_export_class_summary(args: argparse.Namespace) -> int:
         return 1
 
     print_exported_class_summary(exported)
+    return 0
+
+
+def handle_export_student_performance_summary(args: argparse.Namespace) -> int:
+    """Export one compact teacher-facing student performance summary CSV."""
+    try:
+        workspace_root = resolve_workspace_root()
+        exported = export_student_performance_summary(
+            workspace_root, args.class_id, args.assignment_id, overwrite=args.overwrite
+        )
+    except (WorkspaceRootError, StudentPerformanceSummaryExportError) as error:
+        print(f"Error: could not export student performance summary: {error}")
+        return 1
+    print_exported_student_performance_summary(exported)
     return 0
 
 

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -35,6 +35,9 @@ from quillan.review_tags import AddedReviewTag
 from quillan.route_planning import RouteFailure
 from quillan.routing_review import RoutingReviewRecord
 from quillan.standards_summary_export import ExportedStandardsSummary
+from quillan.student_performance_summary_export import (
+    ExportedStudentPerformanceSummary,
+)
 from quillan.submission_review_opening import OpenedSubmissionReview
 from quillan.submission_review_state import UpdatedSubmissionReviewState
 from quillan.submission_status import AssignmentSubmissionStatus
@@ -316,7 +319,8 @@ def print_exported_feedback_pdf(exported: ExportedFeedbackPdf) -> None:
 
 def print_exported_class_summary(exported: ExportedClassSummary) -> None:
     """Print a concise teacher-facing class summary export result."""
-    print("Exported assignment-local class summary:")
+    print("Exported assignment-local class summary: Comprehensive Class Summary")
+    print("Purpose: audit/troubleshooting")
     print(f"Class: {exported.class_id}")
     print(f"Assignment: {exported.assignment_id}")
     print(f"Rows: {exported.row_count}")
@@ -332,6 +336,22 @@ def print_exported_class_summary(exported: ExportedClassSummary) -> None:
     )
     print(f"Feedback PDF present: {exported.feedback_pdf_present_count}")
     print(f"Feedback PDF stale: {exported.feedback_pdf_stale_count}")
+    print(f"Overwrote existing: {format_bool(exported.overwrote_existing)}")
+    print(f"Summary file: {exported.summary_relative_path}")
+
+
+def print_exported_student_performance_summary(
+    exported: ExportedStudentPerformanceSummary,
+) -> None:
+    """Print a concise student performance summary export result."""
+    print("Exported Student Performance Summary:")
+    print(f"Class: {exported.class_id}")
+    print(f"Assignment: {exported.assignment_id}")
+    print(f"Rows: {exported.row_count}")
+    print(f"Reviewed: {exported.reviewed_count}")
+    print(f"Returned without full review: {exported.returned_without_full_review_count}")
+    print(f"Missing submission: {exported.missing_submission_count}")
+    print(f"Missing review: {exported.missing_review_count}")
     print(f"Overwrote existing: {format_bool(exported.overwrote_existing)}")
     print(f"Summary file: {exported.summary_relative_path}")
 

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -9,6 +9,7 @@ from quillan.cli_app.arguments import positive_integer
 from quillan.cli_app.handlers.exports import (
     handle_export_class_summary,
     handle_export_feedback,
+    handle_export_student_performance_summary,
     handle_export_standards_summary,
 )
 from quillan.cli_app.handlers.decoding import handle_decode_scan
@@ -246,9 +247,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     export_class_summary_parser = subparsers.add_parser(
         "export-class-summary",
-        help="Export an assignment-local class summary CSV.",
+        aliases=["export-comprehensive-class-summary"],
+        help="Export a comprehensive assignment-local class summary CSV for audit/troubleshooting.",
         description=(
-            "Generate a teacher-facing assignment-local CSV summary from "
+            "Generate a comprehensive audit/troubleshooting CSV summary from "
             "existing submission and review records for one class assignment. "
             "The export reports submission/review status, minimum-requirement "
             "outcomes, Focus Standard ratings, and feedback export status. It "
@@ -262,6 +264,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Replace an existing exports/class_summary.csv file.",
     )
     export_class_summary_parser.set_defaults(handler=handle_export_class_summary)
+
+    export_student_performance_parser = subparsers.add_parser(
+        "export-student-performance-summary",
+        help="Export a compact student-by-Focus-Standard performance summary CSV.",
+        description=(
+            "Generate the ordinary teacher-facing student performance report with "
+            "review status, minimum requirements, and one readable rating column "
+            "per assignment Focus Standard."
+        ),
+    )
+    _add_assignment_identity_arguments(export_student_performance_parser)
+    export_student_performance_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing exports/student_performance_summary.csv file.",
+    )
+    export_student_performance_parser.set_defaults(
+        handler=handle_export_student_performance_summary
+    )
 
     export_standards_summary_parser = subparsers.add_parser(
         "export-standards-summary",

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -34,6 +34,7 @@ from quillan.cli_app.output import (
     print_exported_class_summary,
     print_exported_feedback,
     print_exported_feedback_pdf,
+    print_exported_student_performance_summary,
     print_exported_standards_summary,
     print_completed_overall_standard_ratings,
     print_completed_review_unit_observations,
@@ -63,6 +64,10 @@ from quillan.focus_standard_comments import (
 from quillan.standards_summary_export import (
     StandardsSummaryExportError,
     export_standards_summary,
+)
+from quillan.student_performance_summary_export import (
+    StudentPerformanceSummaryExportError,
+    export_student_performance_summary,
 )
 from quillan.tag_bank_writing import list_valid_tag_banks
 from quillan.review_notes import ReviewNoteError, add_review_note
@@ -5095,6 +5100,23 @@ def _menu_export_standards_summary(
     print_exported_standards_summary(exported)
 
 
+def _menu_export_student_performance_summary(
+    workspace_root: Path, class_id: str, assignment_id: str
+) -> None:
+    overwrite = _prompt_overwrite_export()
+    if overwrite is _CANCEL:
+        return
+    assert isinstance(overwrite, bool)
+    try:
+        exported = export_student_performance_summary(
+            workspace_root, class_id, assignment_id, overwrite=overwrite
+        )
+    except (StudentPerformanceSummaryExportError, OSError) as error:
+        print(f"Error: could not export student performance summary: {error}")
+        return
+    print_exported_student_performance_summary(exported)
+
+
 def _launch_assignment_review_actions(
     workspace_root: Path,
     class_id: str,
@@ -5120,9 +5142,9 @@ def _launch_assignment_review_actions(
 
         print("1. Select student/submission")
         print("2. Assemble routed submissions")
-        print("3. Export assignment-local class summary")
-        print("4. Export assignment-local Focus Standard summary")
-        print("5. Refresh submission status")
+        print("3. Export assignment-local class summary — Comprehensive Class Summary")
+        print("4. Export assignment-local Focus Standard summary — Standards Summary")
+        print("5. Export Student Performance Summary")
         print_navigation_options()
         print()
 
@@ -5153,7 +5175,10 @@ def _launch_assignment_review_actions(
             _menu_export_standards_summary(workspace_root, class_id, assignment_id)
             input("Press Enter to continue...")
         elif choice == "5":
-            continue
+            _menu_export_student_performance_summary(
+                workspace_root, class_id, assignment_id
+            )
+            input("Press Enter to continue...")
         else:
             print("Invalid selection. Please enter a number from 1 to 6.")
             input("Press Enter to continue...")

--- a/quillan/student_performance_summary_export.py
+++ b/quillan/student_performance_summary_export.py
@@ -1,0 +1,278 @@
+"""Compact teacher-facing student-by-standard performance summary export."""
+
+from __future__ import annotations
+
+import csv
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.standards import find_standard_definition, load_workspace_standards_library
+
+from quillan.assignment_summary_context import (
+    LoadedStudentRecord,
+    discover_students,
+    load_assignment,
+    load_student_record,
+    rating_labels,
+    relative_path_for,
+)
+
+MISSING_RATING = ""
+BASE_CSV_COLUMNS = (
+    "student_id",
+    "student_display_name",
+    "review_status",
+    "minimum_requirements",
+)
+
+
+class StudentPerformanceSummaryExportError(Exception):
+    """Raised when a student performance summary cannot be exported safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExportedStudentPerformanceSummary:
+    """Information about one generated student performance summary."""
+
+    class_id: str
+    assignment_id: str
+    summary_path: Path
+    summary_relative_path: str
+    row_count: int
+    reviewed_count: int
+    returned_without_full_review_count: int
+    missing_submission_count: int
+    missing_review_count: int
+    invalid_submission_count: int
+    invalid_review_count: int
+    identity_mismatch_count: int
+    created_at: str
+    overwrote_existing: bool
+
+
+def student_performance_summary_export_path(
+    workspace_root: str | Path, class_id: str, assignment_id: str
+) -> Path:
+    """Return the assignment-local student performance summary CSV path."""
+    _validate_identifier(class_id, "class_id")
+    _validate_identifier(assignment_id, "assignment_id")
+    return (
+        Path(workspace_root)
+        / "classes"
+        / class_id
+        / "assignments"
+        / assignment_id
+        / "exports"
+        / "student_performance_summary.csv"
+    )
+
+
+def export_student_performance_summary(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    *,
+    overwrite: bool = False,
+    created_at: datetime | str | None = None,
+) -> ExportedStudentPerformanceSummary:
+    """Export one compact row per rostered or discovered student."""
+    timestamp = _normalize_timestamp(created_at)
+    try:
+        root = Path(workspace_root).resolve(strict=False)
+        path = student_performance_summary_export_path(root, class_id, assignment_id)
+        assignment = load_assignment(root, class_id, assignment_id)
+        standard_ids = list(assignment["focus_standard_ids"])
+        labels = rating_labels(assignment)
+        records = [
+            load_student_record(student, class_id, assignment_id)
+            for student in discover_students(root, class_id, assignment_id)
+        ]
+        headers, metadata_missing = _standard_headers(root, standard_ids)
+    except (OSError, RuntimeError, ValueError, StudentPerformanceSummaryExportError) as error:
+        raise StudentPerformanceSummaryExportError(str(error)) from error
+
+    existed = path.exists()
+    if existed and not overwrite:
+        raise StudentPerformanceSummaryExportError(
+            f"Student performance summary export already exists: {path}. "
+            "Use --overwrite to replace it."
+        )
+    rows = [
+        _student_row(record, standard_ids, headers, labels, metadata_missing)
+        for record in records
+    ]
+    _write_csv(path, rows, BASE_CSV_COLUMNS + tuple(headers.values()) + ("notes_flags",), overwrite)
+    return ExportedStudentPerformanceSummary(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        summary_path=path,
+        summary_relative_path=relative_path_for(path, root),
+        row_count=len(rows),
+        reviewed_count=sum(row["review_status"] == "Reviewed" for row in rows),
+        returned_without_full_review_count=sum(row["review_status"] == "Returned" for row in rows),
+        missing_submission_count=_warning_count(records, "missing_submission"),
+        missing_review_count=_warning_count(records, "missing_review"),
+        invalid_submission_count=_warning_count(records, "invalid_submission"),
+        invalid_review_count=_warning_count(records, "invalid_review"),
+        identity_mismatch_count=_warning_count(records, "identity_mismatch"),
+        created_at=timestamp,
+        overwrote_existing=existed,
+    )
+
+
+def _standard_headers(root: Path, standard_ids: list[str]) -> tuple[dict[str, str], set[str]]:
+    try:
+        library = load_workspace_standards_library(root)
+    except OSError:
+        library = None
+    headers: dict[str, str] = {}
+    missing: set[str] = set()
+    used: set[str] = set()
+    for standard_id in standard_ids:
+        definition = None if library is None else find_standard_definition(library, standard_id)
+        header = standard_id
+        if definition is not None:
+            header = f"{definition.code} — {definition.short_name}"
+        else:
+            missing.add(standard_id)
+        if header in used:
+            header = standard_id
+        used.add(header)
+        headers[standard_id] = header
+    return headers, missing
+
+
+def _student_row(
+    loaded: LoadedStudentRecord,
+    standard_ids: list[str],
+    headers: dict[str, str],
+    labels: dict[int, str],
+    metadata_missing: set[str],
+) -> dict[str, str]:
+    review = loaded.review
+    warnings = list(loaded.warnings)
+    if metadata_missing:
+        warnings.append("standard_metadata_missing")
+    returned = _returned(review)
+    ratings: dict[str, dict[str, Any]] = {}
+    if review is not None:
+        for rating in review["overall_standard_ratings"]:
+            standard_id = str(rating["standard_id"])
+            if standard_id not in standard_ids:
+                warnings.append("rating_for_non_assignment_standard")
+            else:
+                ratings[standard_id] = rating
+
+    row = {
+        "student_id": loaded.student.student_id,
+        "student_display_name": loaded.student.display_name,
+        "review_status": _review_status(loaded),
+        "minimum_requirements": _minimum_requirements(review),
+    }
+    for standard_id in standard_ids:
+        rating = None if returned else ratings.get(standard_id)
+        if rating is None:
+            row[headers[standard_id]] = MISSING_RATING
+            continue
+        value = int(rating["rating"])
+        label = labels.get(value)
+        if label is None:
+            warnings.append("unknown_rating_value")
+        row[headers[standard_id]] = str(value) if label is None else f"{value} - {label}"
+    if returned:
+        warnings.append("returned_without_full_review")
+    row["notes_flags"] = ";".join(dict.fromkeys(warnings))
+    return row
+
+
+def _review_status(loaded: LoadedStudentRecord) -> str:
+    warnings = set(loaded.warnings)
+    if "identity_mismatch" in warnings:
+        return "Needs attention"
+    if "invalid_submission" in warnings:
+        return "Invalid submission"
+    if "missing_submission" in warnings:
+        return "Not submitted"
+    if "invalid_review" in warnings:
+        return "Invalid review"
+    if loaded.review is None:
+        return "Not reviewed"
+    if _returned(loaded.review):
+        return "Returned"
+    state = str(loaded.review["review_state"])
+    if state in {"ready_for_export", "reviewed", "completed"}:
+        return "Reviewed"
+    if state in {"in_progress", "reviewing"}:
+        return "In progress"
+    return "Not reviewed"
+
+
+def _minimum_requirements(review: dict[str, Any] | None) -> str:
+    if review is None:
+        return "Not checked"
+    outcome = review["minimum_requirement_outcome"]
+    if outcome["returned_without_full_review"]:
+        return "Not met"
+    return {"met": "Met", "not_met": "Not met", "not_checked": "Not checked"}.get(
+        str(outcome["status"]), str(outcome["status"]).replace("_", " ").title()
+    )
+
+
+def _returned(review: dict[str, Any] | None) -> bool:
+    return review is not None and bool(
+        review["minimum_requirement_outcome"]["returned_without_full_review"]
+    )
+
+
+def _warning_count(records: list[LoadedStudentRecord], warning: str) -> int:
+    return sum(warning in record.warnings for record in records)
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]], fields: tuple[str, ...], overwrite: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", newline="", prefix=f".{path.name}.",
+            suffix=".tmp", dir=path.parent, delete=False
+        ) as file:
+            temporary = Path(file.name)
+            writer = csv.DictWriter(file, fieldnames=fields, lineterminator="\n")
+            writer.writeheader()
+            writer.writerows(rows)
+            file.flush()
+            os.fsync(file.fileno())
+        if overwrite:
+            os.replace(temporary, path)
+        else:
+            os.link(temporary, path)
+            temporary.unlink()
+        temporary = None
+    except (OSError, csv.Error) as error:
+        raise StudentPerformanceSummaryExportError(
+            f"Could not write student performance summary export {path}: {error}"
+        ) from error
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    parsed = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise StudentPerformanceSummaryExportError("created_at must be timezone-aware.")
+    return value.isoformat() if isinstance(value, datetime) else value
+
+
+def _validate_identifier(value: str, field: str) -> None:
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise StudentPerformanceSummaryExportError(str(error)) from error

--- a/tests/test_student_performance_summary_export.py
+++ b/tests/test_student_performance_summary_export.py
@@ -1,0 +1,100 @@
+"""Tests for the compact student performance summary export."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from quillan.student_performance_summary_export import (
+    MISSING_RATING,
+    export_student_performance_summary,
+)
+from tests.test_class_summary_export import (
+    STANDARD_A,
+    STANDARD_B,
+    _student_dir,
+    _write_assignment,
+    _write_json,
+    _write_records,
+    _write_roster,
+)
+from tests.test_review_tags import ASSIGNMENT_ID, CLASS_ID
+
+
+def test_compact_rows_preserve_missing_and_returned_ratings(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_roster(tmp_path)
+    _, reviewed_path, reviewed = _write_records(tmp_path, "00100")
+    reviewed["minimum_requirement_outcome"]["status"] = "met"
+    reviewed["minimum_requirement_outcome"]["updated_at"] = reviewed["updated_at"]
+    reviewed["overall_standard_ratings"] = [
+        {
+            "standard_id": STANDARD_A,
+            "rating": 3,
+            "rationale": "Synthetic rationale.",
+            "include_in_feedback": True,
+            "updated_at": reviewed["updated_at"],
+            "module_details": {},
+        }
+    ]
+    _write_json(reviewed_path, reviewed)
+    _, returned_path, returned = _write_records(tmp_path, "00200")
+    returned["minimum_requirement_outcome"].update(
+        {
+            "status": "returned_without_full_review",
+            "returned_without_full_review": True,
+            "updated_at": returned["updated_at"],
+        }
+    )
+    returned["review_state"] = "returned_without_full_review"
+    _write_json(returned_path, returned)
+    _student_dir(tmp_path, "00300").mkdir(parents=True)
+    missing_review_manifest, _, _ = _write_records(tmp_path, "00400")
+    missing_review_manifest.parent.joinpath("review.json").unlink()
+    invalid_submission_dir = _student_dir(tmp_path, "00500")
+    invalid_submission_dir.mkdir(parents=True)
+    invalid_submission_dir.joinpath("submission.json").write_text(
+        "not json", encoding="utf-8"
+    )
+    _, invalid_review_path, _ = _write_records(tmp_path, "00600")
+    invalid_review_path.write_text("not json", encoding="utf-8")
+
+    result = export_student_performance_summary(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+    with result.summary_path.open(encoding="utf-8", newline="") as file:
+        reader = csv.DictReader(file)
+        fields = reader.fieldnames or []
+        rows = {row["student_id"]: row for row in reader}
+
+    assert fields == [
+        "student_id",
+        "student_display_name",
+        "review_status",
+        "minimum_requirements",
+        STANDARD_A,
+        STANDARD_B,
+        "notes_flags",
+    ]
+    assert rows["00100"][STANDARD_A] == "3 - Secure"
+    assert rows["00100"][STANDARD_B] == MISSING_RATING
+    assert rows["00200"]["review_status"] == "Returned"
+    assert rows["00200"][STANDARD_A] == MISSING_RATING
+    assert "returned_without_full_review" in rows["00200"]["notes_flags"]
+    assert rows["00900"]["review_status"] == "Not submitted"
+    assert "missing_submission" in rows["00900"]["notes_flags"]
+    assert rows["00900"][STANDARD_A] == ""
+    assert rows["00300"]["review_status"] == "Not submitted"
+    assert "unrostered_submission" in rows["00300"]["notes_flags"]
+    assert rows["00300"][STANDARD_A] == ""
+    assert rows["00400"]["review_status"] == "Not reviewed"
+    assert "missing_review" in rows["00400"]["notes_flags"]
+    assert rows["00400"][STANDARD_A] == ""
+    assert rows["00500"]["review_status"] == "Invalid submission"
+    assert "invalid_submission" in rows["00500"]["notes_flags"]
+    assert rows["00500"][STANDARD_A] == ""
+    assert rows["00600"]["review_status"] == "Invalid review"
+    assert "invalid_review" in rows["00600"]["notes_flags"]
+    assert rows["00600"][STANDARD_A] == ""
+    forbidden = {"submission_manifest_path", "review_record_path", "roster_status"}
+    assert forbidden.isdisjoint(fields)


### PR DESCRIPTION
## Summary

* Add a compact Student Performance Summary export at `exports/student_performance_summary.csv`.
* Add CLI support for:

  * `export-student-performance-summary`
  * `export-comprehensive-class-summary`
* Update menu/export labels to distinguish:

  * Standards Summary
  * Student Performance Summary
  * Comprehensive Class Summary
* Preserve existing `class_summary.csv` as the comprehensive/audit-oriented report.
* Preserve all existing diagnostic fields in the comprehensive class summary.
* Add compact per-standard rating cells such as `3 - Secure`.
* Use blank CSV cells for missing ratings, returned-without-full-review ratings, missing submissions/reviews, and invalid submissions/reviews.
* Add actionable `notes_flags` for exceptions such as missing submissions, missing reviews, returned work, and unrostered submissions.
* Keep missing submissions and unrostered submissions visible in the compact report.
* Exclude internal paths and routine audit columns from the Student Performance Summary.
* Update `docs/assignment_reporting_contract.md` to define the three assignment-local report types.
* Add regression coverage for compact performance reporting, comprehensive reporting, CLI/menu labels, blank missing-rating cells, and non-mutation behavior.

## Validation

* Targeted pytest: `1 passed` for the blank-cell follow-up
* Earlier targeted pytest for #262: `39 passed`
* Full pytest: `1159 passed`
* Ruff: passed
* Mypy: no issues found in 159 source files
* Ran `git diff --check`
* Diff check: passed
* Synthetic smoke verification confirmed:

  * compact report excludes internal paths and routine audit columns
  * reviewed ratings display correctly
  * missing ratings use blank CSV cells
  * returned-without-full-review rows use blank rating cells and include explanatory status/flags
  * missing submissions/reviews use blank rating cells and remain visible/flagged
  * invalid submissions/reviews use blank rating cells and remain visible/flagged
  * unrostered submissions remain visible and flagged
  * comprehensive `class_summary.csv` retains diagnostic fields
  * source assignment, roster, submission, and review records are not mutated

Closes #262
