### PR TITLE
Add minimum requirement review CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -47,6 +47,52 @@ quillan [command] [arguments]
 Calling `quillan.cli.main()` from Python is useful for tests, but it is not a
 separate public Python API contract.
 
+## Direct Minimum-Requirement Review
+
+The `requirements` namespace exposes the teacher-facing minimum-requirement
+workflow as direct, non-interactive commands. Running `quillan requirements`
+prints namespace help and exits successfully without resolving a workspace or
+loading any records.
+
+All three subcommands require a valid canonical assignment and an existing,
+valid canonical `submission.json` for the requested class, assignment, and
+student. Routed evidence alone is not review-ready; teachers must assemble the
+submission first. Evidence-less plain-paper manifests are valid, and a valid
+historical or unrostered submission does not require a current roster entry.
+
+`requirements list` prints configured requirements, current checks, summary
+counts, review state, and outcome in teacher-facing text. It is strictly
+read-only. When `review.json` is absent it reports `not_started`, shows each
+requirement as `not checked`, reports outcome `not_checked`, and creates
+nothing. Stale checks whose keys are no longer configured are excluded from
+configured completion counts.
+
+`requirements set-check` accepts only a key currently derived from the
+assignment's `basic_requirements`. Numeric keys are `paragraphs_min`,
+`paragraphs_max`, `word_count_min`, and `word_count_max`; required-element keys
+use `required_elements:<element>`. Labels and expected values come from the
+assignment and cannot be supplied by the caller. `--met` becomes a boolean. A
+supplied note is trimmed and stored; omission clears an earlier note. Updating
+a key retains its check ID and does not infer or recalculate the outcome.
+
+`requirements set-outcome` accepts exactly `met`, `unmet_continue_review`, or
+`returned_without_full_review`. `met` requires every configured requirement to
+be checked and met. `unmet_continue_review` requires at least one configured
+unmet check; unchecked requirements may remain. Returning without full review
+also requires a configured unmet check, an explicit nonblank note, and
+`minimum_requirement_policy.allow_return_without_full_review: true` in the
+assignment. No CLI flag overrides that policy.
+
+These commands record teacher judgments only. They do not open evidence, count
+words or paragraphs, detect required elements, run OCR or AI, infer outcomes,
+grade, score, create observations or ratings, or compose feedback. The list
+command writes nothing. The two set commands may create or replace only the
+canonical
+`classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json`,
+through the validated atomic review-record writer. They do not modify the
+assignment, submission manifest, roster, evidence, scans, exports, reports, or
+other suite data.
+
 ## Current Command Surface
 
 The implemented command surface currently exposed through argparse is:
@@ -57,6 +103,9 @@ quillan --help
 quillan assignment create <class_id> <assignment_id> --title <title> --writing-type <type> (--prompt <text> | --prompt-file <path>) --standards-profile-id <profile_id> --focus-standard-ids <id,...> (--yes | --dry-run)
 quillan assignment show <class_id> <assignment_id>
 quillan assignment validate <class_id> <assignment_id>
+quillan requirements list <class_id> <assignment_id> <student_id>
+quillan requirements set-check <class_id> <assignment_id> <student_id> --requirement-key <key> --met true|false [--note <text>]
+quillan requirements set-outcome <class_id> <assignment_id> <student_id> --outcome met|unmet_continue_review|returned_without_full_review [--note <text>]
 quillan roster create <class_id> --input <roster.csv> [--school-year YYYY-YYYY] [--overwrite] (--yes | --dry-run)
 quillan roster show <class_id>
 quillan roster validate <class_id>

--- a/docs/prepared_review_workflow.md
+++ b/docs/prepared_review_workflow.md
@@ -80,6 +80,14 @@ Supported outcome statuses are `met`, `unmet_continue_review`, and
 `returned_without_full_review`. Returning work without full standards review
 requires a teacher note when the assignment policy permits that path.
 
+Teachers may use either the interactive review menu or the direct,
+non-interactive `quillan requirements list`, `set-check`, and `set-outcome`
+commands. Both paths share assignment-derived requirement definitions and
+outcome eligibility rules. Direct commands require an assembled canonical
+`submission.json`; they never assemble submissions, inspect writing, count
+text, run OCR or AI, or infer a teacher judgment. Listing is read-only, while
+the set commands may change only the submission's canonical `review.json`.
+
 Minimum-requirement checks do not count words, count paragraphs, parse writing,
 run OCR, use AI, change ratings, or calculate grades.
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -385,6 +385,14 @@ note, updates top-level `updated_at`, and preserves unrelated review data.
 `minimum_requirement_outcome` records the teacher's decision after minimum
 requirement checks.
 
