### PR TITLE
Add Focus Standard observation CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -109,6 +109,8 @@ quillan requirements set-outcome <class_id> <assignment_id> <student_id> --outco
 quillan review-units show <class_id> <assignment_id> <student_id>
 quillan review-units set <class_id> <assignment_id> <student_id> --count <positive_integer>
 quillan review-units set <class_id> <assignment_id> <student_id> --units <units.json>
+quillan observations list <class_id> <assignment_id> <student_id>
+quillan observations set <class_id> <assignment_id> <student_id> --unit-id <unit_id> --standard-id <standard_id> --applicable true|false [--evidence-present true|false] [--rating <integer>] [--rationale <text>] [--include-in-feedback true|false]
 quillan roster create <class_id> --input <roster.csv> [--school-year YYYY-YYYY] [--overwrite] (--yes | --dry-run)
 quillan roster show <class_id>
 quillan roster validate <class_id>
@@ -151,6 +153,9 @@ successfully without resolving or inspecting the workspace.
 Running `quillan review-units` without a subcommand prints review-unit help
 and exits successfully without resolving or inspecting the workspace.
 
+Running `quillan observations` without a subcommand prints observation help
+and exits successfully without resolving or inspecting the workspace.
+
 ### `review-units` commands
 
 `review-units show` loads the canonical assignment and assembled submission
@@ -178,6 +183,64 @@ metadata change. Removed IDs remove their observations, and stale feedback
 observation references are cleaned while feedback records, ratings, minimum
 requirements, exports, private notes, metadata, and surviving observations
 remain intact.
+
+### `observations` commands
+
+The `observations` namespace exposes review-unit Focus Standard observations
+as direct, non-interactive commands. Both commands validate the canonical
+assignment, require an existing valid canonical `submission.json`, and validate
+an existing `review.json` rather than treating a malformed or mismatched record
+as empty. Routed evidence is not assembled automatically. A valid plain-paper
+manual submission and a valid unrostered historical submission are accepted.
+
+`observations list` is strictly read-only. It reports canonical paths, review
+state, review-unit and Focus Standard totals, expected/recorded/unrecorded pair
+counts, applicability, evidence, unit-rating and feedback-inclusion counts, and
+the assignment rating scale. It then displays every active unit-standard pair,
+with units ordered by `sequence` and standards ordered by the assignment's
+`focus_standard_ids`. Recorded rows include the observation ID, applicability,
+evidence presence, optional unit-level rating and assignment label, rationale,
+feedback eligibility, and timestamp. Unit-level ratings are clearly separate
+from overall Focus Standard ratings. When no review or no units exist, list
+reports zero units and explains that units must be defined first; it returns
+success and creates nothing. A `returned_without_full_review` record remains
+readable.
+
+`observations set` requires an existing review with defined units. `--unit-id`
+must match an active unit and `--standard-id` must match an assignment Focus
+Standard. The command completely replaces the editable values for that pair;
+it is not a sparse patch. A new pair receives the next globally unique
+`observation_NNNN` ID. Updating a pair preserves its observation ID and clears
+an earlier rating or rationale when the corresponding optional argument is
+omitted.
+
+`--applicable` accepts exactly `true` or `false`. Applicable observations
+require an explicit `--evidence-present true|false`; this records only whether
+the teacher found related evidence and does not imply mastery. `--rating` is
+optional for applicable observations. When present it must be an integer value
+from the current assignment's `rating_scale.levels`; when omitted the stored
+rating is `null`. Not-applicable observations reject `--evidence-present` and
+`--rating`, and store both fields as `null`. Rationale text is trimmed; omission
+or blank text stores `null`. Omitted `--include-in-feedback` defaults to `true`
+for applicable observations and `false` for not-applicable observations, while
+either default may be explicitly overridden.
+
+Feedback eligibility belongs to the observation. Setting it does not compose
+feedback or add/remove IDs in `feedback.standard_feedback`. Observation writes
+do not create or alter `overall_standard_ratings`. They preserve unrelated
+units, observations, minimum-requirement data, feedback records and comments,
+exports, notes, top-level metadata, and the original creation timestamp. The
+shared observation service performs review-state transitions and refuses to
+modify `returned_without_full_review` records until the minimum-requirements
+outcome changes.
+
+List writes nothing. Set may modify only
+`classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json`
+through the shared validated atomic writer. Neither command opens evidence,
+parses PDFs or images, runs OCR, handwriting recognition, or AI, infers any
+teacher judgment, calculates overall ratings, grades, or scores, marks review
+complete, composes feedback, or modifies assignments, submissions, rosters,
+evidence, exports, reports, Core data, or ScoreForm data.
 
 Both commands require a valid canonical `submission.json`, including for
 plain-paper submissions without digital evidence. They do not require current

--- a/docs/prepared_review_workflow.md
+++ b/docs/prepared_review_workflow.md
@@ -125,6 +125,26 @@ their stale feedback references are removed. These commands never inspect
 evidence content, run OCR or AI, or infer segmentation, labels, observations,
 ratings, feedback, grades, or scores.
 
