### PR TITLE
Delegate source retention to pds-core

### DIFF
--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -28,8 +28,9 @@ review.
 
 Quillan now implements the first successful-write slice through
 `quillan.evidence_filing.file_routed_response_evidence()`. Given a readable
-source file and an existing successful `RoutePlan`, it exclusively copies the
-source into `scans/source/YYYY-MM-DD/`, files the retained source or a
+source file and an existing successful `RoutePlan`, Quillan delegates canonical
+source retention to `pds-core`'s `retain_source_scan(...)` helper, then files
+the retained source or a
 caller-supplied page artifact into assignment `scans/`, preserves duplicates,
 and returns provenance. Quillan also implements metadata-only failure
 preservation through `quillan.routing_review`, writing shared failure records
@@ -85,8 +86,9 @@ follow the shared `pds-core` contract:
    source scan.
 
 `scans_inbox/` remains the shared teacher-facing intake/drop location. It is
-not the canonical retained source store. The exact retained-source naming,
-copying, and helper APIs belong to `pds-core`, not this Quillan design.
+not the canonical retained source store. Quillan uses `pds-core`'s
+`retain_source_scan(...)` helper for retained-source naming, copying,
+provenance, and safety instead of maintaining a parallel implementation.
 
 ## Assumed Quillan Routing Input
 

