### PR TITLE
Add roster management CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -57,6 +57,12 @@ quillan --help
 quillan assignment create <class_id> <assignment_id> --title <title> --writing-type <type> (--prompt <text> | --prompt-file <path>) --standards-profile-id <profile_id> --focus-standard-ids <id,...> (--yes | --dry-run)
 quillan assignment show <class_id> <assignment_id>
 quillan assignment validate <class_id> <assignment_id>
+quillan roster create <class_id> --input <roster.csv> [--school-year YYYY-YYYY] [--overwrite] (--yes | --dry-run)
+quillan roster show <class_id>
+quillan roster validate <class_id>
+quillan roster add-student <class_id> --student-id <student_id> --last-name <name> --first-name <name> --period <period> [--field <column=value> ...] (--yes | --dry-run)
+quillan roster update-student <class_id> <student_id> [--last-name <name>] [--first-name <name>] [--period <period>] [--field <column=value> ...] (--yes | --dry-run)
+quillan roster remove-student <class_id> <student_id> (--yes | --dry-run)
 quillan validate-assignment <path>
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
 quillan route-scan <source-image> --decode-qr
@@ -87,6 +93,9 @@ Running `quillan` without a command launches the teacher-facing terminal menu.
 Running `quillan workspace` without a subcommand prints top-level help and
 exits successfully; it does not inspect or modify the workspace.
 