+Teachers may likewise inspect or record unit-standard observations through
+the direct, non-interactive `quillan observations list` and `quillan
+observations set` commands. Listing shows the complete active matrix in unit
+sequence and assignment Focus Standard order and never writes. Setting
+requires an existing unit, an assignment Focus Standard, explicit
+applicability, and explicit evidence presence for applicable observations.
+Applicable unit ratings remain optional and, when supplied, are validated
+against the assignment rating scale. Not-applicable observations store null
+evidence presence and rating. Updates replace editable values while preserving
+the observation ID. Feedback eligibility does not compose feedback or change
+included-observation lists, and observation writes never create or alter
+overall Focus Standard ratings.
+
+Both observation commands require an assembled canonical submission manifest.
+Only `set` writes, and it may change only the canonical `review.json`. Returned
+without-full-review records can be listed but cannot be changed until the
+minimum-requirements outcome changes. These commands do not inspect evidence,
+run OCR, handwriting recognition, or AI, infer judgments, calculate ratings,
+grades, or scores, mark observations complete, or generate feedback.
+
 ## Overall Focus Standard Ratings
 
 Overall ratings are stored in:

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -565,9 +565,9 @@ Field rules:
 * `applicable` is a boolean.
 * `evidence_present` is a boolean when `applicable` is `true`.
 * `evidence_present` may be `null` only when `applicable` is `false`.
-* `rating` must be a value from the assignment's `rating_scale.levels` when
-  `applicable` is `true`.
-* `rating` may be `null` only when `applicable` is `false`.
+* when `applicable` is `true`, `rating` is either `null` or a value from the
+  assignment's `rating_scale.levels`;
+* when `applicable` is `false`, `rating` must be `null`.
 * `rationale` is either `null` or a non-empty string.
 * `include_in_feedback` is a boolean.
 * `updated_at` is the most recent teacher update timestamp for the observation.

