### PR TITLE
Add review unit management CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -106,6 +106,9 @@ quillan assignment validate <class_id> <assignment_id>
 quillan requirements list <class_id> <assignment_id> <student_id>
 quillan requirements set-check <class_id> <assignment_id> <student_id> --requirement-key <key> --met true|false [--note <text>]
 quillan requirements set-outcome <class_id> <assignment_id> <student_id> --outcome met|unmet_continue_review|returned_without_full_review [--note <text>]
+quillan review-units show <class_id> <assignment_id> <student_id>
+quillan review-units set <class_id> <assignment_id> <student_id> --count <positive_integer>
+quillan review-units set <class_id> <assignment_id> <student_id> --units <units.json>
 quillan roster create <class_id> --input <roster.csv> [--school-year YYYY-YYYY] [--overwrite] (--yes | --dry-run)
 quillan roster show <class_id>
 quillan roster validate <class_id>
@@ -144,6 +147,46 @@ exits successfully; it does not inspect or modify the workspace.
 
 Running `quillan roster` without a subcommand prints roster help and exits
 successfully without resolving or inspecting the workspace.
+
+Running `quillan review-units` without a subcommand prints review-unit help
+and exits successfully without resolving or inspecting the workspace.
+
+### `review-units` commands
+
+`review-units show` loads the canonical assignment and assembled submission
+manifest, plus `review.json` when it exists. It reports assignment-derived
+unit labels, canonical paths, review state, units, and observation counts. If
+there is no review record it reports `not_started`, zero units, and zero
+observations without creating a file or directory.
+
+`review-units set` is an immediate, non-interactive replacement operation.
+Exactly one of `--count` and `--units` is required. Count mode generates
+sequences `1..N`. JSON mode reads a non-empty UTF-8 JSON array whose objects
+may contain only `sequence`, `label`, `page_number`, and `evidence_id`.
+`sequence` is explicit, unique, positive, non-boolean, and sorted ascending
+before writing; it need not be contiguous. Labels must be nonblank. Page and
+evidence references are validated only against submission-manifest metadata,
+including page/evidence membership. Unknown fields and raw record fields such
+as `unit_id`, `unit_type`, `standard_observations`, and `module_details` are
+rejected.
+
+The assignment supplies `review_unit.type` and its singular and plural labels.
+Canonical IDs are `<type>_<sequence>` and omitted labels become the title-cased
+singular label plus the sequence, such as `paragraph_2` / `Paragraph 2`.
+Stable canonical IDs preserve their observations when labels or evidence
+metadata change. Removed IDs remove their observations, and stale feedback
+observation references are cleaned while feedback records, ratings, minimum
+requirements, exports, private notes, metadata, and surviving observations
+remain intact.
+
+Both commands require a valid canonical `submission.json`, including for
+plain-paper submissions without digital evidence. They do not require current
+roster membership and never assemble a submission automatically. `show` is
+read-only and remains available for returned submissions. `set` may create or
+atomically update only the canonical `review.json` and rejects a
+`returned_without_full_review` record. Neither command opens evidence files,
+parses PDFs or images, runs OCR or AI, counts or segments writing, or creates
+observations, ratings, feedback, or grades.
 
 The teacher-facing menu may also be launched explicitly:
 
@@ -1210,8 +1253,8 @@ explicitly outside the current end-to-end foundation:
   automatic production scan routing;
 * OCR or handwriting interpretation;
 * PDF text extraction;
-* a direct CLI command for requirements review, review-unit observations,
-  overall Focus Standard ratings, or feedback composition;
+* a direct CLI command for review-unit observations, overall Focus Standard
+  ratings, or feedback composition;
 * AI grading, scoring, tagging, or feedback;
 * automatic grading, mastery calculation, review-state decisions, or
   duplicate-evidence selection;

--- a/docs/prepared_review_workflow.md
+++ b/docs/prepared_review_workflow.md
@@ -114,6 +114,17 @@ observation should be considered for student feedback.
 Ratings on review-unit observations are optional. Overall Focus Standard
 ratings are entered separately.
 
+Teachers may define or inspect units through the interactive menu or the
+direct, non-interactive `quillan review-units` commands. `show` performs no
+writes. `set --count N` creates assignment-derived sequences `1..N`, while
+`set --units units.json` permits explicit sequences, custom labels, and
+optional manifest-backed page/evidence references. Both paths require an
+assembled canonical submission manifest and use the same atomic review-unit
+service. Stable unit IDs preserve observations; removed-unit observations and
+their stale feedback references are removed. These commands never inspect
+evidence content, run OCR or AI, or infer segmentation, labels, observations,
+ratings, feedback, grades, or scores.
+
 ## Overall Focus Standard Ratings
 
 Overall ratings are stored in:

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -499,6 +499,17 @@ Review units are teacher-created or teacher-confirmed. Quillan must not parse
 student writing, run OCR, or automatically infer how many review units a
 student wrote.
 
