### PR TITLE
Add plain-paper manual submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,14 @@ Recommended pull request workflow:
 ## License
 
 MIT
+
+### Plain-paper manual submissions
+
+When a student writes on paper outside Quillan, select that roster student in
+Review Student Work and choose **Create plain-paper submission for this
+student**. Quillan creates a review-ready `submission.json` and `review.json`
+without routing a scan, running OCR, or fabricating digital evidence. The
+physical paper remains under the teacher's control, and the normal
+standards-based review and export actions apply after setup. This does not
+change printable QR/PDS1 response pages. Never commit real student data or
+workspace artifacts.

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -1052,3 +1052,12 @@ explicitly outside the current end-to-end foundation:
 
 Their presence in design documents or Python modules does not add them to the
 CLI contract.
+
+## Selected-student plain-paper action
+
+When a roster student has no routed evidence and no submission manifest, the
+interactive selected-student review menu offers creation of a plain-paper
+manual submission. It requires `y` or `yes` confirmation. Existing manifests,
+existing orphan review records, and routed-evidence-only students are not
+converted. Opening evidence for a manual submission reports that no digital
+evidence is attached instead of invoking an evidence opener.

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -194,3 +194,12 @@ other personally identifiable student information.
 
 Reusable comments and reporting examples must avoid student-identifying details
 and private classroom context, even when the example is synthetic.
+
+## Plain-paper manual submissions
+
+An evidence-less manual submission uses submission-manifest schema version 1
+with `expected_pages: null`, `pages: []`, and `submission_state: "unreviewed"`.
+Its `module_details` records `submission_entry_method: "plain_paper_manual"`,
+`physical_evidence_status: "teacher_has_external_plain_paper"`, and
+`created_by_workflow: "plain_paper_submission"`. No routed evidence path or
+digital artifact is created; the physical paper remains outside Quillan.

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -634,3 +634,12 @@ Future enhancements may include:
 * optional desktop packaging.
 
 These should not distract from the MVP.
+
+## Plain-paper manual submission entry
+
+Quillan supports a focused teacher-facing setup path for students who wrote on
+plain paper when printable response pages were unavailable. The path creates
+the existing submission and review contracts without scans, OCR, placeholder
+files, fake evidence, bulk creation, or changes to QR/PDS1 printing. Subsequent
+work remains in the active standards-based review and assignment-local export
+model.

--- a/docs/prepared_review_workflow.md
+++ b/docs/prepared_review_workflow.md
@@ -232,3 +232,12 @@ notes, feedback, exports, or personally identifiable information.
 * [`assignment_reporting_contract.md`](assignment_reporting_contract.md)
 * [`teacher_review_model.md`](teacher_review_model.md)
 * [`workspace_lifecycle.md`](workspace_lifecycle.md)
+
+## Work completed on plain paper
+
+For a roster student with neither routed evidence nor a manifest, the selected
+student review screen can create a plain-paper manual submission after teacher
+confirmation. This creates only `submission.json` and `review.json`; it does
+not route scans, attach images, run OCR, or invent evidence paths. Continue
+with the existing minimum-requirement, review-unit, Focus Standard, feedback,
+note, state, and export actions while reviewing the physical paper.

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -1438,3 +1438,11 @@ This contract does not implement:
 * report visualization.
 
 The record describes teacher-entered or teacher-confirmed judgment only.
+
+## Plain-paper entry
+
+The plain-paper workflow immediately creates a normal schema-version-2 empty
+review record pointing to the canonical submission manifest. Its
+`module_details` contains `review_entry_method: "plain_paper_manual"` and
+`created_by_workflow: "plain_paper_submission"`. It does not add top-level
+fields or prefill checks, units, observations, ratings, feedback, or notes.

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -197,3 +197,11 @@ feedback, or exports.
 * [`feedback_export_contract.md`](feedback_export_contract.md)
 * [`assignment_reporting_contract.md`](assignment_reporting_contract.md)
 * [`workspace_lifecycle.md`](workspace_lifecycle.md)
+
+## Plain-paper evidence under teacher control
+
+Quillan can initialize the standards-based review model for work written on
+plain paper outside Quillan. The submission has no digital pages; the teacher
+retains and reviews the physical paper, then records judgments through the
+same review units, Focus Standards, feedback, private notes, and workflow
+states used for scanned submissions.