--- a/quillan/cli_app/handlers/observations.py
+++ b/quillan/cli_app/handlers/observations.py
@@ -1,0 +1,151 @@
+"""Direct, non-interactive Focus Standard observation handlers."""
+
+from __future__ import annotations
+
+import argparse
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.cli_app.output import print_updated_review_unit_observation
+from quillan.observation_management import (
+    ObservationContext,
+    ObservationManagementError,
+    UnitStandardObservationStatus,
+    load_observation_context,
+)
+from quillan.review_observations import (
+    ReviewObservationError,
+    set_review_unit_observation,
+)
+
+
+def handle_observations_list(args: argparse.Namespace) -> int:
+    """Display all active unit-standard observation pairs without writing."""
+    try:
+        context = load_observation_context(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id
+        )
+        _print_observation_context(context)
+        return 0
+    except (
+        OSError,
+        ValueError,
+        WorkspaceRootError,
+        ObservationManagementError,
+    ) as error:
+        return _error(error)
+
+
+def handle_observations_set(args: argparse.Namespace) -> int:
+    """Record one complete teacher-entered unit-standard judgment."""
+    try:
+        if args.applicable and args.evidence_present is None:
+            raise ReviewObservationError(
+                "--evidence-present true|false is required when --applicable true."
+            )
+        if not args.applicable and args.evidence_present is not None:
+            raise ReviewObservationError(
+                "--evidence-present must be omitted when --applicable false."
+            )
+        if not args.applicable and args.rating is not None:
+            raise ReviewObservationError(
+                "--rating must be omitted when --applicable false."
+            )
+        updated = set_review_unit_observation(
+            resolve_workspace_root(),
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            unit_id=args.unit_id,
+            standard_id=args.standard_id,
+            applicable=args.applicable,
+            evidence_present=args.evidence_present,
+            rating=args.rating,
+            rationale=args.rationale,
+            include_in_feedback=args.include_in_feedback,
+        )
+        print_updated_review_unit_observation(updated)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewObservationError) as error:
+        return _error(error)
+
+
+def _print_observation_context(context: ObservationContext) -> None:
+    summary = context.summary
+    print("Focus Standard observations:")
+    print(f"Class: {context.class_id}")
+    print(f"Assignment: {context.assignment_id}")
+    print(f"Student: {context.student_id}")
+    print(f"Review state: {context.review_state}")
+    print(f"Submission manifest: {context.submission_manifest_relative_path}")
+    print(f"Review record: {context.review_record_relative_path}")
+    print(f"Review record exists: {_yes_no(context.review_exists)}")
+    print(f"Review units: {context.unit_count}")
+    print(f"Focus Standards: {len(context.focus_standard_ids)}")
+    print(f"Expected unit-standard pairs: {summary.expected_pair_count}")
+    print(f"Recorded observations: {summary.recorded_count}")
+    print(f"Unrecorded pairs: {summary.unrecorded_count}")
+    print(f"Applicable: {summary.applicable_count}")
+    print(f"Not applicable: {summary.not_applicable_count}")
+    print(f"Evidence present: {summary.evidence_present_count}")
+    print(f"Evidence missing: {summary.evidence_missing_count}")
+    print(f"Unit-level observation ratings: {summary.rating_count}")
+    print(f"Included for feedback: {summary.included_for_feedback_count}")
+    print(f"Assignment rating scale: {context.rating_scale_id}")
+    for level in context.rating_scale_levels:
+        print(f"- {level.value}: {level.label}")
+
+    if context.unit_count == 0:
+        print()
+        print("Review units must be defined before observations can be recorded.")
+        return
+
+    print()
+    print("Unit-standard matrix:")
+    for pair in context.pairs:
+        _print_pair(pair)
+
+
+def _print_pair(pair: UnitStandardObservationStatus) -> None:
+    if pair.observation_id is None:
+        status = "not recorded"
+        observation_id = "not recorded"
+        evidence = "not recorded"
+        rating = "not recorded"
+        rationale = "none"
+        feedback = "not recorded"
+        updated = "not recorded"
+    else:
+        status = "applicable" if pair.applicable else "not applicable"
+        observation_id = pair.observation_id
+        if pair.applicable:
+            evidence = _yes_no(pair.evidence_present is True)
+            rating = (
+                "none"
+                if pair.rating is None
+                else f"{pair.rating} ({pair.rating_label})"
+            )
+        else:
+            evidence = "not applicable"
+            rating = "not applicable"
+        rationale = pair.rationale or "none"
+        feedback = _yes_no(pair.include_in_feedback is True)
+        updated = pair.updated_at or "none"
+    print(f"{pair.unit_sequence}. {pair.unit_label} ({pair.unit_id})")
+    print(f"   Focus Standard: {pair.standard_id}")
+    print(f"   Status: {status}")
+    print(f"   Observation ID: {observation_id}")
+    print(f"   Evidence present: {evidence}")
+    print(f"   Unit-level rating: {rating}")
+    print(f"   Rationale: {rationale}")
+    print(f"   Include in feedback: {feedback}")
+    print(f"   Updated: {updated}")
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _error(error: Exception) -> int:
+    print(f"Error: {error}")
+    return 1

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -117,10 +117,19 @@ def print_updated_review_unit_observation(
     if updated.evidence_present is not None:
         evidence = format_bool(updated.evidence_present)
     print(f"Evidence present: {evidence}")
+    if not updated.applicable:
+        rating = "not applicable"
+    elif updated.rating is None:
+        rating = "none"
+    else:
+        rating = f"{updated.rating} ({updated.rating_label})"
+    print(f"Unit-level rating: {rating}")
+    print(f"Rationale: {'present' if updated.rationale is not None else 'none'}")
     print(f"Include in feedback: {format_bool(updated.include_in_feedback)}")
     print(f"Action: {'created' if updated.was_created else 'updated'}")
     print(f"Review state: {updated.review_state}")
     print(f"Review record: {updated.review_record_relative_path}")
+    print(f"Updated: {updated.updated_at}")
 
 
 def print_completed_review_unit_observations(

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -26,6 +26,10 @@ from quillan.cli_app.handlers.review_units import (
     handle_review_units_set,
     handle_review_units_show,
 )
+from quillan.cli_app.handlers.observations import (
+    handle_observations_list,
+    handle_observations_set,
+)
 from quillan.cli_app.handlers.rosters import (
     handle_roster_add_student,
     handle_roster_create,
@@ -232,6 +236,47 @@ def build_parser() -> argparse.ArgumentParser:
         help="UTF-8 JSON file containing constrained review-unit definitions.",
     )
     review_units_set_parser.set_defaults(handler=handle_review_units_set)
+
+    observations_parser = subparsers.add_parser(
+        "observations",
+        help="List and record review-unit Focus Standard observations.",
+        description=(
+            "List or record explicit teacher-entered Focus Standard observations "
+            "without inspecting evidence or inferring judgments."
+        ),
+    )
+    observations_parser.set_defaults(
+        handler=partial(_print_parser_help, observations_parser)
+    )
+    observations_subparsers = observations_parser.add_subparsers(
+        dest="observations_command"
+    )
+    observations_list_parser = observations_subparsers.add_parser(
+        "list", help="List all current unit-standard observation pairs."
+    )
+    _add_submission_identity_arguments(observations_list_parser)
+    observations_list_parser.set_defaults(handler=handle_observations_list)
+
+    observations_set_parser = observations_subparsers.add_parser(
+        "set", help="Create or replace one teacher-entered observation."
+    )
+    _add_submission_identity_arguments(observations_set_parser)
+    observations_set_parser.add_argument("--unit-id", required=True)
+    observations_set_parser.add_argument("--standard-id", required=True)
+    observations_set_parser.add_argument(
+        "--applicable", required=True, type=_true_false, metavar="true|false"
+    )
+    observations_set_parser.add_argument(
+        "--evidence-present", type=_true_false, metavar="true|false"
+    )
+    observations_set_parser.add_argument(
+        "--rating", type=int, help="Optional assignment-scale unit-level rating."
+    )
+    observations_set_parser.add_argument("--rationale")
+    observations_set_parser.add_argument(
+        "--include-in-feedback", type=_true_false, metavar="true|false"
+    )
+    observations_set_parser.set_defaults(handler=handle_observations_set)
 
     roster_parser = subparsers.add_parser(
         "roster",
@@ -756,6 +801,15 @@ def _boolean(value: str) -> bool:
     if normalized in {"true", "yes", "1"}:
         return True
     if normalized in {"false", "no", "0"}:
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
+
+
+def _true_false(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
         return False
     raise argparse.ArgumentTypeError("expected true or false")
 

--- a/quillan/observation_management.py
+++ b/quillan/observation_management.py
@@ -1,0 +1,176 @@
+"""Read-only assignment-aware context for review-unit observations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from quillan.review_unit_management import (
+    ReviewUnitManagementError,
+    load_review_unit_context,
+)
+
+
+class ObservationManagementError(ValueError):
+    """Raised when observation context cannot be loaded safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationRatingLevel:
+    """One assignment-owned rating-scale level."""
+
+    value: int
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class UnitStandardObservationStatus:
+    """One deterministic review-unit and Focus Standard pair."""
+
+    unit_sequence: int
+    unit_id: str
+    unit_label: str
+    standard_id: str
+    observation_id: str | None
+    applicable: bool | None
+    evidence_present: bool | None
+    rating: int | None
+    rating_label: str | None
+    rationale: str | None
+    include_in_feedback: bool | None
+    updated_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationSummary:
+    """Counts for active unit-standard observation pairs."""
+
+    expected_pair_count: int
+    recorded_count: int
+    unrecorded_count: int
+    applicable_count: int
+    not_applicable_count: int
+    evidence_present_count: int
+    evidence_missing_count: int
+    rating_count: int
+    included_for_feedback_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationContext:
+    """Validated, read-only observation list context."""
+
+    workspace_root: Path
+    class_id: str
+    assignment_id: str
+    student_id: str
+    submission_manifest_path: Path
+    submission_manifest_relative_path: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_exists: bool
+    review_state: str
+    focus_standard_ids: tuple[str, ...]
+    rating_scale_id: str
+    rating_scale_levels: tuple[ObservationRatingLevel, ...]
+    unit_count: int
+    pairs: tuple[UnitStandardObservationStatus, ...]
+    summary: ObservationSummary
+
+
+def load_observation_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> ObservationContext:
+    """Load every active unit-standard pair without writing or inspecting evidence."""
+    try:
+        loaded = load_review_unit_context(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewUnitManagementError as error:
+        raise ObservationManagementError(str(error)) from error
+
+    assignment = loaded.assignment
+    focus_standard_ids = tuple(str(value) for value in assignment["focus_standard_ids"])
+    rating_levels = tuple(
+        ObservationRatingLevel(value=level["value"], label=level["label"])
+        for level in assignment["rating_scale"]["levels"]
+    )
+    rating_labels = {level.value: level.label for level in rating_levels}
+    units: list[dict[str, Any]] = []
+    if loaded.review is not None:
+        units = sorted(loaded.review["review_units"], key=lambda unit: unit["sequence"])
+
+    pairs: list[UnitStandardObservationStatus] = []
+    for unit in units:
+        observations = {
+            observation["standard_id"]: observation
+            for observation in unit["standard_observations"]
+        }
+        for standard_id in focus_standard_ids:
+            observation = observations.get(standard_id)
+            pairs.append(
+                UnitStandardObservationStatus(
+                    unit_sequence=unit["sequence"],
+                    unit_id=unit["unit_id"],
+                    unit_label=unit["label"],
+                    standard_id=standard_id,
+                    observation_id=(
+                        observation["observation_id"] if observation is not None else None
+                    ),
+                    applicable=(observation["applicable"] if observation is not None else None),
+                    evidence_present=(
+                        observation["evidence_present"] if observation is not None else None
+                    ),
+                    rating=observation["rating"] if observation is not None else None,
+                    rating_label=(
+                        rating_labels.get(observation["rating"])
+                        if observation is not None and observation["rating"] is not None
+                        else None
+                    ),
+                    rationale=observation["rationale"] if observation is not None else None,
+                    include_in_feedback=(
+                        observation["include_in_feedback"]
+                        if observation is not None
+                        else None
+                    ),
+                    updated_at=observation["updated_at"] if observation is not None else None,
+                )
+            )
+
+    recorded = [pair for pair in pairs if pair.observation_id is not None]
+    applicable = [pair for pair in recorded if pair.applicable is True]
+    summary = ObservationSummary(
+        expected_pair_count=len(pairs),
+        recorded_count=len(recorded),
+        unrecorded_count=len(pairs) - len(recorded),
+        applicable_count=len(applicable),
+        not_applicable_count=sum(pair.applicable is False for pair in recorded),
+        evidence_present_count=sum(pair.evidence_present is True for pair in applicable),
+        evidence_missing_count=sum(pair.evidence_present is False for pair in applicable),
+        rating_count=sum(pair.rating is not None for pair in applicable),
+        included_for_feedback_count=sum(
+            pair.include_in_feedback is True for pair in recorded
+        ),
+    )
+    return ObservationContext(
+        workspace_root=loaded.workspace_root,
+        class_id=loaded.class_id,
+        assignment_id=loaded.assignment_id,
+        student_id=loaded.student_id,
+        submission_manifest_path=loaded.submission_manifest_path,
+        submission_manifest_relative_path=loaded.submission_manifest_relative_path,
+        review_record_path=loaded.review_record_path,
+        review_record_relative_path=loaded.review_record_relative_path,
+        review_exists=loaded.review is not None,
+        review_state=loaded.review_state,
+        focus_standard_ids=focus_standard_ids,
+        rating_scale_id=str(assignment["rating_scale"]["scale_id"]),
+        rating_scale_levels=rating_levels,
+        unit_count=len(units),
+        pairs=tuple(pairs),
+        summary=summary,
+    )

--- a/quillan/review_observations.py
+++ b/quillan/review_observations.py
@@ -68,6 +68,9 @@ class UpdatedReviewUnitObservation:
     observation_id: str
     applicable: bool
     evidence_present: bool | None
+    rating: int | None
+    rating_label: str | None
+    rationale: str | None
     include_in_feedback: bool
     was_created: bool
     updated_at: str
@@ -221,8 +224,17 @@ def set_review_unit_observation(
     context = _load_context(workspace_root, class_id, assignment_id, student_id)
     assignment = context["assignment"]
     if normalized_standard_id not in assignment["focus_standard_ids"]:
+        valid = ", ".join(assignment["focus_standard_ids"])
         raise ReviewObservationError(
-            f"standard_id {normalized_standard_id!r} is not a Focus Standard for this assignment."
+            f"standard_id {normalized_standard_id!r} is not a Focus Standard for this "
+            f"assignment. Valid Focus Standard IDs: {valid}."
+        )
+    rating_labels = _rating_labels_by_value(assignment)
+    if normalized_rating is not None and normalized_rating not in rating_labels:
+        allowed = ", ".join(str(value) for value in rating_labels)
+        raise ReviewObservationError(
+            f"rating {normalized_rating!r} is not in the assignment rating scale. "
+            f"Allowed values: {allowed}."
         )
 
     review = _load_existing_review(context)
@@ -234,7 +246,10 @@ def set_review_unit_observation(
         None,
     )
     if unit is None:
-        raise ReviewObservationError(f"Review unit not found: {normalized_unit_id}")
+        valid = ", ".join(candidate["unit_id"] for candidate in review["review_units"])
+        raise ReviewObservationError(
+            f"Review unit not found: {normalized_unit_id}. Valid unit IDs: {valid}."
+        )
 
     if applicable:
         if not isinstance(evidence_present, bool):
@@ -300,6 +315,11 @@ def set_review_unit_observation(
         observation_id=observation_id,
         applicable=applicable,
         evidence_present=normalized_evidence_present,
+        rating=normalized_rating,
+        rating_label=(
+            rating_labels[normalized_rating] if normalized_rating is not None else None
+        ),
+        rationale=normalized_rationale,
         include_in_feedback=normalized_include,
         was_created=was_created,
         updated_at=normalized_updated_at,
@@ -499,6 +519,13 @@ def _normalize_rating(value: Any) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int):
         raise ReviewObservationError("rating must be an integer or null.")
     return value
+
+
+def _rating_labels_by_value(assignment: dict[str, Any]) -> dict[int, str]:
+    return {
+        level["value"]: level["label"]
+        for level in assignment["rating_scale"]["levels"]
+    }
 
 
 def _normalize_required_string(value: Any, field: str) -> str:

--- a/tests/test_cli_observations.py
+++ b/tests/test_cli_observations.py
@@ -1,0 +1,340 @@
+"""Direct CLI coverage for Focus Standard review-unit observations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.cli import main
+from quillan.cli_app.handlers import observations as handlers
+from quillan.review_observations import set_review_units
+from quillan.review_record import build_empty_review_record
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english10_p2"
+ASSIGNMENT_ID = "argument_01"
+STUDENT_ID = "00107"
+TIMESTAMP = "2026-07-13T12:00:00+00:00"
+
+
+def _assignment() -> dict[str, Any]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Argument",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Make an argument.",
+        "standards_profile_id": "ela",
+        "focus_standard_ids": ["W.1", "L.2"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "unusual",
+            "levels": [
+                {"value": 0, "label": "Beginning", "description": "Beginning."},
+                {"value": 7, "label": "Secure", "description": "Secure."},
+            ],
+        },
+        "basic_requirements": {},
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {"submission_entry_method": "plain_paper_manual"},
+    }
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    assignment_path = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment_path.parent.mkdir(parents=True)
+    assignment_path.write_text(json.dumps(_assignment()), encoding="utf-8")
+    write_submission_manifest(
+        submission_manifest_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        _manifest(),
+    )
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _set_args(*extra: str) -> list[str]:
+    return [
+        "observations",
+        "set",
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "--unit-id",
+        "paragraph_1",
+        "--standard-id",
+        "W.1",
+        *extra,
+    ]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--help"],
+        ["observations", "--help"],
+        ["observations", "list", "--help"],
+        ["observations", "set", "--help"],
+    ],
+)
+def test_observation_help_exits_successfully(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(argv)
+    assert error.value.code == 0
+
+
+def test_bare_namespace_prints_help_without_resolving_workspace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        handlers,
+        "resolve_workspace_root",
+        lambda: pytest.fail("bare namespace resolved the workspace"),
+    )
+    assert main(["observations"]) == 0
+    assert "{list,set}" in capsys.readouterr().out
+
+
+def test_list_without_review_is_read_only_and_reports_setup_guidance(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assignment_path = (
+        workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    )
+    manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = assignment_path.read_bytes(), manifest_path.read_bytes()
+
+    assert main(["observations", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Review state: not_started" in output
+    assert "Review record exists: no" in output
+    assert "Review units: 0" in output
+    assert "must be defined before observations" in output
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+    assert (assignment_path.read_bytes(), manifest_path.read_bytes()) == before
+
+
+def test_list_orders_units_and_standards_and_reports_matrix_totals(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    set_review_units(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 3, "label": "Conclusion"}, {"sequence": 1, "label": "Opening"}],
+        updated_at=TIMESTAMP,
+    )
+    assert main(_set_args("--applicable", "true", "--evidence-present", "false")) == 0
+    record_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = record_path.read_bytes()
+    capsys.readouterr()
+
+    assert main(["observations", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    assert output.index("1. Opening") < output.index("3. Conclusion")
+    first_unit = output[output.index("1. Opening") : output.index("3. Conclusion")]
+    assert first_unit.index("Focus Standard: W.1") < first_unit.index("Focus Standard: L.2")
+    assert "Expected unit-standard pairs: 4" in output
+    assert "Recorded observations: 1" in output
+    assert "Unrecorded pairs: 3" in output
+    assert "Evidence missing: 1" in output
+    assert "Observation ID: observation_0001" in output
+    assert "Status: not recorded" in output
+    assert record_path.read_bytes() == before
+
+
+def test_set_applicable_supports_optional_assignment_scale_rating_and_replacement(
+    workspace: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    set_review_units(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=TIMESTAMP,
+    )
+    monkeypatch.setattr("builtins.input", lambda *_args: pytest.fail("CLI prompted"))
+    assert main(
+        _set_args(
+            "--applicable",
+            "true",
+            "--evidence-present",
+            "true",
+            "--rating",
+            "7",
+            "--rationale",
+            "  Strong evidence.  ",
+            "--include-in-feedback",
+            "false",
+        )
+    ) == 0
+    first_output = capsys.readouterr().out
+    assert "Unit-level rating: 7 (Secure)" in first_output
+    assert "Rationale: present" in first_output
+
+    assert main(_set_args("--applicable", "true", "--evidence-present", "false")) == 0
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    observation = review["review_units"][0]["standard_observations"][0]
+    assert observation["observation_id"] == "observation_0001"
+    assert observation["evidence_present"] is False
+    assert observation["rating"] is None
+    assert observation["rationale"] is None
+    assert observation["include_in_feedback"] is True
+    assert review["overall_standard_ratings"] == []
+    assert review["feedback"]["standard_feedback"] == []
+    assert "Action: updated" in capsys.readouterr().out
+
+
+def test_set_not_applicable_stores_nulls_and_allows_feedback_override(
+    workspace: Path,
+) -> None:
+    set_review_units(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=TIMESTAMP,
+    )
+    assert main(
+        _set_args(
+            "--applicable",
+            "false",
+            "--rationale",
+            "Transition only.",
+            "--include-in-feedback",
+            "true",
+        )
+    ) == 0
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    observation = review["review_units"][0]["standard_observations"][0]
+    assert observation["applicable"] is False
+    assert observation["evidence_present"] is None
+    assert observation["rating"] is None
+    assert observation["include_in_feedback"] is True
+
+
+@pytest.mark.parametrize(
+    "extra,message",
+    [
+        (("--applicable", "true"), "required when --applicable true"),
+        (
+            ("--applicable", "false", "--evidence-present", "true"),
+            "must be omitted when --applicable false",
+        ),
+        (("--applicable", "false", "--rating", "7"), "--rating must be omitted"),
+        (
+            ("--applicable", "true", "--evidence-present", "true", "--rating", "4"),
+            "Allowed values: 0, 7",
+        ),
+    ],
+)
+def test_invalid_combinations_do_not_change_review(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    extra: tuple[str, ...],
+    message: str,
+) -> None:
+    set_review_units(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=TIMESTAMP,
+    )
+    record_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = record_path.read_bytes()
+    assert main(_set_args(*extra)) == 1
+    assert message in capsys.readouterr().out
+    assert record_path.read_bytes() == before
+
+
+def test_returned_review_can_be_listed_but_not_changed(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    review = build_empty_review_record(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        created_at=TIMESTAMP,
+    )
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [],
+            "module_details": {},
+        }
+    ]
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Missing work.",
+        "updated_at": TIMESTAMP,
+    }
+    record_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    write_review_record(record_path, review)
+    before = record_path.read_bytes()
+
+    assert main(["observations", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+    assert "Review state: returned_without_full_review" in capsys.readouterr().out
+    assert main(_set_args("--applicable", "true", "--evidence-present", "true")) == 1
+    assert "Change the minimum-requirements outcome" in capsys.readouterr().out
+    assert record_path.read_bytes() == before

--- a/tests/test_review_observations.py
+++ b/tests/test_review_observations.py
@@ -381,6 +381,50 @@ def test_observation_requires_existing_unit_and_assignment_focus_standard(
         )
 
 
+def test_observation_rating_uses_assignment_scale_and_remains_optional(
+    tmp_path: Path,
+) -> None:
+    _write_workspace(tmp_path)
+    set_review_units(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=FIRST_TIMESTAMP,
+    )
+    record_path = review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = record_path.read_bytes()
+    with pytest.raises(ReviewObservationError, match="Allowed values"):
+        set_review_unit_observation(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            unit_id="paragraph_1",
+            standard_id="njsls-ela:W.1",
+            applicable=True,
+            evidence_present=True,
+            rating=99,
+            updated_at=SECOND_TIMESTAMP,
+        )
+    assert record_path.read_bytes() == before
+
+    updated = set_review_unit_observation(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        unit_id="paragraph_1",
+        standard_id="njsls-ela:W.1",
+        applicable=True,
+        evidence_present=True,
+        rating=2,
+        updated_at=SECOND_TIMESTAMP,
+    )
+    assert updated.rating == 2
+    assert updated.rating_label == "Secure"
+
 def test_mark_observations_complete_sets_state_without_creating_ratings(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

* Add direct CLI commands for listing and recording review-unit Focus Standard observations:

  * `quillan observations list`
  * `quillan observations set`
* Add an immutable read-only observation context with deterministic unit-standard matrix ordering.
* Validate optional unit-level ratings against the assignment’s configured rating scale.
* Preserve existing observation IDs when updating the same unit-standard pair.
* Enforce applicable and not-applicable observation shapes.
* Keep observation entry explicitly teacher-controlled, with no evidence inspection or inferred judgments.

## Command Surface

```text
quillan observations list <class_id> <assignment_id> <student_id>

quillan observations set <class_id> <assignment_id> <student_id> \
  --unit-id <unit_id> \
  --standard-id <standard_id> \
  --applicable true|false \
  [--evidence-present true|false] \
  [--rating <integer>] \
  [--rationale <text>] \
  [--include-in-feedback true|false]
```

Running:

```text
quillan observations
```

without a subcommand prints observation-command help and exits successfully without resolving the workspace.

The commands are direct and non-interactive. They do not call `input()` or invoke menu functions.

## Shared Architecture

Added immutable read-only observation context and matrix construction in:

* `quillan/observation_management.py`

Added direct CLI handlers in:

* `quillan/cli_app/handlers/observations.py`

Registered the command namespace in:

* `quillan/cli_app/parser.py`

Updated the shared observation mutation service in:

* `quillan/review_observations.py`

Extended teacher-facing output in:

* `quillan/cli_app/output.py`

The implementation preserves the intended application boundary:

```text
menu -> shared observation service
CLI  -> same shared observation service
GUI  -> same shared observation service later
```

CLI handlers do not edit raw review-record dictionaries.

All observation writes continue through the shared observation service and canonical atomic review-record writer.

## `observations list`

`observations list` is strictly read-only.

It reports:

* class ID;
* assignment ID;
* student ID;
* current review state;
* canonical submission-manifest path;
* canonical review-record path;
* review-record existence;
* review-unit count;
* assignment Focus Standard count;
* expected unit-standard pair count;
* recorded observation count;
* unrecorded pair count;
* applicable count;
* not-applicable count;
* evidence-present count;
* evidence-missing count;
* rated observation count;
* feedback-inclusion count;
* assignment rating-scale levels.

The command displays a deterministic unit-standard matrix:

1. review units are ordered by sequence;
2. Focus Standards are ordered according to the assignment’s `focus_standard_ids`.

Each pair reports its current teacher-entered state, including:

* unit ID and label;
* Focus Standard ID;
* observation ID when present;
* applicability;
* evidence presence;
* optional unit-level rating;
* rating label when rated;
* rationale;
* feedback inclusion;
* update timestamp.

Unrecorded unit-standard pairs are shown explicitly rather than omitted.

The command does not dump raw JSON.

## No-Review and No-Unit Behavior

When the canonical submission exists but no `review.json` exists, listing reports:

* review state: `not_started`;
* zero review units;
* zero observations;
* guidance that review units must be defined before recording observations.

It does not create a review record, directories, or other files.

When a valid review exists but contains no review units, listing succeeds and reports that units must be defined first.

Malformed or identity-mismatched review records fail clearly rather than being treated as empty.

## Submission and Identity Validation

Both observation commands require a valid canonical submission manifest.

The workflow validates:

* class, assignment, and student identifiers;
* canonical assignment existence and schema;
* assignment identity;
* selected class membership in assignment `class_ids`;
* canonical submission-manifest existence and schema;
* submission identity;
* canonical review-record schema and identity when present;
* canonical assignment and submission references.

When routed evidence exists without an assembled `submission.json`, the commands return the existing submission-assembly guidance.

The workflow does not assemble submissions automatically.

Valid plain-paper manual submissions remain supported even when no digital evidence files are attached.

Current roster membership is not required when a valid canonical submission exists.

## Review-Unit Requirement

`observations set` requires an existing review record containing defined review units.

It does not:

* create review units;
* infer unit boundaries;
* create a review record when units are absent.

The supplied `--unit-id` must match an active review unit exactly.

Invalid, stale, or removed unit IDs fail without writing.

## Focus Standard Requirement

The supplied `--standard-id` must appear in the current assignment’s:

```text
focus_standard_ids
```

A standard is not accepted merely because it exists in the shared standards library.

The assignment remains the source of truth for which standards may be observed.

Invalid Focus Standard IDs fail without writing.

## Applicable Observation Behavior

When:

```text
--applicable true
```

the teacher must explicitly provide:

```text
--evidence-present true|false
```

Both evidence states are valid:

```text
--applicable true --evidence-present true
--applicable true --evidence-present false
```

Evidence presence is stored as an explicit teacher judgment.

It is not interpreted as:

* mastery;
* a successful rating;
* an overall standard result;
* a grade;
* a score.

The CLI never infers evidence presence from files or student writing.

## Not-Applicable Observation Behavior

When:

```text
--applicable false
```

the caller must omit:

* `--evidence-present`;
* `--rating`.

The stored observation uses:

```json
{
  "applicable": false,
  "evidence_present": null,
  "rating": null
}
```

Contradictory combinations are rejected rather than silently discarded.

Changing an existing applicable observation to not applicable clears its prior:

* evidence-presence value;
* unit-level rating.

Not-applicable observations otherwise preserve the same shape and behavior as menu-created observations.

## Optional Unit-Level Ratings

Unit-level observation ratings remain optional for applicable observations.

When no rating is supplied:

```json
"rating": null
```

is stored.

This preserves the active menu behavior, which does not collect a unit-level rating.

When a rating is supplied, the shared observation service validates it against:

```text
assignment.rating_scale.levels[*].value
```

The implementation does not assume a hardcoded `1–4` scale.

Custom integer scale values are supported when defined by the assignment.

Invalid rating values fail without writing and report the allowed assignment values.

Successful output includes the corresponding assignment rating label.

Unit-level ratings remain distinct from overall Focus Standard ratings.

## Review-Record Contract Correction

Updated the review-record documentation to reflect active runtime behavior:

* an applicable observation may have:

  * `rating: null`; or
  * a rating value from the assignment rating scale;
* a not-applicable observation must have:

  * `rating: null`.

This aligns the written contract with the existing menu, service, validator, and tests.

No review schema-version change was introduced.

## Rationale Behavior

`--rationale` is optional and always teacher-entered.

When supplied:

* surrounding whitespace is trimmed;
* nonblank text is stored.

When omitted or blank:

* `rationale` is stored as `null`;
* an earlier rationale is cleared when updating the observation.

No rationale is generated, rewritten, or inferred.

## Feedback-Inclusion Behavior

`--include-in-feedback` is optional.

When omitted, the existing shared-service defaults apply:

* applicable observation: `true`;
* not-applicable observation: `false`.

Explicit values override those defaults.

A teacher may explicitly include a not-applicable observation in feedback.

Changing an observation’s inclusion flag does not automatically:

* create a standard-feedback record;
* add the observation to `included_observation_ids`;
* remove it from `included_observation_ids`;
* compose feedback;
* export feedback.

Feedback composition remains a separate explicit workflow.

## Observation Creation

When the selected unit-standard pair has no existing observation, the service creates a globally unique sequential observation ID.

Example:

```text
observation_0001
```

The new observation stores:

* assignment Focus Standard ID;
* applicability;
* explicit or null evidence presence;
* optional validated unit-level rating;
* optional rationale;
* feedback-inclusion choice;
* update timestamp;
* empty module metadata.

No observations are generated automatically for other unit-standard pairs.

## Observation Updates

When the selected unit already contains an observation for the same Focus Standard:

* the existing `observation_id` is preserved;
* no duplicate observation is created;
* editable values are replaced.

Replacement includes:

* `applicable`;
* `evidence_present`;
* `rating`;
* `rationale`;
* `include_in_feedback`;
* `updated_at`;
* `module_details`.

Omitting optional values clears or resets them according to the command contract:

* omitted rating clears an earlier unit-level rating;
* omitted rationale clears an earlier rationale;
* omitted feedback inclusion resets to the applicability-based default.

## Preserved Review Data

Observation writes preserve unrelated review data, including:

* all other review units;
* all other observations;
* minimum-requirement checks;
* minimum-requirement outcome;
* overall Focus Standard ratings;
* feedback records;
* feedback comments;
* observation inclusion lists;
* export metadata;
* private teacher notes;
* top-level module metadata;
* original `created_at`.

Observation writes do not automatically recalculate or modify overall ratings.

They also do not rewrite feedback-composition records.

## Review-State Behavior

Observation state transitions remain controlled by the shared observation service.

Current behavior includes:

* `not_started` -> `observations_in_progress`;
* `requirements_checked` -> `observations_in_progress`;
* `observations_in_progress` remains unchanged;
* `observations_complete` -> `observations_in_progress`.

The CLI does not mark observations complete automatically.

The resulting review state is included in successful write output.

## Returned-Without-Full-Review Behavior

Reviews in:

```text
returned_without_full_review
```

remain listable.

`observations set` rejects changes to those records through the existing shared guard.

The error explains that the minimum-requirements outcome must be changed before standards review can continue.

Rejected writes leave the existing review unchanged.

## Successful Write Output

A successful observation write reports:

* class ID;
* assignment ID;
* student ID;
* unit label;
* unit ID;
* Focus Standard ID;
* observation ID;
* whether the observation was created or updated;
* applicability;
* evidence presence;
* optional unit-level rating and rating label;
* rationale status;
* feedback-inclusion status;
* resulting review state;
* canonical workspace-relative review-record path;
* update timestamp.

The output does not dump raw review JSON.

Unit-level ratings are not described as overall ratings.

## Write Boundaries

`observations list` writes nothing.

`observations set` may modify only:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
```

All writes use the existing validated atomic review writer.

The implementation does not modify:

* `assignment.json`;
* `submission.json`;
* class rosters;
* class metadata;
* routed evidence;
* retained scans;
* source scans;
* PDFs;
* images;
* standards libraries;
* reusable comment libraries;
* feedback exports;
* assignment reports;
* PDS Core data;
* ScoreForm data.

Tests confirm that assignment and submission records remain unchanged.

## No Automated Judgment

Confirmed that the implementation does not:

* open evidence files;
* inspect PDF text;
* inspect images;
* parse student writing;
* run OCR;
* perform handwriting recognition;
* use AI;
* infer applicability;
* infer evidence presence;
* infer ratings;
* infer rationales;
* infer feedback inclusion;
* calculate overall ratings;
* average unit ratings;
* calculate grades;
* calculate scores;
* generate feedback;
* mark observations complete automatically.

Every substantive observation value is explicitly supplied by the teacher.

## Documentation

Updated:

* `docs/cli_contract.md`
* `docs/review_record_contract.md`
* `docs/prepared_review_workflow.md`

The documentation now covers:

* the `observations` namespace;
* deterministic list ordering;
* conditional evidence arguments;
* applicable and not-applicable observation shapes;
* optional unit-level ratings;
* assignment-scale validation;
* observation replacement semantics;
* stable observation IDs;
* feedback-inclusion defaults;
* separation from overall ratings and feedback composition;
* submission and review-unit prerequisites;
* returned-without-full-review restrictions;
* exact read and write boundaries;
* the prohibition on evidence inspection, OCR, AI, grading, and inference.

## Files Changed

Ten intended Quillan source, test, and documentation files were modified or added:

* `quillan/observation_management.py`
* `quillan/cli_app/handlers/observations.py`
* `quillan/cli_app/parser.py`
* `quillan/cli_app/output.py`
* `quillan/review_observations.py`
* `tests/test_cli_observations.py`
* `tests/test_review_observations.py`
* `docs/cli_contract.md`
* `docs/review_record_contract.md`
* `docs/prepared_review_workflow.md`

## Safety

Confirmed:

* bare namespace help does not resolve the workspace;
* direct handlers are non-interactive;
* listing is read-only;
* missing submissions do not create review records;
* review units must already exist before setting observations;
* invalid unit IDs fail without writing;
* invalid Focus Standards fail without writing;
* applicable observations require explicit evidence presence;
* evidence presence is never inferred;
* optional ratings are validated against the assignment;
* not-applicable observations clear evidence and rating fields;
* observation IDs remain stable during updates;
* overall ratings remain unchanged;
* feedback composition remains unchanged;
* assignment and submission records remain unchanged;
* returned-without-full-review records cannot be modified;
* leading-zero student IDs remain strings;
* expected failures return nonzero without tracebacks;
* no PDS Core files were modified;
* no ScoreForm files were modified;
* no workspace records were added;
* no real student data was added;
* no generated review, evidence, report, feedback, or export artifacts were added.

## Validation

* Focused observation tests: `22 passed`
* Observation and menu regressions: `43 passed`
* Broader CLI and review tests: `551 passed`
* Full pytest suite: `1170 passed`
* Ruff: passed
* mypy: passed, `153` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* Git status contains only intended Quillan source, test, and documentation changes
* No workspace records, student data, or generated review/export artifacts present

Closes #303
