### PR TITLE
Add overall Focus Standard ratings CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -111,6 +111,9 @@ quillan review-units set <class_id> <assignment_id> <student_id> --count <positi
 quillan review-units set <class_id> <assignment_id> <student_id> --units <units.json>
 quillan observations list <class_id> <assignment_id> <student_id>
 quillan observations set <class_id> <assignment_id> <student_id> --unit-id <unit_id> --standard-id <standard_id> --applicable true|false [--evidence-present true|false] [--rating <integer>] [--rationale <text>] [--include-in-feedback true|false]
+quillan ratings list <class_id> <assignment_id> <student_id>
+quillan ratings set <class_id> <assignment_id> <student_id> --standard-id <standard_id> --rating <integer> [--rationale <text>] --include-in-feedback true|false
+quillan ratings mark-complete <class_id> <assignment_id> <student_id> --yes
 quillan roster create <class_id> --input <roster.csv> [--school-year YYYY-YYYY] [--overwrite] (--yes | --dry-run)
 quillan roster show <class_id>
 quillan roster validate <class_id>
@@ -155,6 +158,9 @@ and exits successfully without resolving or inspecting the workspace.
 
 Running `quillan observations` without a subcommand prints observation help
 and exits successfully without resolving or inspecting the workspace.
+
+Running `quillan ratings` without a subcommand prints ratings help and exits
+successfully without resolving or inspecting the workspace.
 
 ### `review-units` commands
 
@@ -241,6 +247,62 @@ parses PDFs or images, runs OCR, handwriting recognition, or AI, infers any
 teacher judgment, calculates overall ratings, grades, or scores, marks review
 complete, composes feedback, or modifies assignments, submissions, rosters,
 evidence, exports, reports, Core data, or ScoreForm data.
+
+### `ratings` commands
+
+The `ratings` namespace exposes teacher-entered overall Focus Standard ratings
+as direct, non-interactive commands. All commands require a valid canonical
+assignment and assembled `submission.json`; routed evidence is not assembled
+automatically. Plain-paper manual and valid unrostered submissions are
+accepted. An existing malformed, mismatched, unsupported, or noncanonical
+`review.json` is an error rather than an empty review.
+
+`ratings list` is strictly read-only. It reports canonical paths, review and
+completion states, every assignment-owned rating-scale level, rating and
+missing counts, and every assignment Focus Standard in configured order. Each
+standard shows its current overall value and assignment label or `not rated`,
+rationale, feedback-inclusion choice, update timestamp, and advisory
+observation counts. With no review it reports `not_started`, zero ratings,
+zero observations, and creates nothing. Stored ratings no longer configured by
+the assignment appear separately for audit and do not count toward completion.
+Returned-without-full-review records remain listable, with ratings identified
+as not applicable to that completed workflow state.
+
+`ratings set` requires an existing review and completely replaces one
+configured standard's rating, optional rationale, feedback-inclusion choice,
+timestamp, and rating-level module details. It prevents duplicates and reports
+`created` or `updated`. `--standard-id` must occur in the assignment's current
+`focus_standard_ids`; existence in a shared standards library is insufficient.
+`--rating` must be an exact integer value from the assignment-owned scale, so
+zero, negative, gapped, and non-1-to-4 scales remain valid. Supplied rationale
+is trimmed; omission or blank text stores `null` and clears an earlier value.
+The direct CLI requires `--include-in-feedback true|false` and has no default.
+That choice does not compose feedback or change feedback options.
+
+Observation summaries and warnings are advisory. Missing units, missing or
+incomplete observations, and unobserved pairs never block `ratings set` and
+never produce or infer a rating. The shared service owns state transitions:
+early states return to `observations_in_progress`, downstream composed/export
+states return to `ratings_complete`, and other documented rating states remain
+unchanged. Existing observations, feedback, exports, notes, requirement data,
+metadata, and the original creation timestamp are preserved.
+
+`ratings mark-complete` requires the explicit `--yes` flag and never prompts.
+It calls the shared completion service and may mark `ratings_complete` with all,
+some, or none of the assignment Focus Standards rated. Missing ratings are
+counted and warned about, but never filled from observations or placeholders.
+Observation readiness is not a completion gate. Both write commands reject a
+`returned_without_full_review` record until its minimum-requirements outcome
+changes.
+
+List writes nothing. Set and mark-complete may modify only canonical
+`classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json`
+through the validated atomic writer. They do not modify assignments,
+submission manifests, rosters, evidence, scans, observations, feedback
+composition, exports, reports, Core, or ScoreForm. They do not open evidence,
+parse PDFs or images, run OCR, handwriting recognition, or AI, infer or average
+ratings, calculate mastery, percentages, grades, or scores, generate feedback,
+or complete ratings automatically after a set operation.
 
 Both commands require a valid canonical `submission.json`, including for
 plain-paper submissions without digital evidence. They do not require current
@@ -1316,8 +1378,7 @@ explicitly outside the current end-to-end foundation:
   automatic production scan routing;
 * OCR or handwriting interpretation;
 * PDF text extraction;
-* a direct CLI command for review-unit observations, overall Focus Standard
-  ratings, or feedback composition;
+* a direct CLI command for feedback composition;
 * AI grading, scoring, tagging, or feedback;
 * automatic grading, mastery calculation, review-state decisions, or
   duplicate-evidence selection;

--- a/docs/prepared_review_workflow.md
+++ b/docs/prepared_review_workflow.md
@@ -158,7 +158,13 @@ assignment `rating_scale`. Ratings are teacher-entered and are not inferred
 from review-unit observations, requirement checks, notes, exports, or evidence
 metadata.
 