+The direct `quillan requirements` commands use the same assignment-aware
+services as the teacher menu. Configured keys, labels, expected values, and
+outcome eligibility derive from the current assignment. Arbitrary or stale
+keys cannot be written or used to satisfy outcome eligibility. These commands
+require an existing canonical submission manifest and preserve every unrelated
+section of an existing schema-version-2 review. They do not inspect evidence or
+infer checks, outcomes, ratings, or feedback.
+
 Example:
 
 ```json

--- a/quillan/cli_app/handlers/requirements.py
+++ b/quillan/cli_app/handlers/requirements.py
@@ -1,0 +1,143 @@
+"""Direct, non-interactive minimum-requirement review handlers."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.minimum_requirement_review import (
+    load_minimum_requirement_review_context,
+    set_configured_minimum_requirement_outcome,
+    set_configured_requirement_check,
+)
+from quillan.review_requirements import ReviewRequirementError
+
+
+def handle_requirements_list(args: argparse.Namespace) -> int:
+    """Display configured requirements and current teacher-entered state."""
+    try:
+        context = load_minimum_requirement_review_context(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id
+        )
+        review = context.review
+        outcome = review["minimum_requirement_outcome"] if review is not None else None
+        checks = context.configured_checks
+        print("Minimum-requirement review:")
+        print(f"Class: {context.class_id}")
+        print(f"Assignment: {context.assignment_id}")
+        print(f"Student: {context.student_id}")
+        print(f"Submission manifest: {context.submission_manifest_relative_path}")
+        print(f"Review record: {context.review_record_relative_path}")
+        print(f"Review record exists: {_yes_no(review is not None)}")
+        print(f"Review state: {review['review_state'] if review is not None else 'not_started'}")
+        print()
+        if not context.requirements:
+            print("Minimum requirements: none configured")
+        else:
+            print("Minimum requirements:")
+            for index, requirement in enumerate(context.requirements, start=1):
+                check = checks.get(requirement.key)
+                print(f"{index}. {requirement.label}")
+                print(f"   Key: {requirement.key}")
+                print(f"   Expected: {requirement.expected}")
+                print(f"   State: {_check_state(check)}")
+                print(f"   Teacher note: {_value_or_none(check, 'teacher_note')}")
+                print(f"   Check ID: {_value_or_none(check, 'requirement_check_id')}")
+                print(f"   Updated: {_value_or_none(check, 'updated_at')}")
+        summary = context.summary
+        print()
+        print(f"Total configured requirements: {summary.total}")
+        print(f"Checked: {summary.checked}")
+        print(f"Unchecked: {summary.unchecked}")
+        print(f"Met: {summary.met}")
+        print(f"Unmet: {summary.unmet}")
+        if context.stale_checks:
+            print(f"Unrecognized/stale checks: {len(context.stale_checks)}")
+        print(f"Overall outcome: {outcome['status'] if outcome is not None else 'not_checked'}")
+        returned = outcome is not None and outcome["returned_without_full_review"] is True
+        print(f"Returned without full standards review: {_yes_no(returned)}")
+        print(f"Outcome teacher note: {_value_or_none(outcome, 'teacher_note')}")
+        print(f"Outcome updated: {_value_or_none(outcome, 'updated_at')}")
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewRequirementError) as error:
+        return _error(error)
+
+
+def handle_requirements_set_check(args: argparse.Namespace) -> int:
+    """Record one explicit teacher-entered configured requirement check."""
+    try:
+        result = set_configured_requirement_check(
+            resolve_workspace_root(),
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            requirement_key=args.requirement_key,
+            met=args.met,
+            teacher_note=args.note,
+        )
+        update = result.update
+        print("Recorded minimum-requirement check:")
+        print(f"Requirement key: {result.requirement.key}")
+        print(f"Label: {result.requirement.label}")
+        print(f"Expected: {result.requirement.expected}")
+        print(f"Met: {_yes_no(update.met)}")
+        print(f"Action: {'created' if update.was_created else 'updated'}")
+        print(f"Teacher note: {result.teacher_note or 'none'}")
+        print(f"Review state: {update.review_state}")
+        print(f"Review record: {update.review_record_relative_path}")
+        print(f"Updated: {update.updated_at}")
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewRequirementError) as error:
+        return _error(error)
+
+
+def handle_requirements_set_outcome(args: argparse.Namespace) -> int:
+    """Record one explicit teacher-selected assignment-aware outcome."""
+    try:
+        result = set_configured_minimum_requirement_outcome(
+            resolve_workspace_root(),
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            status=args.outcome,
+            teacher_note=args.note,
+        )
+        print("Finalized minimum-requirements outcome:")
+        print(f"Outcome: {result.status}")
+        print(
+            "Returned without full standards review: "
+            f"{_yes_no(result.returned_without_full_review)}"
+        )
+        print(f"Teacher note: {result.teacher_note or 'none'}")
+        print(f"Review state: {result.review_state}")
+        print(f"Review record: {result.review_record_relative_path}")
+        print(f"Updated: {result.updated_at}")
+        if result.returned_without_full_review:
+            print("Full standards review was not completed.")
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewRequirementError) as error:
+        return _error(error)
+
+
+def _check_state(check: dict[str, Any] | None) -> str:
+    if check is None:
+        return "not checked"
+    return "met" if check["met"] is True else "not met"
+
+
+def _value_or_none(record: dict[str, Any] | None, key: str) -> Any:
+    if record is None:
+        return "none"
+    value = record.get(key)
+    return value if value is not None else "none"
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _error(error: Exception) -> int:
+    print(f"Error: {error}")
+    return 1

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -17,6 +17,11 @@ from quillan.cli_app.handlers.decoding import handle_decode_scan
 from quillan.cli_app.handlers.review import (
     handle_add_note,
 )
+from quillan.cli_app.handlers.requirements import (
+    handle_requirements_list,
+    handle_requirements_set_check,
+    handle_requirements_set_outcome,
+)
 from quillan.cli_app.handlers.rosters import (
     handle_roster_add_student,
     handle_roster_create,
@@ -103,6 +108,87 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_assignment_identity_arguments(assignment_validate_parser)
     assignment_validate_parser.set_defaults(handler=handle_canonical_assignment_validate)
+
+    requirements_parser = subparsers.add_parser(
+        "requirements",
+        help="Review assignment minimum requirements for one assembled submission.",
+        description=(
+            "List and record teacher-entered minimum-requirement judgments for "
+            "one canonical assembled submission. These commands do not inspect "
+            "student writing or infer checks or outcomes."
+        ),
+    )
+    requirements_parser.set_defaults(
+        handler=partial(_print_parser_help, requirements_parser)
+    )
+    requirements_subparsers = requirements_parser.add_subparsers(
+        dest="requirements_command"
+    )
+    requirements_list_parser = requirements_subparsers.add_parser(
+        "list",
+        help="List configured requirements and current teacher-entered status.",
+        description=(
+            "Read the canonical assignment, assembled submission manifest, and "
+            "optional review record without writing any files."
+        ),
+    )
+    _add_submission_identity_arguments(requirements_list_parser)
+    requirements_list_parser.set_defaults(handler=handle_requirements_list)
+
+    requirements_check_parser = requirements_subparsers.add_parser(
+        "set-check",
+        help="Create or update one configured teacher-entered check.",
+        description=(
+            "Resolve a requirement key from the canonical assignment and record "
+            "the teacher's explicit met/not-met judgment in canonical review.json."
+        ),
+    )
+    _add_submission_identity_arguments(requirements_check_parser)
+    requirements_check_parser.add_argument(
+        "--requirement-key",
+        required=True,
+        help="Configured key, such as paragraphs_min or required_elements:thesis.",
+    )
+    requirements_check_parser.add_argument(
+        "--met",
+        required=True,
+        type=_boolean,
+        metavar="true|false",
+        help="Explicit teacher judgment: true or false.",
+    )
+    requirements_check_parser.add_argument(
+        "--note",
+        help="Optional nonblank teacher note; omission clears an earlier note.",
+    )
+    requirements_check_parser.set_defaults(handler=handle_requirements_set_check)
+
+    requirements_outcome_parser = requirements_subparsers.add_parser(
+        "set-outcome",
+        help="Set an eligible teacher-selected overall outcome.",
+        description=(
+            "Set met, unmet_continue_review, or returned_without_full_review "
+            "after validating configured checks and canonical assignment policy."
+        ),
+    )
+    _add_submission_identity_arguments(requirements_outcome_parser)
+    requirements_outcome_parser.add_argument(
+        "--outcome",
+        required=True,
+        choices=(
+            "met",
+            "unmet_continue_review",
+            "returned_without_full_review",
+        ),
+        help="Explicit teacher-selected outcome.",
+    )
+    requirements_outcome_parser.add_argument(
+        "--note",
+        help=(
+            "Optional nonblank teacher note; required when returning without "
+            "full standards review."
+        ),
+    )
+    requirements_outcome_parser.set_defaults(handler=handle_requirements_set_outcome)
 
     roster_parser = subparsers.add_parser(
         "roster",

--- a/quillan/minimum_requirement_review.py
+++ b/quillan/minimum_requirement_review.py
@@ -1,0 +1,399 @@
+"""Assignment-aware minimum-requirement review application services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.review_record_paths import ReviewRecordPathError, review_record_path
+from quillan.review_requirements import (
+    ReviewRequirementError,
+    UpdatedMinimumRequirementOutcome,
+    UpdatedRequirementCheck,
+    set_minimum_requirement_outcome,
+    set_requirement_check,
+)
+from quillan.storage import assignment_config_path
+from quillan.submission_guidance import missing_submission_guidance
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+ExpectedValue = str | int | float
+OUTCOME_STATUSES = (
+    "met",
+    "unmet_continue_review",
+    "returned_without_full_review",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ConfiguredRequirement:
+    """One canonical requirement derived from an assignment."""
+
+    key: str
+    label: str
+    expected: ExpectedValue
+    question: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class MinimumRequirementReviewSummary:
+    """Counts for currently configured requirements only."""
+
+    total: int
+    checked: int
+    unchecked: int
+    met: int
+    unmet: int
+
+
+@dataclass(frozen=True, slots=True)
+class MinimumRequirementReviewContext:
+    """Validated canonical assignment, submission, and optional review context."""
+
+    workspace_root: Path
+    class_id: str
+    assignment_id: str
+    student_id: str
+    assignment_path: Path
+    submission_manifest_path: Path
+    review_record_path: Path
+    assignment: dict[str, Any]
+    requirements: tuple[ConfiguredRequirement, ...]
+    review: dict[str, Any] | None
+    checks: tuple[dict[str, Any], ...]
+    summary: MinimumRequirementReviewSummary
+    allow_return_without_full_review: bool
+
+    @property
+    def review_record_relative_path(self) -> str:
+        return _workspace_relative_path(
+            self.review_record_path, self.workspace_root, "review record"
+        )
+
+    @property
+    def submission_manifest_relative_path(self) -> str:
+        return _workspace_relative_path(
+            self.submission_manifest_path, self.workspace_root, "submission manifest"
+        )
+
+    @property
+    def configured_checks(self) -> dict[str, dict[str, Any]]:
+        keys = {requirement.key for requirement in self.requirements}
+        return {
+            str(check["requirement_key"]): check
+            for check in self.checks
+            if check.get("requirement_key") in keys
+        }
+
+    @property
+    def stale_checks(self) -> tuple[dict[str, Any], ...]:
+        keys = {requirement.key for requirement in self.requirements}
+        return tuple(
+            check for check in self.checks if check.get("requirement_key") not in keys
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SetConfiguredRequirementCheckResult:
+    """Assignment-aware result for a requirement-check write."""
+
+    requirement: ConfiguredRequirement
+    update: UpdatedRequirementCheck
+    teacher_note: str | None
+
+
+def configured_requirements(
+    assignment: dict[str, Any],
+) -> tuple[ConfiguredRequirement, ...]:
+    """Derive canonical configured requirements in teacher-facing order."""
+    basic = assignment.get("basic_requirements")
+    if not isinstance(basic, dict):
+        return ()
+    specs = (
+        (
+            "paragraphs_min",
+            "Minimum paragraphs",
+            "Does the submission meet the minimum paragraph requirement?",
+            "Minimum: {value} paragraphs",
+        ),
+        (
+            "paragraphs_max",
+            "Maximum paragraphs",
+            "Does the submission stay within the maximum paragraph requirement?",
+            "Maximum: {value} paragraphs",
+        ),
+        (
+            "word_count_min",
+            "Minimum word count",
+            "Does the submission meet the minimum word count?",
+            "Minimum: {value} words",
+        ),
+        (
+            "word_count_max",
+            "Maximum word count",
+            "Does the submission stay within the maximum word count?",
+            "Maximum: {value} words",
+        ),
+    )
+    items: list[ConfiguredRequirement] = []
+    for key, label, question, detail_template in specs:
+        value = basic.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            items.append(
+                ConfiguredRequirement(
+                    key=key,
+                    label=label,
+                    expected=value,
+                    question=question,
+                    detail=detail_template.format(value=value),
+                )
+            )
+    elements = basic.get("required_elements")
+    if isinstance(elements, list):
+        for element in elements:
+            if isinstance(element, str) and element.strip():
+                value = element.strip()
+                items.append(
+                    ConfiguredRequirement(
+                        key=f"required_elements:{value}",
+                        label=f"Required element: {value}",
+                        expected=value,
+                        question="Does the submission include this required element?",
+                        detail=f"Required element: {value}",
+                    )
+                )
+    return tuple(items)
+
+
+def summarize_minimum_requirements(
+    requirements: tuple[ConfiguredRequirement, ...] | list[ConfiguredRequirement],
+    checks: tuple[dict[str, Any], ...] | list[dict[str, Any]],
+) -> MinimumRequirementReviewSummary:
+    """Summarize checks that still correspond to configured requirements."""
+    keys = {requirement.key for requirement in requirements}
+    relevant = [check for check in checks if check.get("requirement_key") in keys]
+    checked = len(relevant)
+    return MinimumRequirementReviewSummary(
+        total=len(requirements),
+        checked=checked,
+        unchecked=len(requirements) - checked,
+        met=sum(check.get("met") is True for check in relevant),
+        unmet=sum(check.get("met") is False for check in relevant),
+    )
+
+
+def available_minimum_requirement_outcomes(
+    summary: MinimumRequirementReviewSummary,
+    *,
+    allow_return_without_full_review: bool,
+) -> tuple[str, ...]:
+    """Return assignment-aware outcomes currently available to a teacher."""
+    outcomes: list[str] = []
+    if summary.total and summary.checked == summary.total and summary.unmet == 0:
+        outcomes.append("met")
+    if summary.unmet:
+        outcomes.append("unmet_continue_review")
+        if allow_return_without_full_review:
+            outcomes.append("returned_without_full_review")
+    return tuple(outcomes)
+
+
+def allows_return_without_full_review(assignment: dict[str, Any]) -> bool:
+    """Return the canonical assignment-policy decision for returned work."""
+    policy = assignment.get("minimum_requirement_policy")
+    return (
+        isinstance(policy, dict)
+        and policy.get("allow_return_without_full_review") is True
+    )
+
+
+def load_minimum_requirement_review_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> MinimumRequirementReviewContext:
+    """Load and validate canonical assignment, submission, and optional review."""
+    try:
+        root = Path(workspace_root).resolve(strict=False)
+        assignment_path = assignment_config_path(root, class_id, assignment_id)
+        manifest_path = submission_manifest_path(root, class_id, assignment_id, student_id)
+        record_path = review_record_path(root, class_id, assignment_id, student_id)
+    except (OSError, RuntimeError, ValueError, SubmissionManifestPathError, ReviewRecordPathError) as error:
+        raise ReviewRequirementError(str(error)) from error
+
+    try:
+        assignment = load_assignment_config(assignment_path)
+    except (OSError, AssignmentConfigError) as error:
+        raise ReviewRequirementError(str(error)) from error
+    if assignment["assignment_id"] != assignment_id:
+        raise ReviewRequirementError(
+            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
+        )
+    if class_id not in assignment["class_ids"]:
+        raise ReviewRequirementError(
+            f"Assignment config class_ids does not include {class_id!r}."
+        )
+
+    if not manifest_path.exists():
+        raise ReviewRequirementError(missing_submission_guidance())
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise ReviewRequirementError(f"Could not load submission manifest: {error}") from error
+    _validate_identity(
+        manifest,
+        "Submission manifest",
+        class_id,
+        assignment_id,
+        student_id,
+    )
+
+    review = None
+    checks: tuple[dict[str, Any], ...] = ()
+    if record_path.exists():
+        try:
+            review = load_review_record(record_path)
+        except (OSError, ReviewRecordError) as error:
+            raise ReviewRequirementError(f"Could not load review record: {error}") from error
+        _validate_identity(review, "Review record", class_id, assignment_id, student_id)
+        checks = tuple(review["minimum_requirement_checks"])
+
+    requirements = configured_requirements(assignment)
+    allow_return = allows_return_without_full_review(assignment)
+    return MinimumRequirementReviewContext(
+        workspace_root=root,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        assignment_path=assignment_path,
+        submission_manifest_path=manifest_path,
+        review_record_path=record_path,
+        assignment=assignment,
+        requirements=requirements,
+        review=review,
+        checks=checks,
+        summary=summarize_minimum_requirements(requirements, checks),
+        allow_return_without_full_review=allow_return,
+    )
+
+
+def set_configured_requirement_check(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    requirement_key: str,
+    met: bool,
+    teacher_note: str | None = None,
+) -> SetConfiguredRequirementCheckResult:
+    """Resolve and set one currently configured teacher-entered check."""
+    context = load_minimum_requirement_review_context(
+        workspace_root, class_id, assignment_id, student_id
+    )
+    if not context.requirements:
+        raise ReviewRequirementError("This assignment has no configured minimum requirements.")
+    requirement = next(
+        (item for item in context.requirements if item.key == requirement_key), None
+    )
+    if requirement is None:
+        valid = ", ".join(item.key for item in context.requirements)
+        raise ReviewRequirementError(
+            f"Unknown or unconfigured requirement key {requirement_key!r}. Valid keys: {valid}."
+        )
+    update = set_requirement_check(
+        context.workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        requirement_key=requirement.key,
+        label=requirement.label,
+        expected=requirement.expected,
+        met=met,
+        teacher_note=teacher_note,
+    )
+    normalized_note = teacher_note.strip() if teacher_note is not None else None
+    return SetConfiguredRequirementCheckResult(requirement, update, normalized_note)
+
+
+def set_configured_minimum_requirement_outcome(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    status: str,
+    teacher_note: str | None = None,
+) -> UpdatedMinimumRequirementOutcome:
+    """Validate assignment-aware eligibility and set the selected outcome."""
+    context = load_minimum_requirement_review_context(
+        workspace_root, class_id, assignment_id, student_id
+    )
+    if status not in OUTCOME_STATUSES:
+        raise ReviewRequirementError(
+            "status must be one of: met, unmet_continue_review, returned_without_full_review."
+        )
+    if not context.requirements:
+        raise ReviewRequirementError("This assignment has no configured minimum requirements.")
+    available = available_minimum_requirement_outcomes(
+        context.summary,
+        allow_return_without_full_review=context.allow_return_without_full_review,
+    )
+    if status not in available:
+        if status == "met":
+            reason = "every configured requirement must be checked and met"
+        elif status == "unmet_continue_review":
+            reason = "at least one configured requirement must be checked and not met"
+        elif not context.allow_return_without_full_review:
+            reason = "assignment policy does not allow returning without full review"
+        else:
+            reason = "at least one configured requirement must be checked and not met"
+        raise ReviewRequirementError(f"Outcome {status!r} is unavailable: {reason}.")
+    return set_minimum_requirement_outcome(
+        context.workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        status=status,
+        teacher_note=teacher_note,
+        allow_return_without_full_review=context.allow_return_without_full_review,
+    )
+
+
+def _validate_identity(
+    record: dict[str, Any],
+    name: str,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> None:
+    for field, expected in (
+        ("class_id", class_id),
+        ("assignment_id", assignment_id),
+        ("student_id", student_id),
+    ):
+        if record[field] != expected:
+            raise ReviewRequirementError(
+                f"{name} {field} is {record[field]!r}, expected {expected!r}."
+            )
+
+
+def _workspace_relative_path(path: Path, root: Path, description: str) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewRequirementError(
+            f"Could not resolve workspace-relative {description} path: {error}"
+        ) from error

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -53,6 +53,17 @@ from quillan.focus_standard_comments import (
     lookup_comments,
     normalize_teacher_tags,
 )
+from quillan.minimum_requirement_review import (
+    ConfiguredRequirement,
+    MinimumRequirementReviewSummary,
+    allows_return_without_full_review,
+    available_minimum_requirement_outcomes,
+    configured_requirements,
+    load_minimum_requirement_review_context,
+    set_configured_minimum_requirement_outcome,
+    set_configured_requirement_check,
+    summarize_minimum_requirements,
+)
 from quillan.standards_summary_export import (
     StandardsSummaryExportError,
     export_standards_summary,
@@ -106,11 +117,7 @@ from quillan.review_targets import (
     format_review_target,
     parse_paragraph_selection,
 )
-from quillan.review_requirements import (
-    ReviewRequirementError,
-    set_minimum_requirement_outcome,
-    set_requirement_check,
-)
+from quillan.review_requirements import ReviewRequirementError
 from quillan.storage import assignment_config_path
 from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
@@ -3005,29 +3012,24 @@ def _menu_finalize_minimum_requirement_outcome(
         )
         print()
     allow_return = _allow_return_without_full_review(assignment)
-    options: list[tuple[str, str]] = []
-    if summary["checked"] == len(requirements) and summary["unmet"] == 0:
-        options.append(("met", "Mark minimum requirements as met"))
-    if summary["unmet"] > 0:
-        options.append(
-            (
-                "unmet_continue_review",
-                "Continue full standards review despite unmet requirements",
-            )
+    labels = {
+        "met": "Mark minimum requirements as met",
+        "unmet_continue_review": (
+            "Continue full standards review despite unmet requirements"
+        ),
+        "returned_without_full_review": "Return without full standards review",
+    }
+    available = available_minimum_requirement_outcomes(
+        MinimumRequirementReviewSummary(**summary),
+        allow_return_without_full_review=allow_return,
+    )
+    options = [(status, labels[status]) for status in available]
+    if summary["unmet"] > 0 and not allow_return:
+        print(
+            "Assignment policy does not allow returning work without full "
+            "standards review."
         )
-        if allow_return:
-            options.append(
-                (
-                    "returned_without_full_review",
-                    "Return without full standards review",
-                )
-            )
-        else:
-            print(
-                "Assignment policy does not allow returning work without full "
-                "standards review."
-            )
-            print()
+        print()
     if not options:
         print("No final outcome is available yet. Record requirement checks first.")
         return
@@ -3058,14 +3060,13 @@ def _menu_finalize_minimum_requirement_outcome(
             "Outcome note (leave blank if not applicable): "
         ).strip() or None
     try:
-        updated = set_minimum_requirement_outcome(
+        updated = set_configured_minimum_requirement_outcome(
             workspace_root,
             class_id,
             assignment_id,
             student_id,
             status=status,
             teacher_note=teacher_note,
-            allow_return_without_full_review=allow_return,
         )
     except (ReviewRequirementError, OSError) as error:
         print(f"Error: could not finalize minimum requirements: {error}")
@@ -3117,14 +3118,12 @@ def _prompt_and_set_requirement_check(
         "Teacher note (leave blank if not applicable): "
     ).strip() or None
     try:
-        updated = set_requirement_check(
+        result = set_configured_requirement_check(
             workspace_root,
             class_id,
             assignment_id,
             student_id,
             requirement_key=str(requirement["key"]),
-            label=str(requirement["label"]),
-            expected=requirement["expected"],
             met=met,
             teacher_note=teacher_note,
         )
@@ -3134,6 +3133,7 @@ def _prompt_and_set_requirement_check(
 
     print()
     print("Recorded requirement check:")
+    updated = result.update
     print(f"Requirement: {updated.requirement_key}")
     print(f"Met: {_format_yes_no(updated.met)}")
     print(f"Action: {'created' if updated.was_created else 'updated'}")
@@ -3145,66 +3145,16 @@ def _prompt_and_set_requirement_check(
 def _requirement_items_from_assignment(
     assignment: dict[str, Any],
 ) -> list[dict[str, Any]]:
-    basic_requirements = assignment.get("basic_requirements")
-    if not isinstance(basic_requirements, dict):
-        return []
-
-    items: list[dict[str, Any]] = []
-    numeric_specs = (
-        (
-            "paragraphs_min",
-            "Minimum paragraphs",
-            "Does the submission meet the minimum paragraph requirement?",
-            "Minimum: {value} paragraphs",
-        ),
-        (
-            "paragraphs_max",
-            "Maximum paragraphs",
-            "Does the submission stay within the maximum paragraph requirement?",
-            "Maximum: {value} paragraphs",
-        ),
-        (
-            "word_count_min",
-            "Minimum word count",
-            "Does the submission meet the minimum word count?",
-            "Minimum: {value} words",
-        ),
-        (
-            "word_count_max",
-            "Maximum word count",
-            "Does the submission stay within the maximum word count?",
-            "Maximum: {value} words",
-        ),
-    )
-    for key, label, question, detail_template in numeric_specs:
-        value = basic_requirements.get(key)
-        if isinstance(value, int) and not isinstance(value, bool):
-            items.append(
-                {
-                    "key": key,
-                    "label": label,
-                    "expected": value,
-                    "question": question,
-                    "detail": detail_template.format(value=value),
-                }
-            )
-
-    required_elements = basic_requirements.get("required_elements")
-    if isinstance(required_elements, list):
-        for element in required_elements:
-            if not isinstance(element, str) or not element.strip():
-                continue
-            normalized = element.strip()
-            items.append(
-                {
-                    "key": f"required_elements:{normalized}",
-                    "label": f"Required element: {normalized}",
-                    "expected": normalized,
-                    "question": "Does the submission include this required element?",
-                    "detail": f"Required element: {normalized}",
-                }
-            )
-    return items
+    return [
+        {
+            "key": item.key,
+            "label": item.label,
+            "expected": item.expected,
+            "question": item.question,
+            "detail": item.detail,
+        }
+        for item in configured_requirements(assignment)
+    ]
 
 
 def _current_requirement_checks(
@@ -3213,21 +3163,13 @@ def _current_requirement_checks(
     assignment_id: str,
     student_id: str,
 ) -> dict[str, dict[str, Any]]:
-    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
-    if not path.exists():
-        return {}
     try:
-        record = load_review_record(path)
-    except (OSError, ReviewRecordError):
+        context = load_minimum_requirement_review_context(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except (OSError, ReviewRequirementError):
         return {}
-    checks = record.get("minimum_requirement_checks")
-    if not isinstance(checks, list):
-        return {}
-    return {
-        str(check["requirement_key"]): check
-        for check in checks
-        if isinstance(check, dict) and isinstance(check.get("requirement_key"), str)
-    }
+    return context.configured_checks
 
 
 def _current_minimum_requirement_outcome(
@@ -3236,14 +3178,15 @@ def _current_minimum_requirement_outcome(
     assignment_id: str,
     student_id: str,
 ) -> dict[str, Any] | None:
-    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
-    if not path.exists():
-        return None
     try:
-        record = load_review_record(path)
-    except (OSError, ReviewRecordError):
+        context = load_minimum_requirement_review_context(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except (OSError, ReviewRequirementError):
         return None
-    outcome = record.get("minimum_requirement_outcome")
+    if context.review is None:
+        return None
+    outcome = context.review.get("minimum_requirement_outcome")
     return outcome if isinstance(outcome, dict) else None
 
 
@@ -3251,20 +3194,23 @@ def _minimum_requirement_summary(
     requirements: list[dict[str, Any]],
     checks: dict[str, dict[str, Any]],
 ) -> dict[str, int]:
-    requirement_keys = {str(requirement["key"]) for requirement in requirements}
-    relevant_checks = [
-        check
-        for key, check in checks.items()
-        if key in requirement_keys and isinstance(check, dict)
+    configured = [
+        ConfiguredRequirement(
+            key=str(requirement["key"]),
+            label=str(requirement["label"]),
+            expected=requirement["expected"],
+            question=str(requirement["question"]),
+            detail=str(requirement["detail"]),
+        )
+        for requirement in requirements
     ]
-    checked = len(relevant_checks)
-    unmet = sum(1 for check in relevant_checks if check.get("met") is False)
+    result = summarize_minimum_requirements(configured, list(checks.values()))
     return {
-        "total": len(requirements),
-        "checked": checked,
-        "unchecked": len(requirements) - checked,
-        "met": sum(1 for check in relevant_checks if check.get("met") is True),
-        "unmet": unmet,
+        "total": result.total,
+        "checked": result.checked,
+        "unchecked": result.unchecked,
+        "met": result.met,
+        "unmet": result.unmet,
     }
 
 
@@ -3311,10 +3257,7 @@ def _print_minimum_requirement_summary(
 
 
 def _allow_return_without_full_review(assignment: dict[str, Any]) -> bool:
-    policy = assignment.get("minimum_requirement_policy")
-    if not isinstance(policy, dict):
-        return False
-    return policy.get("allow_return_without_full_review") is True
+    return allows_return_without_full_review(assignment)
 
 
 def _requirement_status(check: dict[str, Any] | None) -> str:

--- a/tests/test_cli_requirements.py
+++ b/tests/test_cli_requirements.py
@@ -1,0 +1,310 @@
+"""Direct CLI coverage for assignment-aware minimum-requirement review."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.cli import main
+from quillan.cli_app.handlers import requirements as handlers
+from quillan.review_record import build_empty_review_record
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english10_p2"
+ASSIGNMENT_ID = "argument_01"
+STUDENT_ID = "00107"
+TIMESTAMP = "2026-07-13T12:00:00+00:00"
+
+
+def _assignment() -> dict[str, Any]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Argument",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Make an argument.",
+        "standards_profile_id": "ela",
+        "focus_standard_ids": ["W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "two_level",
+            "levels": [
+                {"value": 1, "label": "Developing", "description": "Developing."}
+            ],
+        },
+        "basic_requirements": {
+            "paragraphs_min": 3,
+            "paragraphs_max": 6,
+            "word_count_min": 400,
+            "word_count_max": 900,
+            "required_elements": ["thesis", "textual evidence"],
+        },
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {"submission_entry_method": "plain_paper_manual"},
+    }
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    assignment_path = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment_path.parent.mkdir(parents=True)
+    assignment_path.write_text(json.dumps(_assignment()), encoding="utf-8")
+    write_submission_manifest(
+        submission_manifest_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        _manifest(),
+    )
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--help"],
+        ["requirements", "--help"],
+        ["requirements", "list", "--help"],
+        ["requirements", "set-check", "--help"],
+        ["requirements", "set-outcome", "--help"],
+    ],
+)
+def test_requirement_help_exits_successfully(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(argv)
+    assert error.value.code == 0
+
+
+def test_bare_requirements_prints_help_without_resolving_workspace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        handlers,
+        "resolve_workspace_root",
+        lambda: pytest.fail("bare namespace resolved the workspace"),
+    )
+    assert main(["requirements"]) == 0
+    output = capsys.readouterr().out
+    assert "{list,set-check,set-outcome}" in output
+
+
+def test_list_is_read_only_and_preserves_requirement_order(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "builtins.input", lambda *_args: pytest.fail("direct command prompted")
+    )
+    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = (assignment_path.read_bytes(), manifest_path.read_bytes())
+
+    assert main(["requirements", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    keys = [
+        "paragraphs_min",
+        "paragraphs_max",
+        "word_count_min",
+        "word_count_max",
+        "required_elements:thesis",
+        "required_elements:textual evidence",
+    ]
+    assert [output.index(f"Key: {key}") for key in keys] == sorted(
+        output.index(f"Key: {key}") for key in keys
+    )
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Review record exists: no" in output
+    assert "Review state: not_started" in output
+    assert "Overall outcome: not_checked" in output
+    assert output.count("State: not checked") == 6
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+    assert (assignment_path.read_bytes(), manifest_path.read_bytes()) == before
+
+
+def test_set_check_uses_assignment_values_and_clears_omitted_note(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = ["requirements", "set-check", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    assert main(args + ["--requirement-key", "paragraphs_min", "--met", "false", "--note", " Too short. "]) == 0
+    assert main(args + ["--requirement-key", "paragraphs_min", "--met", "true"]) == 0
+
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(encoding="utf-8")
+    )
+    check = review["minimum_requirement_checks"][0]
+    assert check["requirement_check_id"] == "requirement_check_0001"
+    assert check["label"] == "Minimum paragraphs"
+    assert check["expected"] == 3
+    assert check["met"] is True
+    assert "teacher_note" not in check
+    assert len(review["minimum_requirement_checks"]) == 1
+    assert "Action: updated" in capsys.readouterr().out
+
+
+def test_unknown_key_and_missing_manifest_fail_without_writing(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    command = [
+        "requirements", "set-check", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+        "--requirement-key", "arbitrary", "--met", "true",
+    ]
+    assert main(command) == 1
+    assert "Valid keys:" in capsys.readouterr().out
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+
+    submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).unlink()
+    assert main(command) == 1
+    assert "assemble" in capsys.readouterr().out.lower()
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+
+
+def test_outcome_eligibility_and_return_safeguards(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    base = ["requirements", "set-check", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    assert main(base + ["--requirement-key", "paragraphs_min", "--met", "false"]) == 0
+    outcome = ["requirements", "set-outcome", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    assert main(outcome + ["--outcome", "met"]) == 1
+    assert main(outcome + ["--outcome", "returned_without_full_review"]) == 1
+    assert main(outcome + ["--outcome", "unmet_continue_review"]) == 0
+    assert main(outcome + ["--outcome", "returned_without_full_review", "--note", " Revise and resubmit. "]) == 0
+
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(encoding="utf-8")
+    )
+    assert review["review_state"] == "returned_without_full_review"
+    assert review["minimum_requirement_outcome"] == {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Revise and resubmit.",
+        "updated_at": review["minimum_requirement_outcome"]["updated_at"],
+    }
+    assert "Full standards review was not completed." in capsys.readouterr().out
+
+
+def test_met_succeeds_only_after_every_configured_check_is_met(workspace: Path) -> None:
+    base = ["requirements", "set-check", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    for key in (
+        "paragraphs_min",
+        "paragraphs_max",
+        "word_count_min",
+        "word_count_max",
+        "required_elements:thesis",
+        "required_elements:textual evidence",
+    ):
+        assert main(base + ["--requirement-key", key, "--met", "true"]) == 0
+    assert main(
+        ["requirements", "set-outcome", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+         "--outcome", "met"]
+    ) == 0
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(encoding="utf-8")
+    )
+    assert review["review_state"] == "requirements_checked"
+    assert review["minimum_requirement_outcome"]["status"] == "met"
+
+
+def test_assignment_policy_cannot_be_overridden(workspace: Path) -> None:
+    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment = _assignment()
+    assignment["minimum_requirement_policy"]["allow_return_without_full_review"] = False
+    assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
+    assert main(
+        ["requirements", "set-check", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+         "--requirement-key", "paragraphs_min", "--met", "false"]
+    ) == 0
+    assert main(
+        ["requirements", "set-outcome", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+         "--outcome", "returned_without_full_review", "--note", "Revise."]
+    ) == 1
+
+
+def test_malformed_existing_review_fails_list_without_repair(workspace: Path) -> None:
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    path.write_text("{malformed", encoding="utf-8")
+    before = path.read_bytes()
+    assert main(["requirements", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 1
+    assert path.read_bytes() == before
+
+
+def test_stale_unmet_check_does_not_enable_outcome(workspace: Path) -> None:
+    review = build_empty_review_record(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        created_at=TIMESTAMP,
+    )
+    review["minimum_requirement_checks"] = [
+        {
+            "requirement_check_id": "requirement_check_0001",
+            "requirement_key": "removed_key",
+            "label": "Removed",
+            "expected": "old",
+            "met": False,
+            "updated_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    write_review_record(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID), review
+    )
+    assert main(
+        ["requirements", "set-outcome", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+         "--outcome", "unmet_continue_review"]
+    ) == 1
+
+
+def test_no_configured_requirements_list_succeeds_but_set_fails(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment = _assignment()
+    assignment["basic_requirements"] = {}
+    path.write_text(json.dumps(assignment), encoding="utf-8")
+    assert main(["requirements", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+    assert "Minimum requirements: none configured" in capsys.readouterr().out
+    assert main(
+        ["requirements", "set-check", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+         "--requirement-key", "paragraphs_min", "--met", "true"]
+    ) == 1
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()


### PR DESCRIPTION
## Summary

* Add direct CLI commands for assignment minimum-requirement review:

  * `quillan requirements list`
  * `quillan requirements set-check`
  * `quillan requirements set-outcome`
* Add shared assignment-aware minimum-requirement services.
* Refactor the teacher-facing review menu to use the same requirement definitions, summaries, policy checks, and outcome eligibility rules as the direct CLI.
* Preserve the existing schema-version-2 review-record contract and canonical atomic write path.
* Keep all minimum-requirement decisions explicitly teacher-entered.

## Command Surface

```text
quillan requirements list <class_id> <assignment_id> <student_id>