+The direct `review-units set` command replaces the complete array through the
+shared review-unit service. It accepts either an explicit count or constrained
+JSON definitions containing only `sequence`, `label`, `page_number`, and
+`evidence_id`. The assignment always supplies `unit_type`; `unit_id` is always
+`<unit_type>_<sequence>`. Matching IDs preserve observations. Removed IDs
+remove their observations and any stale feedback observation references,
+while unrelated review data and the original `created_at` remain unchanged.
+Page and evidence references are checked against the canonical submission
+manifest without opening evidence files. This does not change schema version
+`2`.
+
 For an assignment whose review unit is paragraphs, a teacher-facing prompt
 should use the assignment's configured plural label:
 

--- a/quillan/cli_app/handlers/review_units.py
+++ b/quillan/cli_app/handlers/review_units.py
@@ -1,0 +1,77 @@
+"""Direct, non-interactive review-unit management handlers."""
+
+from __future__ import annotations
+
+import argparse
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.cli_app.output import print_updated_review_units
+from quillan.review_observations import ReviewObservationError, set_review_units
+from quillan.review_unit_management import (
+    ReviewUnitManagementError,
+    load_review_unit_context,
+    load_review_unit_definitions_file,
+)
+
+
+def handle_review_units_show(args: argparse.Namespace) -> int:
+    """Display assignment configuration and current review units without writing."""
+    try:
+        context = load_review_unit_context(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id
+        )
+        print("Review units:")
+        print(f"Class: {context.class_id}")
+        print(f"Assignment: {context.assignment_id}")
+        print(f"Student: {context.student_id}")
+        print(f"Review-unit type: {context.unit_type}")
+        print(f"Singular label: {context.singular_label}")
+        print(f"Plural label: {context.plural_label}")
+        print(f"Submission manifest: {context.submission_manifest_relative_path}")
+        print(f"Review record: {context.review_record_relative_path}")
+        print(f"Review record exists: {'yes' if context.review is not None else 'no'}")
+        print(f"Review state: {context.review_state}")
+        print(f"Total units: {len(context.units)}")
+        print(f"Total observations: {context.observation_count}")
+        for unit in context.units:
+            details = (
+                f"- {unit.sequence}. {unit.label} ({unit.unit_id}); "
+                f"type: {unit.unit_type}; observations: {unit.observation_count}"
+            )
+            if unit.page_number is not None:
+                details += f"; page: {unit.page_number}"
+            if unit.evidence_id is not None:
+                details += f"; evidence: {unit.evidence_id}"
+            print(details)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewUnitManagementError) as error:
+        return _error(error)
+
+
+def handle_review_units_set(args: argparse.Namespace) -> int:
+    """Replace review units from an explicit count or constrained JSON file."""
+    try:
+        workspace_root = resolve_workspace_root()
+        if args.count is not None:
+            units = [{"sequence": sequence} for sequence in range(1, args.count + 1)]
+        else:
+            units = load_review_unit_definitions_file(args.units)
+        updated = set_review_units(
+            workspace_root, args.class_id, args.assignment_id, args.student_id, units
+        )
+        print_updated_review_units(updated)
+        return 0
+    except (
+        OSError,
+        ValueError,
+        WorkspaceRootError,
+        ReviewObservationError,
+        ReviewUnitManagementError,
+    ) as error:
+        return _error(error)
+
+
+def _error(error: Exception) -> int:
+    print(f"Error: {error}")
+    return 1

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -86,9 +86,19 @@ def print_updated_review_units(updated: UpdatedReviewUnits) -> None:
     print(f"Class: {updated.class_id}")
     print(f"Assignment: {updated.assignment_id}")
     print(f"Student: {updated.student_id}")
-    print(f"Units: {updated.unit_count}")
+    print(f"Review-unit type: {updated.unit_type}")
+    print(f"Previous unit count: {updated.previous_unit_count}")
+    print(f"Resulting unit count: {updated.unit_count}")
+    print(f"Observations preserved: {updated.observations_preserved}")
+    print(f"Observations removed: {updated.observations_removed}")
+    print(f"Newly empty units added: {updated.empty_units_added}")
+    print(
+        "Stale feedback observation references removed: "
+        f"{updated.stale_feedback_references_removed}"
+    )
     print(f"Review state: {updated.review_state}")
     print(f"Review record: {updated.review_record_relative_path}")
