### PR TITLE
Fix duplicate routed file status

### DIFF
--- a/quillan/assignment_picker.py
+++ b/quillan/assignment_picker.py
@@ -56,12 +56,18 @@ def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
             break
         print(f"Invalid class selection. {navigation_hint()}")
 
+    from quillan.menu import clear_screen, print_menu_header
+
+    clear_screen()
+    print_menu_header("Select Assignment")
+    print(f"Class: {class_id}")
+    print()
+
     assignments = available_assignments(workspace_root, class_id)
     if not assignments:
         print(f"No valid assignments found for class {class_id}.")
         return None
-    print()
-    print(f"Assignments for {class_id}:")
+    print("Assignments:")
     for index, assignment in enumerate(assignments, start=1):
         label = assignment.assignment_id
         if assignment.title:

--- a/quillan/cli_app/handlers/submissions.py
+++ b/quillan/cli_app/handlers/submissions.py
@@ -60,7 +60,11 @@ def handle_list_submissions(args: argparse.Namespace) -> int:
         print(f"Error: could not list submission status: {error}")
         return 1
 
-    print_assignment_submission_status(result, workspace_root)
+    print_assignment_submission_status(
+        result,
+        workspace_root,
+        show_unused_duplicate_files=True,
+    )
     return 0
 
 

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -384,6 +384,8 @@ def print_exported_standards_summary(
 def print_assignment_submission_status(
     result: AssignmentSubmissionStatus,
     workspace_root: Path,
+    *,
+    show_unused_duplicate_files: bool = False,
 ) -> None:
     """Print a deterministic teacher-facing assignment status summary."""
     submission_states = (
@@ -434,6 +436,11 @@ def print_assignment_submission_status(
     )
     print(f"Students needing assembly: {len(result.students_without_manifests)}")
     print(f"Unassembled routed files: {len(result.unassembled_routed_files)}")
+    if show_unused_duplicate_files:
+        print(
+            "Duplicate routed files not used: "
+            f"{len(result.unused_duplicate_routed_files)}"
+        )
     print(f"Skipped routed files: {len(result.skipped_routed_files)}")
     print()
     print("Submission states:")
@@ -489,6 +496,12 @@ def print_assignment_submission_status(
         print()
         print("Unassembled routed files:")
         for path in result.unassembled_routed_files:
+            print(f"- {workspace_relative_display(path, workspace_root)}")
+
+    if show_unused_duplicate_files and result.unused_duplicate_routed_files:
+        print()
+        print("Duplicate routed files not used:")
+        for path in result.unused_duplicate_routed_files:
             print(f"- {workspace_relative_display(path, workspace_root)}")
 
 

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -605,6 +605,9 @@ def _assemble_assignment(
     """Assemble routed evidence without replacing existing teacher records."""
     from quillan.cli_app.output import print_assignment_submission_assembly
 
+    _print_assignment_action_header(
+        "Assemble Routed Submissions", class_id, assignment_id
+    )
     try:
         result = assemble_assignment_submissions(
             workspace_root, class_id, assignment_id, overwrite=False
@@ -613,6 +616,20 @@ def _assemble_assignment(
         print(f"Error: could not assemble submissions: {error}")
         return
     print_assignment_submission_assembly(result, workspace_root)
+
+
+def _print_assignment_action_header(
+    title: str,
+    class_id: str,
+    assignment_id: str,
+) -> None:
+    from quillan.menu import clear_screen, print_menu_header
+
+    clear_screen()
+    print_menu_header(title)
+    print(f"Class: {class_id}")
+    print(f"Assignment: {assignment_id}")
+    print()
 
 
 def _print_review_action_header(

--- a/quillan/submission_status.py
+++ b/quillan/submission_status.py
@@ -54,6 +54,7 @@ class AssignmentSubmissionStatus:
     students_with_routed_evidence: tuple[str, ...]
     students_without_manifests: tuple[str, ...]
     unassembled_routed_files: tuple[Path, ...]
+    unused_duplicate_routed_files: tuple[Path, ...]
     skipped_routed_files: tuple[SkippedRoutedEvidenceFile, ...]
     student_statuses: tuple[StudentSubmissionStatus, ...]
 
@@ -91,19 +92,32 @@ def list_assignment_submission_status(
         for page in manifest["pages"]
         for item in page["evidence"]
     }
+    represented_evidence_pages = {
+        student_id: {
+            page["page_number"] for page in manifest["pages"] if page["evidence"]
+        }
+        for student_id, (_, manifest) in manifests.items()
+    }
+    unassembled: list[Path] = []
+    unused_duplicates: list[Path] = []
+    for student_id, items in discovery.evidence_by_student.items():
+        for item in items:
+            path = _resolved_evidence_path(root, item.routed_evidence_path)
+            if path in assembled_paths:
+                continue
+            if (
+                item.duplicate_number is not None
+                and item.page_number
+                in represented_evidence_pages.get(student_id, set())
+            ):
+                unused_duplicates.append(path)
+            else:
+                unassembled.append(path)
     unassembled_routed_files = tuple(
-        sorted(
-            (
-                _resolved_evidence_path(root, item.routed_evidence_path)
-                for items in discovery.evidence_by_student.values()
-                for item in items
-                if _resolved_evidence_path(
-                    root, item.routed_evidence_path
-                )
-                not in assembled_paths
-            ),
-            key=lambda path: str(path).casefold(),
-        )
+        sorted(unassembled, key=lambda path: str(path).casefold())
+    )
+    unused_duplicate_routed_files = tuple(
+        sorted(unused_duplicates, key=lambda path: str(path).casefold())
     )
 
     statuses = [
@@ -127,6 +141,7 @@ def list_assignment_submission_status(
         students_with_routed_evidence=routed_students,
         students_without_manifests=students_without_manifests,
         unassembled_routed_files=unassembled_routed_files,
+        unused_duplicate_routed_files=unused_duplicate_routed_files,
         skipped_routed_files=discovery.skipped_files,
         student_statuses=tuple(statuses),
     )

--- a/tests/test_assignment_picker.py
+++ b/tests/test_assignment_picker.py
@@ -6,7 +6,12 @@ import json
 from pathlib import Path
 from typing import Any
 
-from quillan.assignment_picker import available_assignments
+import pytest
+
+from quillan.assignment_picker import (
+    available_assignments,
+    prompt_assignment_choice,
+)
 
 
 CLASS_ID = "english_12_p3"
@@ -67,6 +72,16 @@ def _write_assignment(
     path.write_text(json.dumps(assignment), encoding="utf-8")
 
 
+def _write_roster(workspace_root: Path) -> None:
+    path = workspace_root / "classes" / CLASS_ID / "roster.csv"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "class_id,student_id,last_name,first_name,period\n"
+        f"{CLASS_ID},student_001,Student,Synthetic,3\n",
+        encoding="utf-8",
+    )
+
+
 def test_available_assignments_lists_valid_v2_assignments(tmp_path: Path) -> None:
     _write_assignment(
         tmp_path,
@@ -104,3 +119,60 @@ def test_available_assignments_skips_invalid_and_legacy_configs(
     choices = available_assignments(tmp_path, CLASS_ID)
 
     assert [choice.assignment_id for choice in choices] == ["valid_assignment"]
+
+
+def test_prompt_assignment_choice_clears_and_reframes_after_class_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(
+        tmp_path,
+        "valid_assignment",
+        _assignment("valid_assignment", title="Visible Title"),
+    )
+    events: list[str] = []
+    responses = iter(("1", "1"))
+
+    def fake_input(prompt: str = "") -> str:
+        events.append(prompt)
+        return next(responses)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr(
+        "quillan.menu.clear_screen", lambda: events.append("clear")
+    )
+
+    choice = prompt_assignment_choice(tmp_path)
+
+    assert choice is not None
+    assert choice.assignment_id == "valid_assignment"
+    assert events == ["Select class: ", "clear", "Select assignment: "]
+    output = capsys.readouterr().out
+    assert "Select Assignment" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert "Assignments:\n" in output
+    assert "1. valid_assignment - Visible Title" in output
+    assert f"Assignments for {CLASS_ID}:" not in output
+
+
+def test_prompt_assignment_choice_reframes_when_class_has_no_assignments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    clear_calls: list[str] = []
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
+    monkeypatch.setattr(
+        "quillan.menu.clear_screen", lambda: clear_calls.append("clear")
+    )
+
+    assert prompt_assignment_choice(tmp_path) is None
+
+    assert clear_calls == ["clear"]
+    output = capsys.readouterr().out
+    assert "Select Assignment" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"No valid assignments found for class {CLASS_ID}." in output

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -305,6 +305,53 @@ def test_assignment_review_actions_menu_includes_export_choices(
     assert "4. Export assignment-local Focus Standard summary" in output
 
 
+def test_assignment_review_dashboard_hides_unused_duplicate_files(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    duplicate = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_stu_0001_pg_001__dup_001.pdf"
+    )
+    duplicate.write_bytes(b"duplicate synthetic evidence")
+    _menu_input(monkeypatch, ["6"])
+
+    assert (
+        review_menu._launch_assignment_review_actions(
+            workspace, CLASS_ID, ASSIGNMENT_ID
+        )
+        == 0
+    )
+
+    output = capsys.readouterr().out
+    assert "Unassembled routed files: 0" in output
+    assert "Duplicate routed files not used" not in output
+    assert duplicate.name not in output
+
+
+def test_assignment_assembly_action_clears_and_prints_focused_header(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: print("<clear>"))
+
+    review_menu._assemble_assignment(workspace, CLASS_ID, ASSIGNMENT_ID)
+
+    output = capsys.readouterr().out
+    assert output.startswith("<clear>\n")
+    assert "Quillan\x1b[0m\nAssemble Routed Submissions" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert "Skipped existing manifests: 1" in output
+
+
 def test_selected_student_review_menu_includes_feedback_export(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -209,6 +209,7 @@ def _assignment_status(
             student_id for student_id in routed if student_id not in manifests
         ),
         unassembled_routed_files=unassembled,
+        unused_duplicate_routed_files=(),
         skipped_routed_files=(),
         student_statuses=(),
     )
@@ -567,6 +568,7 @@ def test_post_route_multi_target_lists_status_labels(
             students_with_routed_evidence=(STUDENT_ID,),
             students_without_manifests=(),
             unassembled_routed_files=(),
+            unused_duplicate_routed_files=(),
             skipped_routed_files=(),
             student_statuses=(),
         )

--- a/tests/test_submission_status.py
+++ b/tests/test_submission_status.py
@@ -171,6 +171,73 @@ def test_new_routed_file_for_manifest_student_is_unassembled(
     assert result.unassembled_routed_files == (path,)
 
 
+def test_unused_duplicates_for_represented_manifest_page_are_not_unassembled(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _write_status_manifest(tmp_path)
+    original = manifest_path.read_bytes()
+    primary = _touch_routed(tmp_path, "response_00107_pg_001.pdf")
+    duplicate_1 = _touch_routed(
+        tmp_path, "response_00107_pg_001__dup_001.pdf"
+    )
+    duplicate_2 = _touch_routed(
+        tmp_path, "response_00107_pg_001__dup_002.pdf"
+    )
+
+    result = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert result.students_with_manifests == ("00107",)
+    assert result.students_without_manifests == ()
+    assert result.unassembled_routed_files == ()
+    assert result.unused_duplicate_routed_files == (duplicate_1, duplicate_2)
+    assert primary.exists()
+    assert duplicate_1.exists()
+    assert duplicate_2.exists()
+    assert manifest_path.read_bytes() == original
+
+
+def test_duplicate_for_manifest_page_without_evidence_remains_unassembled(
+    tmp_path: Path,
+) -> None:
+    _write_status_manifest(tmp_path)
+    path = _touch_routed(
+        tmp_path, "response_00107_pg_002__dup_001.pdf"
+    )
+
+    result = list_assignment_submission_status(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    )
+
+    assert result.unassembled_routed_files == (path,)
+    assert result.unused_duplicate_routed_files == ()
+
+
+def test_cli_labels_unused_duplicate_files_separately(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_status_manifest(tmp_path)
+    _touch_routed(tmp_path, "response_00107_pg_001.pdf")
+    _touch_routed(tmp_path, "response_00107_pg_001__dup_001.pdf")
+    _touch_routed(tmp_path, "response_00107_pg_001__dup_002.pdf")
+    monkeypatch.setattr(
+        cli_submissions, "resolve_workspace_root", lambda: tmp_path
+    )
+
+    assert main(["list-submissions", CLASS_ID, ASSIGNMENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    assert "Students needing assembly: 0" in output
+    assert "Unassembled routed files: 0" in output
+    assert "Duplicate routed files not used: 2" in output
+    duplicate_section = output.split("Duplicate routed files not used:\n", 1)[1]
+    assert "response_00107_pg_001__dup_001.pdf" in duplicate_section
+    assert "response_00107_pg_001__dup_002.pdf" in duplicate_section
+
+
 def test_skipped_routed_files_are_reported_and_sorted(tmp_path: Path) -> None:
     _touch_routed(tmp_path, "response_00107_pg_zero.pdf")
     _touch_routed(tmp_path, "debug_page.png")


### PR DESCRIPTION
## Summary

* Fix assignment submission status classification for duplicate routed files.
* Add `unused_duplicate_routed_files` to assignment submission status.
* Classify duplicate `__dup_###` routed files separately when an existing manifest already contains evidence for that page.
* Keep genuinely new routed evidence for unrepresented or empty manifest pages visible as unassembled/attention-worthy.
* Hide non-actionable unused duplicate routed files from the default Assignment Review Actions dashboard.
* Keep unused duplicate routed files available internally and through direct `list-submissions` CLI diagnostics.
* Preserve students-without-manifests behavior so routed students still appear as needing assembly.
* Preserve assembly semantics: existing manifests are skipped and never overwritten unless the existing overwrite path is explicitly used.
* Update the assignment-level assembly action so selecting `Assemble routed submissions` clears the previous dashboard and shows a focused action screen with class and assignment context.
* Fix the live Review Student Work class-to-assignment transition in `quillan.assignment_picker.prompt_assignment_choice(...)`.
* After class selection, clear the previous class list and show a focused `Select Assignment` screen.
* Display the selected class ID and use a concise `Assignments:` heading.
* Apply the same clear/reframe behavior when the selected class has no valid assignments.
* Preserve assignment discovery, sorting, navigation, and selection semantics.
* Remove the earlier test against the inactive `review_menu._prompt_assignment(...)` helper.
* Add regression coverage for the actual assignment picker path and verify the event order: class input → clear screen → assignment input.
* Preserve read-only status reporting and workspace-relative output.

## Validation

* Targeted pytest: `73 passed`
* Full pytest: `1166 passed`
* Ruff: passed
* Mypy: no issues found in 159 source files
* Ran `git diff --check`
* Diff check: passed

Confirmed through tests and simulation:

* unused duplicate routed files no longer appear as unassembled
* unused duplicate routed files are hidden from the default teacher dashboard
* unused duplicate routed files remain tracked internally
* direct `list-submissions` CLI diagnostics still show duplicate counts and file lists
* students without manifests still appear as needing assembly
* new or otherwise attention-worthy evidence remains unassembled
* selecting `Assemble routed submissions` clears/reframes before showing output
* existing manifests are skipped and not overwritten
* status reporting does not mutate manifests or routed files
* Review Student Work clears after valid class selection
* assignment selection shows a focused `Select Assignment` screen
* assignment discovery, sorting, navigation, and selection behavior are preserved
* the no-valid-assignments path also clears and reframes correctly

Closes #287