quillan requirements set-check <class_id> <assignment_id> <student_id> \
  --requirement-key <key> \
  --met true|false \
  [--note <text>]

quillan requirements set-outcome <class_id> <assignment_id> <student_id> \
  --outcome met|unmet_continue_review|returned_without_full_review \
  [--note <text>]
```

Running `quillan requirements` without a subcommand prints requirements help and exits successfully without resolving or inspecting the workspace.

## Shared Architecture

Added shared assignment-aware services in:

* `quillan/minimum_requirement_review.py`

Added direct CLI handlers in:

* `quillan/cli_app/handlers/requirements.py`

The menu and direct CLI now share:

* configured requirement extraction;
* canonical requirement-key generation;
* teacher-facing labels and expected values;
* current-check loading;
* current-outcome loading;
* summary calculation;
* assignment policy handling;
* outcome eligibility rules;
* canonical check and outcome write services.

CLI handlers remain non-interactive and do not invoke menu prompts.

## Requirement Definitions

Requirement definitions are derived only from the assignment’s validated `basic_requirements`.

Supported requirement keys include:

* `paragraphs_min`
* `paragraphs_max`
* `word_count_min`
* `word_count_max`
* `required_elements:<element>`

For example:

```text
required_elements:thesis
required_elements:textual evidence
```

The assignment remains the source of truth for:

* requirement keys;
* labels;
* expected values;
* requirement order.

The direct CLI cannot create arbitrary requirement keys or override assignment-defined labels and expected values.

## Submission Prerequisite

All three commands require a valid canonical submission manifest:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
```