+    print(f"Updated: {updated.updated_at}")
 
 
 def print_updated_review_unit_observation(

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -22,6 +22,10 @@ from quillan.cli_app.handlers.requirements import (
     handle_requirements_set_check,
     handle_requirements_set_outcome,
 )
+from quillan.cli_app.handlers.review_units import (
+    handle_review_units_set,
+    handle_review_units_show,
+)
 from quillan.cli_app.handlers.rosters import (
     handle_roster_add_student,
     handle_roster_create,
@@ -189,6 +193,45 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     requirements_outcome_parser.set_defaults(handler=handle_requirements_set_outcome)
+
+    review_units_parser = subparsers.add_parser(
+        "review-units",
+        help="Display or replace review units for one assembled submission.",
+        description=(
+            "Display or explicitly replace canonical review units without inspecting "
+            "student evidence or inferring unit boundaries."
+        ),
+    )
+    review_units_parser.set_defaults(
+        handler=partial(_print_parser_help, review_units_parser)
+    )
+    review_units_subparsers = review_units_parser.add_subparsers(
+        dest="review_units_command"
+    )
+    review_units_show_parser = review_units_subparsers.add_parser(
+        "show", help="Display current review units without writing files."
+    )
+    _add_submission_identity_arguments(review_units_show_parser)
+    review_units_show_parser.set_defaults(handler=handle_review_units_show)
+
+    review_units_set_parser = review_units_subparsers.add_parser(
+        "set", help="Replace all review units from a count or JSON file."
+    )
+    _add_submission_identity_arguments(review_units_set_parser)
+    review_units_source = review_units_set_parser.add_mutually_exclusive_group(
+        required=True
+    )
+    review_units_source.add_argument(
+        "--count",
+        type=positive_integer,
+        help="Create canonical units with sequences 1 through COUNT.",
+    )
+    review_units_source.add_argument(
+        "--units",
+        type=Path,
+        help="UTF-8 JSON file containing constrained review-unit definitions.",
+    )
+    review_units_set_parser.set_defaults(handler=handle_review_units_set)
 
     roster_parser = subparsers.add_parser(
         "roster",

--- a/quillan/review_observations.py
+++ b/quillan/review_observations.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.review_record import (
     ReviewRecordError,
     build_empty_review_record,
@@ -18,18 +17,12 @@ from quillan.review_record import (
 )
 from quillan.review_record_paths import (
     ReviewRecordPathError,
-    review_record_path,
     write_review_record,
 )
-from quillan.storage import assignment_config_path
-from quillan.submission_guidance import missing_submission_guidance
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
-)
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
+from quillan.review_unit_management import (
+    ReviewUnitManagementError,
+    load_review_unit_context,
+    validate_review_unit_definitions,
 )
 
 _SEQUENTIAL_OBSERVATION_ID = re.compile(r"^observation_(\d{4})$")
@@ -46,10 +39,16 @@ class UpdatedReviewUnits:
     class_id: str
     assignment_id: str
     student_id: str
+    unit_type: str
     review_record_path: Path
     review_record_relative_path: str
     review_state: str
+    previous_unit_count: int
     unit_count: int
+    observations_preserved: int
+    observations_removed: int
+    empty_units_added: int
+    stale_feedback_references_removed: int
     updated_at: str
 
 
@@ -106,6 +105,22 @@ def set_review_units(
     review = _load_or_create_review(context, normalized_updated_at)
     _guard_returned_without_full_review(review)
 
+    try:
+        units = validate_review_unit_definitions(units, context["manifest"])
+    except ReviewUnitManagementError as error:
+        raise ReviewObservationError(str(error)) from error
+
+    previous_unit_count = len(review["review_units"])
+    previous_observation_ids = {
+        observation["observation_id"]
+        for unit in review["review_units"]
+        for observation in unit["standard_observations"]
+    }
+    previous_feedback_reference_count = sum(
+        len(item["included_observation_ids"])
+        for item in review["feedback"]["standard_feedback"]
+    )
+
     existing_by_id = {
         unit["unit_id"]: unit
         for unit in review["review_units"]
@@ -146,17 +161,36 @@ def set_review_units(
     review["review_state"] = _observations_in_progress_state(review["review_state"])
     review["updated_at"] = normalized_updated_at
 
+    resulting_observation_ids = {
+        observation["observation_id"]
+        for unit in review["review_units"]
+        for observation in unit["standard_observations"]
+    }
+    resulting_feedback_reference_count = sum(
+        len(item["included_observation_ids"])
+        for item in review["feedback"]["standard_feedback"]
+    )
     _write_review(context, review)
     return UpdatedReviewUnits(
         class_id=class_id,
         assignment_id=assignment_id,
         student_id=student_id,
+        unit_type=unit_type,
         review_record_path=context["record_path"],
         review_record_relative_path=_workspace_relative_path(
             context["record_path"], context["workspace_root"], "review record"
         ),
         review_state=review["review_state"],
+        previous_unit_count=previous_unit_count,
         unit_count=len(canonical_units),
+        observations_preserved=len(previous_observation_ids & resulting_observation_ids),
+        observations_removed=len(previous_observation_ids - resulting_observation_ids),
+        empty_units_added=sum(
+            unit["unit_id"] not in existing_by_id for unit in canonical_units
+        ),
+        stale_feedback_references_removed=(
+            previous_feedback_reference_count - resulting_feedback_reference_count
+        ),
         updated_at=normalized_updated_at,
     )
 
@@ -319,53 +353,18 @@ def _load_context(
     student_id: str,
 ) -> dict[str, Any]:
     try:
-        resolved_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_root, class_id, assignment_id, student_id
+        loaded = load_review_unit_context(
+            workspace_root, class_id, assignment_id, student_id
         )
-        record_path = review_record_path(
-            resolved_root, class_id, assignment_id, student_id
-        )
-        assignment_path = assignment_config_path(resolved_root, class_id, assignment_id)
-    except (
-        OSError,
-        RuntimeError,
-        SubmissionManifestPathError,
-        ReviewRecordPathError,
-    ) as error:
+    except ReviewUnitManagementError as error:
         raise ReviewObservationError(str(error)) from error
-
-    if not manifest_path.exists():
-        raise ReviewObservationError(missing_submission_guidance())
-
-    try:
-        manifest = load_submission_manifest(manifest_path)
-        assignment = load_assignment_config(assignment_path)
-    except (OSError, SubmissionManifestError, AssignmentConfigError) as error:
-        raise ReviewObservationError(str(error)) from error
-
-    _validate_identity(
-        manifest,
-        record_name="Submission manifest",
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-    )
-    if class_id not in assignment["class_ids"]:
-        raise ReviewObservationError(
-            f"Assignment config class_ids does not include {class_id!r}."
-        )
-    if assignment["assignment_id"] != assignment_id:
-        raise ReviewObservationError(
-            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
-        )
-
     return {
-        "workspace_root": resolved_root,
-        "manifest_path": manifest_path,
-        "record_path": record_path,
-        "assignment_path": assignment_path,
-        "assignment": assignment,
+        "workspace_root": loaded.workspace_root,
+        "manifest_path": loaded.submission_manifest_path,
+        "record_path": loaded.review_record_path,
+        "assignment_path": loaded.assignment_path,
+        "assignment": loaded.assignment,
+        "manifest": loaded.manifest,
         "class_id": class_id,
         "assignment_id": assignment_id,
         "student_id": student_id,

--- a/quillan/review_unit_management.py
+++ b/quillan/review_unit_management.py
@@ -1,0 +1,266 @@
+"""Read-only context and constrained input validation for review units."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.review_record_paths import ReviewRecordPathError, review_record_path
+from quillan.storage import assignment_config_path
+from quillan.submission_guidance import missing_submission_guidance
+from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
+from quillan.submission_manifest_paths import (
+    SubmissionManifestPathError,
+    submission_manifest_path,
+)
+
+_ALLOWED_UNIT_FIELDS = frozenset({"sequence", "label", "page_number", "evidence_id"})
+
+
+class ReviewUnitManagementError(ValueError):
+    """Raised when review-unit context or input is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewUnitDefinition:
+    """One current canonical review unit and its observation count."""
+
+    sequence: int
+    unit_id: str
+    label: str
+    unit_type: str
+    page_number: int | None
+    evidence_id: str | None
+    observation_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewUnitContext:
+    """Validated canonical assignment, submission, and optional review context."""
+
+    workspace_root: Path
+    class_id: str
+    assignment_id: str
+    student_id: str
+    assignment_path: Path
+    submission_manifest_path: Path
+    review_record_path: Path
+    assignment: dict[str, Any]
+    manifest: dict[str, Any]
+    review: dict[str, Any] | None
+
+    @property
+    def unit_type(self) -> str:
+        return cast(str, self.assignment["review_unit"]["type"])
+
+    @property
+    def singular_label(self) -> str:
+        return cast(str, self.assignment["review_unit"]["singular_label"])
+
+    @property
+    def plural_label(self) -> str:
+        return cast(str, self.assignment["review_unit"]["plural_label"])
+
+    @property
+    def review_state(self) -> str:
+        return cast(str, self.review["review_state"]) if self.review else "not_started"
+
+    @property
+    def submission_manifest_relative_path(self) -> str:
+        return _relative(self.submission_manifest_path, self.workspace_root, "submission manifest")
+
+    @property
+    def review_record_relative_path(self) -> str:
+        return _relative(self.review_record_path, self.workspace_root, "review record")
+
+    @property
+    def units(self) -> tuple[ReviewUnitDefinition, ...]:
+        if self.review is None:
+            return ()
+        return tuple(
+            ReviewUnitDefinition(
+                sequence=unit["sequence"],
+                unit_id=unit["unit_id"],
+                label=unit["label"],
+                unit_type=unit["unit_type"],
+                page_number=unit.get("page_number"),
+                evidence_id=unit.get("evidence_id"),
+                observation_count=len(unit["standard_observations"]),
+            )
+            for unit in self.review["review_units"]
+        )
+
+    @property
+    def observation_count(self) -> int:
+        return sum(unit.observation_count for unit in self.units)
+
+
+def load_review_unit_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> ReviewUnitContext:
+    """Load canonical review-unit context without writing anything."""
+    try:
+        root = Path(workspace_root).resolve(strict=False)
+        assignment_path = assignment_config_path(root, class_id, assignment_id)
+        manifest_path = submission_manifest_path(root, class_id, assignment_id, student_id)
+        record_path = review_record_path(root, class_id, assignment_id, student_id)
+    except (OSError, RuntimeError, ValueError, SubmissionManifestPathError, ReviewRecordPathError) as error:
+        raise ReviewUnitManagementError(str(error)) from error
+
+    try:
+        assignment = load_assignment_config(assignment_path)
+    except (OSError, AssignmentConfigError) as error:
+        raise ReviewUnitManagementError(str(error)) from error
+    if assignment["assignment_id"] != assignment_id:
+        raise ReviewUnitManagementError(
+            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
+        )
+    if class_id not in assignment["class_ids"]:
+        raise ReviewUnitManagementError(
+            f"Assignment config class_ids does not include {class_id!r}."
+        )
+
+    if not manifest_path.exists():
+        raise ReviewUnitManagementError(missing_submission_guidance())
+    try:
+        manifest = load_submission_manifest(manifest_path)
+    except (OSError, SubmissionManifestError) as error:
+        raise ReviewUnitManagementError(f"Could not load submission manifest: {error}") from error
+    _validate_identity(manifest, "Submission manifest", class_id, assignment_id, student_id)
+
+    review = None
+    if record_path.exists():
+        try:
+            review = load_review_record(record_path)
+        except (OSError, ReviewRecordError) as error:
+            raise ReviewUnitManagementError(f"Could not load review record: {error}") from error
+        _validate_identity(review, "Review record", class_id, assignment_id, student_id)
+
+    return ReviewUnitContext(
+        workspace_root=root,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        assignment_path=assignment_path,
+        submission_manifest_path=manifest_path,
+        review_record_path=record_path,
+        assignment=assignment,
+        manifest=manifest,
+        review=review,
+    )
+
+
+def load_review_unit_definitions_file(path: str | Path) -> list[dict[str, Any]]:
+    """Read a UTF-8 JSON unit-description file and validate its basic shape."""
+    input_path = Path(path)
+    try:
+        with input_path.open("r", encoding="utf-8") as file:
+            value = json.load(file)
+    except FileNotFoundError as error:
+        raise ReviewUnitManagementError(f"Review-unit input file not found: {input_path}") from error
+    except json.JSONDecodeError as error:
+        raise ReviewUnitManagementError(
+            f"Review-unit input file is not valid JSON: {input_path}"
+        ) from error
+    except (OSError, UnicodeError) as error:
+        raise ReviewUnitManagementError(
+            f"Could not read review-unit input file {input_path}: {error}"
+        ) from error
+    if not isinstance(value, list):
+        raise ReviewUnitManagementError("Review-unit input root must be a JSON array.")
+    return cast(list[dict[str, Any]], value)
+
+
+def validate_review_unit_definitions(
+    units: list[Any], manifest: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Validate constrained unit descriptions against manifest metadata."""
+    if not units:
+        raise ReviewUnitManagementError("Review-unit input array must not be empty.")
+    pages = {page["page_number"]: page for page in manifest["pages"]}
+    evidence_pages = {
+        evidence["evidence_id"]: page["page_number"]
+        for page in manifest["pages"]
+        for evidence in page["evidence"]
+    }
+    normalized: list[dict[str, Any]] = []
+    sequences: set[int] = set()
+    for index, value in enumerate(units):
+        context = f"units[{index}]"
+        if not isinstance(value, dict):
+            raise ReviewUnitManagementError(f"{context} must be an object.")
+        unknown = sorted(set(value) - _ALLOWED_UNIT_FIELDS)
+        if unknown:
+            raise ReviewUnitManagementError(
+                f"{context} contains prohibited or unknown field {unknown[0]!r}."
+            )
+        if "sequence" not in value:
+            raise ReviewUnitManagementError(f"{context} is missing required field 'sequence'.")
+        sequence = value["sequence"]
+        if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
+            raise ReviewUnitManagementError(f"{context}.sequence must be a positive integer.")
+        if sequence in sequences:
+            raise ReviewUnitManagementError(f"Duplicate review-unit sequence: {sequence}.")
+        sequences.add(sequence)
+        item: dict[str, Any] = {"sequence": sequence}
+
+        if "label" in value:
+            label = value["label"]
+            if not isinstance(label, str) or not label.strip():
+                raise ReviewUnitManagementError(f"{context}.label must be a non-empty string.")
+            item["label"] = label.strip()
+        if "page_number" in value:
+            page_number = value["page_number"]
+            if isinstance(page_number, bool) or not isinstance(page_number, int) or page_number < 1:
+                raise ReviewUnitManagementError(f"{context}.page_number must be a positive integer.")
+            if page_number not in pages:
+                raise ReviewUnitManagementError(
+                    f"{context}.page_number {page_number} is not present in the submission manifest."
+                )
+            item["page_number"] = page_number
+        if "evidence_id" in value:
+            evidence_id = value["evidence_id"]
+            if not isinstance(evidence_id, str) or not evidence_id.strip():
+                raise ReviewUnitManagementError(f"{context}.evidence_id must be a non-empty string.")
+            evidence_id = evidence_id.strip()
+            if evidence_id not in evidence_pages:
+                raise ReviewUnitManagementError(
+                    f"{context}.evidence_id {evidence_id!r} is not present in the submission manifest."
+                )
+            if "page_number" in item and evidence_pages[evidence_id] != item["page_number"]:
+                raise ReviewUnitManagementError(
+                    f"{context}.evidence_id {evidence_id!r} does not belong to page {item['page_number']}."
+                )
+            item["evidence_id"] = evidence_id
+        normalized.append(item)
+    return sorted(normalized, key=lambda item: cast(int, item["sequence"]))
+
+
+def _validate_identity(
+    record: dict[str, Any], name: str, class_id: str, assignment_id: str, student_id: str
+) -> None:
+    for field, expected in {
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+    }.items():
+        if record[field] != expected:
+            raise ReviewUnitManagementError(
+                f"{name} {field} is {record[field]!r}, expected {expected!r}."
+            )
+
+
+def _relative(path: Path, root: Path, name: str) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError as error:
+        raise ReviewUnitManagementError(
+            f"Canonical {name} path is outside the workspace root."
+        ) from error

--- a/tests/test_cli_review_units.py
+++ b/tests/test_cli_review_units.py
@@ -1,0 +1,202 @@
+"""Direct CLI coverage for canonical review-unit management."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.cli import main
+from quillan.cli_app.handlers import review_units as handlers
+from quillan.review_record_paths import review_record_path
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english10_p2"
+ASSIGNMENT_ID = "argument_01"
+STUDENT_ID = "00107"
+TIMESTAMP = "2026-07-13T12:00:00+00:00"
+
+
+def _assignment() -> dict[str, Any]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Argument",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Make an argument.",
+        "standards_profile_id": "ela",
+        "focus_standard_ids": ["W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "two_level",
+            "levels": [{"value": 1, "label": "Developing", "description": "Developing."}],
+        },
+        "basic_requirements": {},
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {"submission_entry_method": "plain_paper_manual"},
+    }
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    assignment_path = (
+        tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    )
+    assignment_path.parent.mkdir(parents=True)
+    assignment_path.write_text(json.dumps(_assignment()), encoding="utf-8")
+    write_submission_manifest(
+        submission_manifest_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        _manifest(),
+    )
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--help"],
+        ["review-units", "--help"],
+        ["review-units", "show", "--help"],
+        ["review-units", "set", "--help"],
+    ],
+)
+def test_review_unit_help_exits_successfully(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(argv)
+    assert error.value.code == 0
+
+
+def test_bare_namespace_prints_help_without_resolving_workspace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        handlers,
+        "resolve_workspace_root",
+        lambda: pytest.fail("bare namespace resolved the workspace"),
+    )
+    assert main(["review-units"]) == 0
+    assert "{show,set}" in capsys.readouterr().out
+
+
+def test_show_without_review_is_read_only(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = assignment_path.read_bytes(), manifest_path.read_bytes()
+
+    assert main(["review-units", "show", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Review-unit type: paragraph" in output
+    assert "Review record exists: no" in output
+    assert "Review state: not_started" in output
+    assert "Total units: 0" in output
+    assert "Total observations: 0" in output
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+    assert (assignment_path.read_bytes(), manifest_path.read_bytes()) == before
+
+
+def test_count_creates_menu_equivalent_canonical_units(
+    workspace: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("builtins.input", lambda *_args: pytest.fail("CLI prompted"))
+    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = assignment_path.read_bytes(), manifest_path.read_bytes()
+    args = ["review-units", "set", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    assert main(args + ["--count", "2"]) == 0
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert [(unit["unit_id"], unit["label"]) for unit in review["review_units"]] == [
+        ("paragraph_1", "Paragraph 1"),
+        ("paragraph_2", "Paragraph 2"),
+    ]
+    assert all("page_number" not in unit and "evidence_id" not in unit for unit in review["review_units"])
+    assert (assignment_path.read_bytes(), manifest_path.read_bytes()) == before
+    output = capsys.readouterr().out
+    assert "Resulting unit count: 2" in output
+    assert "Newly empty units added: 2" in output
+    assert "Review state: observations_in_progress" in output
+
+
+def test_json_units_are_constrained_and_sorted(
+    workspace: Path, tmp_path: Path
+) -> None:
+    units_path = tmp_path / "units.json"
+    units_path.write_text(
+        json.dumps([{"sequence": 3, "label": "Conclusion"}, {"sequence": 1}]),
+        encoding="utf-8",
+    )
+    args = ["review-units", "set", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    assert main(args + ["--units", str(units_path)]) == 0
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert [unit["sequence"] for unit in review["review_units"]] == [1, 3]
+    assert [unit["label"] for unit in review["review_units"]] == ["Paragraph 1", "Conclusion"]
+
+
+@pytest.mark.parametrize(
+    "value,error_text",
+    [
+        ({"sequence": 1}, "root must be a JSON array"),
+        ([], "must not be empty"),
+        ([{"sequence": 1, "unit_id": "injected"}], "prohibited or unknown"),
+        ([{"sequence": True}], "positive integer"),
+        ([{"sequence": 1, "label": "  "}], "non-empty string"),
+    ],
+)
+def test_invalid_json_input_does_not_create_review(
+    workspace: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    value: Any,
+    error_text: str,
+) -> None:
+    units_path = tmp_path / "invalid-units.json"
+    units_path.write_text(json.dumps(value), encoding="utf-8")
+    args = ["review-units", "set", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    assert main(args + ["--units", str(units_path)]) == 1
+    output = capsys.readouterr().out
+    assert "Error: " in output
+    assert error_text in output
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()


### PR DESCRIPTION
## Summary

* Add direct CLI commands for displaying and defining review units:

  * `quillan review-units show`
  * `quillan review-units set --count`
  * `quillan review-units set --units`
* Add shared read-only review-unit context and structured JSON-input validation.
* Continue using the existing review-unit mutation service and canonical atomic `review.json` writer.
* Preserve observations for stable unit IDs during replacement.
* Remove observations and feedback references belonging to removed units.
* Keep review-unit setup explicitly teacher-directed, with no evidence inspection or automatic segmentation.

## Command Surface

```text
quillan review-units show <class_id> <assignment_id> <student_id>

quillan review-units set <class_id> <assignment_id> <student_id> \
  --count <positive_integer>

quillan review-units set <class_id> <assignment_id> <student_id> \
  --units <units.json>
```

`--count` and `--units` are mutually exclusive.

Running:

```text
quillan review-units
```

without a subcommand prints namespace help and exits successfully without resolving the workspace.

All commands are direct and non-interactive. They do not call `input()` or invoke menu functions.

## Shared Architecture

Added shared review-unit context and input validation in:

* `quillan/review_unit_management.py`

Added direct CLI handlers in:

* `quillan/cli_app/handlers/review_units.py`

Registered the new namespace in:

* `quillan/cli_app/parser.py`

Extended replacement summaries in:

* `quillan/review_observations.py`
* `quillan/cli_app/output.py`

The implementation preserves the intended interface boundary:

```text
menu -> shared review-unit service
CLI  -> same shared review-unit service
GUI  -> same shared review-unit service later
```

CLI handlers do not edit raw review-record dictionaries.

All mutations continue through the existing `set_review_units(...)` service.

## `review-units show`

`review-units show` is strictly read-only.

It reports:

* class ID;
* assignment ID;
* student ID;
* assignment review-unit type;
* singular and plural labels;
* review-record existence;
* current review state;
* total review-unit count;
* total observation count;
* canonical unit IDs;
* unit sequences;
* unit labels;
* optional page numbers;
* optional evidence IDs;
* per-unit observation counts;
* canonical review-record path.

When no `review.json` exists, the command reports:

* review state: `not_started`;
* zero review units;
* zero observations.

It does not create a review record, directories, or other files.

Returned-without-full-review records remain displayable.

Malformed or identity-mismatched review records fail clearly rather than appearing as empty reviews.

## `review-units set --count`

Count mode accepts a positive integer and generates sequential unit definitions from `1` through `N`.

For an assignment configured with:

```json
{
  "type": "paragraph",
  "singular_label": "paragraph",
  "plural_label": "paragraphs"
}
```

the following command:

```text
quillan review-units set english10 essay_01 00107 --count 3
```

creates:

```text
paragraph_1 — Paragraph 1
paragraph_2 — Paragraph 2
paragraph_3 — Paragraph 3
```

Unit IDs and labels derive from the assignment configuration.

Count mode does not add page-number or evidence-ID references.

The resulting units are equivalent to those created through the existing teacher-facing menu count workflow.

## `review-units set --units`

Structured JSON input supports custom labels and optional submission-manifest references.

Example:

```json
[
  {
    "sequence": 1,
    "label": "Introduction",
    "page_number": 1,
    "evidence_id": "evidence_001"
  },
  {
    "sequence": 2,
    "label": "First Body Paragraph",
    "page_number": 2,
    "evidence_id": "evidence_002"
  },
  {
    "sequence": 3,
    "label": "Conclusion"
  }
]
```

### Allowed fields

Each input object may contain only:

* `sequence`
* `label`
* `page_number`
* `evidence_id`

### Rejected fields

The validator rejects raw review-record fields, including:

* `unit_id`
* `unit_type`
* `standard_observations`
* `module_details`

Unknown fields are also rejected rather than ignored.

The input file therefore cannot act as an alternate raw `review.json` editor.

## Sequence and Label Behavior

Sequences must be:

* explicitly supplied;
* integers rather than booleans;
* positive;
* unique.

Input units are sorted by sequence before writing.

Sequences do not need to be contiguous.

Canonical unit IDs remain:

```text
<assignment review_unit.type>_<sequence>
```

Examples include:

```text
paragraph_1
stanza_2
section_4
response_1
```

When a label is omitted, it derives from the assignment’s singular review-unit label.

Custom labels are trimmed and must remain nonblank.

The caller cannot supply or override `unit_type` or `unit_id`.

## Page and Evidence References

Optional `page_number` and `evidence_id` values are validated only against canonical `submission.json` metadata.

Validation confirms:

* referenced pages exist;
* referenced evidence IDs exist;
* a supplied evidence ID belongs to the supplied page;
* an evidence ID supplied without a page can be resolved from the manifest.

The implementation does not:

* open evidence files;
* parse PDFs;
* parse images;
* inspect evidence contents.

Plain-paper manual submissions remain supported when review units omit page and evidence references.

## Submission and Identity Validation

Both `show` and `set` require a valid canonical submission manifest.

The workflow validates:

* identifiers;
* canonical assignment existence;
* assignment schema and identity;
* class membership in assignment `class_ids`;
* canonical submission-manifest existence;
* submission schema and identity;
* existing review schema and identity;
* canonical assignment and submission references.

When a submission has not been assembled, the command returns the existing assembly guidance.

The commands do not assemble submissions automatically or create `submission.json`.

Valid canonical submissions remain usable even when the student is no longer present in the active roster.

## Review Creation

When no review exists, `set` may create a canonical schema-version-2 `review.json` through the existing shared service.

The created review:

* uses canonical assignment and submission references;
* preserves leading-zero student IDs as strings;
* uses assignment-derived unit types and labels;
* sets review timestamps;
* enters the existing observation-workflow state;
* retains normal empty structures for requirements, ratings, feedback, exports, and notes.

The CLI handler does not construct the review record directly.

## Replacement and Preservation

`set` replaces the complete active review-unit array.

Observation preservation is based on stable canonical unit ID.

For example, `paragraph_1` remains stable when:

* its label changes;
* its page number changes;
* its evidence ID changes;
* additional units are added;
* other units are removed.

Observations attached to that unit remain preserved.

### Added units

New unit IDs receive empty `standard_observations` arrays.

### Removed units

Units omitted from the replacement are removed along with their observations.

### Changed unit type

Observations are not preserved when the assignment’s unit type changes the canonical ID.

For example:

```text
paragraph_1
```

and:

```text
section_1
```

are different unit IDs.

Sequence equality alone does not preserve observations.

## Feedback Reference Cleanup

When removed units cause observations to disappear, their IDs are removed from:

```text
feedback.standard_feedback[*].included_observation_ids
```

The implementation preserves:

* surviving observation references;
* feedback records;
* feedback comments;
* overall-rating inclusion settings;
* unrelated feedback configuration.

No dangling references to removed observations remain.

## Preserved Review Data

Review-unit replacement preserves unrelated review data, including:

* minimum-requirement checks;
* minimum-requirement outcome;
* observations attached to surviving unit IDs;
* overall Focus Standard ratings;
* feedback records;
* feedback comments;
* export metadata;
* private teacher notes;
* top-level module metadata;
* original `created_at`.

Replacement updates `updated_at` through the existing review service.

It does not automatically clear ratings, feedback, exports, or minimum-requirement decisions.

## Review-State Behavior

Review-state transitions remain owned by the existing review-unit service.

Defining units for a new or early-stage review enters:

```text
observations_in_progress
```

A review in:

```text
returned_without_full_review
```

may be displayed but cannot be modified through `set`.

The command instructs the teacher to change the minimum-requirements outcome before continuing with standards review.

## Write Summary

Successful writes report a compact summary including:

* class ID;
* assignment ID;
* student ID;
* assignment review-unit type;
* previous unit count;
* resulting unit count;
* preserved observation count;
* removed observation count;
* newly added empty-unit count;
* removed stale feedback-reference count;
* resulting review state;
* canonical review-record path;
* update timestamp.

The command does not dump raw review JSON.

## Write Boundaries

`review-units show` writes nothing.

`review-units set` may create or modify only:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
```

All writes use the existing validated atomic writer.

The implementation does not modify:

* `assignment.json`;
* `submission.json`;
* class rosters;
* class metadata;
* routed evidence;
* retained scans;
* source scans;
* PDF or image evidence;
* standards libraries;
* reusable comment libraries;
* exported feedback;
* class reports;
* PDS Core data;
* ScoreForm data.

Tests confirm that assignment and submission-manifest bytes remain unchanged.

## No Automated Judgment

Confirmed that the implementation does not:

* inspect evidence contents;
* parse student writing;
* parse PDFs;
* parse images;
* run OCR;
* count paragraphs;
* count stanzas;
* count review units automatically;
* segment student writing;
* infer unit boundaries;
* infer page mappings;
* use AI;
* create observations;
* create ratings;
* create grades or scores;
* generate feedback.

The teacher explicitly supplies either the unit count or the structured unit definitions.

The assignment supplies the unit type and default labels.

## Documentation

Updated:

* `docs/cli_contract.md`
* `docs/review_record_contract.md`
* `docs/prepared_review_workflow.md`

The documentation now covers:

* the `review-units` namespace;
* count and JSON-file input modes;
* canonical unit-ID generation;
* allowed and prohibited JSON fields;
* replacement semantics;
* observation preservation;
* removed-observation behavior;
* feedback-reference cleanup;
* submission-manifest prerequisites;
* read and write boundaries;
* the prohibition on OCR, AI, segmentation, counting, and evidence inspection.

## Files Changed

Nine intended Quillan source, test, and documentation files were modified or added, including:

* `quillan/review_unit_management.py`
* `quillan/cli_app/handlers/review_units.py`
* `quillan/cli_app/parser.py`
* `quillan/review_observations.py`
* `quillan/cli_app/output.py`
* `tests/test_cli_review_units.py`
* `docs/cli_contract.md`
* `docs/review_record_contract.md`
* `docs/prepared_review_workflow.md`

## Safety

Confirmed:

* bare namespace help does not resolve the workspace;
* direct handlers are non-interactive;
* `show` is read-only;
* missing submissions do not create review records;
* JSON input cannot inject raw review fields;
* canonical assignment configuration controls unit type and IDs;
* stable unit IDs preserve observations;
* removed observations do not leave dangling feedback references;
* unrelated review data remains preserved;
* returned-without-full-review reviews cannot be mutated;
* leading-zero student IDs remain strings;
* expected failures return nonzero without tracebacks;
* no PDS Core files were modified;
* no ScoreForm files were modified;
* no workspace data was added;
* no real student data was added;
* no generated review, evidence, report, feedback, or export artifacts were added.

## Validation

* Focused review-unit service and CLI tests: `20 passed`
* Final focused CLI review-unit tests: `13 passed`
* Review-unit and menu regression tests: `53 passed`
* Broader CLI and review selection: `536 passed`
* Full pytest suite: `1155 passed`
* Ruff: passed
* mypy: passed, `150` source files
* `git diff --cached --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* Quillan working tree contains only the nine intended changes
* No workspace data, real student data, or generated review/evidence/export artifacts present

Closes #302