-Marking ratings complete is an explicit teacher action.
+Teachers may list, create, replace, and explicitly complete these ratings with
+the direct, non-interactive `quillan ratings` commands. The assignment's Focus
+Standards and rating scale are authoritative. Missing or incomplete
+observations are warnings only and never cause a rating to be inferred.
+`ratings mark-complete --yes` may complete the phase with all, some, or no
+Focus Standards rated; it reports missing ratings and never fills them.
+Marking ratings complete is always a separate explicit teacher action.
 
 ## Focus Standard Feedback
 

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -635,6 +635,13 @@ calculate them automatically from review-unit observations. The teacher may
 use the review-unit observation summary as evidence, but the overall rating is
 not an average, weighted score, percentage, grade, or mastery calculation.
 
+Completing the overall-rating phase is an explicit teacher action and is
+permitted when configured Focus Standards are still unrated. Completion
+reports the current configured rating count and missing count; it does not
+create placeholders, copy observation ratings, or otherwise fill missing
+ratings. Ratings for standards no longer configured by the assignment remain
+auditable but do not count toward current assignment completion.
+
 Old generic criterion scores are superseded by overall Focus Standard ratings.
 
 ## Feedback Composition

--- a/quillan/cli_app/handlers/ratings.py
+++ b/quillan/cli_app/handlers/ratings.py
@@ -1,0 +1,198 @@
+"""Direct, non-interactive overall Focus Standard rating handlers."""
+
+from __future__ import annotations
+
+import argparse
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.cli_app.output import (
+    print_completed_overall_standard_ratings,
+    print_updated_overall_standard_rating,
+)
+from quillan.rating_management import (
+    OverallRatingContext,
+    OverallRatingSummary,
+    RatingManagementError,
+    load_overall_rating_context,
+)
+from quillan.review_ratings import (
+    ReviewRatingError,
+    mark_overall_ratings_complete,
+    set_overall_standard_rating,
+)
+
+
+def handle_ratings_list(args: argparse.Namespace) -> int:
+    """Display teacher-entered overall ratings without writing."""
+    try:
+        context = load_overall_rating_context(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id
+        )
+        _print_rating_context(context)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, RatingManagementError) as error:
+        return _error(error)
+
+
+def handle_ratings_set(args: argparse.Namespace) -> int:
+    """Create or replace one complete teacher-entered overall rating."""
+    try:
+        workspace_root = resolve_workspace_root()
+        context = load_overall_rating_context(
+            workspace_root, args.class_id, args.assignment_id, args.student_id
+        )
+        if not context.review_exists:
+            raise ReviewRatingError(
+                "A review record must exist before recording or completing ratings."
+            )
+        selected = next(
+            (item for item in context.standards if item.standard_id == args.standard_id),
+            None,
+        )
+        updated = set_overall_standard_rating(
+            workspace_root,
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            standard_id=args.standard_id,
+            rating=args.rating,
+            rationale=args.rationale,
+            include_in_feedback=args.include_in_feedback,
+        )
+        if selected is not None:
+            _print_observation_warning(selected, context.observations_complete)
+        print_updated_overall_standard_rating(updated)
+        return 0
+    except (
+        OSError,
+        ValueError,
+        WorkspaceRootError,
+        RatingManagementError,
+        ReviewRatingError,
+    ) as error:
+        return _error(error)
+
+
+def handle_ratings_mark_complete(args: argparse.Namespace) -> int:
+    """Explicitly mark overall ratings complete without prompting."""
+    try:
+        workspace_root = resolve_workspace_root()
+        context = load_overall_rating_context(
+            workspace_root, args.class_id, args.assignment_id, args.student_id
+        )
+        if not context.review_exists:
+            raise ReviewRatingError(
+                "A review record must exist before recording or completing ratings."
+            )
+        if context.missing_rating_count:
+            print(
+                "Warning: "
+                f"{context.missing_rating_count} assignment Focus Standard rating(s) "
+                "are missing; explicit completion will not create them."
+            )
+        completed = mark_overall_ratings_complete(
+            workspace_root, args.class_id, args.assignment_id, args.student_id
+        )
+        print_completed_overall_standard_ratings(completed)
+        if completed.missing_rating_count:
+            print(
+                "Warning: Ratings were marked complete with "
+                f"{completed.missing_rating_count} missing rating(s); none were created."
+            )
+        return 0
+    except (
+        OSError,
+        ValueError,
+        WorkspaceRootError,
+        RatingManagementError,
+        ReviewRatingError,
+    ) as error:
+        return _error(error)
+
+
+def _print_rating_context(context: OverallRatingContext) -> None:
+    print("Overall Focus Standard ratings:")
+    print(f"Class: {context.class_id}")
+    print(f"Assignment: {context.assignment_id}")
+    print(f"Student: {context.student_id}")
+    print(f"Submission manifest: {context.submission_manifest_relative_path}")
+    print(f"Review record: {context.review_record_relative_path}")
+    print(f"Review record exists: {_yes_no(context.review_exists)}")
+    print(f"Review state: {context.review_state}")
+    print(f"Observations complete: {_yes_no(context.observations_complete)}")
+    print(f"Overall ratings complete: {_yes_no(context.ratings_complete)}")
+    if context.review_state == "returned_without_full_review":
+        print("Completed workflow applicability: overall ratings not applicable")
+        print("Stored ratings are shown below for audit visibility.")
+    print(f"Assignment rating scale: {context.rating_scale_id}")
+    for level in context.rating_scale_levels:
+        print(f"- {level.value}: {level.label}")
+    print(f"Assignment Focus Standards: {len(context.standards)}")
+    print(f"Ratings recorded: {context.rating_count}")
+    print(f"Ratings missing: {context.missing_rating_count}")
+    if context.review_exists and all(
+        item.observation_count == 0 for item in context.standards
+    ):
+        print("Warning: No supporting observations are recorded; ratings remain teacher-entered.")
+    print()
+    print("Assignment Focus Standards (configured order):")
+    for item in context.standards:
+        _print_standard(item)
+    if context.stale_ratings:
+        print()
+        print("Unrecognized or stale stored ratings (audit only):")
+        for stale_rating in context.stale_ratings:
+            print(
+                f"- {stale_rating.standard_id}: {stale_rating.rating}; "
+                f"updated {stale_rating.updated_at}"
+            )
+
+
+def _print_standard(item: OverallRatingSummary) -> None:
+    rating = (
+        "not rated"
+        if item.rating is None
+        else f"{item.rating} ({item.rating_label or 'unrecognized assignment value'})"
+    )
+    feedback = (
+        "not recorded"
+        if item.include_in_feedback is None
+        else _yes_no(item.include_in_feedback)
+    )
+    print(f"- Focus Standard: {item.standard_id}")
+    print(f"  Overall rating: {rating}")
+    print(f"  Rationale: {item.rationale or 'none'}")
+    print(f"  Include in feedback: {feedback}")
+    print(f"  Rating updated: {item.updated_at or 'not recorded'}")
+    print(f"  Total review units: {item.total_review_units}")
+    print(f"  Recorded observations: {item.observation_count}")
+    print(f"  Applicable observations: {item.applicable_count}")
+    print(f"  Not-applicable observations: {item.not_applicable_count}")
+    print(f"  Evidence-present observations: {item.evidence_present_count}")
+    print(f"  Evidence-missing observations: {item.evidence_missing_count}")
+    print(f"  Observations marked for feedback: {item.included_for_feedback_count}")
+
+
+def _print_observation_warning(
+    selected: OverallRatingSummary, observations_complete: bool
+) -> None:
+    if selected.observation_count == 0:
+        print(
+            "Warning: No supporting observations are recorded for this Focus Standard; "
+            "the teacher-entered rating was still recorded."
+        )
+    if not observations_complete:
+        print(
+            "Warning: Observations are not marked complete; this does not block an "
+            "overall teacher-entered rating."
+        )
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _error(error: Exception) -> int:
+    print(f"Error: {error}")
+    return 1

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -157,10 +157,12 @@ def print_updated_overall_standard_rating(
     print(f"Student: {updated.student_id}")
     print(f"Standard: {updated.standard_id}")
     print(f"Rating: {updated.rating} - {updated.rating_label}")
+    print(f"Rationale: {'present' if updated.rationale is not None else 'none'}")
     print(f"Include in feedback: {format_bool(updated.include_in_feedback)}")
     print(f"Action: {'created' if updated.was_created else 'updated'}")
     print(f"Review state: {updated.review_state}")
     print(f"Review record: {updated.review_record_relative_path}")
+    print(f"Updated: {updated.updated_at}")
 
 
 def print_completed_overall_standard_ratings(
@@ -176,6 +178,7 @@ def print_completed_overall_standard_ratings(
     print(f"Missing ratings: {completed.missing_rating_count}")
     print(f"Review state: {completed.review_state}")
     print(f"Review record: {completed.review_record_relative_path}")
+    print(f"Updated: {completed.updated_at}")
 
 
 def print_updated_standard_feedback_options(

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -30,6 +30,11 @@ from quillan.cli_app.handlers.observations import (
     handle_observations_list,
     handle_observations_set,
 )
+from quillan.cli_app.handlers.ratings import (
+    handle_ratings_list,
+    handle_ratings_mark_complete,
+    handle_ratings_set,
+)
 from quillan.cli_app.handlers.rosters import (
     handle_roster_add_student,
     handle_roster_create,
@@ -277,6 +282,60 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-in-feedback", type=_true_false, metavar="true|false"
     )
     observations_set_parser.set_defaults(handler=handle_observations_set)
+
+    ratings_parser = subparsers.add_parser(
+        "ratings",
+        help="List, record, and complete overall Focus Standard ratings.",
+        description=(
+            "Display or record explicit teacher-entered overall Focus Standard "
+            "ratings without inspecting evidence or inferring judgments."
+        ),
+    )
+    ratings_parser.set_defaults(handler=partial(_print_parser_help, ratings_parser))
+    ratings_subparsers = ratings_parser.add_subparsers(dest="ratings_command")
+
+    ratings_list_parser = ratings_subparsers.add_parser(
+        "list", help="List assignment Focus Standards and current overall ratings."
+    )
+    _add_submission_identity_arguments(ratings_list_parser)
+    ratings_list_parser.set_defaults(handler=handle_ratings_list)
+
+    ratings_set_parser = ratings_subparsers.add_parser(
+        "set", help="Create or replace one teacher-entered overall rating."
+    )
+    _add_submission_identity_arguments(ratings_set_parser)
+    ratings_set_parser.add_argument("--standard-id", required=True)
+    ratings_set_parser.add_argument(
+        "--rating",
+        required=True,
+        type=int,
+        help="Integer value from the assignment-owned rating scale.",
+    )
+    ratings_set_parser.add_argument(
+        "--rationale",
+        help="Optional teacher rationale; omission or blank text clears it.",
+    )
+    ratings_set_parser.add_argument(
+        "--include-in-feedback",
+        required=True,
+        type=_true_false,
+        metavar="true|false",
+        help="Required explicit teacher choice: true or false.",
+    )
+    ratings_set_parser.set_defaults(handler=handle_ratings_set)
+
+    ratings_complete_parser = ratings_subparsers.add_parser(
+        "mark-complete",
+        help="Explicitly mark overall ratings complete, including when ratings are missing.",
+    )
+    _add_submission_identity_arguments(ratings_complete_parser)
+    ratings_complete_parser.add_argument(
+        "--yes",
+        required=True,
+        action="store_true",
+        help="Explicitly confirm completion without prompting.",
+    )
+    ratings_complete_parser.set_defaults(handler=handle_ratings_mark_complete)
 
     roster_parser = subparsers.add_parser(
         "roster",

--- a/quillan/rating_management.py
+++ b/quillan/rating_management.py
@@ -1,0 +1,177 @@
+"""Immutable, read-only context for overall Focus Standard ratings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from quillan.review_status_display import review_progress_status
+from quillan.review_unit_management import (
+    ReviewUnitManagementError,
+    load_review_unit_context,
+)
+
+
+class RatingManagementError(ValueError):
+    """Raised when overall-rating context cannot be loaded safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class RatingScaleLevel:
+    """One assignment-owned rating-scale level."""
+
+    value: int
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class OverallRatingSummary:
+    """Current rating and advisory observation counts for one Focus Standard."""
+
+    standard_id: str
+    rating: int | None
+    rating_label: str | None
+    rationale: str | None
+    include_in_feedback: bool | None
+    updated_at: str | None
+    total_review_units: int
+    observation_count: int
+    applicable_count: int
+    not_applicable_count: int
+    evidence_present_count: int
+    evidence_missing_count: int
+    included_for_feedback_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class StaleOverallRating:
+    """A stored overall rating no longer configured by the assignment."""
+
+    standard_id: str
+    rating: int
+    rationale: str | None
+    include_in_feedback: bool
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class OverallRatingContext:
+    """Validated canonical read model for direct overall-rating display."""
+
+    workspace_root: Path
+    class_id: str
+    assignment_id: str
+    student_id: str
+    submission_manifest_path: Path
+    submission_manifest_relative_path: str
+    review_record_path: Path
+    review_record_relative_path: str
+    review_exists: bool
+    review_state: str
+    observations_complete: bool
+    ratings_complete: bool
+    rating_scale_id: str
+    rating_scale_levels: tuple[RatingScaleLevel, ...]
+    standards: tuple[OverallRatingSummary, ...]
+    stale_ratings: tuple[StaleOverallRating, ...]
+    rating_count: int
+    missing_rating_count: int
+
+
+def load_overall_rating_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> OverallRatingContext:
+    """Load overall ratings and observation counts without writing or scoring."""
+    try:
+        loaded = load_review_unit_context(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewUnitManagementError as error:
+        raise RatingManagementError(str(error)) from error
+
+    assignment = loaded.assignment
+    review = loaded.review
+    focus_standard_ids = tuple(assignment["focus_standard_ids"])
+    levels = tuple(
+        RatingScaleLevel(value=level["value"], label=level["label"])
+        for level in assignment["rating_scale"]["levels"]
+    )
+    labels = {level.value: level.label for level in levels}
+    ratings = review["overall_standard_ratings"] if review is not None else []
+    ratings_by_standard = {item["standard_id"]: item for item in ratings}
+    units = review["review_units"] if review is not None else []
+
+    standards: list[OverallRatingSummary] = []
+    for standard_id in focus_standard_ids:
+        observations = [
+            observation
+            for unit in units
+            for observation in unit["standard_observations"]
+            if observation["standard_id"] == standard_id
+        ]
+        applicable = [item for item in observations if item["applicable"]]
+        current = ratings_by_standard.get(standard_id)
+        rating = current["rating"] if current is not None else None
+        standards.append(
+            OverallRatingSummary(
+                standard_id=standard_id,
+                rating=rating,
+                rating_label=labels.get(rating) if rating is not None else None,
+                rationale=current["rationale"] if current is not None else None,
+                include_in_feedback=(
+                    current["include_in_feedback"] if current is not None else None
+                ),
+                updated_at=current["updated_at"] if current is not None else None,
+                total_review_units=len(units),
+                observation_count=len(observations),
+                applicable_count=len(applicable),
+                not_applicable_count=sum(not item["applicable"] for item in observations),
+                evidence_present_count=sum(
+                    item["evidence_present"] is True for item in applicable
+                ),
+                evidence_missing_count=sum(
+                    item["evidence_present"] is False for item in applicable
+                ),
+                included_for_feedback_count=sum(
+                    item["include_in_feedback"] for item in observations
+                ),
+            )
+        )
+
+    configured = set(focus_standard_ids)
+    stale = tuple(
+        StaleOverallRating(
+            standard_id=item["standard_id"],
+            rating=item["rating"],
+            rationale=item["rationale"],
+            include_in_feedback=item["include_in_feedback"],
+            updated_at=item["updated_at"],
+        )
+        for item in ratings
+        if item["standard_id"] not in configured
+    )
+    rating_count = sum(item.rating is not None for item in standards)
+    progress = review_progress_status(review) if review is not None else None
+    return OverallRatingContext(
+        workspace_root=loaded.workspace_root,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        submission_manifest_path=loaded.submission_manifest_path,
+        submission_manifest_relative_path=loaded.submission_manifest_relative_path,
+        review_record_path=loaded.review_record_path,
+        review_record_relative_path=loaded.review_record_relative_path,
+        review_exists=review is not None,
+        review_state=loaded.review_state,
+        observations_complete=(progress.observations_complete if progress else False),
+        ratings_complete=(progress.ratings_complete if progress else False),
+        rating_scale_id=assignment["rating_scale"]["scale_id"],
+        rating_scale_levels=levels,
+        standards=tuple(standards),
+        stale_ratings=stale,
+        rating_count=rating_count,
+        missing_rating_count=len(standards) - rating_count,
+    )

--- a/quillan/review_ratings.py
+++ b/quillan/review_ratings.py
@@ -73,6 +73,7 @@ class UpdatedOverallStandardRating:
     standard_id: str
     rating: int
     rating_label: str
+    rationale: str | None
     include_in_feedback: bool
     was_created: bool
     updated_at: str
@@ -190,8 +191,10 @@ def set_overall_standard_rating(
     context = _load_context(workspace_root, class_id, assignment_id, student_id)
     assignment = context["assignment"]
     if normalized_standard_id not in assignment["focus_standard_ids"]:
+        allowed = ", ".join(assignment["focus_standard_ids"])
         raise ReviewRatingError(
-            f"standard_id {normalized_standard_id!r} is not a Focus Standard for this assignment."
+            f"standard_id {normalized_standard_id!r} is not a Focus Standard for this "
+            f"assignment. Valid Focus Standard IDs: {allowed}."
         )
     rating_labels = _rating_labels_by_value(assignment)
     if normalized_rating not in rating_labels:
@@ -242,6 +245,7 @@ def set_overall_standard_rating(
         standard_id=normalized_standard_id,
         rating=normalized_rating,
         rating_label=rating_labels[normalized_rating],
+        rationale=normalized_rationale,
         include_in_feedback=include_in_feedback,
         was_created=was_created,
         updated_at=normalized_updated_at,

--- a/tests/test_cli_ratings.py
+++ b/tests/test_cli_ratings.py
@@ -1,0 +1,318 @@
+"""Direct CLI coverage for teacher-entered overall Focus Standard ratings."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.cli import main
+from quillan.cli_app.handlers import ratings as handlers
+from quillan.review_record import build_empty_review_record
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english10_p2"
+ASSIGNMENT_ID = "argument_01"
+STUDENT_ID = "00107"
+TIMESTAMP = "2026-07-13T12:00:00+00:00"
+
+
+def _assignment() -> dict[str, Any]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Argument",
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Make an argument.",
+        "standards_profile_id": "ela",
+        "focus_standard_ids": ["W.1", "L.2"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "unusual",
+            "levels": [
+                {"value": -2, "label": "Beginning", "description": "Beginning."},
+                {"value": 0, "label": "Developing", "description": "Developing."},
+                {"value": 7, "label": "Secure", "description": "Secure."},
+            ],
+        },
+        "basic_requirements": {},
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {"submission_entry_method": "plain_paper_manual"},
+    }
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    assignment_path = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    assignment_path.parent.mkdir(parents=True)
+    assignment_path.write_text(json.dumps(_assignment()), encoding="utf-8")
+    write_submission_manifest(
+        submission_manifest_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        _manifest(),
+    )
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _write_review(workspace: Path) -> Path:
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    write_review_record(
+        path,
+        build_empty_review_record(
+            class_id=CLASS_ID,
+            assignment_id=ASSIGNMENT_ID,
+            student_id=STUDENT_ID,
+            created_at=TIMESTAMP,
+        ),
+    )
+    return path
+
+
+def _set_args(*extra: str) -> list[str]:
+    return [
+        "ratings",
+        "set",
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        "--standard-id",
+        "W.1",
+        "--rating",
+        "7",
+        "--include-in-feedback",
+        "false",
+        *extra,
+    ]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--help"],
+        ["ratings", "--help"],
+        ["ratings", "list", "--help"],
+        ["ratings", "set", "--help"],
+        ["ratings", "mark-complete", "--help"],
+    ],
+)
+def test_ratings_help_exits_successfully(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(argv)
+    assert error.value.code == 0
+
+
+def test_bare_namespace_prints_help_without_resolving_workspace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        handlers,
+        "resolve_workspace_root",
+        lambda: pytest.fail("bare ratings namespace resolved workspace"),
+    )
+    assert main(["ratings"]) == 0
+    assert "{list,set,mark-complete}" in capsys.readouterr().out
+
+
+def test_list_without_review_is_ordered_and_strictly_read_only(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = assignment_path.read_bytes(), manifest_path.read_bytes()
+
+    assert main(["ratings", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    assert f"Student: {STUDENT_ID}" in output
+    assert "Review state: not_started" in output
+    assert "Review record exists: no" in output
+    assert "Overall ratings complete: no" in output
+    assert "Ratings recorded: 0" in output
+    assert "Ratings missing: 2" in output
+    assert output.index("- -2: Beginning") < output.index("- 0: Developing")
+    assert output.index("Focus Standard: W.1") < output.index("Focus Standard: L.2")
+    assert output.count("Overall rating: not rated") == 2
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+    assert (assignment_path.read_bytes(), manifest_path.read_bytes()) == before
+
+
+def test_set_creates_then_replaces_without_inference_or_duplicate(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_review(workspace)
+    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    immutable = assignment_path.read_bytes(), manifest_path.read_bytes()
+    monkeypatch.setattr("builtins.input", lambda *_args: pytest.fail("CLI prompted"))
+
+    assert main(_set_args("--rationale", "  Teacher judgment.  ")) == 0
+    output = capsys.readouterr().out
+    assert "Rating: 7 - Secure" in output
+    assert "Rationale: present" in output
+    assert "Include in feedback: no" in output
+    assert "Action: created" in output
+    assert "No supporting observations" in output
+
+    assert main(_set_args()) == 0
+    review = json.loads(path.read_text(encoding="utf-8"))
+    assert len(review["overall_standard_ratings"]) == 1
+    assert review["overall_standard_ratings"][0]["rationale"] is None
+    assert review["review_units"] == []
+    assert review["feedback"]["standard_feedback"] == []
+    assert "Action: updated" in capsys.readouterr().out
+    assert (assignment_path.read_bytes(), manifest_path.read_bytes()) == immutable
+
+
+def test_write_commands_require_an_existing_review(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(_set_args()) == 1
+    assert "review record must exist" in capsys.readouterr().out
+    assert main(
+        ["ratings", "mark-complete", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--yes"]
+    ) == 1
+    assert "review record must exist" in capsys.readouterr().out
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+
+
+@pytest.mark.parametrize("rating", ["-2", "0"])
+def test_set_accepts_every_configured_unusual_integer(
+    workspace: Path, rating: str
+) -> None:
+    _write_review(workspace)
+    argv = _set_args()
+    argv[argv.index("7")] = rating
+    assert main(argv) == 0
+
+
+def test_invalid_standard_and_rating_fail_without_writing(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_review(workspace)
+    before = path.read_bytes()
+    argv = _set_args()
+    argv[argv.index("W.1")] = "CORE.BUT.NOT.CONFIGURED"
+    assert main(argv) == 1
+    assert "Valid Focus Standard IDs: W.1, L.2" in capsys.readouterr().out
+    assert path.read_bytes() == before
+    argv = _set_args()
+    argv[argv.index("7")] = "5"
+    assert main(argv) == 1
+    assert "Allowed values: -2, 0, 7" in capsys.readouterr().out
+    assert path.read_bytes() == before
+
+
+def test_mark_complete_requires_yes_and_allows_zero_ratings(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_review(workspace)
+    before = path.read_bytes()
+    with pytest.raises(SystemExit) as error:
+        main(["ratings", "mark-complete", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID])
+    assert error.value.code == 2
+    assert path.read_bytes() == before
+
+    assert main(
+        ["ratings", "mark-complete", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--yes"]
+    ) == 0
+    review = json.loads(path.read_text(encoding="utf-8"))
+    assert review["review_state"] == "ratings_complete"
+    assert review["overall_standard_ratings"] == []
+    output = capsys.readouterr().out
+    assert "Ratings recorded: 0" in output
+    assert "Missing ratings: 2" in output
+    assert "none were created" in output
+
+
+def test_returned_review_is_listable_but_byte_stable_for_failed_writes(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_review(workspace)
+    review = json.loads(path.read_text(encoding="utf-8"))
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Missing work.",
+        "updated_at": TIMESTAMP,
+    }
+    write_review_record(path, review, overwrite=True)
+    before = path.read_bytes()
+
+    assert main(["ratings", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+    assert "overall ratings not applicable" in capsys.readouterr().out
+    assert main(_set_args()) == 1
+    assert "returned without full standards review" in capsys.readouterr().out
+    assert main(
+        ["ratings", "mark-complete", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--yes"]
+    ) == 1
+    assert path.read_bytes() == before
+
+
+def test_list_reports_stale_rating_without_counting_it(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_review(workspace)
+    review = json.loads(path.read_text(encoding="utf-8"))
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": "STALE.9",
+            "rating": 7,
+            "rationale": None,
+            "include_in_feedback": False,
+            "updated_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    write_review_record(path, review, overwrite=True)
+    before = copy.deepcopy(path.read_bytes())
+
+    assert main(["ratings", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+    output = capsys.readouterr().out
+    assert "Ratings recorded: 0" in output
+    assert "Ratings missing: 2" in output
+    assert "Unrecognized or stale stored ratings" in output
+    assert "STALE.9: 7" in output
+    assert path.read_bytes() == before

--- a/tests/test_review_ratings.py
+++ b/tests/test_review_ratings.py
@@ -374,6 +374,18 @@ def test_set_overall_rating_validates_assignment_scale_and_standard(
             include_in_feedback=1,  # type: ignore[arg-type]
             updated_at=FIRST_TIMESTAMP,
         )
+    with pytest.raises(ReviewRatingError, match="rating must be an integer"):
+        set_overall_standard_rating(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            standard_id="njsls-ela:W.1",
+            rating=True,
+            rationale=None,
+            include_in_feedback=True,
+            updated_at=FIRST_TIMESTAMP,
+        )
 
 
 def test_focus_standard_summary_groups_counts_and_current_rating(


### PR DESCRIPTION
## Summary

* Add direct CLI commands for listing, recording, updating, and completing overall Focus Standard ratings:

  * `quillan ratings list`
  * `quillan ratings set`
  * `quillan ratings mark-complete`
* Add an immutable, assignment-aware read model for overall-rating status.
* Continue routing all mutations through the existing shared rating services and canonical atomic `review.json` writer.
* Preserve the existing menu workflow in which observation readiness and missing ratings produce warnings rather than hard completion gates.
* Keep all ratings explicitly teacher-entered, with no inference, averaging, grading, or automatic scoring.

## Command Surface

```text
quillan ratings list <class_id> <assignment_id> <student_id>

quillan ratings set <class_id> <assignment_id> <student_id> \
  --standard-id <standard_id> \
  --rating <integer> \
  [--rationale <text>] \
  --include-in-feedback true|false

quillan ratings mark-complete <class_id> <assignment_id> <student_id> \
  --yes
```

Running:

```text
quillan ratings
```

without a subcommand prints ratings-command help and exits successfully without resolving the workspace.

All commands are direct and non-interactive. They do not call `input()` or invoke menu functions.

## Shared Architecture

Added immutable read-only rating context in:

* `quillan/rating_management.py`

Added direct CLI handlers in:

* `quillan/cli_app/handlers/ratings.py`

Registered the new command namespace in:

* `quillan/cli_app/parser.py`

Extended shared result and output behavior in:

* `quillan/review_ratings.py`
* `quillan/cli_app/output.py`

The implementation preserves the intended application boundary:

```text
menu -> shared overall-rating services
CLI  -> same shared overall-rating services
GUI  -> same shared overall-rating services later
```

CLI handlers do not edit raw review-record dictionaries.

All rating writes continue through:

* `set_overall_standard_rating(...)`
* `mark_overall_ratings_complete(...)`

and the existing validated atomic review-record writer.

## `ratings list`

`ratings list` is strictly read-only.

It reports:

* class ID;
* assignment ID;
* student ID;
* canonical submission-manifest path;
* canonical review-record path;
* review-record existence;
* current review state;
* observation-completion status;
* rating-completion status;
* assignment rating-scale ID;
* all assignment rating-scale levels;
* assignment Focus Standard count;
* ratings recorded;
* ratings missing;
* stale or unrecognized rating count.

Focus Standards are displayed in the exact order defined by:

```text
assignment.focus_standard_ids
```

For each configured Focus Standard, the command reports:

* standard ID;
* current overall rating;
* assignment-owned rating label;
* rationale;
* feedback-inclusion state;
* rating update timestamp;
* total review units;
* recorded observation count;
* applicable observation count;
* not-applicable observation count;
* evidence-present count;
* evidence-missing count;
* observations marked for feedback.

The output clearly identifies these as overall Focus Standard ratings rather than unit-level observation ratings.

The command does not dump raw review JSON.

## Missing Review Behavior

When the canonical submission exists but no `review.json` exists, listing reports:

* review state: `not_started`;
* ratings recorded: `0`;
* every assignment Focus Standard as `not rated`;
* ratings complete: `no`;
* zero observation counts.

The command returns successfully without:

* creating a review record;
* creating directories;
* changing assignment or submission records;
* altering timestamps.

## Missing Observation Context

Overall ratings remain teacher-entered judgments and do not require supporting observations as a write prerequisite.

When a valid review has:

* no review units;
* no observations;
* incomplete observations;
* no observations for a selected Focus Standard;

the CLI reports advisory context but does not treat those conditions as invalid rating records.

This matches the existing menu workflow.

## Stale Ratings

The assignment’s current `focus_standard_ids` controls:

* primary display order;
* valid rating targets;
* current rating counts;
* missing-rating counts;
* completion summaries.

Ratings for standards no longer configured by the assignment:

* do not satisfy current assignment completion;
* do not replace configured standards in the primary display;
* remain preserved in the review record;
* are reported separately for audit visibility.

The CLI does not silently delete or normalize stale ratings.

## `ratings set`

`ratings set` records one complete teacher-entered overall Focus Standard rating.

The supplied command values replace that standard’s editable rating fields rather than acting as a sparse patch.

### Focus Standard Validation

The supplied `--standard-id` must appear in the current assignment’s:

```text
focus_standard_ids
```

A standard is not accepted merely because it exists in the shared standards library.

Invalid or unconfigured standards fail without writing.

### Assignment Rating-Scale Validation

The supplied `--rating` must exactly match one value from:

```text
assignment.rating_scale.levels[*].value
```

The implementation does not hardcode a `1–4` scale or assume that ratings must be positive.

Assignment-owned scales may include:

* zero;
* negative integers;
* noncontiguous integer values;
* values that do not begin at one.

For example, a configured scale containing:

```text
-1 — Insufficient Evidence
0  — Not Yet Demonstrated
2  — Secure
```

accepts those exact values and rejects unconfigured values.

Successful output includes the assignment-owned rating label.

## Rationale Behavior

`--rationale` is optional and teacher-entered.

When supplied:

* surrounding whitespace is trimmed;
* nonblank text is stored.

When omitted or blank:

* `rationale` is stored as `null`;
* an earlier rationale is cleared when updating the same standard.

No rationale is generated, summarized, rewritten, or inferred.

## Feedback-Inclusion Behavior

`--include-in-feedback` is required and must be an explicit boolean:

```text
--include-in-feedback true
--include-in-feedback false
```

The direct CLI does not choose a default on the teacher’s behalf.

Changing this field does not automatically:

* create a `feedback.standard_feedback` record;
* change `include_overall_rating`;
* change `include_overall_rationale`;
* create feedback comments;
* compose feedback;
* export feedback.

Feedback composition remains a separate explicit workflow.

## Rating Creation

When no rating exists for the selected assignment Focus Standard, the service creates one canonical overall-rating record.

The resulting record contains:

* standard ID;
* validated rating value;
* optional rationale;
* feedback-inclusion choice;
* update timestamp;
* empty module metadata.

Successful output reports the action as:

```text
created
```

## Rating Updates

When a rating already exists for the selected Focus Standard:

* the existing standard entry is replaced;
* no duplicate is created;
* the action is reported as `updated`.

The update replaces:

* `rating`;
* `rationale`;
* `include_in_feedback`;
* `updated_at`;
* `module_details`.

It preserves:

* all other overall ratings;
* minimum-requirement checks;
* minimum-requirement outcome;
* review units;
* observations;
* feedback configuration;
* feedback comments;
* exports;
* private notes;
* top-level module metadata;
* original `created_at`.

Overall-rating records do not receive a separate record ID.

## Observation Readiness Is Advisory

Rating entry remains permitted when:

* no review units have been defined;
* no observations have been recorded;
* observations are not marked complete;
* the selected Focus Standard has no observations;
* some unit-standard pairs remain unobserved.

These conditions may be reported as warnings or context.

They do not cause Quillan to infer a rating or block a teacher-entered rating.

## Rating-Edit State Transitions

Rating edits preserve the existing shared-service state behavior:

* `not_started` -> `observations_in_progress`
* `requirements_checked` -> `observations_in_progress`
* `observations_in_progress` remains unchanged
* `observations_complete` remains unchanged
* `ratings_complete` remains unchanged
* `feedback_composed` -> `ratings_complete`
* `ready_for_export` -> `ratings_complete`
* `exported` -> `ratings_complete`

The CLI handler does not assign review states directly.

When downstream workflow states return to `ratings_complete`, existing feedback and export metadata remain preserved.

## Successful Rating Output

A successful `ratings set` operation reports:

* class ID;
* assignment ID;
* student ID;
* Focus Standard ID;
* rating value;
* rating label;
* rationale status;
* feedback-inclusion state;
* action: `created` or `updated`;
* resulting review state;
* canonical workspace-relative review-record path;
* update timestamp.

The command does not dump raw review JSON.

## `ratings mark-complete`

The completion command is:

```text
quillan ratings mark-complete <class_id> <assignment_id> <student_id> --yes
```

It calls the existing:

```text
mark_overall_ratings_complete(...)
```

service.

The handler does not reproduce completion logic.

## Explicit Completion Confirmation

`--yes` is required.

When it is omitted:

* the command does not prompt;
* no files are changed;
* the command returns nonzero through normal argument validation.

This keeps the completion action explicit while remaining non-interactive.

## Completion with Missing Ratings

The command calculates and reports:

* configured Focus Standard count;
* ratings recorded;
* ratings missing.

Explicit completion is allowed when:

* every Focus Standard is rated;
* only some Focus Standards are rated;
* no Focus Standards are rated.

When ratings are missing:

* the command reports a warning;
* `--yes` confirms that the teacher intends to continue;
* no placeholder ratings are created;
* no ratings are inferred from observations.

The resulting review state becomes:

```text
ratings_complete
```

This mirrors the existing menu’s warning-only completion workflow.

## Completion Without Observation Readiness

Marking ratings complete does not require:

* review units;
* observations;
* completed observations;
* every unit-standard pair to be observed.

Completion does not create:

* review units;
* observations;
* ratings;
* feedback.

It records only the teacher’s explicit workflow-completion decision.

## Completion Preservation Behavior

A successful completion preserves:

* all overall ratings;
* minimum-requirement data;
* review units;
* observations;
* feedback data;
* exports;
* private notes;
* top-level metadata;
* original `created_at`.

Only the following completion fields change:

* `review_state`;
* top-level `updated_at`.

## Returned-Without-Full-Review Behavior

Records in:

```text
returned_without_full_review
```

remain listable for audit purposes.

Both write commands reject those records:

* `ratings set`
* `ratings mark-complete --yes`

The error explains that the minimum-requirements outcome must be changed before standards review can continue.

Rejected operations leave the existing review unchanged.

## Submission and Identity Validation

All commands require a valid canonical submission manifest.

The workflow validates:

* class, assignment, and student identifiers;
* canonical assignment existence and schema;
* assignment ID;
* selected class membership in `class_ids`;
* canonical submission-manifest existence and schema;
* submission identity;
* canonical review schema and identity when present;
* canonical assignment and submission references.

When routed evidence exists without an assembled `submission.json`, the command returns the existing assembly guidance.

The commands do not assemble submissions automatically.

Valid plain-paper manual submissions remain supported even without digital evidence.

Current roster membership is not required when a valid canonical submission exists.

## Review-Record Prerequisite

`ratings set` and `ratings mark-complete` require an existing valid review record.

When `review.json` is missing:

* the write command fails clearly;
* no review record is created;
* no files are modified.

`ratings list` remains read-only and can display a valid submission whose review has not started.

## Write Boundaries

`ratings list` writes nothing.

`ratings set` and `ratings mark-complete` may modify only:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
```

All writes use the existing validated atomic review-record writer.

The implementation does not modify:

* `assignment.json`;
* `submission.json`;
* class rosters;
* class metadata;
* routed evidence;
* retained scans;
* source scans;
* PDFs;
* images;
* standards libraries;
* reusable comment libraries;
* feedback export files;
* assignment reports;
* PDS Core data;
* ScoreForm data.

Tests verify that assignment and submission-manifest bytes remain unchanged.

## Preserved Review Data

Rating operations preserve unrelated review data, including:

* minimum-requirement checks;
* minimum-requirement outcomes;
* review units;
* review-unit observations;
* other overall ratings;
* feedback configuration;
* feedback comments;
* observation inclusion lists;
* export metadata;
* private teacher notes;
* top-level module metadata;
* original creation timestamp.

No observation or feedback-composition record is implicitly rewritten.

## No Automated Judgment

Confirmed that the implementation does not:

* open evidence files;
* inspect PDF text;
* inspect images;
* parse student writing;
* run OCR;
* perform handwriting recognition;
* use AI;
* infer overall ratings;
* infer rationales;
* infer feedback inclusion;
* average unit-level ratings;
* aggregate observation ratings;
* convert evidence counts into ratings;
* calculate mastery;
* calculate percentages;
* calculate grades;
* calculate scores;
* synthesize missing ratings;
* generate feedback;
* mark ratings complete automatically.

Every rating remains an explicit teacher-entered judgment.

## Documentation

Updated:

* `docs/cli_contract.md`
* `docs/review_record_contract.md`
* `docs/prepared_review_workflow.md`

The documentation now covers:

* the `ratings` namespace;
* assignment-order listing;
* assignment-owned rating scales;
* unusual integer scale values;
* Focus Standard validation;
* rating creation and replacement;
* rationale clearing behavior;
* explicit feedback-inclusion choices;
* advisory observation warnings;
* explicit `--yes` completion;
* completion with missing ratings;
* returned-without-full-review restrictions;
* review-state transitions;
* exact read and write boundaries;
* the prohibition on inference, averaging, grading, OCR, and AI.

## Files Changed

Ten intended Quillan source, test, and documentation files were modified or added:

* `quillan/cli_app/parser.py`
* `quillan/cli_app/output.py`
* `quillan/cli_app/handlers/ratings.py`
* `quillan/rating_management.py`
* `quillan/review_ratings.py`
* `tests/test_cli_ratings.py`
* `tests/test_review_ratings.py`
* `docs/cli_contract.md`
* `docs/review_record_contract.md`
* `docs/prepared_review_workflow.md`

## Safety

Confirmed:

* bare namespace help does not resolve the workspace;
* direct handlers are non-interactive;
* listing is read-only;
* missing submissions do not create review records;
* write commands require an existing review;
* standards must belong to the assignment;
* ratings must belong to the assignment-owned scale;
* unusual integer scales are supported;
* rationales are teacher-entered;
* feedback inclusion is explicit;
* rating updates do not create duplicates;
* observation readiness remains advisory;
* completion requires `--yes`;
* missing ratings do not block explicit completion;
* completion does not synthesize ratings;
* returned-without-full-review records cannot be modified;
* assignment and submission records remain unchanged;
* observations remain unchanged;
* feedback composition remains unchanged;
* unrelated review data remains preserved;
* expected failures return nonzero without tracebacks;
* no PDS Core files were modified;
* no ScoreForm files were modified;
* no workspace data was added;
* no real student data was added;
* no generated review, evidence, feedback, report, or export artifacts were added.

## Validation

* Focused rating tests: `21 passed`
* Rating and menu regression tests: `54 passed`
* Broader CLI and review tests: `565 passed`
* Full pytest suite: `1185 passed`
* Ruff: passed
* mypy: passed, `156` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed, including all `1185` tests
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* Git status contains only intended Quillan source, test, and documentation changes
* No workspace data, real student data, or generated review/evidence/feedback/report/export artifacts present

Closes #304