The workflow validates:

* identifiers;
* canonical assignment existence and structure;
* assignment identity;
* submission-manifest existence and structure;
* submission identity;
* canonical paths.

When the submission has not been assembled, the command exits nonzero with guidance to assemble submissions before returning to review.

The commands do not:

* assemble submissions automatically;
* create submission manifests;
* infer review readiness from routed evidence alone.

Valid plain-paper manual submissions remain supported because they contain a canonical `submission.json`, even when no digital evidence is attached.

## `requirements list`

`requirements list` is strictly read-only.

It reports:

* class, assignment, and student identity;
* configured requirements;
* requirement keys;
* labels;
* expected values;
* current met, not-met, or not-checked state;
* teacher notes;
* completion summary;
* current minimum-requirement outcome;
* returned-without-full-review status;
* current review state;
* canonical review-record location.

When no `review.json` exists, it reports:

* review state: `not_started`;
* outcome: `not_checked`;
* configured requirements as not checked.

It does not create a review record, directories, or other files.

Checks no longer configured by the assignment do not count toward current configured completion or outcome eligibility.

## `requirements set-check`

`requirements set-check` records one explicit teacher judgment.

Behavior:

* resolves the supplied requirement key against the current assignment;
* obtains the canonical label and expected value from the assignment;
* parses `--met true|false` into an actual boolean;
* creates `review.json` through the existing safe review service when needed;
* updates an existing check by `requirement_key`;
* preserves the existing `requirement_check_id`;
* creates a sequential ID for a new configured key;
* updates the check and top-level timestamps;
* changes `not_started` to `requirements_checked`;
* otherwise preserves the existing review state;
* preserves all unrelated review data.

