### PR TITLE
Add plain-paper submission CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -757,6 +757,23 @@ files, and skipped filenames without creating or modifying records.
 These commands do not open evidence, update review state, create review
 records, score work, tag work, generate feedback, run OCR, or perform AI work.
 
+## Plain-Paper Manual Submission
+
+```powershell
+quillan create-plain-paper-submission <class_id> <assignment_id> <student_id> --yes
+quillan create-plain-paper-submission <class_id> <assignment_id> <student_id> --dry-run
+```
+
+This command is for student work completed on physical plain paper when no
+digital, QR, or scanned evidence exists. It creates only the canonical
+evidence-less `submission.json` and paired empty `review.json`; it does not
+create scans, routed evidence, OCR output, PDFs, images, or feedback.
+
+`--yes` is required to write without an interactive prompt. `--dry-run` runs
+the same identity, assignment, roster, and existing-record validation and
+reports the workspace-relative target paths without writing files. The flags
+are mutually exclusive.
+
 ## Evidence and Submission Opening
 
 ```powershell

--- a/quillan/cli_app/handlers/submissions.py
+++ b/quillan/cli_app/handlers/submissions.py
@@ -16,6 +16,10 @@ from quillan.cli_app.output import (
     print_updated_submission_review_state,
 )
 from quillan.evidence_opening import EvidenceOpeningError, open_workspace_evidence
+from quillan.plain_paper_submission import (
+    create_plain_paper_submission,
+    plan_plain_paper_submission,
+)
 from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
     open_student_submission_for_review,
@@ -25,6 +29,49 @@ from quillan.submission_review_state import (
     update_submission_review_state,
 )
 from quillan.submission_status import list_assignment_submission_status
+
+
+def handle_create_plain_paper_submission(args: argparse.Namespace) -> int:
+    """Validate or create one evidence-less plain-paper submission."""
+    if not args.yes and not args.dry_run:
+        print("Error: creating a plain-paper submission requires --yes or --dry-run.")
+        return 1
+
+    try:
+        workspace_root = resolve_workspace_root()
+        if args.dry_run:
+            plan = plan_plain_paper_submission(
+                workspace_root, args.class_id, args.assignment_id, args.student_id
+            )
+        else:
+            created = create_plain_paper_submission(
+                workspace_root, args.class_id, args.assignment_id, args.student_id
+            )
+    except Exception as error:
+        action = "dry run failed" if args.dry_run else "was not created"
+        print(f"Error: plain-paper submission {action}: {error}")
+        return 1
+
+    if args.dry_run:
+        print("Plain-paper submission dry run:")
+        print(f"Class: {plan.class_id}")
+        print(f"Assignment: {plan.assignment_id}")
+        print(f"Student: {plan.student_id}")
+        print(
+            "Would create submission manifest: "
+            f"{plan.submission_manifest_relative_path}"
+        )
+        print(f"Would create review record: {plan.review_record_relative_path}")
+        print("No files were written.")
+    else:
+        print("Created plain-paper submission:")
+        print(f"Class: {created.class_id}")
+        print(f"Assignment: {created.assignment_id}")
+        print(f"Student: {created.student_id}")
+        print(f"Submission manifest: {created.submission_manifest_relative_path}")
+        print(f"Review record: {created.review_record_relative_path}")
+        print(f"Created at: {created.created_at}")
+    return 0
 
 
 def handle_assemble_submissions(args: argparse.Namespace) -> int:

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -23,6 +23,7 @@ from quillan.cli_app.handlers.scan_review import (
 )
 from quillan.cli_app.handlers.submissions import (
     handle_assemble_submissions,
+    handle_create_plain_paper_submission,
     handle_list_submissions,
     handle_open_evidence,
     handle_open_submission,
@@ -201,6 +202,28 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     assemble_parser.set_defaults(handler=handle_assemble_submissions)
+
+    plain_paper_parser = subparsers.add_parser(
+        "create-plain-paper-submission",
+        help="Create a review-ready submission for physical plain-paper work.",
+        description=(
+            "Validate and create an evidence-less submission manifest and empty "
+            "review record for work completed on physical plain paper."
+        ),
+    )
+    _add_submission_identity_arguments(plain_paper_parser)
+    confirmation_group = plain_paper_parser.add_mutually_exclusive_group()
+    confirmation_group.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm creation without an interactive prompt.",
+    )
+    confirmation_group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and report target paths without writing files.",
+    )
+    plain_paper_parser.set_defaults(handler=handle_create_plain_paper_submission)
 
     status_parser = subparsers.add_parser(
         "list-submissions",

--- a/quillan/plain_paper_submission.py
+++ b/quillan/plain_paper_submission.py
@@ -46,15 +46,26 @@ class CreatedPlainPaperSubmission:
     created_at: str
 
 
-def create_plain_paper_submission(
+@dataclass(frozen=True, slots=True)
+class PlainPaperSubmissionPlan:
+    """Validated target paths for a plain-paper submission."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    submission_manifest_path: Path
+    submission_manifest_relative_path: str
+    review_record_path: Path
+    review_record_relative_path: str
+
+
+def plan_plain_paper_submission(
     workspace_root: str | Path,
     class_id: str,
     assignment_id: str,
     student_id: str,
-    *,
-    created_at: datetime | str | None = None,
-) -> CreatedPlainPaperSubmission:
-    """Create an evidence-less manifest and empty v2 review record safely."""
+) -> PlainPaperSubmissionPlan:
+    """Validate a plain-paper submission request without writing files."""
     root = Path(workspace_root).resolve(strict=False)
     for value, field in (
         (class_id, "class_id"),
@@ -95,6 +106,30 @@ def create_plain_paper_submission(
             "submission before continuing."
         )
 
+    return PlainPaperSubmissionPlan(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        submission_manifest_path=manifest_path,
+        submission_manifest_relative_path=manifest_path.relative_to(root).as_posix(),
+        review_record_path=review_path,
+        review_record_relative_path=review_path.relative_to(root).as_posix(),
+    )
+
+
+def create_plain_paper_submission(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    created_at: datetime | str | None = None,
+) -> CreatedPlainPaperSubmission:
+    """Create an evidence-less manifest and empty v2 review record safely."""
+    plan = plan_plain_paper_submission(
+        workspace_root, class_id, assignment_id, student_id
+    )
+
     timestamp = _timestamp(created_at)
     manifest: dict[str, Any] = {
         "schema_version": "1",
@@ -127,22 +162,22 @@ def create_plain_paper_submission(
     validate_submission_manifest(manifest)
     validate_review_record(review)
 
-    write_submission_manifest(manifest_path, manifest)
+    write_submission_manifest(plan.submission_manifest_path, manifest)
     try:
-        write_review_record(review_path, review)
+        write_review_record(plan.review_record_path, review)
     except Exception:
         # Restore the original no-record state if the paired write cannot finish.
-        manifest_path.unlink(missing_ok=True)
+        plan.submission_manifest_path.unlink(missing_ok=True)
         raise
 
     return CreatedPlainPaperSubmission(
         class_id=class_id,
         assignment_id=assignment_id,
         student_id=student_id,
-        submission_manifest_path=manifest_path,
-        submission_manifest_relative_path=manifest_path.relative_to(root).as_posix(),
-        review_record_path=review_path,
-        review_record_relative_path=review_path.relative_to(root).as_posix(),
+        submission_manifest_path=plan.submission_manifest_path,
+        submission_manifest_relative_path=plan.submission_manifest_relative_path,
+        review_record_path=plan.review_record_path,
+        review_record_relative_path=plan.review_record_relative_path,
         created_at=timestamp,
     )
 

--- a/tests/test_plain_paper_submission.py
+++ b/tests/test_plain_paper_submission.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 import pytest
 
+from quillan.cli_app import parser as cli_parser
+from quillan.cli_app.handlers import submissions as cli_submissions
+from quillan.cli_app.main import main
 from quillan.plain_paper_submission import (
     PlainPaperSubmissionError,
     create_plain_paper_submission,
@@ -175,3 +178,247 @@ def test_status_and_evidence_opening_are_teacher_friendly(
     output = capsys.readouterr().out
     assert "No digital evidence is attached" in output
     assert "Review the physical paper" in output
+
+
+def test_cli_help_lists_plain_paper_command_and_arguments(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit, match="0"):
+        main(["--help"])
+    assert "create-plain-paper-submission" in capsys.readouterr().out
+
+    with pytest.raises(SystemExit, match="0"):
+        main(["create-plain-paper-submission", "--help"])
+    output = capsys.readouterr().out
+    assert "class_id" in output
+    assert "assignment_id" in output
+    assert "student_id" in output
+    assert "--yes" in output
+    assert "--dry-run" in output
+
+
+@pytest.fixture
+def cli_workspace(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    monkeypatch.setattr(cli_submissions, "resolve_workspace_root", lambda: workspace)
+    return workspace
+
+
+def test_cli_creates_plain_paper_submission(
+    cli_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = main(
+        [
+            "create-plain-paper-submission",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--yes",
+        ]
+    )
+
+    assert result == 0
+    student_dir = (
+        cli_workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+    )
+    manifest = load_submission_manifest(student_dir / "submission.json")
+    review = load_review_record(student_dir / "review.json")
+    assert manifest["pages"] == []
+    assert manifest["expected_pages"] is None
+    assert manifest["module_details"]["submission_entry_method"] == (
+        "plain_paper_manual"
+    )
+    assert review["schema_version"] == "2"
+    assert review["module_details"]["review_entry_method"] == "plain_paper_manual"
+    assert {path.name for path in student_dir.iterdir()} == {
+        "submission.json",
+        "review.json",
+    }
+    output = capsys.readouterr().out
+    assert "Created plain-paper submission:" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID}" in output
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Submission manifest: classes/" in output
+    assert "Review record: classes/" in output
+
+
+def test_cli_dry_run_validates_without_writing(
+    cli_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = main(
+        [
+            "create-plain-paper-submission",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--dry-run",
+        ]
+    )
+
+    assert result == 0
+    assert not (cli_workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "submissions").exists()
+    output = capsys.readouterr().out
+    assert "Plain-paper submission dry run:" in output
+    assert "Would create submission manifest: classes/" in output
+    assert "Would create review record: classes/" in output
+    assert "No files were written." in output
+
+
+def test_cli_requires_confirmation_without_writing(
+    cli_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = main(
+        ["create-plain-paper-submission", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    )
+
+    assert result == 1
+    assert "requires --yes or --dry-run" in capsys.readouterr().out
+    assert not (cli_workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "submissions").exists()
+
+
+def test_cli_flags_are_mutually_exclusive() -> None:
+    parser = cli_parser.build_parser()
+    with pytest.raises(SystemExit, match="2"):
+        parser.parse_args(
+            [
+                "create-plain-paper-submission",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--yes",
+                "--dry-run",
+            ]
+        )
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_cli_rejects_invalid_student(
+    cli_workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    dry_run: bool,
+) -> None:
+    flag = "--dry-run" if dry_run else "--yes"
+    result = main(
+        [
+            "create-plain-paper-submission",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            "stu_999",
+            flag,
+        ]
+    )
+
+    assert result == 1
+    assert "not in the roster" in capsys.readouterr().out
+    assert not (cli_workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "submissions").exists()
+
+
+def test_cli_refuses_existing_manifest_without_changing_it(
+    cli_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    created = create_plain_paper_submission(
+        cli_workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+    )
+    original = created.submission_manifest_path.read_bytes()
+
+    assert main(
+        [
+            "create-plain-paper-submission",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--yes",
+        ]
+    ) == 1
+    assert created.submission_manifest_path.read_bytes() == original
+    assert "already exists" in capsys.readouterr().out
+
+
+def test_cli_refuses_orphan_review_without_changing_it(
+    cli_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    student_dir = cli_workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "submissions" / STUDENT_ID
+    student_dir.mkdir(parents=True)
+    review_path = student_dir / "review.json"
+    review_path.write_bytes(b"existing review")
+
+    assert main(
+        [
+            "create-plain-paper-submission",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--yes",
+        ]
+    ) == 1
+    assert review_path.read_bytes() == b"existing review"
+    assert not (student_dir / "submission.json").exists()
+    assert "without a submission manifest" in capsys.readouterr().out
+
+
+def test_cli_workspace_error_is_reported_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fail_workspace() -> Path:
+        raise RuntimeError("workspace unavailable")
+
+    monkeypatch.setattr(cli_submissions, "resolve_workspace_root", fail_workspace)
+    result = main(
+        [
+            "create-plain-paper-submission",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--yes",
+        ]
+    )
+
+    assert result == 1
+    assert capsys.readouterr().out == (
+        "Error: plain-paper submission was not created: workspace unavailable\n"
+    )
+
+
+def test_cli_rejects_class_not_in_assignment(
+    cli_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assignment_path = (
+        cli_workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment = json.loads(assignment_path.read_text(encoding="utf-8"))
+    assignment["class_ids"] = ["english10_p3"]
+    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
+
+    result = main(
+        [
+            "create-plain-paper-submission",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            "--yes",
+        ]
+    )
+
+    assert result == 1
+    assert "is not included in assignment" in capsys.readouterr().out
+    assert not (
+        cli_workspace
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "submissions"
+    ).exists()


### PR DESCRIPTION
## Summary

- Add a direct CLI command for creating Quillan plain-paper manual submissions.
- Support both write and dry-run modes:

    quillan create-plain-paper-submission <class_id> <assignment_id> <student_id> --yes
    quillan create-plain-paper-submission <class_id> <assignment_id> <student_id> --dry-run

- Require either `--yes` or `--dry-run`; omitting both exits nonzero without prompting or writing.
- Keep `--yes` and `--dry-run` mutually exclusive.
- Reuse the existing `create_plain_paper_submission(...)` service as the canonical write path.
- Add shared non-writing `plan_plain_paper_submission(...)` preflight for dry-run validation.
- Preserve the #295 menu-created data shape and plain-paper provenance.
- Update the CLI contract.

## Behavior

The write command creates only:

- `submission.json`
- `review.json`

The dry-run command validates and reports the paths that would be created, but writes nothing.

Preflight validates:

- identifiers;
- assignment configuration;
- selected class membership in the assignment;
- roster membership;
- existing submission manifests;
- orphan review records.

## Safety

Confirmed:

- no scans are created;
- no evidence files are created;
- no PDFs are created;
- no images are created;
- no OCR output is created;
- no feedback exports are created;
- no placeholder artifacts are created;
- existing manifests are refused;
- orphan review records are refused;
- invalid students are refused;
- invalid class/assignment relationships are refused;
- menu behavior remains unchanged;
- Core was not modified;
- ScoreForm was not modified;
- no workspace data or generated artifacts were added.

## Files Changed

- `quillan/plain_paper_submission.py`
- `quillan/cli_app/handlers/submissions.py`
- `quillan/cli_app/parser.py`
- `tests/test_plain_paper_submission.py`
- `docs/cli_contract.md`

## Validation

- Focused module: `16 passed`
- Requested focused selector: `132 passed, 954 deselected`
- Full pytest: `1086 passed`
- Ruff: passed
- mypy: passed, `138` source files
- `git diff --check`: passed
- `run_tests.ps1`: passed
- Core status: clean
- ScoreForm status: clean
- Quillan status: only five intended source/test/doc files modified

Closes #298