--- a/quillan/plain_paper_submission.py
+++ b/quillan/plain_paper_submission.py
@@ -1,0 +1,175 @@
+"""Create review-ready submissions for work completed on plain paper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pds_core.classes import load_class_roster
+from pds_core.identifiers import validate_identifier
+
+from quillan.assignments import load_assignment_config
+from quillan.review_record import build_empty_review_record, validate_review_record
+from quillan.review_record_paths import (
+    review_record_path,
+    write_review_record,
+)
+from quillan.storage import assignment_config_path
+from quillan.submission_manifest import validate_submission_manifest
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+PLAIN_PAPER_ENTRY_METHOD = "plain_paper_manual"
+PLAIN_PAPER_PHYSICAL_EVIDENCE_STATUS = "teacher_has_external_plain_paper"
+PLAIN_PAPER_WORKFLOW = "plain_paper_submission"
+
+
+class PlainPaperSubmissionError(ValueError):
+    """Raised when a plain-paper submission cannot be safely created."""
+
+
+@dataclass(frozen=True, slots=True)
+class CreatedPlainPaperSubmission:
+    """Paths and identity for a newly created plain-paper submission."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    submission_manifest_path: Path
+    submission_manifest_relative_path: str
+    review_record_path: Path
+    review_record_relative_path: str
+    created_at: str
+
+
+def create_plain_paper_submission(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    created_at: datetime | str | None = None,
+) -> CreatedPlainPaperSubmission:
+    """Create an evidence-less manifest and empty v2 review record safely."""
+    root = Path(workspace_root).resolve(strict=False)
+    for value, field in (
+        (class_id, "class_id"),
+        (assignment_id, "assignment_id"),
+        (student_id, "student_id"),
+    ):
+        validate_identifier(value, field)
+
+    assignment = load_assignment_config(
+        assignment_config_path(root, class_id, assignment_id)
+    )
+    if assignment["assignment_id"] != assignment_id:
+        raise PlainPaperSubmissionError(
+            "The selected assignment ID does not match its assignment config."
+        )
+    if class_id not in assignment["class_ids"]:
+        raise PlainPaperSubmissionError(
+            f"Class {class_id!r} is not included in assignment {assignment_id!r}."
+        )
+
+    roster = load_class_roster(root, class_id)
+    if not any(student.student_id == student_id for student in roster.students):
+        raise PlainPaperSubmissionError(
+            f"Student {student_id!r} is not in the roster for class {class_id!r}."
+        )
+
+    manifest_path = submission_manifest_path(root, class_id, assignment_id, student_id)
+    review_path = review_record_path(root, class_id, assignment_id, student_id)
+    if manifest_path.exists():
+        raise PlainPaperSubmissionError(
+            "A submission record already exists for this student. "
+            "Plain-paper submission was not created."
+        )
+    if review_path.exists():
+        raise PlainPaperSubmissionError(
+            "A review record exists without a submission manifest. "
+            "Plain-paper submission was not created. Repair this student "
+            "submission before continuing."
+        )
+
+    timestamp = _timestamp(created_at)
+    manifest: dict[str, Any] = {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "module_details": {
+            "submission_entry_method": PLAIN_PAPER_ENTRY_METHOD,
+            "physical_evidence_status": PLAIN_PAPER_PHYSICAL_EVIDENCE_STATUS,
+            "created_by_workflow": PLAIN_PAPER_WORKFLOW,
+        },
+    }
+    review = build_empty_review_record(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        created_at=timestamp,
+    )
+    review["module_details"] = {
+        "review_entry_method": PLAIN_PAPER_ENTRY_METHOD,
+        "created_by_workflow": PLAIN_PAPER_WORKFLOW,
+    }
+    validate_submission_manifest(manifest)
+    validate_review_record(review)
+
+    write_submission_manifest(manifest_path, manifest)
+    try:
+        write_review_record(review_path, review)
+    except Exception:
+        # Restore the original no-record state if the paired write cannot finish.
+        manifest_path.unlink(missing_ok=True)
+        raise
+
+    return CreatedPlainPaperSubmission(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        submission_manifest_path=manifest_path,
+        submission_manifest_relative_path=manifest_path.relative_to(root).as_posix(),
+        review_record_path=review_path,
+        review_record_relative_path=review_path.relative_to(root).as_posix(),
+        created_at=timestamp,
+    )
+
+
+def is_plain_paper_submission(manifest: dict[str, object]) -> bool:
+    """Return whether a manifest carries the plain-paper entry marker."""
+    details = manifest.get("module_details")
+    return isinstance(details, dict) and details.get(
+        "submission_entry_method"
+    ) == PLAIN_PAPER_ENTRY_METHOD
+
+
+def _timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        value = datetime.now(timezone.utc)
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise PlainPaperSubmissionError("created_at must be timezone-aware.")
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise PlainPaperSubmissionError("created_at must be a datetime or string.")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise PlainPaperSubmissionError(
+            "created_at must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise PlainPaperSubmissionError("created_at must be timezone-aware.")
+    return value

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -140,6 +140,11 @@ from quillan.menu_navigation import (
     parse_navigation_choice,
     print_navigation_options,
 )
+from quillan.plain_paper_submission import (
+    PlainPaperSubmissionError,
+    create_plain_paper_submission,
+    is_plain_paper_submission,
+)
 
 _BACK = object()
 _CANCEL = object()
@@ -325,6 +330,13 @@ def _student_status_label(status: StudentSubmissionStatus | None) -> str:
         return "no manifest; no routed evidence"
     if status.manifest_path is None:
         return "routed evidence exists; no manifest"
+    try:
+        if is_plain_paper_submission(
+            load_submission_manifest(status.manifest_path)
+        ):
+            return "plain-paper manual submission; no digital evidence"
+    except (OSError, SubmissionManifestError):
+        pass
     evidence_count = sum(page.evidence_count for page in status.pages)
     return (
         f"{status.submission_state}; manifest exists; "
@@ -353,24 +365,27 @@ def _launch_selected_student_review(
         status = _load_submission_status(workspace_root, class_id, assignment_id)
         student_status = _student_submission_status(status, student_id)
         if student_status is None:
-            print("No routed evidence has been found for this student yet.")
-            print(
-                "Route a scan for this assignment, then assemble submissions "
-                "before review."
-            )
+            print("No digital submission evidence has been found for this student.")
             print()
-            print("1. View routed evidence status")
-            print("2. Refresh summary")
+            print("1. Create plain-paper submission for this student")
+            print("2. View routed evidence status")
+            print("3. Refresh summary")
             print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
             navigation = parse_navigation_choice(choice)
             print()
-            if choice in {"", "3"} or navigation is NavigationChoice.BACK:
+            if choice in {"", "4"} or navigation is NavigationChoice.BACK:
                 return 0
-            if choice in {"1", "2"}:
+            if choice == "1":
+                _create_plain_paper_submission_menu(
+                    workspace_root, class_id, assignment_id, student_id
+                )
+                input("Press Enter to continue...")
                 continue
-            print("Invalid selection. Please enter a number from 1 to 3.")
+            if choice in {"2", "3"}:
+                continue
+            print("Invalid selection. Please enter a number from 1 to 4.")
             input("Press Enter to continue...")
             continue
         if student_status.manifest_path is None:
@@ -1195,6 +1210,24 @@ def _open_submission_evidence(
     assignment_id: str,
     student_id: str,
 ) -> None:
+    try:
+        manifest = load_submission_manifest(
+            submission_manifest_path(
+                workspace_root, class_id, assignment_id, student_id
+            )
+        )
+        if is_plain_paper_submission(manifest):
+            print(
+                "This is a plain-paper manual submission. "
+                "No digital evidence is attached."
+            )
+            print(
+                "Review the physical paper, then use Quillan's review actions "
+                "to record your judgment."
+            )
+            return
+    except (OSError, SubmissionManifestError, SubmissionManifestPathError):
+        pass
     page_number = _choose_submission_evidence_page(
         workspace_root,
         class_id,
@@ -1219,6 +1252,50 @@ def _open_submission_evidence(
         return
 
     print_opened_submission_review(opened)
+
+
+def _create_plain_paper_submission_menu(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    _print_review_action_header(
+        "Create Plain-Paper Submission", class_id, assignment_id, student_id
+    )
+    print("Use this only when the student completed the assignment on paper outside")
+    print("Quillan and you want to review the physical paper manually.")
+    print()
+    print("This will create:")
+    print("- submission.json")
+    print("- review.json")
+    print()
+    print(
+        "It will not create scan evidence, PDFs, images, OCR output, "
+        "or generated feedback."
+    )
+    print()
+    confirmation = input("Create plain-paper submission? (y/yes): ").strip().casefold()
+    if confirmation not in {"y", "yes"}:
+        print("Plain-paper submission creation canceled.")
+        return
+    try:
+        create_plain_paper_submission(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except Exception as error:
+        if isinstance(error, PlainPaperSubmissionError):
+            print(str(error))
+        else:
+            print(f"Error: plain-paper submission was not created: {error}")
+        return
+    student_label = student_review_label(workspace_root, class_id, student_id)
+    print(f"Plain-paper submission created for {student_label}.")
+    print()
+    print(
+        "You can now review minimum requirements, review units, Focus Standard "
+        "observations, overall Focus Standard ratings, feedback, and private notes."
+    )
 
 
 def _choose_submission_evidence_page(

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -1155,7 +1155,7 @@ def test_review_menu_reports_missing_openable_evidence(
 ) -> None:
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "2", "1", "", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "2", "1", "n", "", "b", "b", "b", "q"],
     )
 
     assert main(["menu"]) == 0
@@ -1163,9 +1163,42 @@ def test_review_menu_reports_missing_openable_evidence(
     output = capsys.readouterr().out
     assert f"Student: Mina Patel ({SECOND_STUDENT_ID})" in output
     assert "Submission: not assembled" in output
-    assert "No routed evidence has been found for this student yet." in output
+    assert "No digital submission evidence has been found" in output
+    assert "1. Create plain-paper submission for this student" in output
+    assert "Plain-paper submission creation canceled." in output
     assert "1. Assemble this assignment now" not in output
     assert not list(workspace.rglob("review.json"))
+
+
+def test_review_menu_creates_plain_paper_submission_and_shows_review_actions(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _menu_input(
+        monkeypatch,
+        ["2", "1", "1", "1", "1", "2", "1", "yes", "", "12", "6", "b", "q"],
+    )
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Plain-paper submission created for Mina Patel" in output
+    assert "1. Open submission evidence" in output
+    assert "5. Overall Focus Standard ratings" in output
+    student_dir = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / SECOND_STUDENT_ID
+    )
+    assert {path.name for path in student_dir.iterdir()} == {
+        "submission.json",
+        "review.json",
+    }
 
 
 

--- a/tests/test_plain_paper_submission.py
+++ b/tests/test_plain_paper_submission.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from quillan.plain_paper_submission import (
+    PlainPaperSubmissionError,
+    create_plain_paper_submission,
+)
+from quillan.review_record import load_review_record
+import quillan.review_menu as review_menu
+from quillan.submission_manifest import load_submission_manifest
+from quillan.submission_status import list_assignment_submission_status
+
+CLASS_ID = "english10_p2"
+ASSIGNMENT_ID = "literary_analysis"
+STUDENT_ID = "stu_001"
+TIMESTAMP = "2026-07-12T12:30:00-04:00"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    class_dir = tmp_path / "classes" / CLASS_ID
+    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir.mkdir(parents=True)
+    with (class_dir / "roster.csv").open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(
+            file,
+            fieldnames=("class_id", "student_id", "last_name", "first_name", "period"),
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "class_id": CLASS_ID,
+                "student_id": STUDENT_ID,
+                "last_name": "Johnson",
+                "first_name": "Mack",
+                "period": "2",
+            }
+        )
+    assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Literary Analysis",
+        "class_ids": [CLASS_ID],
+        "writing_type": "analysis",
+        "student_prompt": "Analyze the text.",
+        "standards_profile_id": "ela",
+        "focus_standard_ids": ["W.9"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "two_level",
+            "levels": [
+                {"value": 1, "label": "Developing", "description": "Developing."}
+            ],
+        },
+        "basic_requirements": {"paragraphs_min": 1},
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+    }
+    (assignment_dir / "assignment.json").write_text(
+        json.dumps(assignment), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def test_creates_valid_evidence_less_manifest_and_empty_review(workspace: Path) -> None:
+    created = create_plain_paper_submission(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+
+    manifest = load_submission_manifest(created.submission_manifest_path)
+    assert manifest == {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {
+            "submission_entry_method": "plain_paper_manual",
+            "physical_evidence_status": "teacher_has_external_plain_paper",
+            "created_by_workflow": "plain_paper_submission",
+        },
+    }
+    review = load_review_record(created.review_record_path)
+    assert review["schema_version"] == "2"
+    assert review["submission_manifest_path"] == created.submission_manifest_relative_path
+    assert review["review_state"] == "not_started"
+    assert review["review_units"] == []
+    assert review["overall_standard_ratings"] == []
+    assert review["feedback"]["standard_feedback"] == []
+    assert review["private_notes"] == []
+    assert review["module_details"] == {
+        "review_entry_method": "plain_paper_manual",
+        "created_by_workflow": "plain_paper_submission",
+    }
+    assert {path.name for path in created.submission_manifest_path.parent.iterdir()} == {
+        "submission.json",
+        "review.json",
+    }
+
+
+def test_rejects_student_not_in_roster(workspace: Path) -> None:
+    with pytest.raises(PlainPaperSubmissionError, match="not in the roster"):
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, "stu_999", created_at=TIMESTAMP
+        )
+
+
+def test_does_not_overwrite_existing_submission(workspace: Path) -> None:
+    created = create_plain_paper_submission(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+    original = created.submission_manifest_path.read_bytes()
+
+    with pytest.raises(PlainPaperSubmissionError, match="already exists"):
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert created.submission_manifest_path.read_bytes() == original
+
+
+def test_rejects_orphan_review_without_writing_manifest(workspace: Path) -> None:
+    student_dir = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+    )
+    student_dir.mkdir(parents=True)
+    review_path = student_dir / "review.json"
+    review_path.write_text("existing review", encoding="utf-8")
+
+    with pytest.raises(PlainPaperSubmissionError, match="without a submission"):
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert review_path.read_text(encoding="utf-8") == "existing review"
+    assert not (student_dir / "submission.json").exists()
+
+
+def test_status_and_evidence_opening_are_teacher_friendly(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    create_plain_paper_submission(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+    status = list_assignment_submission_status(workspace, CLASS_ID, ASSIGNMENT_ID)
+
+    assert review_menu._student_status_label(status.student_statuses[0]) == (
+        "plain-paper manual submission; no digital evidence"
+    )
+    review_menu._open_submission_evidence(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    output = capsys.readouterr().out
+    assert "No digital evidence is attached" in output
+    assert "Review the physical paper" in output


### PR DESCRIPTION
## Summary

- Add plain-paper manual submissions to the selected-student review workflow.
- Allow teachers to create a review-ready Quillan submission when students wrote responses on plain paper and no QR/scanned artifact exists.
- Add `quillan/plain_paper_submission.py` for assignment/roster validation, safe paired writes, no-overwrite protection, and rollback on partial failure.
- Update `quillan/review_menu.py` to:
  - offer creation only when no manifest or routed evidence exists;
  - require explicit `y`/`yes` confirmation;
  - display the normal review menu after creation;
  - label manual submissions clearly;
  - explain gracefully that no digital evidence is attached.
- Add focused helper and menu tests.
- Update README and supporting contract/workflow documentation.

## Data Shape

Created `submission.json` uses the existing submission manifest contract:

- `schema_version`: `1`
- `record_type`: `submission_manifest`
- `expected_pages`: `null`
- `submission_state`: `unreviewed`
- `pages`: `[]`

The submission manifest records plain-paper provenance in `module_details`:

```json
{
  "submission_entry_method": "plain_paper_manual",
  "physical_evidence_status": "teacher_has_external_plain_paper",
  "created_by_workflow": "plain_paper_submission"
}
```

Created `review.json` is the normal empty schema-version-2 review record and records plain-paper provenance in `module_details`:

```json
{
  "review_entry_method": "plain_paper_manual",
  "created_by_workflow": "plain_paper_submission"
}
```

## Safety

Confirmed:

- no fake evidence paths are created;
- no PDFs are created;
- no images are created;
- no scans are created;
- no OCR output is created;
- no placeholder artifacts are created;
- existing manifests are not overwritten;
- existing routed submissions are not overwritten;
- existing review records are not overwritten;
- PDS Core was not modified;
- ScoreForm was not modified;
- no student workspace data or generated artifacts were added.

## Validation

- Plain-paper tests: `6 passed`
- Review/submission selection: `594 passed`
- Menu selection: `110 passed`
- Full pytest: `1075 passed`
- Ruff: passed
- mypy: passed
- `git diff --check`: passed
- `run_tests.ps1`: passed, including `1075 passed`, Ruff, mypy, and whitespace checks
- `git status --short`: only intentional Quillan source, tests, and documentation changes

Closes #295