When `--note` is omitted while updating an existing check, the earlier check note is cleared, matching the established service and menu behavior.

Updating a check does not automatically recalculate or change the overall minimum-requirement outcome.

## `requirements set-outcome`

Supported outcomes are exactly:

* `met`
* `unmet_continue_review`
* `returned_without_full_review`

`not_met` is not accepted or stored.

### `met`

Allowed only when:

* at least one minimum requirement is configured;
* every configured requirement has been checked;
* no configured requirement is unmet.

### `unmet_continue_review`

Allowed only when:

* at least one currently configured requirement is marked unmet.

This records the teacher’s decision to continue a full standards review despite unmet minimum requirements.

Unchecked requirements are not treated as unmet.

### `returned_without_full_review`

Allowed only when:

* the assignment policy permits returning without full review;
* at least one currently configured requirement is marked unmet;
* a nonblank teacher note is supplied.

The CLI cannot override assignment policy through an argument.

A stale or unconfigured failed check does not satisfy the unmet-check requirement.

This outcome sets the review state to:

```text
returned_without_full_review
```

It does not create a grade, zero, standards rating, completed review, inferred feedback, or automatic judgment.

## Review Record Behavior

Write commands may create or modify only:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
```

All writes use the existing validated atomic review-record writer.

The implementation preserves unrelated review data, including:

* other minimum-requirement checks;
* review units;
* Focus Standard observations;
* overall ratings;
* feedback configuration and comments;
* exports;
* private teacher notes;
* module metadata;
* original creation timestamp.

Assignment and submission records remain unchanged.

Malformed or incompatible existing review records are rejected rather than silently normalized or repaired.

## No Automated Judgment

Confirmed that the workflow does not:

* inspect student evidence;
* parse student writing;
* count words;
* count paragraphs;
* detect required elements;
* run OCR;
* use AI;
* infer whether a requirement was met;
* infer an overall outcome;
* create grades;
* create scores;
* create standards ratings;
* generate feedback.

The assignment defines the requirements.

The teacher supplies the check and outcome decisions.

## Menu Behavior

The teacher-facing menu now shares the same application services as the direct CLI for:

* requirement definitions;
* requirement ordering;
* current checks;
* current outcome;
* completion summaries;
* assignment policy;
* outcome eligibility.

Existing menu behavior remains intact, including:

* missing checks not being treated as unmet;
* `met` requiring all configured checks;
* continuing review when requirements are unmet;
* policy-controlled return without full review;
* required return note;
* required configured unmet check;
* returned-work feedback and export workflows.

## Documentation

Updated:

* `docs/cli_contract.md`
* `docs/review_record_contract.md`
* `docs/prepared_review_workflow.md`

The documentation now describes:

* the direct requirements command surface;
* canonical outcome values;
* assignment-derived requirement keys;
* submission-manifest prerequisites;
* teacher-entered-only behavior;
* returned-without-full-review safeguards;
* exact read and write boundaries;
* the prohibition on OCR, AI, counting, and inferred judgment.

## Files Changed

Eight intended Quillan source, test, and documentation files were modified or added, including:

* `quillan/minimum_requirement_review.py`
* `quillan/cli_app/handlers/requirements.py`
* `quillan/cli_app/parser.py`
* `quillan/review_menu.py`
* `tests/test_cli_requirements.py`
* minimum-requirement service/menu tests
* `docs/cli_contract.md`
* review workflow and contract documentation

## Safety

Confirmed:

* `requirements list` is read-only;
* missing submissions do not create review records;
* write commands affect only canonical `review.json`;
* assignment records remain unchanged;
* submission manifests remain unchanged;
* evidence files remain unchanged;
* unrelated review data remains preserved;
* arbitrary requirement keys cannot be written;
* assignment policy cannot be overridden;
* leading-zero student IDs remain strings;
* expected failures return nonzero without tracebacks;
* no PDS Core files were modified;
* no ScoreForm files were modified;
* no workspace data was added;
* no real student data was added;
* no generated review or export artifacts were added.

## Validation

* Focused requirement tests: `27 passed`
* Requirement and menu regression tests: `43 passed`
* Broader CLI and review selection: `523 passed`
* Full pytest suite: `1142 passed`
* Ruff: passed
* mypy: passed
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* No workspace data, real student data, or generated review/export artifacts present

Closes #301