+Running `quillan roster` without a subcommand prints roster help and exits
+successfully without resolving or inspecting the workspace.
+
 The teacher-facing menu may also be launched explicitly:
 
 ```powershell
@@ -95,6 +104,59 @@ quillan menu
 
 Bare `quillan` and the explicit `menu` command launch the same interactive
 menu. The other commands remain direct and non-interactive.
+
+### `roster` commands
+
+The `roster` namespace manages canonical shared roster artifacts under
+`classes/<class_id>/`. All commands resolve the active Paper Data Suite
+workspace through PDS Core; Quillan has no separate roster workspace setting.
+Direct roster commands never enter the menu or prompt with `input()`.
+
+`roster create` loads `--input` through the shared roster CSV loader. The CSV
+must contain `class_id`, `student_id`, `last_name`, `first_name`, and `period`,
+with at least one valid row. Its class ID must exactly match the positional
+class ID. The validated roster is written through the shared canonical writer,
+not copied byte-for-byte. Student IDs remain strings, so leading zeros are
+preserved. Optional columns, their order, blank values, and row order are also
+preserved.
+
+Creation uses an explicit valid `--school-year` when supplied, otherwise the
+workspace's active school year. If neither exists, creation fails with guidance
+and writes nothing. A confirmed creation writes exactly the paired canonical
+artifacts `classes/<class_id>/roster.csv` and
+`classes/<class_id>/class.json`. If either target already exists, replacement
+requires both `--overwrite` and `--yes`; the paired plan is fully validated
+before writing. A failed new paired write removes artifacts newly created by
+that operation.
+
+`roster show` and `roster validate` are read-only. Both load the canonical CSV
+through PDS Core. Show displays every required and optional column, the student
+count, paths, and the class school year when valid metadata exists. Missing
+metadata is reported as `not set`; malformed metadata is reported without a
+traceback. Validate also checks canonical folder identity and any existing
+metadata. Missing metadata remains valid for older class folders, while invalid
+existing metadata makes validation fail.
+
+`add-student`, `update-student`, and `remove-student` construct a new immutable
+roster through shared PDS Core mutation functions and replace only
+`classes/<class_id>/roster.csv` after `--yes`. They never modify `class.json`.
+Add appends a student; update preserves both row position and the positional
+student ID as stable identity; remove affects only the active roster and cannot
+remove its final student.
+
+Optional values use repeatable `--field column=value` arguments. Only columns
+already present in the roster's optional schema are allowed. Required columns,
+unknown columns, and duplicate keys fail. Add fills omitted optional values
+with blank strings. Update retains omitted values, while `--field name=` clears
+that value. These commands cannot add CSV columns.
+
+Every roster write requires exactly one of `--yes` or `--dry-run`. Omitting
+both fails without prompting or writing. Dry runs perform normal validation,
+show the target and resulting count, and create no directories or files.
+Active-roster removal does not traverse or delete class metadata, assignments,
+submission manifests, reviews, scans, printable PDFs, evidence, notes,
+observations, ratings, feedback, exports, reports, historical results, or other
+module data.
 
 ### `assignment create`, `show`, and `validate`
 

--- a/quillan/cli_app/handlers/rosters.py
+++ b/quillan/cli_app/handlers/rosters.py
@@ -1,0 +1,228 @@
+"""Direct, non-interactive canonical roster command handlers."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+
+from pds_core.rosters import RosterError, RosterValidationError
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.roster_management import (
+    RosterCreationPlan,
+    RosterMutationPlan,
+    load_canonical_roster,
+    optional_roster_columns,
+    plan_add_student,
+    plan_remove_student,
+    plan_roster_creation,
+    plan_update_student,
+    write_roster_creation,
+    write_roster_mutation,
+)
+from quillan.roster_workflows import format_roster_for_display
+
+
+def _error(error: Exception) -> int:
+    print(f"Error: {error}")
+    if isinstance(error, RosterValidationError):
+        for issue in error.issues:
+            location: list[str] = []
+            if issue.row_number is not None:
+                location.append(f"row {issue.row_number}")
+            if issue.column:
+                location.append(f"column {issue.column}")
+            prefix = f"  {' / '.join(location)}: " if location else "  "
+            print(f"{prefix}[{issue.code}] {issue.message}")
+    return 1
+
+
+def _confirmation_error(args: argparse.Namespace) -> int | None:
+    if not args.yes and not args.dry_run:
+        return _error(ValueError("use --yes to confirm or --dry-run."))
+    return None
+
+
+def _optional_columns_label(columns: tuple[str, ...]) -> str:
+    return ", ".join(columns) if columns else "none"
+
+
+def _fields_label(student_fields: Mapping[str, str]) -> str:
+    fields = dict(student_fields)
+    if not fields:
+        return "none"
+    return ", ".join(f"{key}={value}" for key, value in fields.items())
+
+
+def _print_creation(plan: RosterCreationPlan, *, dry_run: bool) -> None:
+    title = "Roster creation dry run:" if dry_run else "Created canonical roster:"
+    print(title)
+    print(f"Class ID: {plan.roster.class_id}")
+    print(f"Source CSV: {plan.source_path}")
+    print(f"School year: {plan.metadata.school_year}")
+    print(f"Student count: {len(plan.roster.students)}")
+    print(
+        "Optional columns: "
+        f"{_optional_columns_label(optional_roster_columns(plan.roster))}"
+    )
+    print(f"Roster path: {plan.roster_path}")
+    print(f"Class metadata path: {plan.metadata_path}")
+    print(f"Existing target: {'yes' if plan.target_exists else 'no'}")
+    if dry_run:
+        print("No files were written.")
+
+
+def handle_roster_create(args: argparse.Namespace) -> int:
+    """Plan and optionally create a canonical roster/metadata pair."""
+    if args.overwrite and not args.yes:
+        return _error(ValueError("--overwrite requires --yes."))
+    confirmation_error = _confirmation_error(args)
+    if confirmation_error is not None:
+        return confirmation_error
+    try:
+        plan = plan_roster_creation(
+            resolve_workspace_root(),
+            args.class_id,
+            args.input,
+            school_year=args.school_year,
+        )
+        if args.dry_run:
+            _print_creation(plan, dry_run=True)
+            return 0
+        if plan.target_exists and not args.overwrite:
+            raise ValueError(
+                "canonical roster or class metadata already exists; "
+                "use --overwrite --yes."
+            )
+        write_roster_creation(plan, overwrite=args.overwrite)
+        _print_creation(plan, dry_run=False)
+        return 0
+    except (OSError, ValueError, RosterError, WorkspaceRootError) as error:
+        return _error(error)
+
+
+def handle_roster_show(args: argparse.Namespace) -> int:
+    """Show a canonical roster and optional metadata without writing."""
+    try:
+        loaded = load_canonical_roster(resolve_workspace_root(), args.class_id)
+        print(
+            format_roster_for_display(
+                loaded.roster,
+                loaded.roster_path,
+                metadata=loaded.metadata,
+                metadata_path=loaded.metadata_path,
+                metadata_error=loaded.metadata_error,
+            )
+        )
+        return 0
+    except (OSError, ValueError, RosterError, WorkspaceRootError) as error:
+        return _error(error)
+
+
+def handle_roster_validate(args: argparse.Namespace) -> int:
+    """Validate a canonical roster and any existing class metadata."""
+    try:
+        loaded = load_canonical_roster(resolve_workspace_root(), args.class_id)
+        if loaded.metadata_error is not None:
+            raise loaded.metadata_error
+        print("Canonical roster is valid.")
+        print(f"Class ID: {loaded.roster.class_id}")
+        print(f"Student count: {len(loaded.roster.students)}")
+        print(f"Roster path: {loaded.roster_path}")
+        print(
+            "School year: "
+            f"{loaded.metadata.school_year if loaded.metadata is not None else 'not set'}"
+        )
+        print(
+            "Optional columns: "
+            f"{_optional_columns_label(optional_roster_columns(loaded.roster))}"
+        )
+        return 0
+    except (OSError, ValueError, RosterError, WorkspaceRootError) as error:
+        return _error(error)
+
+
+def _print_mutation(plan: RosterMutationPlan, *, dry_run: bool) -> None:
+    action = {"add": "add", "update": "update", "remove": "remove"}[plan.action]
+    print(f"Roster {action} {'dry run' if dry_run else 'complete'}:")
+    print(f"Class ID: {plan.roster.class_id}")
+    print(f"Student ID: {plan.student.student_id}")
+    print(f"Student: {plan.student.first_name} {plan.student.last_name}")
+    print(f"Period: {plan.student.period}")
+    print(f"Optional fields: {_fields_label(plan.student.extra_fields)}")
+    print(f"Resulting student count: {len(plan.roster.students)}")
+    print(f"Roster path: {plan.roster_path}")
+    if dry_run:
+        print("No files were written.")
+
+
+def _finish_mutation(args: argparse.Namespace, plan: RosterMutationPlan) -> int:
+    if args.dry_run:
+        _print_mutation(plan, dry_run=True)
+        return 0
+    write_roster_mutation(plan)
+    _print_mutation(plan, dry_run=False)
+    return 0
+
+
+def handle_roster_add_student(args: argparse.Namespace) -> int:
+    """Plan and optionally append one student to the active roster."""
+    confirmation_error = _confirmation_error(args)
+    if confirmation_error is not None:
+        return confirmation_error
+    try:
+        plan = plan_add_student(
+            resolve_workspace_root(),
+            args.class_id,
+            student_id=args.student_id,
+            last_name=args.last_name,
+            first_name=args.first_name,
+            period=args.period,
+            fields=args.field,
+        )
+        return _finish_mutation(args, plan)
+    except (OSError, ValueError, RosterError, WorkspaceRootError) as error:
+        return _error(error)
+
+
+def handle_roster_update_student(args: argparse.Namespace) -> int:
+    """Plan and optionally update one student without changing its ID."""
+    confirmation_error = _confirmation_error(args)
+    if confirmation_error is not None:
+        return confirmation_error
+    try:
+        plan = plan_update_student(
+            resolve_workspace_root(),
+            args.class_id,
+            args.student_id,
+            last_name=args.last_name,
+            first_name=args.first_name,
+            period=args.period,
+            fields=args.field,
+        )
+        return _finish_mutation(args, plan)
+    except (OSError, ValueError, RosterError, WorkspaceRootError) as error:
+        return _error(error)
+
+
+_REMOVAL_BOUNDARY = (
+    "Active-roster removal changes only roster.csv. It does not delete class "
+    "metadata, assignments, submission manifests, review records, routed scans, "
+    "source scans, printable PDFs, evidence files, teacher notes, observations, "
+    "ratings, feedback, exports, reports, historical results, or other module data."
+)
+
+
+def handle_roster_remove_student(args: argparse.Namespace) -> int:
+    """Plan and optionally remove one student only from active roster.csv."""
+    confirmation_error = _confirmation_error(args)
+    if confirmation_error is not None:
+        return confirmation_error
+    try:
+        plan = plan_remove_student(
+            resolve_workspace_root(), args.class_id, args.student_id
+        )
+        print(_REMOVAL_BOUNDARY)
+        return _finish_mutation(args, plan)
+    except (OSError, ValueError, RosterError, WorkspaceRootError) as error:
+        return _error(error)

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from functools import partial
 from pathlib import Path
 
 from quillan.cli_app.arguments import nonnegative_integer, positive_integer
@@ -15,6 +16,14 @@ from quillan.cli_app.handlers.exports import (
 from quillan.cli_app.handlers.decoding import handle_decode_scan
 from quillan.cli_app.handlers.review import (
     handle_add_note,
+)
+from quillan.cli_app.handlers.rosters import (
+    handle_roster_add_student,
+    handle_roster_create,
+    handle_roster_remove_student,
+    handle_roster_show,
+    handle_roster_update_student,
+    handle_roster_validate,
 )
 from quillan.cli_app.handlers.routing import handle_route_scan
 from quillan.cli_app.handlers.scan_review import (
@@ -94,6 +103,98 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_assignment_identity_arguments(assignment_validate_parser)
     assignment_validate_parser.set_defaults(handler=handle_canonical_assignment_validate)
+
+    roster_parser = subparsers.add_parser(
+        "roster",
+        help="Create, show, validate, and modify canonical class rosters.",
+        description=(
+            "Manage canonical shared class rosters non-interactively. Student IDs "
+            "are strings and leading zeros are preserved."
+        ),
+    )
+    roster_parser.set_defaults(handler=partial(_print_parser_help, roster_parser))
+    roster_subparsers = roster_parser.add_subparsers(dest="roster_command")
+
+    roster_create_parser = roster_subparsers.add_parser(
+        "create",
+        help="Create a canonical roster and class metadata from a validated CSV.",
+    )
+    roster_create_parser.add_argument("class_id", help="Canonical class identifier.")
+    roster_create_parser.add_argument(
+        "--input", type=Path, required=True, help="Source roster CSV path."
+    )
+    roster_create_parser.add_argument(
+        "--school-year",
+        help="Consecutive school year (YYYY-YYYY); defaults to the active year.",
+    )
+    roster_create_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace both existing roster.csv and class.json; requires --yes.",
+    )
+    _add_write_confirmation(roster_create_parser)
+    roster_create_parser.set_defaults(handler=handle_roster_create)
+
+    roster_show_parser = roster_subparsers.add_parser(
+        "show", help="Display every canonical roster column without writing."
+    )
+    roster_show_parser.add_argument("class_id", help="Canonical class identifier.")
+    roster_show_parser.set_defaults(handler=handle_roster_show)
+
+    roster_validate_parser = roster_subparsers.add_parser(
+        "validate", help="Validate canonical roster.csv and existing class.json."
+    )
+    roster_validate_parser.add_argument("class_id", help="Canonical class identifier.")
+    roster_validate_parser.set_defaults(handler=handle_roster_validate)
+
+    roster_add_parser = roster_subparsers.add_parser(
+        "add-student",
+        help="Append one string-ID student; leading zeros are preserved.",
+    )
+    roster_add_parser.add_argument("class_id", help="Canonical class identifier.")
+    roster_add_parser.add_argument(
+        "--student-id", required=True, help="String student ID; leading zeros remain."
+    )
+    roster_add_parser.add_argument("--last-name", required=True)
+    roster_add_parser.add_argument("--first-name", required=True)
+    roster_add_parser.add_argument("--period", required=True)
+    _add_optional_roster_fields(roster_add_parser)
+    _add_write_confirmation(roster_add_parser)
+    roster_add_parser.set_defaults(handler=handle_roster_add_student)
+
+    roster_update_parser = roster_subparsers.add_parser(
+        "update-student",
+        help="Update one student while preserving its stable string student_id.",
+        description=(
+            "Update an active-roster student. The positional student_id is stable "
+            "and cannot be changed."
+        ),
+    )
+    roster_update_parser.add_argument("class_id", help="Canonical class identifier.")
+    roster_update_parser.add_argument(
+        "student_id", help="Stable string student ID; leading zeros remain."
+    )
+    roster_update_parser.add_argument("--last-name")
+    roster_update_parser.add_argument("--first-name")
+    roster_update_parser.add_argument("--period")
+    _add_optional_roster_fields(roster_update_parser)
+    _add_write_confirmation(roster_update_parser)
+    roster_update_parser.set_defaults(handler=handle_roster_update_student)
+
+    roster_remove_parser = roster_subparsers.add_parser(
+        "remove-student",
+        help="Remove one student only from the active roster.csv.",
+        description=(
+            "Remove a student only from the active roster. Historical evidence and "
+            "all other class/module data are retained."
+        ),
+    )
+    roster_remove_parser.add_argument("class_id", help="Canonical class identifier.")
+    roster_remove_parser.add_argument(
+        "student_id", help="Exact string student ID; leading zeros remain."
+    )
+    _add_write_confirmation(roster_remove_parser)
+    roster_remove_parser.set_defaults(handler=handle_roster_remove_student)
 
     validate_assignment_parser = subparsers.add_parser(
         "validate-assignment",
@@ -491,6 +592,34 @@ def _add_assignment_identity_arguments(
 ) -> None:
     parser.add_argument("class_id", help="Class identifier.")
     parser.add_argument("assignment_id", help="Assignment identifier.")
+
+
+def _print_parser_help(parser: argparse.ArgumentParser, _args: argparse.Namespace) -> int:
+    parser.print_help()
+    return 0
+
+
+def _add_write_confirmation(parser: argparse.ArgumentParser) -> None:
+    confirmation = parser.add_mutually_exclusive_group()
+    confirmation.add_argument(
+        "--yes", action="store_true", help="Confirm the validated write."
+    )
+    confirmation.add_argument(
+        "--dry-run", action="store_true", help="Validate and report without writing."
+    )
+
+
+def _add_optional_roster_fields(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--field",
+        action="append",
+        default=[],
+        metavar="COLUMN=VALUE",
+        help=(
+            "Set an existing optional roster column; repeat for multiple columns. "
+            "This cannot add columns or set required fields."
+        ),
+    )
 
 
 def _boolean(value: str) -> bool:

--- a/quillan/roster_management.py
+++ b/quillan/roster_management.py
@@ -1,0 +1,380 @@
+"""Non-interactive planning and writes for canonical class rosters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from pds_core.class_metadata import (
+    ClassMetadata,
+    ClassMetadataError,
+    class_metadata_path,
+    create_class_metadata,
+    load_class_metadata_for_class,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import class_folder, load_class_roster, write_class_roster
+from pds_core.identifiers import validate_identifier
+from pds_core.rosters import (
+    ROSTER_REQUIRED_COLUMNS,
+    Roster,
+    StudentRecord,
+    add_student_record,
+    create_roster,
+    load_roster,
+    remove_student_record,
+    replace_student_record,
+)
+from pds_core.school_years import get_active_school_year, validate_school_year
+
+
+@dataclass(frozen=True, slots=True)
+class RosterCreationPlan:
+    """A fully validated, non-writing canonical roster creation."""
+
+    workspace_root: Path
+    source_path: Path
+    roster_path: Path
+    metadata_path: Path
+    roster: Roster
+    metadata: ClassMetadata
+    target_exists: bool
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedCanonicalRoster:
+    """A canonical roster with optional class metadata state."""
+
+    workspace_root: Path
+    roster_path: Path
+    metadata_path: Path
+    roster: Roster
+    metadata: ClassMetadata | None
+    metadata_error: ClassMetadataError | None
+
+
+@dataclass(frozen=True, slots=True)
+class RosterMutationPlan:
+    """A validated immutable replacement of one canonical roster."""
+
+    workspace_root: Path
+    roster_path: Path
+    original: Roster
+    roster: Roster
+    student: StudentRecord
+    action: str
+
+
+def optional_roster_columns(roster: Roster) -> tuple[str, ...]:
+    """Return optional columns in canonical CSV order."""
+    return tuple(
+        column for column in roster.columns if column not in ROSTER_REQUIRED_COLUMNS
+    )
+
+
+def parse_optional_fields(
+    roster: Roster,
+    fields: Sequence[str],
+) -> Mapping[str, str]:
+    """Validate repeatable ``column=value`` values against the roster schema."""
+    allowed = set(optional_roster_columns(roster))
+    parsed: dict[str, str] = {}
+    for field in fields:
+        if "=" not in field:
+            raise ValueError(f"--field must use column=value: {field!r}.")
+        column, value = field.split("=", 1)
+        column = column.strip()
+        if not column:
+            raise ValueError("--field column must not be blank.")
+        if column in ROSTER_REQUIRED_COLUMNS:
+            raise ValueError(
+                f"--field cannot set required roster column {column!r}."
+            )
+        if column not in allowed:
+            raise ValueError(
+                f"--field column {column!r} is not an existing optional column."
+            )
+        if column in parsed:
+            raise ValueError(f"--field column {column!r} was supplied more than once.")
+        parsed[column] = value.strip()
+    return parsed
+
+
+def student_record_from_values(
+    roster: Roster,
+    student_id: str,
+    values: Mapping[str, str],
+) -> StudentRecord:
+    """Build a student while preserving the roster's optional schema."""
+    return StudentRecord(
+        class_id=roster.class_id,
+        student_id=student_id.strip(),
+        last_name=values["last_name"].strip(),
+        first_name=values["first_name"].strip(),
+        period=values["period"].strip(),
+        extra_fields={
+            column: values.get(column, "").strip()
+            for column in optional_roster_columns(roster)
+        },
+    )
+
+
+def plan_roster_creation(
+    workspace_root: str | Path,
+    class_id: str,
+    source_path: str | Path,
+    *,
+    school_year: str | None = None,
+) -> RosterCreationPlan:
+    """Validate an external CSV and all canonical creation inputs without writes."""
+    root = Path(workspace_root)
+    expected_class_id = validate_identifier(class_id, "class_id")
+    source = Path(source_path)
+    roster = load_roster(source)
+    if roster.class_id != expected_class_id:
+        raise ValueError(
+            f"source roster class_id {roster.class_id!r} does not match "
+            f"requested class_id {expected_class_id!r}."
+        )
+    selected_year = (
+        validate_school_year(school_year)
+        if school_year is not None
+        else get_active_school_year(root)
+    )
+    if selected_year is None:
+        raise ValueError(
+            "no active school year is open; supply --school-year or open a "
+            "school year."
+        )
+    selected_year = validate_school_year(selected_year)
+    now = datetime.now(timezone.utc)
+    metadata = create_class_metadata(
+        expected_class_id,
+        selected_year,
+        created_at=now,
+        updated_at=now,
+    )
+    folder = class_folder(root, expected_class_id)
+    return RosterCreationPlan(
+        workspace_root=root,
+        source_path=source,
+        roster_path=folder.roster_path,
+        metadata_path=folder.metadata_path,
+        roster=roster,
+        metadata=metadata,
+        target_exists=folder.roster_path.exists() or folder.metadata_path.exists(),
+    )
+
+
+def plan_roster_creation_from_values(
+    workspace_root: str | Path,
+    class_id: str,
+    students: Sequence[Mapping[str, str]],
+    *,
+    school_year: str,
+) -> RosterCreationPlan:
+    """Plan menu-entered roster values through the same creation boundary."""
+    root = Path(workspace_root)
+    roster = create_roster(class_id, students)
+    selected_year = validate_school_year(school_year)
+    now = datetime.now(timezone.utc)
+    metadata = create_class_metadata(
+        roster.class_id, selected_year, created_at=now, updated_at=now
+    )
+    folder = class_folder(root, roster.class_id)
+    return RosterCreationPlan(
+        workspace_root=root,
+        source_path=Path("<interactive>"),
+        roster_path=folder.roster_path,
+        metadata_path=folder.metadata_path,
+        roster=roster,
+        metadata=metadata,
+        target_exists=folder.roster_path.exists() or folder.metadata_path.exists(),
+    )
+
+
+def add_student_to_roster(roster: Roster, student: StudentRecord) -> Roster:
+    """Validate and stage an in-memory addition for menu and adapters."""
+    return add_student_record(roster, student)
+
+
+def update_student_in_roster(roster: Roster, student: StudentRecord) -> Roster:
+    """Validate and stage an in-memory stable-ID replacement."""
+    return replace_student_record(roster, student)
+
+
+def remove_student_from_roster(roster: Roster, student_id: str) -> Roster:
+    """Validate and stage active-roster-only removal."""
+    return remove_student_record(roster, student_id)
+
+
+def write_roster_creation(
+    plan: RosterCreationPlan,
+    *,
+    overwrite: bool = False,
+) -> tuple[Path, Path]:
+    """Write a validated roster/metadata pair and clean up newly created halves."""
+    roster_existed = plan.roster_path.exists()
+    metadata_existed = plan.metadata_path.exists()
+    class_dir_existed = plan.roster_path.parent.exists()
+    if (roster_existed or metadata_existed) and not overwrite:
+        raise ValueError(
+            "canonical roster or class metadata already exists; use --overwrite --yes."
+        )
+    try:
+        roster_path = write_class_roster(
+            plan.workspace_root, plan.roster, overwrite=overwrite
+        )
+        metadata_path = write_class_metadata_for_class(
+            plan.workspace_root, plan.metadata, overwrite=overwrite
+        )
+    except Exception:
+        if not roster_existed:
+            plan.roster_path.unlink(missing_ok=True)
+        if not metadata_existed:
+            plan.metadata_path.unlink(missing_ok=True)
+        if not class_dir_existed:
+            _remove_new_empty_class_directories(plan)
+        raise
+    return roster_path, metadata_path
+
+
+def _remove_new_empty_class_directories(plan: RosterCreationPlan) -> None:
+    class_dir = plan.roster_path.parent
+    assignments_dir = class_dir / "assignments"
+    try:
+        assignments_dir.rmdir()
+    except OSError:
+        pass
+    try:
+        class_dir.rmdir()
+    except OSError:
+        pass
+
+
+def load_canonical_roster(
+    workspace_root: str | Path,
+    class_id: str,
+) -> LoadedCanonicalRoster:
+    """Load a canonical roster and optional metadata without writing."""
+    root = Path(workspace_root)
+    validated_class_id = validate_identifier(class_id, "class_id")
+    folder = class_folder(root, validated_class_id)
+    roster = load_class_roster(root, validated_class_id)
+    metadata: ClassMetadata | None = None
+    metadata_error: ClassMetadataError | None = None
+    if folder.metadata_path.is_file():
+        try:
+            metadata = load_class_metadata_for_class(root, validated_class_id)
+        except ClassMetadataError as error:
+            metadata_error = error
+    return LoadedCanonicalRoster(
+        workspace_root=root,
+        roster_path=folder.roster_path,
+        metadata_path=class_metadata_path(root, validated_class_id),
+        roster=roster,
+        metadata=metadata,
+        metadata_error=metadata_error,
+    )
+
+
+def plan_add_student(
+    workspace_root: str | Path,
+    class_id: str,
+    *,
+    student_id: str,
+    last_name: str,
+    first_name: str,
+    period: str,
+    fields: Sequence[str] = (),
+) -> RosterMutationPlan:
+    """Plan an append using shared roster validation."""
+    loaded = load_canonical_roster(workspace_root, class_id)
+    extras = parse_optional_fields(loaded.roster, fields)
+    student = student_record_from_values(
+        loaded.roster,
+        student_id,
+        {"last_name": last_name, "first_name": first_name, "period": period, **extras},
+    )
+    updated = add_student_record(loaded.roster, student)
+    return RosterMutationPlan(
+        loaded.workspace_root,
+        loaded.roster_path,
+        loaded.roster,
+        updated,
+        student,
+        "add",
+    )
+
+
+def plan_update_student(
+    workspace_root: str | Path,
+    class_id: str,
+    student_id: str,
+    *,
+    last_name: str | None = None,
+    first_name: str | None = None,
+    period: str | None = None,
+    fields: Sequence[str] = (),
+) -> RosterMutationPlan:
+    """Plan a stable-ID student replacement using shared validation."""
+    loaded = load_canonical_roster(workspace_root, class_id)
+    stable_id = validate_identifier(student_id.strip(), "student_id")
+    existing = next(
+        (student for student in loaded.roster.students if student.student_id == stable_id),
+        None,
+    )
+    if existing is None:
+        raise ValueError(f"student_id {stable_id!r} is not in the active roster.")
+    extras = parse_optional_fields(loaded.roster, fields)
+    if last_name is None and first_name is None and period is None and not fields:
+        raise ValueError("at least one update field must be supplied.")
+    values = {
+        "last_name": existing.last_name if last_name is None else last_name,
+        "first_name": existing.first_name if first_name is None else first_name,
+        "period": existing.period if period is None else period,
+        **existing.extra_fields,
+        **extras,
+    }
+    replacement = student_record_from_values(loaded.roster, stable_id, values)
+    updated = replace_student_record(loaded.roster, replacement)
+    return RosterMutationPlan(
+        loaded.workspace_root,
+        loaded.roster_path,
+        loaded.roster,
+        updated,
+        replacement,
+        "update",
+    )
+
+
+def plan_remove_student(
+    workspace_root: str | Path,
+    class_id: str,
+    student_id: str,
+) -> RosterMutationPlan:
+    """Plan removal from only the active canonical roster."""
+    loaded = load_canonical_roster(workspace_root, class_id)
+    stable_id = validate_identifier(student_id.strip(), "student_id")
+    existing = next(
+        (student for student in loaded.roster.students if student.student_id == stable_id),
+        None,
+    )
+    if existing is None:
+        raise ValueError(f"student_id {stable_id!r} is not in the active roster.")
+    updated = remove_student_record(loaded.roster, stable_id)
+    return RosterMutationPlan(
+        loaded.workspace_root,
+        loaded.roster_path,
+        loaded.roster,
+        updated,
+        existing,
+        "remove",
+    )
+
+
+def write_roster_mutation(plan: RosterMutationPlan) -> Path:
+    """Replace only canonical roster.csv for a validated mutation."""
+    return write_class_roster(plan.workspace_root, plan.roster, overwrite=True)

--- a/quillan/roster_workflows.py
+++ b/quillan/roster_workflows.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 import re
 import unicodedata
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timezone
 from pathlib import Path
 
 from pds_core.class_metadata import (
     ClassMetadata,
     ClassMetadataError,
     class_metadata_path,
-    create_class_metadata,
     load_class_metadata_for_class,
-    write_class_metadata_for_class,
 )
 from pds_core.classes import (
     ClassFolder,
@@ -24,16 +21,11 @@ from pds_core.classes import (
 )
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
 from pds_core.rosters import (
-    ROSTER_REQUIRED_COLUMNS,
     Roster,
     RosterError,
     RosterValidationError,
     StudentRecord,
-    add_student_record,
-    create_roster,
     load_roster,
-    remove_student_record,
-    replace_student_record,
 )
 from pds_core.routes import class_roster_path
 from pds_core.school_years import (
@@ -44,14 +36,22 @@ from pds_core.school_years import (
 )
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
+from quillan.roster_management import (
+    add_student_to_roster,
+    optional_roster_columns as managed_optional_roster_columns,
+    plan_roster_creation_from_values,
+    remove_student_from_roster,
+    student_record_from_values as managed_student_record_from_values,
+    update_student_in_roster,
+    write_roster_creation,
+)
+
 _REQUIRED_STUDENT_FIELDS = ("student_id", "last_name", "first_name", "period")
 
 
 def optional_roster_columns(roster: Roster) -> tuple[str, ...]:
     """Return existing optional columns in their shared-roster order."""
-    return tuple(
-        column for column in roster.columns if column not in ROSTER_REQUIRED_COLUMNS
-    )
+    return managed_optional_roster_columns(roster)
 
 
 def shared_roster_period(roster: Roster) -> str | None:
@@ -137,17 +137,7 @@ def student_record_from_values(
     values: Mapping[str, str],
 ) -> StudentRecord:
     """Build a student record while preserving the roster's optional schema."""
-    return StudentRecord(
-        class_id=roster.class_id,
-        student_id=student_id.strip(),
-        last_name=values["last_name"].strip(),
-        first_name=values["first_name"].strip(),
-        period=values["period"].strip(),
-        extra_fields={
-            column: values.get(column, "").strip()
-            for column in optional_roster_columns(roster)
-        },
-    )
+    return managed_student_record_from_values(roster, student_id, values)
 
 
 def create_class_roster(
@@ -159,19 +149,11 @@ def create_class_roster(
     overwrite: bool = False,
 ) -> tuple[Roster, Path, ClassMetadata, Path]:
     """Create and write validated roster and metadata artifacts."""
-    roster = create_roster(class_id, students)
-    metadata = create_class_metadata(
-        class_id,
-        school_year,
-        created_at=datetime.now(timezone.utc),
+    plan = plan_roster_creation_from_values(
+        workspace_root, class_id, students, school_year=school_year
     )
-    path = write_class_roster(workspace_root, roster, overwrite=overwrite)
-    metadata_path = write_class_metadata_for_class(
-        workspace_root,
-        metadata,
-        overwrite=overwrite,
-    )
-    return roster, path, metadata, metadata_path
+    path, metadata_path = write_roster_creation(plan, overwrite=overwrite)
+    return plan.roster, path, plan.metadata, metadata_path
 
 
 def validate_roster_file(path: str | Path) -> Roster:
@@ -331,7 +313,7 @@ def prompt_add_student_to_roster(roster: Roster) -> Roster:
     for column in optional_roster_columns(roster):
         values[column] = input(f"  {column} (optional): ").strip()
     student = student_record_from_values(roster, values["student_id"], values)
-    return add_student_record(roster, student)
+    return add_student_to_roster(roster, student)
 
 
 def prompt_edit_student_in_roster(roster: Roster) -> Roster:
@@ -354,7 +336,7 @@ def prompt_edit_student_in_roster(roster: Roster) -> Roster:
         entered = input(f"  {column} [{current}]: ").strip()
         values[column] = entered or current
     replacement = student_record_from_values(roster, student.student_id, values)
-    return replace_student_record(roster, replacement)
+    return update_student_in_roster(roster, replacement)
 
 
 def prompt_remove_student_from_roster(roster: Roster) -> Roster:
@@ -379,7 +361,7 @@ def prompt_remove_student_from_roster(roster: Roster) -> Roster:
     if confirmation != "REMOVE":
         print("Canceled: removal not confirmed.")
         return roster
-    return remove_student_record(roster, student.student_id)
+    return remove_student_from_roster(roster, student.student_id)
 
 
 def _print_roster_action_header(title: str) -> None:

--- a/tests/test_cli_rosters.py
+++ b/tests/test_cli_rosters.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    load_class_metadata_for_class,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import load_class_roster, write_class_roster
+from pds_core.rosters import create_roster
+from pds_core.school_years import open_school_year
+
+from quillan.cli import main
+from quillan.cli_app.handlers import rosters as handlers
+from quillan import roster_management
+
+
+def _source_csv(path: Path, *, class_id: str = "english_10_p2") -> Path:
+    path.write_text(
+        "class_id,student_id,last_name,first_name,period,preferred_name,notes\n"
+        f"{class_id},0007,Example,Avery,2,Ari,\n"
+        f"{class_id},0042,Sample,Morgan,2,,synthetic\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _canonical_roster(workspace: Path) -> Path:
+    roster = create_roster(
+        "english_10_p2",
+        [
+            {
+                "student_id": "0007",
+                "last_name": "Example",
+                "first_name": "Avery",
+                "period": "2",
+                "preferred_name": "Ari",
+                "notes": "",
+            },
+            {
+                "student_id": "0042",
+                "last_name": "Sample",
+                "first_name": "Morgan",
+                "period": "2",
+                "preferred_name": "",
+                "notes": "synthetic",
+            },
+        ],
+    )
+    return write_class_roster(workspace, roster)
+
+
+def _use_workspace(monkeypatch: pytest.MonkeyPatch, workspace: Path) -> None:
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: workspace)
+
+
+def test_roster_help_and_bare_namespace_do_not_resolve_workspace(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_workspace() -> Path:
+        raise AssertionError("workspace must not be resolved for roster help")
+
+    monkeypatch.setattr(handlers, "resolve_workspace_root", fail_workspace)
+    assert main(["roster"]) == 0
+    output = capsys.readouterr().out
+    for command in (
+        "create",
+        "show",
+        "validate",
+        "add-student",
+        "update-student",
+        "remove-student",
+    ):
+        assert command in output
+    with pytest.raises(SystemExit) as help_exit:
+        main(["roster", "update-student", "--help"])
+    assert help_exit.value.code == 0
+    assert "cannot be changed" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["create", "show", "validate", "add-student", "update-student", "remove-student"],
+)
+def test_each_roster_subcommand_help_exits_successfully(command: str) -> None:
+    with pytest.raises(SystemExit) as help_exit:
+        main(["roster", command, "--help"])
+    assert help_exit.value.code == 0
+
+
+def test_create_preserves_ids_columns_blanks_order_and_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    source = _source_csv(tmp_path / "source.csv")
+    _use_workspace(monkeypatch, workspace)
+
+    assert main(
+        [
+            "roster",
+            "create",
+            "english_10_p2",
+            "--input",
+            str(source),
+            "--school-year",
+            "2026-2027",
+            "--yes",
+        ]
+    ) == 0
+
+    roster = load_class_roster(workspace, "english_10_p2")
+    assert roster.columns == (
+        "class_id",
+        "student_id",
+        "last_name",
+        "first_name",
+        "period",
+        "preferred_name",
+        "notes",
+    )
+    assert [student.student_id for student in roster.students] == ["0007", "0042"]
+    assert roster.students[0].extra_fields["notes"] == ""
+    assert load_class_metadata_for_class(
+        workspace, "english_10_p2"
+    ).school_year == "2026-2027"
+
+
+def test_create_uses_active_year_and_dry_run_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    open_school_year(
+        workspace,
+        "2027-2028",
+        opened_at=datetime.now(timezone.utc),
+    )
+    source = _source_csv(tmp_path / "source.csv")
+    _use_workspace(monkeypatch, workspace)
+
+    assert main(
+        [
+            "roster",
+            "create",
+            "english_10_p2",
+            "--input",
+            str(source),
+            "--dry-run",
+        ]
+    ) == 0
+    output = capsys.readouterr().out
+    assert "School year: 2027-2028" in output
+    assert "No files were written." in output
+    assert not (workspace / "classes").exists()
+
+
+@pytest.mark.parametrize(
+    "extra_args", [[], ["--yes"], ["--overwrite", "--dry-run"]]
+)
+def test_create_safety_failures_write_nothing(
+    extra_args: list[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    source = _source_csv(tmp_path / "source.csv", class_id="different_class")
+    _use_workspace(monkeypatch, workspace)
+    args = [
+        "roster",
+        "create",
+        "english_10_p2",
+        "--input",
+        str(source),
+        "--school-year",
+        "2026-2027",
+        *extra_args,
+    ]
+    assert main(args) == 1
+    assert not (workspace / "classes").exists()
+
+
+def test_create_refuses_existing_pair_without_overwrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    original_path = _canonical_roster(workspace)
+    original = original_path.read_bytes()
+    source = _source_csv(tmp_path / "source.csv")
+    _use_workspace(monkeypatch, workspace)
+
+    assert main(
+        [
+            "roster",
+            "create",
+            "english_10_p2",
+            "--input",
+            str(source),
+            "--school-year",
+            "2026-2027",
+            "--yes",
+        ]
+    ) == 1
+    assert original_path.read_bytes() == original
+
+
+def test_new_paired_creation_cleans_up_if_metadata_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    source = _source_csv(tmp_path / "source.csv")
+    plan = roster_management.plan_roster_creation(
+        workspace, "english_10_p2", source, school_year="2026-2027"
+    )
+
+    def fail_metadata(*_args: object, **_kwargs: object) -> Path:
+        raise OSError("synthetic metadata failure")
+
+    monkeypatch.setattr(
+        roster_management, "write_class_metadata_for_class", fail_metadata
+    )
+    with pytest.raises(OSError, match="synthetic metadata failure"):
+        roster_management.write_roster_creation(plan)
+    assert not plan.roster_path.exists()
+    assert not plan.metadata_path.exists()
+    assert not plan.roster_path.parent.exists()
+
+
+def test_show_and_validate_are_read_only_and_report_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    roster_path = _canonical_roster(workspace)
+    before = roster_path.read_bytes()
+    _use_workspace(monkeypatch, workspace)
+
+    assert main(["roster", "show", "english_10_p2"]) == 0
+    shown = capsys.readouterr().out
+    assert "0007" in shown
+    assert "preferred_name" in shown
+    assert "School year: not set" in shown
+    assert main(["roster", "validate", "english_10_p2"]) == 0
+    assert "Canonical roster is valid." in capsys.readouterr().out
+    assert roster_path.read_bytes() == before
+    assert not (roster_path.parent / "class.json").exists()
+
+
+def test_validate_rejects_invalid_existing_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    roster_path = _canonical_roster(workspace)
+    (roster_path.parent / "class.json").write_text("{}\n", encoding="utf-8")
+    _use_workspace(monkeypatch, workspace)
+
+    assert main(["roster", "validate", "english_10_p2"]) == 1
+    output = capsys.readouterr().out
+    assert output.startswith("Error:")
+    assert "Traceback" not in output
+
+
+def test_validate_prints_structured_roster_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    path = workspace / "classes" / "english_10_p2" / "roster.csv"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "class_id,student_id,last_name,first_name,period\n"
+        "english_10_p2,0007,Example,,2\n",
+        encoding="utf-8",
+    )
+    _use_workspace(monkeypatch, workspace)
+
+    assert main(["roster", "validate", "english_10_p2"]) == 1
+    output = capsys.readouterr().out
+    assert "[blank_required_value]" in output
+    assert "row 2" in output
+    assert "column first_name" in output
+    assert "Traceback" not in output
+
+
+def test_add_and_update_preserve_schema_order_values_and_stable_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    _canonical_roster(workspace)
+    _use_workspace(monkeypatch, workspace)
+
+    assert main(
+        [
+            "roster",
+            "add-student",
+            "english_10_p2",
+            "--student-id",
+            "0099",
+            "--last-name",
+            "Person",
+            "--first-name",
+            "Taylor",
+            "--period",
+            "3",
+            "--field",
+            "preferred_name=Tay",
+            "--yes",
+        ]
+    ) == 0
+    added = load_class_roster(workspace, "english_10_p2")
+    assert added.students[-1].student_id == "0099"
+    assert added.students[-1].extra_fields == {"preferred_name": "Tay", "notes": ""}
+
+    assert main(
+        [
+            "roster",
+            "update-student",
+            "english_10_p2",
+            "0007",
+            "--period",
+            "4",
+            "--field",
+            "notes=updated",
+            "--field",
+            "preferred_name=",
+            "--yes",
+        ]
+    ) == 0
+    updated = load_class_roster(workspace, "english_10_p2")
+    assert [student.student_id for student in updated.students] == [
+        "0007",
+        "0042",
+        "0099",
+    ]
+    assert updated.students[0].period == "4"
+    assert updated.students[0].extra_fields == {
+        "preferred_name": "",
+        "notes": "updated",
+    }
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        ["--field", "unknown=value"],
+        ["--field", "student_id=12"],
+        ["--field", "notes=a", "--field", "notes=b"],
+    ],
+)
+def test_add_rejects_invalid_optional_fields_without_writing(
+    fields: list[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    roster_path = _canonical_roster(workspace)
+    before = roster_path.read_bytes()
+    _use_workspace(monkeypatch, workspace)
+    assert main(
+        [
+            "roster",
+            "add-student",
+            "english_10_p2",
+            "--student-id",
+            "0099",
+            "--last-name",
+            "Person",
+            "--first-name",
+            "Taylor",
+            "--period",
+            "3",
+            *fields,
+            "--yes",
+        ]
+    ) == 1
+    assert roster_path.read_bytes() == before
+
+
+def test_remove_changes_only_roster_and_preserves_evidence_and_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    roster_path = _canonical_roster(workspace)
+    metadata = create_class_metadata(
+        "english_10_p2", "2026-2027", created_at=datetime.now(timezone.utc)
+    )
+    metadata_path = write_class_metadata_for_class(workspace, metadata)
+    evidence = roster_path.parent / "assignments" / "essay" / "submissions" / "0007" / "feedback.md"
+    evidence.parent.mkdir(parents=True, exist_ok=True)
+    evidence.write_text("retain", encoding="utf-8")
+    metadata_before = metadata_path.read_bytes()
+    _use_workspace(monkeypatch, workspace)
+
+    assert main(
+        ["roster", "remove-student", "english_10_p2", "0007", "--yes"]
+    ) == 0
+    assert [
+        student.student_id
+        for student in load_class_roster(workspace, "english_10_p2").students
+    ] == ["0042"]
+    assert metadata_path.read_bytes() == metadata_before
+    assert evidence.read_text(encoding="utf-8") == "retain"
+    assert "does not delete" in capsys.readouterr().out
+
+
+def test_mutation_dry_run_and_missing_confirmation_do_not_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    roster_path = _canonical_roster(workspace)
+    before = roster_path.read_bytes()
+    _use_workspace(monkeypatch, workspace)
+
+    base = [
+        "roster",
+        "remove-student",
+        "english_10_p2",
+        "0007",
+    ]
+    assert main([*base, "--dry-run"]) == 0
+    assert main(base) == 1
+    assert roster_path.read_bytes() == before


### PR DESCRIPTION
## Summary

* Add direct canonical roster-management commands:

  * `quillan roster create`
  * `quillan roster show`
  * `quillan roster validate`
  * `quillan roster add-student`
  * `quillan roster update-student`
  * `quillan roster remove-student`
* Add shared non-interactive roster planning and write services.
* Refactor the teacher-facing roster menu to reuse the same roster creation and mutation services as the direct CLI.
* Preserve canonical PDS Core roster and class-metadata contracts.
* Document the new command surface and its safety boundaries.

## Command Surface

```text
quillan roster create <class_id> --input <roster.csv> [--school-year YYYY-YYYY] [--overwrite] (--yes | --dry-run)
quillan roster show <class_id>
quillan roster validate <class_id>
quillan roster add-student <class_id> --student-id <student_id> --last-name <name> --first-name <name> --period <period> [--field <column=value> ...] (--yes | --dry-run)
quillan roster update-student <class_id> <student_id> [--last-name <name>] [--first-name <name>] [--period <period>] [--field <column=value> ...] (--yes | --dry-run)
quillan roster remove-student <class_id> <student_id> (--yes | --dry-run)
```

Running `quillan roster` without a subcommand prints roster help and exits successfully without resolving or inspecting the workspace.

## Shared Architecture

Added shared non-interactive roster-management services in:

* `quillan/roster_management.py`

The direct CLI and teacher-facing menu now share services for:

* canonical roster creation;
* class-metadata creation;
* student-record construction;
* optional-column handling;
* immutable add, update, and remove operations;
* validated canonical writes.

CLI handlers do not invoke interactive menu prompts. Roster business rules remain in shared services and PDS Core rather than being duplicated in CLI-only paths.

## Roster Creation

`roster create`:

* loads the source CSV through the shared PDS Core roster loader;
* validates that the source roster’s `class_id` matches the positional class ID;
* preserves student IDs as strings;
* preserves leading zeros;
* preserves student row order;
* preserves optional columns, column order, values, and blank values;
* uses an explicit `--school-year` or the active workspace school year;
* writes canonical `roster.csv` and `class.json`;
* refuses existing paired artifacts unless both `--overwrite` and `--yes` are supplied;
* supports a non-writing `--dry-run`;
* cleans up newly created artifacts if a new paired creation cannot complete.

The source CSV is validated and rewritten through canonical shared writers rather than copied byte-for-byte.

## Show and Validate

`roster show` and `roster validate` are strictly read-only.

They:

* load the canonical roster through PDS Core;
* preserve and display leading-zero student IDs;
* report required and optional columns;
* report the canonical roster path and student count;
* report the class school year when valid metadata exists;
* treat missing metadata as `not set`;
* report malformed existing metadata without a traceback.

Validation also checks canonical class-folder identity and structured roster diagnostics.

Neither command creates, rewrites, repairs, or updates files.

## Student Mutations

### Add

`roster add-student`:

* appends a validated student;
* preserves the existing optional-column schema;
* fills omitted optional values with blank strings;
* rejects duplicate student IDs;
* rejects unknown or required columns supplied through `--field`.

### Update

`roster update-student`:

* treats the positional student ID as stable identity;
* does not permit changing `student_id`;
* preserves row order;
* preserves omitted required and optional values;
* supports explicitly clearing optional values;
* rejects unknown optional columns and invalid no-op requests.

### Remove

`roster remove-student`:

* removes the selected student only from the active roster;
* preserves the PDS Core rule that the final student cannot be removed;
* does not traverse or delete historical or module-specific data.

All three mutation commands:

* require either `--yes` or `--dry-run`;
* remain non-interactive;
* construct a new immutable roster through shared services;
* modify only canonical `roster.csv` after confirmation;
* leave `class.json` unchanged.

## Safety

Confirmed:

* leading-zero student IDs remain strings;
* optional-column order and values are preserved;
* student row order is preserved;
* all writes require explicit confirmation;
* all write commands support dry-run validation;
* dry runs create no files or directories;
* accidental roster or metadata overwrite is refused;
* add, update, and remove modify only `roster.csv`;
* removal does not delete or modify:

  * class metadata;
  * assignments;
  * submission manifests;
  * review records;
  * scans;
  * printable PDFs;
  * evidence;
  * notes;
  * observations;
  * ratings;
  * feedback;
  * exports;
  * reports;
  * historical results;
  * other module data;
* expected errors are reported without tracebacks;
* no Core files were modified;
* no ScoreForm files were modified;
* no real student data, workspace data, or generated artifacts were added.

## Files Changed

* `docs/cli_contract.md`
* `quillan/cli_app/parser.py`
* `quillan/cli_app/handlers/rosters.py`
* `quillan/roster_management.py`
* `quillan/roster_workflows.py`
* `tests/test_cli_rosters.py`

## Validation

* Focused roster tests: `57 passed`
* Broader CLI/roster selection: `193 passed`
* Full pytest suite: `1113 passed`
* Ruff: passed
* mypy: passed, `144` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* No workspace data, generated artifacts, or real student data present

Closes #300