--- a/quillan/evidence_filing.py
+++ b/quillan/evidence_filing.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-import hashlib
 import shutil
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from pathlib import Path
 from typing import Final
 
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
-from pds_core.scan_routes import (
-    ScanRouteError,
-    build_retained_source_filename,
-    retained_source_scan_path,
+from pds_core.scan_retention import (
+    RetainedSourceScan as RetainedSourceScan,
+    SourceRetentionError,
+    retain_source_scan,
 )
 
 from quillan.route_planning import RoutePlan
@@ -28,17 +27,6 @@ _SUPPORTED_EXTENSIONS: Final[frozenset[str]] = frozenset(
 
 class EvidenceFilingError(RuntimeError):
     """Raised when retained source or routed evidence cannot be filed safely."""
-
-
-@dataclass(frozen=True, slots=True)
-class RetainedSourceScan:
-    """Provenance for one canonical retained source intake event."""
-
-    source_scan_id: str
-    source_filename: str
-    source_sha256: str
-    retained_source_path: Path
-    retained_source_relative_path: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,7 +60,6 @@ def file_routed_response_evidence(
     """
     root = _resolved_workspace_root(workspace_root)
     routed_dir, page_number = _validated_route_plan(root, route_plan)
-    source_path = _readable_regular_file(source_file_path, "source_file_path")
     routed_input = (
         _readable_regular_file(
             routed_source_file_path,
@@ -81,67 +68,29 @@ def file_routed_response_evidence(
         if routed_source_file_path is not None
         else None
     )
+    if routed_extension is not None:
+        extension = _normalized_extension(routed_extension)
+    elif routed_input is not None:
+        extension = _normalized_extension(routed_input.suffix)
+    else:
+        extension = None
 
-    source_sha256 = _sha256_file(source_path, "source_file_path")
     try:
-        retained_filename = build_retained_source_filename(
-            intake_timestamp=intake_timestamp,
-            original_filename=source_path.name,
-            sha256_hex=source_sha256,
-        )
-        source_date = (
-            intake_timestamp.astimezone(timezone.utc).date()
-            if intake_date is None
-            else intake_date
-        )
-        retained_path = retained_source_scan_path(
+        retained_source = retain_source_scan(
             root,
-            intake_date=source_date,
-            retained_filename=retained_filename,
-        ).resolve(strict=False)
-    except (ScanRouteError, OSError, ValueError) as error:
-        raise EvidenceFilingError(f"Invalid retained source route: {error}") from error
-
-    routed_input_for_extension = (
-        source_path if routed_input is None else routed_input
-    )
-    extension = _normalized_extension(
-        routed_extension
-        if routed_extension is not None
-        else routed_input_for_extension.suffix
-    )
-
-    retained_dir = retained_path.parent
-    _require_contained(retained_path, retained_dir, "retained source path")
-    _require_contained(retained_dir, root, "retained source directory")
-    _create_directory(retained_dir, root, "retained source directory")
-
-    try:
-        copied_sha256 = _copy_exclusive_with_sha256(source_path, retained_path)
-    except FileExistsError as error:
-        raise EvidenceFilingError(
-            f"Retained source destination already exists: {retained_path}"
-        ) from error
-    except OSError as error:
-        raise EvidenceFilingError(
-            f"Could not copy retained source to {retained_path}: {error}"
-        ) from error
-    if copied_sha256 != source_sha256:
-        _remove_incomplete_copy(retained_path)
-        raise EvidenceFilingError(
-            "Source file changed while it was being retained; no retained copy "
-            "was kept."
+            source_file_path,
+            intake_timestamp=intake_timestamp,
+            intake_date=intake_date,
         )
+    except SourceRetentionError as error:
+        raise EvidenceFilingError(f"Could not retain source scan: {error}") from error
 
-    retained_source = RetainedSourceScan(
-        source_scan_id=f"scan_{retained_path.stem}",
-        source_filename=source_path.name,
-        source_sha256=source_sha256,
-        retained_source_path=retained_path,
-        retained_source_relative_path=_workspace_relative(retained_path, root),
+    if extension is None:
+        extension = _normalized_extension(retained_source.retained_source_path.suffix)
+
+    routed_input = (
+        retained_source.retained_source_path if routed_input is None else routed_input
     )
-
-    routed_input = retained_path if routed_input is None else routed_input
     _create_directory(routed_dir, root, "routed evidence directory")
     routed_path, duplicate_number = _copy_routed_evidence(
         routed_input,
@@ -230,36 +179,6 @@ def _readable_regular_file(value: str | Path, field_name: str) -> Path:
         raise
     except (OSError, TypeError, ValueError) as error:
         raise EvidenceFilingError(f"Could not read {field_name}: {error}") from error
-
-
-def _sha256_file(path: Path, field_name: str) -> str:
-    digest = hashlib.sha256()
-    try:
-        with path.open("rb") as source:
-            while chunk := source.read(_COPY_BUFFER_SIZE):
-                digest.update(chunk)
-    except OSError as error:
-        raise EvidenceFilingError(f"Could not read {field_name}: {error}") from error
-    return digest.hexdigest()
-
-
-def _copy_exclusive_with_sha256(source: Path, destination: Path) -> str:
-    digest = hashlib.sha256()
-    destination_created = False
-    try:
-        with source.open("rb") as source_file:
-            with destination.open("xb") as destination_file:
-                destination_created = True
-                while chunk := source_file.read(_COPY_BUFFER_SIZE):
-                    destination_file.write(chunk)
-                    digest.update(chunk)
-    except FileExistsError:
-        raise
-    except OSError:
-        if destination_created:
-            _remove_incomplete_copy(destination)
-        raise
-    return digest.hexdigest()
 
 
 def _copy_exclusive(source: Path, destination: Path) -> None:

--- a/tests/test_evidence_filing.py
+++ b/tests/test_evidence_filing.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import replace
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from pds_core.scan_retention import RetainedSourceScan
 from pds_core.scan_routes import build_retained_source_filename
 
+import quillan.evidence_filing as evidence_filing
 from quillan.evidence_filing import (
     EvidenceFilingError,
     file_routed_response_evidence,
@@ -112,6 +114,57 @@ def test_files_retained_source_and_routed_evidence_with_provenance(
     assert source_file.read_bytes() == original_bytes
 
 
+def test_delegates_source_retention_to_core_helper(
+    workspace: Path,
+    route_plan: RoutePlan,
+    source_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    retained_path = workspace / "scans" / "source" / "retained.pdf"
+    retained_path.parent.mkdir(parents=True)
+    retained_path.write_bytes(b"retained by core")
+    retained = RetainedSourceScan(
+        source_scan_id="scan_delegated",
+        source_filename=source_file.name,
+        source_sha256="a" * 64,
+        retained_source_path=retained_path,
+        retained_source_relative_path="scans/source/retained.pdf",
+        intake_timestamp=INTAKE_TIMESTAMP,
+        intake_date=date(2026, 6, 19),
+    )
+    calls: list[tuple[object, object, object, object]] = []
+
+    def fake_retain_source_scan(
+        root: object,
+        source: object,
+        *,
+        intake_timestamp: object,
+        intake_date: object,
+    ) -> RetainedSourceScan:
+        calls.append((root, source, intake_timestamp, intake_date))
+        return retained
+
+    monkeypatch.setattr(
+        evidence_filing,
+        "retain_source_scan",
+        fake_retain_source_scan,
+    )
+
+    result = file_routed_response_evidence(
+        workspace,
+        route_plan=route_plan,
+        source_file_path=source_file,
+        intake_timestamp=INTAKE_TIMESTAMP,
+        intake_date="2026-06-18",
+    )
+
+    assert calls == [
+        (workspace.resolve(), source_file, INTAKE_TIMESTAMP, "2026-06-18")
+    ]
+    assert result.retained_source is retained
+    assert result.routed_evidence_path.read_bytes() == b"retained by core"
+
+
 def test_intake_date_defaults_to_utc_date(
     workspace: Path,
     route_plan: RoutePlan,
@@ -198,7 +251,7 @@ def test_missing_source_fails_without_creating_scan_dirs(
     route_plan: RoutePlan,
     tmp_path: Path,
 ) -> None:
-    with pytest.raises(EvidenceFilingError, match="existing regular file"):
+    with pytest.raises(EvidenceFilingError, match="does not exist"):
         file_routed_response_evidence(
             workspace,
             route_plan=route_plan,
@@ -215,7 +268,7 @@ def test_directory_source_fails(
     route_plan: RoutePlan,
     tmp_path: Path,
 ) -> None:
-    with pytest.raises(EvidenceFilingError, match="existing regular file"):
+    with pytest.raises(EvidenceFilingError, match="not a regular file"):
         file_routed_response_evidence(
             workspace,
             route_plan=route_plan,

--- a/tests/test_routing_review.py
+++ b/tests/test_routing_review.py
@@ -303,6 +303,8 @@ def test_route_failure_adapter_accepts_retained_source_provenance(
         retained_source_relative_path=(
             "scans/source/2026-06-19/retained.pdf"
         ),
+        intake_timestamp=CREATED_AT,
+        intake_date=CREATED_AT.date(),
     )
 
     record = preserve_route_failure_for_review(


### PR DESCRIPTION
## Summary

* Delegate Quillan canonical source-scan retention to pds-core.
* Replace Quillan’s local retained-source copy/provenance implementation with Core’s `retain_source_scan(...)`.
* Preserve Quillan-owned routed evidence behavior.
* Preserve routed evidence filenames and `__dup_###` duplicate behavior.
* Preserve extracted page artifact and routed-extension behavior.
* Preserve routing failure metadata behavior.
* Update scan-routing documentation to state that canonical retained source copying is delegated to Core.
* Do not change pds-core.
* Do not change ScoreForm.

## Behavior

Quillan now imports and calls Core’s shared source-retention helper:

```python
retain_source_scan(...)
```

Retention failures from Core are wrapped as Quillan `EvidenceFilingError`, preserving Quillan’s public error boundary.

Removed Quillan-local retained-source implementation details:

* local `RetainedSourceScan`
* `_sha256_file`
* `_copy_exclusive_with_sha256`

`RetainedSourceScan` remains import-compatible from `quillan.evidence_filing`.

Quillan still owns:

* route-plan validation
* assignment-level routed evidence filing
* routed evidence filenames
* duplicate routed evidence preservation
* extracted page artifact routing
* routed extension handling
* routing failure review metadata
* submission assembly and review workflows

## Validation

* Focused evidence/routing tests: `95 passed`
* Full pytest: `1,048 passed`
* Ruff: passed
* mypy: passed, `130 files checked`
* `git diff --check`: passed, with line-ending warnings only

Confirmed unchanged:

* routed evidence filename format
* `__dup_###` duplicate behavior
* extracted page artifact behavior
* routed-extension behavior
* routing failure metadata behavior
* pds-core files
* ScoreForm files

Closes #291
