### PR TITLE
Add assignment management CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -54,6 +54,9 @@ The implemented command surface currently exposed through argparse is:
 ```powershell
 quillan
 quillan --help
+quillan assignment create <class_id> <assignment_id> --title <title> --writing-type <type> (--prompt <text> | --prompt-file <path>) --standards-profile-id <profile_id> --focus-standard-ids <id,...> (--yes | --dry-run)
+quillan assignment show <class_id> <assignment_id>
+quillan assignment validate <class_id> <assignment_id>
 quillan validate-assignment <path>
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
 quillan route-scan <source-image> --decode-qr
@@ -92,6 +95,36 @@ quillan menu
 
 Bare `quillan` and the explicit `menu` command launch the same interactive
 menu. The other commands remain direct and non-interactive.
+
+### `assignment create`, `show`, and `validate`
+
+```powershell
+quillan assignment create <class_id> <assignment_id> ...
+quillan assignment show <class_id> <assignment_id>
+quillan assignment validate <class_id> <assignment_id>
+```
+
+`assignment create` builds the same schema-version-2 shape and uses the same
+defaults and structural validation as menu assignment creation. It requires an
+existing canonical class roster and validates the selected profile and Focus
+Standards against the active workspace's PDS Core standards library. New writes
+require `--yes`; replacing an existing config requires both `--overwrite` and
+`--yes`. `--dry-run` validates and reports the canonical path without creating
+an assignment directory or writing files.
+
+The prompt may be supplied inline with `--prompt` or read as UTF-8 text with
+`--prompt-file`. Basic paragraph, word-count, and required-element options are
+optional. Review-unit labels and the four-level standards rating scale default
+to the same values used by the menu.
+
+`assignment show` loads the canonical workspace config, validates its structure
+and path identity, and prints the shared assignment summary. `assignment
+validate` additionally validates the standards profile and every Focus Standard
+against the active workspace library. Both commands are read-only.
+
+These commands write or inspect only
+`classes/<class_id>/assignments/<assignment_id>/assignment.json`; they do not
+create submission, review, evidence, scan, export, Core, or ScoreForm data.
 
 ### `validate-assignment`
 

--- a/quillan/assignment_setup.py
+++ b/quillan/assignment_setup.py
@@ -1,0 +1,118 @@
+"""Workspace-aware services for canonical Quillan assignment configs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pds_core.classes import load_class_roster
+from pds_core.identifiers import validate_identifier
+from pds_core.standards import load_workspace_standards_library
+
+from quillan.assignments import (
+    AssignmentConfigError,
+    load_assignment_config,
+    validate_assignment_standards_selection,
+)
+from quillan.assignment_workflows import (
+    build_assignment_config,
+    default_rating_scale,
+    default_review_unit,
+    normalize_writing_type,
+    write_assignment_config,
+)
+from quillan.storage import assignment_config_path
+
+
+@dataclass(frozen=True)
+class AssignmentPlan:
+    """A validated assignment and its canonical output path."""
+
+    workspace_root: Path
+    class_id: str
+    assignment_id: str
+    path: Path
+    assignment: dict[str, Any]
+
+
+def plan_assignment_creation(
+    workspace_root: str | Path,
+    *,
+    class_id: str,
+    assignment_id: str,
+    title: str,
+    writing_type: str,
+    student_prompt: str,
+    standards_profile_id: str,
+    focus_standard_ids: list[str],
+    review_unit: dict[str, Any] | None = None,
+    rating_scale: dict[str, Any] | None = None,
+    basic_requirements: dict[str, Any] | None = None,
+    allow_return_without_full_review: bool = True,
+) -> AssignmentPlan:
+    """Validate creation inputs without creating directories or files."""
+    root = Path(workspace_root).resolve(strict=False)
+    validate_identifier(class_id, "class_id")
+    validate_identifier(assignment_id, "assignment_id")
+    load_class_roster(root, class_id)
+    assignment = build_assignment_config(
+        assignment_id=assignment_id,
+        title=title,
+        class_id=class_id,
+        writing_type=normalize_writing_type(writing_type),
+        student_prompt=student_prompt,
+        standards_profile_id=standards_profile_id,
+        focus_standard_ids=focus_standard_ids,
+        review_unit=review_unit or default_review_unit(),
+        rating_scale=rating_scale or default_rating_scale(),
+        basic_requirements=basic_requirements or {},
+        minimum_requirement_policy={
+            "allow_return_without_full_review": allow_return_without_full_review
+        },
+    )
+    library = load_workspace_standards_library(root)
+    validate_assignment_standards_selection(assignment, library)
+    return AssignmentPlan(
+        workspace_root=root,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        path=assignment_config_path(root, class_id, assignment_id),
+        assignment=assignment,
+    )
+
+
+def create_assignment(plan: AssignmentPlan, *, overwrite: bool = False) -> Path:
+    """Write one prevalidated assignment to its canonical path."""
+    return write_assignment_config(
+        plan.workspace_root,
+        plan.class_id,
+        plan.assignment,
+        overwrite=overwrite,
+    )
+
+
+def load_canonical_assignment(
+    workspace_root: str | Path, class_id: str, assignment_id: str
+) -> AssignmentPlan:
+    """Load and check one canonical assignment's path identity."""
+    root = Path(workspace_root).resolve(strict=False)
+    validate_identifier(class_id, "class_id")
+    validate_identifier(assignment_id, "assignment_id")
+    path = assignment_config_path(root, class_id, assignment_id)
+    assignment = load_assignment_config(path)
+    if assignment["assignment_id"] != assignment_id:
+        raise AssignmentConfigError(
+            "Path assignment_id does not match assignment config assignment_id."
+        )
+    if class_id not in assignment["class_ids"]:
+        raise AssignmentConfigError(
+            "Path class_id is not included in assignment config class_ids."
+        )
+    return AssignmentPlan(root, class_id, assignment_id, path, assignment)
+
+
+def validate_canonical_assignment(plan: AssignmentPlan) -> None:
+    """Validate a canonical assignment against workspace standards."""
+    library = load_workspace_standards_library(plan.workspace_root)
+    validate_assignment_standards_selection(plan.assignment, library)

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -746,7 +746,8 @@ def _prompt_writing_type() -> str:
     return normalized
 
 
-def _default_review_unit() -> dict[str, str]:
+def default_review_unit() -> dict[str, str]:
+    """Return a fresh copy of the menu's default review-unit config."""
     return dict(_DEFAULT_REVIEW_UNIT)
 
 
@@ -756,7 +757,7 @@ def _prompt_review_unit() -> dict[str, str]:
         "later."
     )
     if _prompt_yes_no("Use default paragraph review units? [Y/n]: ", default=True):
-        return _default_review_unit()
+        return default_review_unit()
     return {
         "type": _required_input("Review-unit type: ", "review-unit type"),
         "singular_label": _required_input(
@@ -770,7 +771,8 @@ def _prompt_review_unit() -> dict[str, str]:
     }
 
 
-def _default_rating_scale() -> dict[str, Any]:
+def default_rating_scale() -> dict[str, Any]:
+    """Return a fresh copy of the menu's four-level standards scale."""
     levels = _DEFAULT_RATING_SCALE["levels"]
     assert isinstance(levels, list)
     return {
@@ -782,7 +784,7 @@ def _default_rating_scale() -> dict[str, Any]:
 def _prompt_rating_scale() -> dict[str, Any]:
     print("Rating scale for standards-based review:")
     if _prompt_yes_no("Use default four-level standards scale? [Y/n]: ", default=True):
-        return _default_rating_scale()
+        return default_rating_scale()
 
     scale_id = _required_input("Rating scale ID: ", "rating scale ID")
     level_count = parse_optional_nonnegative_int(

--- a/quillan/cli_app/arguments.py
+++ b/quillan/cli_app/arguments.py
@@ -14,3 +14,14 @@ def positive_integer(value: str) -> int:
     if parsed < 1:
         raise argparse.ArgumentTypeError("must be a positive integer")
     return parsed
+
+
+def nonnegative_integer(value: str) -> int:
+    """Parse a non-negative integer argument."""
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed

--- a/quillan/cli_app/handlers/assignments.py
+++ b/quillan/cli_app/handlers/assignments.py
@@ -1,0 +1,123 @@
+"""Direct canonical assignment command handlers."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.assignment_setup import (
+    create_assignment,
+    load_canonical_assignment,
+    plan_assignment_creation,
+    validate_canonical_assignment,
+)
+from quillan.assignment_workflows import (
+    format_assignment_summary,
+    parse_comma_separated_values,
+)
+
+
+def _relative(path: Path, root: Path) -> Path:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path
+
+
+def _error(action: str, error: Exception) -> int:
+    print(f"Error: assignment {action}: {error}")
+    return 1
+
+
+def handle_assignment_create(args: argparse.Namespace) -> int:
+    """Plan, validate, and optionally write a canonical assignment."""
+    if args.overwrite and not args.yes:
+        return _error("was not created", ValueError("--overwrite requires --yes."))
+    if not args.yes and not args.dry_run:
+        return _error(
+            "was not created", ValueError("use --yes to confirm or --dry-run.")
+        )
+    try:
+        prompt = args.prompt
+        if args.prompt_file is not None:
+            prompt = args.prompt_file.read_text(encoding="utf-8")
+        requirements = {
+            key: value
+            for key, value in {
+                "paragraphs_min": args.paragraphs_min,
+                "paragraphs_max": args.paragraphs_max,
+                "word_count_min": args.word_count_min,
+                "word_count_max": args.word_count_max,
+            }.items()
+            if value is not None
+        }
+        elements = parse_comma_separated_values(args.required_elements or "")
+        if elements:
+            requirements["required_elements"] = elements
+        plan = plan_assignment_creation(
+            resolve_workspace_root(),
+            class_id=args.class_id,
+            assignment_id=args.assignment_id,
+            title=args.title,
+            writing_type=args.writing_type,
+            student_prompt=prompt,
+            standards_profile_id=args.standards_profile_id,
+            focus_standard_ids=parse_comma_separated_values(args.focus_standard_ids),
+            review_unit={
+                "type": args.review_unit_type,
+                "singular_label": args.review_unit_singular,
+                "plural_label": args.review_unit_plural,
+            },
+            basic_requirements=requirements,
+            allow_return_without_full_review=args.allow_return_without_full_review,
+        )
+        relative_path = _relative(plan.path, plan.workspace_root)
+        if args.dry_run:
+            print("Assignment creation dry run:")
+            print(f"Class: {plan.class_id}")
+            print(f"Assignment: {plan.assignment_id}")
+            print(f"Would write: {relative_path}")
+            print(format_assignment_summary(plan.assignment, relative_path))
+            print("No files were written.")
+            return 0
+        path = create_assignment(plan, overwrite=args.overwrite)
+        print("Created assignment:")
+        print(f"Class: {plan.class_id}")
+        print(f"Assignment: {plan.assignment_id}")
+        print(format_assignment_summary(plan.assignment, _relative(path, plan.workspace_root)))
+        return 0
+    except (OSError, ValueError, WorkspaceRootError) as error:
+        return _error("was not created", error)
+
+
+def handle_assignment_show(args: argparse.Namespace) -> int:
+    """Load and show one structurally valid canonical assignment."""
+    try:
+        plan = load_canonical_assignment(
+            resolve_workspace_root(), args.class_id, args.assignment_id
+        )
+        print("Assignment config is valid.")
+        print(format_assignment_summary(plan.assignment, _relative(plan.path, plan.workspace_root)))
+        return 0
+    except (OSError, ValueError, WorkspaceRootError) as error:
+        return _error("could not be shown", error)
+
+
+def handle_assignment_validate(args: argparse.Namespace) -> int:
+    """Validate one canonical assignment and its workspace standards."""
+    try:
+        plan = load_canonical_assignment(
+            resolve_workspace_root(), args.class_id, args.assignment_id
+        )
+        validate_canonical_assignment(plan)
+        print("Valid canonical assignment:")
+        print(f"Class: {plan.class_id}")
+        print(f"Assignment: {plan.assignment_id}")
+        print(f"Standards profile: {plan.assignment['standards_profile_id']}")
+        print(f"Focus Standards: {len(plan.assignment['focus_standard_ids'])}")
+        print(f"Path: {_relative(plan.path, plan.workspace_root)}")
+        return 0
+    except (OSError, ValueError, WorkspaceRootError) as error:
+        return _error("validation failed", error)

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from quillan.cli_app.arguments import positive_integer
+from quillan.cli_app.arguments import nonnegative_integer, positive_integer
 from quillan.cli_app.handlers.exports import (
     handle_export_class_summary,
     handle_export_feedback,
@@ -30,6 +30,11 @@ from quillan.cli_app.handlers.submissions import (
     handle_set_review_state,
 )
 from quillan.cli_app.handlers.validation import handle_validate_assignment
+from quillan.cli_app.handlers.assignments import (
+    handle_assignment_create,
+    handle_assignment_show,
+    handle_assignment_validate as handle_canonical_assignment_validate,
+)
 from quillan.cli_app.handlers.workspace import (
     handle_menu,
     handle_workspace_reset,
@@ -45,6 +50,50 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser and register command handlers."""
     parser = argparse.ArgumentParser(description=APP_DESCRIPTION)
     subparsers = parser.add_subparsers(dest="command")
+
+    assignment_parser = subparsers.add_parser(
+        "assignment", help="Create, show, and validate canonical assignments."
+    )
+    assignment_subparsers = assignment_parser.add_subparsers(dest="assignment_command")
+    assignment_create_parser = assignment_subparsers.add_parser(
+        "create", help="Create a canonical workspace assignment config."
+    )
+    _add_assignment_identity_arguments(assignment_create_parser)
+    assignment_create_parser.add_argument("--title", required=True)
+    assignment_create_parser.add_argument("--writing-type", required=True)
+    prompt_group = assignment_create_parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt")
+    prompt_group.add_argument("--prompt-file", type=Path)
+    assignment_create_parser.add_argument("--standards-profile-id", required=True)
+    assignment_create_parser.add_argument("--focus-standard-ids", required=True)
+    assignment_create_parser.add_argument("--review-unit-type", default="paragraph")
+    assignment_create_parser.add_argument("--review-unit-singular", default="paragraph")
+    assignment_create_parser.add_argument("--review-unit-plural", default="paragraphs")
+    assignment_create_parser.add_argument("--rating-scale", choices=("default",), default="default")
+    assignment_create_parser.add_argument("--paragraphs-min", type=nonnegative_integer)
+    assignment_create_parser.add_argument("--paragraphs-max", type=nonnegative_integer)
+    assignment_create_parser.add_argument("--word-count-min", type=nonnegative_integer)
+    assignment_create_parser.add_argument("--word-count-max", type=nonnegative_integer)
+    assignment_create_parser.add_argument("--required-elements")
+    assignment_create_parser.add_argument(
+        "--allow-return-without-full-review", type=_boolean, default=True
+    )
+    assignment_create_parser.add_argument("--overwrite", action="store_true")
+    confirmation = assignment_create_parser.add_mutually_exclusive_group()
+    confirmation.add_argument("--yes", action="store_true")
+    confirmation.add_argument("--dry-run", action="store_true")
+    assignment_create_parser.set_defaults(handler=handle_assignment_create)
+
+    assignment_show_parser = assignment_subparsers.add_parser(
+        "show", help="Show a canonical workspace assignment config."
+    )
+    _add_assignment_identity_arguments(assignment_show_parser)
+    assignment_show_parser.set_defaults(handler=handle_assignment_show)
+    assignment_validate_parser = assignment_subparsers.add_parser(
+        "validate", help="Validate a canonical assignment and workspace standards."
+    )
+    _add_assignment_identity_arguments(assignment_validate_parser)
+    assignment_validate_parser.set_defaults(handler=handle_canonical_assignment_validate)
 
     validate_assignment_parser = subparsers.add_parser(
         "validate-assignment",
@@ -442,6 +491,15 @@ def _add_assignment_identity_arguments(
 ) -> None:
     parser.add_argument("class_id", help="Class identifier.")
     parser.add_argument("assignment_id", help="Assignment identifier.")
+
+
+def _boolean(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"true", "yes", "1"}:
+        return True
+    if normalized in {"false", "no", "0"}:
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
 
 
 def _add_submission_identity_arguments(

--- a/tests/test_cli_assignments.py
+++ b/tests/test_cli_assignments.py
@@ -1,0 +1,156 @@
+"""Tests for direct canonical assignment CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+from pds_core.standards import (
+    StandardDefinition,
+    StandardsLibrary,
+    StandardsProfile,
+    write_workspace_standards_library,
+)
+import pytest
+
+from quillan.cli import main
+import quillan.cli_app.handlers.assignments as handlers
+
+STANDARD_ID = "njsls-ela:W.AW.9-10.1"
+OTHER_STANDARD_ID = "njsls-ela:RL.CR.9-10.1"
+
+
+def _workspace(root: Path) -> None:
+    write_class_roster(
+        root,
+        create_roster(
+            "english10_p2",
+            [
+                {
+                    "student_id": "student1",
+                    "last_name": "Doe",
+                    "first_name": "A",
+                    "period": "2",
+                }
+            ],
+        ),
+    )
+    write_workspace_standards_library(
+        root,
+        StandardsLibrary(
+            standards=(
+                StandardDefinition(
+                    standard_id=STANDARD_ID,
+                    code="W.AW.9-10.1",
+                    source="NJSLS",
+                    short_name="Argument",
+                    description="Write arguments.",
+                    available_modules=("quillan",),
+                ),
+                StandardDefinition(
+                    standard_id=OTHER_STANDARD_ID,
+                    code="RL.CR.9-10.1",
+                    source="NJSLS",
+                    short_name="Reading",
+                    description="Read closely.",
+                    available_modules=("quillan",),
+                ),
+            ),
+            profiles=(
+                StandardsProfile(
+                    profile_id="english10_profile",
+                    standards=(STANDARD_ID,),
+                    title="English 10",
+                ),
+            ),
+        ),
+    )
+
+
+def _args(*extra: str) -> list[str]:
+    return [
+        "assignment", "create", "english10_p2", "literary_analysis",
+        "--title", "Literary Analysis", "--writing-type", "Literary Analysis",
+        "--prompt", "Analyze the text.", "--standards-profile-id",
+        "english10_profile", "--focus-standard-ids", STANDARD_ID, *extra,
+    ]
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _workspace(tmp_path)
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def test_assignment_help_surface(capsys: pytest.CaptureFixture[str]) -> None:
+    for argv, expected in [
+        (["--help"], "assignment"),
+        (["assignment", "--help"], "create"),
+        (["assignment", "create", "--help"], "--prompt-file"),
+        (["assignment", "show", "--help"], "class_id"),
+        (["assignment", "validate", "--help"], "assignment_id"),
+    ]:
+        with pytest.raises(SystemExit) as error:
+            main(argv)
+        assert error.value.code == 0
+        assert expected in capsys.readouterr().out
+
+
+def test_create_show_validate_and_overwrite_safety(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(_args("--yes", "--paragraphs-min", "4")) == 0
+    path = workspace / "classes/english10_p2/assignments/literary_analysis/assignment.json"
+    assignment = json.loads(path.read_text(encoding="utf-8"))
+    assert assignment["schema_version"] == "2"
+    assert assignment["module"] == "quillan"
+    assert assignment["class_ids"] == ["english10_p2"]
+    assert assignment["writing_type"] == "literary_analysis"
+    assert assignment["basic_requirements"] == {"paragraphs_min": 4}
+    assert len(assignment["rating_scale"]["levels"]) == 4
+    original = path.read_bytes()
+    assert main(_args("--yes")) == 1
+    assert path.read_bytes() == original
+    assert main(_args("--overwrite")) == 1
+    assert path.read_bytes() == original
+    assert main(["assignment", "show", "english10_p2", "literary_analysis"]) == 0
+    assert main(["assignment", "validate", "english10_p2", "literary_analysis"]) == 0
+    output = capsys.readouterr().out
+    assert "Assignment config is valid." in output
+    assert "Valid canonical assignment:" in output
+
+
+def test_dry_run_and_prompt_file_preserve_content(
+    workspace: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(_args("--dry-run")) == 0
+    target = workspace / "classes/english10_p2/assignments/literary_analysis"
+    assert not target.exists()
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("Line one.\nLine two.\n", encoding="utf-8")
+    argv = _args("--yes")
+    prompt_index = argv.index("--prompt")
+    argv[prompt_index : prompt_index + 2] = ["--prompt-file", str(prompt_file)]
+    assert main(argv) == 0
+    assignment = json.loads((target / "assignment.json").read_text(encoding="utf-8"))
+    assert assignment["student_prompt"] == "Line one.\nLine two.\n"
+    assert "No files were written." in capsys.readouterr().out
+
+
+def test_invalid_standards_and_path_identity_fail_cleanly(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = _args("--dry-run")
+    bad[bad.index(STANDARD_ID)] = OTHER_STANDARD_ID
+    assert main(bad) == 1
+    assert "assignment was not created" in capsys.readouterr().out
+    assert main(_args("--yes")) == 0
+    path = workspace / "classes/english10_p2/assignments/literary_analysis/assignment.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["assignment_id"] = "different_id"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    assert main(["assignment", "validate", "english10_p2", "literary_analysis"]) == 1
+    assert "Path assignment_id" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Add direct CLI commands for workspace-aware Quillan assignment management:
  - `quillan assignment create <class_id> <assignment_id>`
  - `quillan assignment show <class_id> <assignment_id>`
  - `quillan assignment validate <class_id> <assignment_id>`
- Add shared assignment setup services in `quillan/assignment_setup.py`.
- Support prompt text, prompt files, dry runs, overwrite protection, basic requirements, review-unit defaults, and rating-scale defaults.
- Validate active workspace roster membership and standards-library references.
- Validate canonical assignment path identity.
- Preserve existing path-based `quillan validate-assignment <path>` behavior.

## Behavior

`assignment create` writes the canonical assignment config:

- `classes/<class_id>/assignments/<assignment_id>/assignment.json`

It validates:

- class ID and assignment ID;
- active workspace;
- class roster existence;
- assignment schema;
- selected standards profile;
- selected Focus Standards;
- Focus Standards belonging to the selected profile;
- canonical path identity;
- overwrite safety.

Existing assignments require both `--overwrite` and `--yes`.

`assignment show` is read-only and prints the shared assignment summary.

`assignment validate` is read-only and validates the canonical workspace assignment against both Quillan structure and the active PDS Core standards library.

## Safety

Confirmed:

- only canonical `assignment.json` is written;
- no submissions are created;
- no review records are created;
- no routed evidence is created;
- no scans are created;
- no exports are created;
- no standards-library data is modified;
- existing assignments are not overwritten accidentally;
- menu assignment behavior still works;
- Core was not modified;
- ScoreForm was not modified.

## Contract Note

`docs/assignment_contract.md` currently documents `created_at`, `updated_at`, and `module_details` as required fields, while current runtime validation and menu-created assignments omit them.

This PR preserves the existing runtime/menu shape. Resolving that documentation/runtime mismatch should be handled in a follow-up issue because it may require a broader schema-contract decision.

## Files Changed

- `quillan/assignment_setup.py`
- `quillan/cli_app/handlers/assignments.py`
- `quillan/cli_app/parser.py`
- assignment CLI tests
- `docs/cli_contract.md`

## Validation

- Focused assignment/CLI selection: `14 passed`
- Assignment workflows: `42 passed`
- Combined focused regression run: `75 passed`
- Full pytest: `1090 passed`
- Ruff: passed
- mypy: passed, `141` source files
- `git diff --check`: passed
- `run_tests.ps1`: passed
- Final focused CLI tests: `4 passed`
- Core status: clean
- ScoreForm status: clean

Closes #299