### PR TITLE
Add Focus Standard feedback CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -114,6 +114,11 @@ quillan observations set <class_id> <assignment_id> <student_id> --unit-id <unit
 quillan ratings list <class_id> <assignment_id> <student_id>
 quillan ratings set <class_id> <assignment_id> <student_id> --standard-id <standard_id> --rating <integer> [--rationale <text>] --include-in-feedback true|false
 quillan ratings mark-complete <class_id> <assignment_id> <student_id> --yes
+quillan feedback show <class_id> <assignment_id> <student_id>
+quillan feedback set-options <class_id> <assignment_id> <student_id> --standard-id <standard_id> --include-overall-rating true|false --include-overall-rationale true|false [--observation-ids <id,...>]
+quillan feedback add-comment <class_id> <assignment_id> <student_id> --standard-id <standard_id> --text <text> --include-in-feedback true|false [--save-for-reuse --reusable-label <label> [--reusable-text <text>] [--purpose <purpose>] [--teacher-tags <tag,...>] [--tag-current-rating true|false]]
+quillan feedback use-reusable-comment <class_id> <assignment_id> <student_id> --standard-id <standard_id> --comment-set-id <comment_set_id> --comment-id <comment_id> --include-in-feedback true|false
+quillan feedback mark-composed <class_id> <assignment_id> <student_id> --yes
 quillan roster create <class_id> --input <roster.csv> [--school-year YYYY-YYYY] [--overwrite] (--yes | --dry-run)
 quillan roster show <class_id>
 quillan roster validate <class_id>
@@ -158,6 +163,72 @@ and exits successfully without resolving or inspecting the workspace.
 
 Running `quillan observations` without a subcommand prints observation help
 and exits successfully without resolving or inspecting the workspace.
+
+## Direct Focus Standard Feedback Composition
+
+The `feedback` namespace exposes the menu's composition model through five
+direct, non-interactive commands. Bare `quillan feedback` prints namespace
+help without resolving a workspace. Every subcommand requires a valid
+canonical assignment and assembled `submission.json`; write commands also
+require an existing valid `review.json`. A valid historical, unrostered, or
+plain-paper submission remains usable. Routed evidence without a manifest
+produces assembly guidance and is never assembled automatically.
+
+`feedback show` is strictly read-only. It reports canonical paths, review and
+completion state, global flags and counts, then lists assignment Focus
+Standards in configured order. Each standard shows its current rating and
+rationale, feedback options, selected observations, eligible candidate
+observations, stored comment snapshots, and compatible reusable comments with
+the set/comment IDs needed for selection. A missing review is reported as
+`not_started` with empty choices; malformed reviews fail. Returned reviews are
+displayable for audit but clearly unavailable for full composition.
+
+`feedback set-options` replaces one configured Focus Standard's complete
+rating/rationale choices and selected-observation list. Both booleans are
+required. Omission of `--observation-ids` clears the list; comma order is
+preserved and blanks or duplicates fail. An observation must exist, belong to
+the same standard, and already have `include_in_feedback: true`; the command
+never enables it. The shared service creates a missing standard-feedback
+record or updates the existing record while preserving comments and module
+metadata, and recomputes the global observation-inclusion flag.
+
+`feedback add-comment` copies the teacher's text after outer whitespace
+trimming without rewriting its internal content. Inclusion is explicit and no
+export occurs. `--save-for-reuse` requires a nonblank label. Separately
+approved `--reusable-text` is stored when supplied; otherwise the custom text
+is reused. Teachers must remove student-specific details from reusable text.
+Purposes are `praise`, `next_step`, `clarification`, `evidence`, `reasoning`,
+`organization`, `style`, `conventions`, `revision`, and `general` (the
+default). Teacher tags use the shared lowercase snake-case normalization.
+`--tag-current-rating true` stores the current rating restriction when a
+rating exists; omission or `false` stores no rating restriction.
+
+`feedback use-reusable-comment` accepts only an active, student-facing comment
+compatible through the shared lookup rules with the assignment standards
+profile, writing type, Focus Standard, and current rating. Selection copies
+the exact reusable text into the review as a stable snapshot, assigns the next
+review-wide sequential feedback-comment ID, and increments source usage once.
+Later source edits do not change that snapshot.
+
+Every standard-specific command validates against the assignment's configured
+Focus Standards, not merely the shared standards library. Feedback edits move
+`feedback_composed`, `ready_for_export`, and `exported` back to
+`ratings_complete`; earlier states remain unchanged and export metadata and
+files are preserved. `mark-composed` requires `--yes`. Missing ratings,
+feedback records, selected observations, or included comments produce summary
+warnings but do not block this explicit action. Returned-without-full-review
+records reject all four write commands.
+
+Write boundaries are exact: show writes nothing; set-options, ordinary
+add-comment, and mark-composed modify only canonical `review.json`; saving for
+reuse modifies that review and its service-selected comment set; reusable
+selection modifies that review and the explicitly selected comment set's
+usage metadata. Assignment and submission records, evidence, scans, rosters,
+unrelated comment sets, exports, reports, Core, and ScoreForm are unchanged.
+Composition is separate from export. These commands never inspect evidence,
+run OCR or handwriting recognition, invoke AI, generate or rewrite language,
+infer observations or ratings, grade, score, auto-select, auto-complete, or
+auto-export.
 
 Running `quillan ratings` without a subcommand prints ratings help and exits
 successfully without resolving or inspecting the workspace.

--- a/docs/focus_standard_comment_contract.md
+++ b/docs/focus_standard_comment_contract.md
@@ -30,6 +30,14 @@ When selected for a student review, reusable comment text is copied into
 `review.json` as a stable snapshot. Later edits to the reusable source must not
 silently change prior student review records or previously generated feedback.
 
+The direct `feedback add-comment --save-for-reuse` workflow uses the canonical
+purposes and shared teacher-tag normalization defined here. Current-rating
+tagging is opt-in; without `--tag-current-rating true`, the saved comment has
+no rating restriction. `feedback use-reusable-comment` applies the existing
+profile, writing-type, standard, rating, active, and student-facing lookup
+rules, then increments `times_used` and updates `last_used_at` exactly once
+after a successful selection.
+
 ## Status
 
 This is the active reusable Focus Standard comment contract for the v0.8.6

--- a/docs/prepared_review_workflow.md
+++ b/docs/prepared_review_workflow.md
@@ -191,6 +191,14 @@ exports use the copied text, not a live lookup into the reusable source file.
 Generic legacy comment banks are not used by the active v0.8.6 feedback
 composition workflow.
 
+The same workflow is available non-interactively through `quillan feedback
+show`, `set-options`, `add-comment`, `use-reusable-comment`, and
+`mark-composed --yes`. The assignment's ordered Focus Standards remain the
+source of truth. Selected observations must already be eligible for feedback.
+Reusable language must be teacher-approved and free of student-specific
+details; selection stores a stable snapshot and increments source usage.
+Composition does not inspect evidence, generate language, or export feedback.
+
 ## Exports And Reports
 
 Student feedback exports are derived artifacts:

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -709,8 +709,11 @@ Field rules:
 * Each Focus Standard may appear at most once in `standard_feedback`.
 * `include_overall_rating` is a boolean.
 * `include_overall_rationale` is a boolean.
-* `included_observation_ids` is an array of `observation_id` values from the
-  same review record.
+* `included_observation_ids` is an ordered array of unique `observation_id`
+  values from the same review record. Each selected observation must belong to
+  this record's `standard_id` and must itself have `include_in_feedback: true`.
+  Excluded observations must be changed through the observation workflow
+  before they can be selected.
 * `comments` is an array of feedback comment records.
 * `module_details` is an object.
 
@@ -742,6 +745,13 @@ Field rules:
 
 Feedback comments are teacher-authored or teacher-selected. Quillan must not
 generate feedback automatically.
+
+Direct composition uses the same shared services as the teacher-facing menu.
+Options replace a standard's full selection while preserving comments;
+custom and reusable selections append review-wide sequential comment IDs.
+Reusable text is copied as a stable snapshot and successful selection updates
+source usage metadata. Explicit composition completion may proceed with
+missing ratings, records, observations, or comments and never exports output.
 
 If a teacher writes a new custom comment and sets `save_for_reuse` to `true`,
 a later reusable-comment workflow may offer to save that language into a

--- a/quillan/cli_app/handlers/feedback.py
+++ b/quillan/cli_app/handlers/feedback.py
@@ -1,0 +1,235 @@
+"""Direct, non-interactive Focus Standard feedback handlers."""
+
+from __future__ import annotations
+
+import argparse
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.cli_app.output import (
+    print_added_feedback_comment,
+    print_completed_feedback_composition,
+    print_selected_reusable_feedback_comment,
+    print_updated_standard_feedback_options,
+)
+from quillan.feedback_management import (
+    FeedbackCompositionContext,
+    FeedbackManagementError,
+    FeedbackObservation,
+    load_feedback_composition_context,
+)
+from quillan.focus_standard_comments import ALLOWED_PURPOSES
+from quillan.review_feedback import (
+    ReviewFeedbackError,
+    add_custom_feedback_comment,
+    mark_feedback_composed,
+    select_reusable_feedback_comment,
+    set_standard_feedback_options,
+)
+
+
+def handle_feedback_show(args: argparse.Namespace) -> int:
+    try:
+        context = load_feedback_composition_context(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id
+        )
+        _print_context(context)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, FeedbackManagementError) as error:
+        return _error(error)
+
+
+def handle_feedback_set_options(args: argparse.Namespace) -> int:
+    try:
+        result = set_standard_feedback_options(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id,
+            standard_id=args.standard_id,
+            include_overall_rating=args.include_overall_rating,
+            include_overall_rationale=args.include_overall_rationale,
+            included_observation_ids=_comma_separated(args.observation_ids, "observation IDs"),
+        )
+        print_updated_standard_feedback_options(result)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewFeedbackError) as error:
+        return _error(error)
+
+
+def handle_feedback_add_comment(args: argparse.Namespace) -> int:
+    try:
+        reusable_values = (
+            args.reusable_label,
+            args.reusable_text,
+            args.purpose,
+            args.teacher_tags,
+            args.tag_current_rating,
+        )
+        if not args.save_for_reuse and any(value is not None for value in reusable_values):
+            raise ReviewFeedbackError(
+                "Reusable-comment options require --save-for-reuse."
+            )
+        if args.save_for_reuse and args.reusable_label is None:
+            raise ReviewFeedbackError("--reusable-label is required with --save-for-reuse.")
+        purpose = args.purpose or "general"
+        if purpose not in ALLOWED_PURPOSES:
+            raise ReviewFeedbackError(
+                f"purpose {purpose!r} is invalid; choose one of: "
+                + ", ".join(sorted(ALLOWED_PURPOSES))
+            )
+        rating_values: list[int | float] | None = (
+            None if args.tag_current_rating is True else []
+        )
+        result = add_custom_feedback_comment(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id,
+            standard_id=args.standard_id,
+            text=args.text,
+            include_in_feedback=args.include_in_feedback,
+            save_for_reuse=args.save_for_reuse,
+            reusable_label=args.reusable_label,
+            reusable_text=args.reusable_text,
+            purpose=purpose,
+            teacher_tags=(
+                _comma_separated(args.teacher_tags, "teacher tags")
+                if args.teacher_tags is not None else None
+            ),
+            rating_values=rating_values,
+        )
+        print_added_feedback_comment(result)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewFeedbackError) as error:
+        return _error(error)
+
+
+def handle_feedback_use_reusable_comment(args: argparse.Namespace) -> int:
+    try:
+        result = select_reusable_feedback_comment(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id,
+            standard_id=args.standard_id,
+            comment_set_id=args.comment_set_id,
+            comment_id=args.comment_id,
+            include_in_feedback=args.include_in_feedback,
+        )
+        print_selected_reusable_feedback_comment(result)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewFeedbackError) as error:
+        return _error(error)
+
+
+def handle_feedback_mark_composed(args: argparse.Namespace) -> int:
+    try:
+        if not args.yes:
+            raise ReviewFeedbackError("--yes is required to mark feedback composed.")
+        result = mark_feedback_composed(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id
+        )
+        print_completed_feedback_composition(result)
+        if result.missing_standard_feedback_count:
+            print("Warning: Feedback records are missing for one or more Focus Standards.")
+        if result.missing_rating_count:
+            print("Warning: Overall ratings are missing for one or more Focus Standards.")
+        if result.selected_observation_count == 0:
+            print("Warning: No review-unit observations are currently selected.")
+        if result.included_comment_count == 0:
+            print("Warning: No feedback comments are currently included.")
+        if result.student_facing_content_count == 0:
+            print("Warning: No student-facing feedback content is currently included.")
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewFeedbackError) as error:
+        return _error(error)
+
+
+def _comma_separated(value: str | None, label: str) -> list[str]:
+    if value is None or value == "":
+        return []
+    items = [item.strip() for item in value.split(",")]
+    if any(not item for item in items):
+        raise ReviewFeedbackError(f"{label} must not contain blank elements.")
+    seen: set[str] = set()
+    for item in items:
+        if item in seen:
+            raise ReviewFeedbackError(f"{label} contains duplicate {item!r}.")
+        seen.add(item)
+    return items
+
+
+def _print_context(context: FeedbackCompositionContext) -> None:
+    print("Focus Standard feedback composition:")
+    print(f"Class: {context.class_id}")
+    print(f"Assignment: {context.assignment_id}")
+    print(f"Student: {context.student_id}")
+    print(f"Submission manifest: {context.submission_manifest_relative_path}")
+    print(f"Review record: {context.review_record_relative_path}")
+    print(f"Review record exists: {_yes_no(context.review_exists)}")
+    print(f"Review state: {context.review_state}")
+    print(f"Ratings complete: {_yes_no(context.ratings_complete)}")
+    print(f"Feedback composed: {_yes_no(context.feedback_composed)}")
+    print(f"Focus Standards: {len(context.standards)}")
+    print(f"Configured feedback records: {context.configured_feedback_count}")
+    print(f"Missing feedback records: {context.missing_feedback_count}")
+    print(f"Stale feedback records: {context.stale_feedback_count}")
+    print(f"Comments: {context.comment_count}")
+    print(f"Included comments: {context.included_comment_count}")
+    print(f"Selected observations: {context.selected_observation_count}")
+    print(f"Include review-unit observations: {_yes_no(context.include_review_unit_observations)}")
+    print(f"Include overall standard ratings: {_yes_no(context.include_overall_standard_ratings)}")
+    if context.returned_without_full_review:
+        print("Notice: Full Focus Standard feedback composition is unavailable until the minimum-requirements outcome changes.")
+    for index, standard in enumerate(context.standards, start=1):
+        print()
+        print(f"{index}. Focus Standard: {standard.standard_id}")
+        rating = "not rated" if standard.rating is None else f"{standard.rating} ({standard.rating_label})"
+        print(f"   Overall rating: {rating}")
+        print(f"   Overall rationale: {standard.rationale or 'none'}")
+        print(f"   Rating include in feedback: {_optional_bool(standard.rating_include_in_feedback)}")
+        print(f"   Feedback record exists: {_yes_no(standard.has_feedback_record)}")
+        print(f"   Include overall rating: {_optional_bool(standard.include_overall_rating)}")
+        print(f"   Include overall rationale: {_optional_bool(standard.include_overall_rationale)}")
+        print("   Selected observations:")
+        _print_observations(standard.selected_observations)
+        print("   Candidate observations:")
+        _print_observations(standard.candidate_observations)
+        print("   Existing comments:")
+        if not standard.comments:
+            print("   - none")
+        for feedback_comment in standard.comments:
+            print(f"   - {feedback_comment.feedback_comment_id} [{feedback_comment.source}]")
+            print(f"     Text: {feedback_comment.text}")
+            print(f"     Reusable comment set: {feedback_comment.reusable_comment_set_id or 'none'}")
+            print(f"     Reusable comment: {feedback_comment.reusable_comment_id or 'none'}")
+            print(f"     Save for reuse: {_yes_no(feedback_comment.save_for_reuse)}")
+            print(f"     Include in feedback: {_yes_no(feedback_comment.include_in_feedback)}")
+            print(f"     Created: {feedback_comment.created_at}")
+        print("   Compatible reusable comments:")
+        if not standard.reusable_comments:
+            print("   - none")
+        for reusable_comment in standard.reusable_comments:
+            print(f"   - {reusable_comment.comment_set_id} / {reusable_comment.comment_id}: {reusable_comment.label}")
+            print(f"     Text: {reusable_comment.text}")
+            print(f"     Purpose: {reusable_comment.purpose}")
+            print(f"     Writing types: {', '.join(reusable_comment.writing_types) or 'all'}")
+            print(f"     Rating values: {', '.join(map(str, reusable_comment.rating_values)) or 'all'}")
+
+
+def _print_observations(items: tuple[FeedbackObservation, ...]) -> None:
+    if not items:
+        print("   - none")
+    for item in items:
+        print(f"   - {item.observation_id}: {item.unit_label} ({item.unit_id})")
+        print(f"     Applicable: {_yes_no(item.applicable)}")
+        evidence = "not applicable" if item.evidence_present is None else _yes_no(item.evidence_present)
+        print(f"     Evidence present: {evidence}")
+        print(f"     Unit-level rating: {item.rating if item.rating is not None else 'none'}")
+        print(f"     Rationale: {item.rationale or 'none'}")
+        print(f"     Include in feedback: {_yes_no(item.include_in_feedback)}")
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _optional_bool(value: bool | None) -> str:
+    return "not configured" if value is None else _yes_no(value)
+
+
+def _error(error: Exception) -> int:
+    print(f"Error: {error}")
+    return 1

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -196,9 +196,14 @@ def print_updated_standard_feedback_options(
         f"{format_bool(updated.include_overall_rationale)}"
     )
     print(f"Included observations: {updated.included_observation_count}")
+    print(
+        "Include review-unit observations: "
+        f"{format_bool(updated.include_review_unit_observations)}"
+    )
     print(f"Action: {'created' if updated.was_created else 'updated'}")
     print(f"Review state: {updated.review_state}")
     print(f"Review record: {updated.review_record_relative_path}")
+    print(f"Updated: {updated.updated_at}")
 
 
 def print_added_feedback_comment(added: AddedFeedbackComment) -> None:
@@ -215,6 +220,7 @@ def print_added_feedback_comment(added: AddedFeedbackComment) -> None:
     print(f"Review record: {added.review_record_relative_path}")
     if added.saved_reusable_comment is not None:
         print_saved_reusable_focus_standard_comment(added.saved_reusable_comment)
+    print(f"Created: {added.created_at}")
 
 
 def print_selected_reusable_feedback_comment(
@@ -232,6 +238,7 @@ def print_selected_reusable_feedback_comment(
     print(f"Include in feedback: {format_bool(selected.include_in_feedback)}")
     print(f"Review state: {selected.review_state}")
     print(f"Review record: {selected.review_record_relative_path}")
+    print(f"Created: {selected.created_at}")
 
 
 def print_completed_feedback_composition(
@@ -245,9 +252,13 @@ def print_completed_feedback_composition(
     print(f"Focus Standards: {completed.focus_standard_count}")
     print(f"Standards with feedback: {completed.standard_feedback_count}")
     print(f"Missing feedback records: {completed.missing_standard_feedback_count}")
+    print(f"Ratings recorded: {completed.rating_count}")
+    print(f"Missing ratings: {completed.missing_rating_count}")
+    print(f"Selected observations: {completed.selected_observation_count}")
     print(f"Included comments: {completed.included_comment_count}")
     print(f"Review state: {completed.review_state}")
     print(f"Review record: {completed.review_record_relative_path}")
+    print(f"Updated: {completed.updated_at}")
 
 
 def print_saved_reusable_focus_standard_comment(

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -13,6 +13,13 @@ from quillan.cli_app.handlers.exports import (
     handle_export_student_performance_summary,
     handle_export_standards_summary,
 )
+from quillan.cli_app.handlers.feedback import (
+    handle_feedback_add_comment,
+    handle_feedback_mark_composed,
+    handle_feedback_set_options,
+    handle_feedback_show,
+    handle_feedback_use_reusable_comment,
+)
 from quillan.cli_app.handlers.decoding import handle_decode_scan
 from quillan.cli_app.handlers.review import (
     handle_add_note,
@@ -336,6 +343,87 @@ def build_parser() -> argparse.ArgumentParser:
         help="Explicitly confirm completion without prompting.",
     )
     ratings_complete_parser.set_defaults(handler=handle_ratings_mark_complete)
+
+    feedback_parser = subparsers.add_parser(
+        "feedback",
+        help="Display and compose student-facing Focus Standard feedback.",
+        description=(
+            "Display or explicitly compose Focus Standard feedback for one "
+            "assembled submission. Composition does not inspect evidence, generate "
+            "language, or export feedback."
+        ),
+    )
+    feedback_parser.set_defaults(handler=partial(_print_parser_help, feedback_parser))
+    feedback_subparsers = feedback_parser.add_subparsers(dest="feedback_command")
+
+    feedback_show_parser = feedback_subparsers.add_parser(
+        "show", help="Display current feedback choices without writing files."
+    )
+    _add_submission_identity_arguments(feedback_show_parser)
+    feedback_show_parser.set_defaults(handler=handle_feedback_show)
+
+    feedback_options_parser = feedback_subparsers.add_parser(
+        "set-options", help="Replace feedback options for one Focus Standard."
+    )
+    _add_submission_identity_arguments(feedback_options_parser)
+    feedback_options_parser.add_argument("--standard-id", required=True)
+    feedback_options_parser.add_argument(
+        "--include-overall-rating", required=True, type=_true_false, metavar="true|false"
+    )
+    feedback_options_parser.add_argument(
+        "--include-overall-rationale", required=True, type=_true_false, metavar="true|false"
+    )
+    feedback_options_parser.add_argument(
+        "--observation-ids",
+        help="Comma-separated eligible observation IDs; omission clears the selection.",
+    )
+    feedback_options_parser.set_defaults(handler=handle_feedback_set_options)
+
+    feedback_comment_parser = feedback_subparsers.add_parser(
+        "add-comment", help="Add one exact teacher-authored feedback comment.",
+        description=(
+            "Add exact teacher-authored text. When saving for reuse, remove all "
+            "student-specific details from the separately approved reusable text."
+        ),
+    )
+    _add_submission_identity_arguments(feedback_comment_parser)
+    feedback_comment_parser.add_argument("--standard-id", required=True)
+    feedback_comment_parser.add_argument("--text", required=True)
+    feedback_comment_parser.add_argument(
+        "--include-in-feedback", required=True, type=_true_false, metavar="true|false"
+    )
+    feedback_comment_parser.add_argument("--save-for-reuse", action="store_true")
+    feedback_comment_parser.add_argument("--reusable-label")
+    feedback_comment_parser.add_argument("--reusable-text")
+    feedback_comment_parser.add_argument("--purpose")
+    feedback_comment_parser.add_argument("--teacher-tags")
+    feedback_comment_parser.add_argument(
+        "--tag-current-rating", type=_true_false, metavar="true|false"
+    )
+    feedback_comment_parser.set_defaults(handler=handle_feedback_add_comment)
+
+    feedback_reusable_parser = feedback_subparsers.add_parser(
+        "use-reusable-comment",
+        help="Copy one compatible reusable comment as a stable review snapshot.",
+    )
+    _add_submission_identity_arguments(feedback_reusable_parser)
+    feedback_reusable_parser.add_argument("--standard-id", required=True)
+    feedback_reusable_parser.add_argument("--comment-set-id", required=True)
+    feedback_reusable_parser.add_argument("--comment-id", required=True)
+    feedback_reusable_parser.add_argument(
+        "--include-in-feedback", required=True, type=_true_false, metavar="true|false"
+    )
+    feedback_reusable_parser.set_defaults(handler=handle_feedback_use_reusable_comment)
+
+    feedback_complete_parser = feedback_subparsers.add_parser(
+        "mark-composed",
+        help="Explicitly mark feedback composed; missing content produces warnings.",
+    )
+    _add_submission_identity_arguments(feedback_complete_parser)
+    feedback_complete_parser.add_argument(
+        "--yes", action="store_true", help="Explicitly confirm completion without prompting."
+    )
+    feedback_complete_parser.set_defaults(handler=handle_feedback_mark_composed)
 
     roster_parser = subparsers.add_parser(
         "roster",

--- a/quillan/feedback_management.py
+++ b/quillan/feedback_management.py
@@ -1,0 +1,222 @@
+"""Immutable, read-only context for Focus Standard feedback composition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from quillan.focus_standard_comments import (
+    FocusStandardCommentError,
+    ReusableFocusStandardComment,
+    lookup_comments,
+)
+from quillan.review_status_display import review_progress_status
+from quillan.review_unit_management import (
+    ReviewUnitManagementError,
+    load_review_unit_context,
+)
+
+
+class FeedbackManagementError(ValueError):
+    """Raised when feedback composition context cannot be loaded safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class FeedbackObservation:
+    observation_id: str
+    unit_id: str
+    unit_label: str
+    applicable: bool
+    evidence_present: bool | None
+    rating: int | None
+    rationale: str | None
+    include_in_feedback: bool
+
+
+@dataclass(frozen=True, slots=True)
+class FeedbackComment:
+    feedback_comment_id: str
+    source: str
+    text: str
+    reusable_comment_id: str | None
+    reusable_comment_set_id: str | None
+    save_for_reuse: bool
+    include_in_feedback: bool
+    created_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class FocusStandardFeedback:
+    standard_id: str
+    rating: int | None
+    rating_label: str | None
+    rationale: str | None
+    rating_include_in_feedback: bool | None
+    has_feedback_record: bool
+    include_overall_rating: bool | None
+    include_overall_rationale: bool | None
+    selected_observations: tuple[FeedbackObservation, ...]
+    candidate_observations: tuple[FeedbackObservation, ...]
+    comments: tuple[FeedbackComment, ...]
+    reusable_comments: tuple[ReusableFocusStandardComment, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FeedbackCompositionContext:
+    workspace_root: Path
+    class_id: str
+    assignment_id: str
+    student_id: str
+    submission_manifest_relative_path: str
+    review_record_relative_path: str
+    review_exists: bool
+    review_state: str
+    ratings_complete: bool
+    feedback_composed: bool
+    returned_without_full_review: bool
+    standards: tuple[FocusStandardFeedback, ...]
+    configured_feedback_count: int
+    missing_feedback_count: int
+    stale_feedback_count: int
+    comment_count: int
+    included_comment_count: int
+    selected_observation_count: int
+    include_review_unit_observations: bool
+    include_overall_standard_ratings: bool
+
+
+def load_feedback_composition_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> FeedbackCompositionContext:
+    """Load feedback choices and compatible reusable comments without writing."""
+    try:
+        loaded = load_review_unit_context(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewUnitManagementError as error:
+        raise FeedbackManagementError(str(error)) from error
+
+    assignment = loaded.assignment
+    review = loaded.review
+    standard_ids = tuple(assignment["focus_standard_ids"])
+    rating_labels = {
+        item["value"]: item["label"] for item in assignment["rating_scale"]["levels"]
+    }
+    ratings = {
+        item["standard_id"]: item
+        for item in (review["overall_standard_ratings"] if review else [])
+    }
+    feedback_records = review["feedback"]["standard_feedback"] if review else []
+    feedback_by_standard = {item["standard_id"]: item for item in feedback_records}
+    observations: dict[str, FeedbackObservation] = {}
+    observations_by_standard: dict[str, list[FeedbackObservation]] = {}
+    if review:
+        for unit in sorted(review["review_units"], key=lambda item: item["sequence"]):
+            for item in unit["standard_observations"]:
+                observation = FeedbackObservation(
+                    observation_id=item["observation_id"],
+                    unit_id=unit["unit_id"],
+                    unit_label=unit["label"],
+                    applicable=item["applicable"],
+                    evidence_present=item["evidence_present"],
+                    rating=item["rating"],
+                    rationale=item["rationale"],
+                    include_in_feedback=item["include_in_feedback"],
+                )
+                observations[observation.observation_id] = observation
+                observations_by_standard.setdefault(item["standard_id"], []).append(
+                    observation
+                )
+
+    standards: list[FocusStandardFeedback] = []
+    for standard_id in standard_ids:
+        rating = ratings.get(standard_id)
+        feedback = feedback_by_standard.get(standard_id)
+        rating_value = rating["rating"] if rating else None
+        try:
+            reusable = lookup_comments(
+                loaded.workspace_root,
+                standards_profile_id=assignment["standards_profile_id"],
+                writing_type=assignment["writing_type"],
+                standard_id=standard_id,
+                rating_value=rating_value,
+            )
+        except (OSError, FocusStandardCommentError) as error:
+            raise FeedbackManagementError(str(error)) from error
+        comments = tuple(
+            FeedbackComment(
+                feedback_comment_id=item["feedback_comment_id"],
+                source=item["source"],
+                text=item["text"],
+                reusable_comment_id=item["reusable_comment_id"],
+                reusable_comment_set_id=item["module_details"].get("comment_set_id"),
+                save_for_reuse=item["save_for_reuse"],
+                include_in_feedback=item["include_in_feedback"],
+                created_at=item["created_at"],
+            )
+            for item in (feedback["comments"] if feedback else [])
+        )
+        selected = tuple(
+            observations[item]
+            for item in (feedback["included_observation_ids"] if feedback else [])
+        )
+        candidates = tuple(
+            item
+            for item in observations_by_standard.get(standard_id, [])
+            if item.include_in_feedback
+        )
+        standards.append(
+            FocusStandardFeedback(
+                standard_id=standard_id,
+                rating=rating_value,
+                rating_label=rating_labels.get(rating_value),
+                rationale=rating["rationale"] if rating else None,
+                rating_include_in_feedback=rating["include_in_feedback"] if rating else None,
+                has_feedback_record=feedback is not None,
+                include_overall_rating=feedback["include_overall_rating"] if feedback else None,
+                include_overall_rationale=feedback["include_overall_rationale"] if feedback else None,
+                selected_observations=selected,
+                candidate_observations=candidates,
+                comments=comments,
+                reusable_comments=reusable,
+            )
+        )
+
+    configured = set(standard_ids)
+    configured_count = sum(item["standard_id"] in configured for item in feedback_records)
+    progress = review_progress_status(review)
+    return FeedbackCompositionContext(
+        workspace_root=loaded.workspace_root,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        submission_manifest_relative_path=loaded.submission_manifest_relative_path,
+        review_record_relative_path=loaded.review_record_relative_path,
+        review_exists=review is not None,
+        review_state=loaded.review_state,
+        ratings_complete=progress.ratings_complete,
+        feedback_composed=progress.feedback_composed,
+        returned_without_full_review=loaded.review_state == "returned_without_full_review",
+        standards=tuple(standards),
+        configured_feedback_count=configured_count,
+        missing_feedback_count=len(standard_ids) - configured_count,
+        stale_feedback_count=sum(item["standard_id"] not in configured for item in feedback_records),
+        comment_count=sum(len(item["comments"]) for item in feedback_records),
+        included_comment_count=sum(
+            comment["include_in_feedback"]
+            for item in feedback_records
+            for comment in item["comments"]
+        ),
+        selected_observation_count=sum(
+            len(item["included_observation_ids"]) for item in feedback_records
+        ),
+        include_review_unit_observations=(
+            review["feedback"]["include_review_unit_observations"] if review else False
+        ),
+        include_overall_standard_ratings=(
+            review["feedback"]["include_overall_standard_ratings"] if review else False
+        ),
+    )

--- a/quillan/review_feedback.py
+++ b/quillan/review_feedback.py
@@ -54,6 +54,7 @@ class UpdatedStandardFeedbackOptions:
     include_overall_rating: bool
     include_overall_rationale: bool
     included_observation_count: int
+    include_review_unit_observations: bool
     was_created: bool
     updated_at: str
 
@@ -107,7 +108,11 @@ class CompletedFeedbackComposition:
     focus_standard_count: int
     standard_feedback_count: int
     missing_standard_feedback_count: int
+    rating_count: int
+    missing_rating_count: int
+    selected_observation_count: int
     included_comment_count: int
+    student_facing_content_count: int
     updated_at: str
 
 
@@ -207,6 +212,9 @@ def set_standard_feedback_options(
         include_overall_rating=include_overall_rating,
         include_overall_rationale=include_overall_rationale,
         included_observation_count=len(included_observation_ids),
+        include_review_unit_observations=review["feedback"][
+            "include_review_unit_observations"
+        ],
         was_created=was_created,
         updated_at=normalized_updated_at,
     )
@@ -446,6 +454,28 @@ def mark_feedback_composed(
         for comment in item["comments"]
         if comment["include_in_feedback"]
     )
+    rating_count = sum(
+        item["standard_id"] in focus_standard_ids
+        for item in review["overall_standard_ratings"]
+    )
+    selected_observation_count = sum(
+        len(item["included_observation_ids"])
+        for item in review["feedback"]["standard_feedback"]
+        if item["standard_id"] in focus_standard_ids
+    )
+    ratings_by_standard = {
+        item["standard_id"]: item for item in review["overall_standard_ratings"]
+    }
+    student_facing_rating_count = 0
+    student_facing_rationale_count = 0
+    for item in review["feedback"]["standard_feedback"]:
+        rating = ratings_by_standard.get(item["standard_id"])
+        if rating is None or item["standard_id"] not in focus_standard_ids:
+            continue
+        student_facing_rating_count += item["include_overall_rating"]
+        student_facing_rationale_count += bool(
+            item["include_overall_rationale"] and rating["rationale"]
+        )
     review["review_state"] = "feedback_composed"
     review["updated_at"] = normalized_updated_at
     _write_review(context, review)
@@ -463,7 +493,16 @@ def mark_feedback_composed(
         missing_standard_feedback_count=max(
             len(focus_standard_ids) - len(standards_with_feedback), 0
         ),
+        rating_count=rating_count,
+        missing_rating_count=len(focus_standard_ids) - rating_count,
+        selected_observation_count=selected_observation_count,
         included_comment_count=included_comment_count,
+        student_facing_content_count=(
+            student_facing_rating_count
+            + student_facing_rationale_count
+            + selected_observation_count
+            + included_comment_count
+        ),
         updated_at=normalized_updated_at,
     )
 
@@ -490,16 +529,23 @@ def _load_context(
         ReviewRecordPathError,
     ) as error:
         raise ReviewFeedbackError(str(error)) from error
+    try:
+        assignment = load_assignment_config(assignment_path)
+    except (OSError, AssignmentConfigError) as error:
+        raise ReviewFeedbackError(str(error)) from error
+    if assignment["assignment_id"] != assignment_id:
+        raise ReviewFeedbackError(
+            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
+        )
+    if class_id not in assignment["class_ids"]:
+        raise ReviewFeedbackError(
+            f"Assignment config class_ids does not include {class_id!r}."
+        )
     if not manifest_path.exists():
         raise ReviewFeedbackError(missing_submission_guidance())
-    if not record_path.exists():
-        raise ReviewFeedbackError(
-            "A review record must exist before composing feedback."
-        )
     try:
         manifest = load_submission_manifest(manifest_path)
-        assignment = load_assignment_config(assignment_path)
-    except (OSError, SubmissionManifestError, AssignmentConfigError) as error:
+    except (OSError, SubmissionManifestError) as error:
         raise ReviewFeedbackError(str(error)) from error
     _validate_identity(
         manifest,
@@ -508,13 +554,9 @@ def _load_context(
         assignment_id=assignment_id,
         student_id=student_id,
     )
-    if class_id not in assignment["class_ids"]:
+    if not record_path.exists():
         raise ReviewFeedbackError(
-            f"Assignment config class_ids does not include {class_id!r}."
-        )
-    if assignment["assignment_id"] != assignment_id:
-        raise ReviewFeedbackError(
-            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
+            "A review record must exist before composing feedback."
         )
     return {
         "workspace_root": resolved_root,
@@ -567,8 +609,10 @@ def _guard_returned_without_full_review(review: dict[str, Any]) -> None:
 
 def _validate_focus_standard(assignment: dict[str, Any], standard_id: str) -> None:
     if standard_id not in assignment["focus_standard_ids"]:
+        valid = ", ".join(assignment["focus_standard_ids"])
         raise ReviewFeedbackError(
-            f"standard_id {standard_id!r} is not a Focus Standard for this assignment."
+            f"standard_id {standard_id!r} is not a Focus Standard for this assignment. "
+            f"Valid Focus Standard IDs: {valid}."
         )
 
 
@@ -598,6 +642,11 @@ def _validate_observation_ids_for_standard(
         if observation["standard_id"] != standard_id:
             raise ReviewFeedbackError(
                 f"observation_id {normalized_id!r} does not belong to standard_id {standard_id!r}."
+            )
+        if not observation["include_in_feedback"]:
+            raise ReviewFeedbackError(
+                f"observation_id {normalized_id!r} is excluded from feedback eligibility. "
+                "Update the observation before selecting it."
             )
 
 

--- a/tests/test_cli_feedback.py
+++ b/tests/test_cli_feedback.py
@@ -1,0 +1,158 @@
+"""Direct CLI coverage for Focus Standard feedback composition."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.cli import main
+from quillan.cli_app.handlers import feedback as handlers
+from quillan.review_record_paths import review_record_path
+from quillan.review_record_paths import write_review_record
+from tests.test_review_feedback import _fresh_review, _write_comment_set
+from tests.test_review_ratings import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STUDENT_ID,
+    _write_workspace,
+)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_workspace(tmp_path, None)
+    review_record_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).unlink()
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _write_review(workspace: Path, review: dict[str, Any]) -> Path:
+    return write_review_record(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID), review
+    )
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--help"],
+        ["feedback", "--help"],
+        ["feedback", "show", "--help"],
+        ["feedback", "set-options", "--help"],
+        ["feedback", "add-comment", "--help"],
+        ["feedback", "use-reusable-comment", "--help"],
+        ["feedback", "mark-composed", "--help"],
+    ],
+)
+def test_feedback_help_exits_successfully(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(argv)
+    assert error.value.code == 0
+
+
+def test_bare_feedback_prints_help_without_resolving_workspace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        handlers, "resolve_workspace_root", lambda: pytest.fail("resolved workspace")
+    )
+    assert main(["feedback"]) == 0
+    output = capsys.readouterr().out
+    assert "{show,set-options,add-comment,use-reusable-comment,mark-composed}" in output
+
+
+def test_show_without_review_is_ordered_read_only(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assignment = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    submission = assignment.parent / "submissions" / STUDENT_ID / "submission.json"
+    before = assignment.read_bytes(), submission.read_bytes()
+    assert main(["feedback", "show", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+    output = capsys.readouterr().out
+    assert "Review state: not_started" in output
+    assert "Configured feedback records: 0" in output
+    assert "Missing feedback records: 2" in output
+    assert output.index("njsls-ela:W.1") < output.index("njsls-ela:L.2")
+    assert output.count("Feedback record exists: no") == 2
+    assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
+    assert (assignment.read_bytes(), submission.read_bytes()) == before
+
+
+def test_set_options_replaces_selection_and_rejects_excluded_observation(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_review(workspace, _fresh_review())
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    base = [
+        "feedback", "set-options", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+        "--standard-id", "njsls-ela:W.1", "--include-overall-rating", "true",
+        "--include-overall-rationale", "false",
+    ]
+    assert main([*base, "--observation-ids", "observation_0001"]) == 0
+    assert "Action: created" in capsys.readouterr().out
+    assert main(base) == 0
+    review = json.loads(path.read_text(encoding="utf-8"))
+    assert review["feedback"]["standard_feedback"][0]["included_observation_ids"] == []
+    before = path.read_bytes()
+    assert main([*base, "--observation-ids", "observation_0003"]) == 1
+    assert "excluded from feedback eligibility" in capsys.readouterr().out
+    assert path.read_bytes() == before
+
+
+def test_add_comment_preserves_exact_inner_text_and_requires_reuse_scope(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_review(workspace, _fresh_review())
+    args = [
+        "feedback", "add-comment", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+        "--standard-id", "njsls-ela:W.1", "--text", "  Keep\nTHIS punctuation!  ",
+        "--include-in-feedback", "false",
+    ]
+    assert main(args) == 0
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    review = json.loads(path.read_text(encoding="utf-8"))
+    assert review["feedback"]["standard_feedback"][0]["comments"][0]["text"] == "Keep\nTHIS punctuation!"
+    before = path.read_bytes()
+    assert main([*args, "--purpose", "general"]) == 1
+    assert "require --save-for-reuse" in capsys.readouterr().out
+    assert path.read_bytes() == before
+
+
+def test_reusable_selection_is_snapshot_and_increments_usage(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    review = _fresh_review()
+    review["overall_standard_ratings"] = [{
+        "standard_id": "njsls-ela:W.1", "rating": 2, "rationale": None,
+        "include_in_feedback": True, "updated_at": review["updated_at"], "module_details": {},
+    }]
+    _write_review(workspace, review)
+    _write_comment_set(workspace)
+    args = [
+        "feedback", "use-reusable-comment", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
+        "--standard-id", "njsls-ela:W.1", "--comment-set-id", "synthetic_argument_focus_comments",
+        "--comment-id", "claim_next_step", "--include-in-feedback", "true",
+    ]
+    assert main(args) == 0
+    assert "feedback_comment_0001" in capsys.readouterr().out
+    review = json.loads(review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(encoding="utf-8"))
+    assert review["feedback"]["standard_feedback"][0]["comments"][0]["text"] == "Explain why this evidence supports your claim."
+    comment_set = json.loads((workspace / "shared" / "focus_standard_comments" / "synthetic_argument_focus_comments.json").read_text(encoding="utf-8"))
+    assert comment_set["comments"][0]["usage"]["times_used"] == 1
+
+
+def test_mark_composed_requires_yes_without_argparse_prompt(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_review(workspace, _fresh_review())
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = path.read_bytes()
+    base = ["feedback", "mark-composed", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
+    assert main(base) == 1
+    assert "--yes is required" in capsys.readouterr().out
+    assert path.read_bytes() == before
+    assert main([*base, "--yes"]) == 0
+    assert json.loads(path.read_text(encoding="utf-8"))["review_state"] == "feedback_composed"

--- a/tests/test_review_feedback.py
+++ b/tests/test_review_feedback.py
@@ -194,6 +194,22 @@ def test_feedback_options_validate_standard_and_observations(
         )
 
 
+def test_feedback_options_reject_observation_excluded_from_feedback(tmp_path: Path) -> None:
+    _write_fresh_workspace(tmp_path)
+    with pytest.raises(ReviewFeedbackError, match="excluded from feedback eligibility"):
+        set_standard_feedback_options(
+            tmp_path,
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            STUDENT_ID,
+            standard_id="njsls-ela:W.1",
+            include_overall_rating=True,
+            include_overall_rationale=True,
+            included_observation_ids=["observation_0003"],
+            updated_at=FIRST_TIMESTAMP,
+        )
+
+
 def test_returned_without_full_review_rejects_feedback_composition(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

* Add direct CLI commands for displaying and composing Focus Standard feedback:

  * `quillan feedback show`
  * `quillan feedback set-options`
  * `quillan feedback add-comment`
  * `quillan feedback use-reusable-comment`
  * `quillan feedback mark-composed`
* Add an immutable, read-only feedback-composition context.
* Continue routing all mutations through the existing shared feedback and reusable-comment services.
* Preserve teacher-authored and teacher-selected feedback text as stable review snapshots.
* Keep feedback composition separate from feedback export.
* Add no AI generation, evidence inspection, grading, scoring, or inferred judgments.

## Command Surface

```text
quillan feedback show <class_id> <assignment_id> <student_id>

quillan feedback set-options <class_id> <assignment_id> <student_id> \
  --standard-id <standard_id> \
  --include-overall-rating true|false \
  --include-overall-rationale true|false \
  [--observation-ids <observation_id,observation_id,...>]

quillan feedback add-comment <class_id> <assignment_id> <student_id> \
  --standard-id <standard_id> \
  --text <text> \
  --include-in-feedback true|false \
  [--save-for-reuse] \
  [--reusable-label <label>] \
  [--reusable-text <text>] \
  [--purpose <purpose>] \
  [--teacher-tags <tag,tag,...>] \
  [--tag-current-rating true|false]

quillan feedback use-reusable-comment <class_id> <assignment_id> <student_id> \
  --standard-id <standard_id> \
  --comment-set-id <comment_set_id> \
  --comment-id <comment_id> \
  --include-in-feedback true|false

quillan feedback mark-composed <class_id> <assignment_id> <student_id> \
  --yes
```

Running:

```text
quillan feedback
```

without a subcommand prints feedback-command help and exits successfully without resolving the workspace.

All commands are direct and non-interactive. They do not call `input()` or invoke menu functions.

## Shared Architecture

Added immutable read-only feedback context in:

* `quillan/feedback_management.py`

Added direct CLI handlers in:

* `quillan/cli_app/handlers/feedback.py`

Updated the command parser and output formatters in:

* `quillan/cli_app/parser.py`
* `quillan/cli_app/output.py`

Extended the shared feedback service and its test coverage.

The implementation preserves the application boundary:

```text
menu -> shared feedback services
CLI  -> same shared feedback services
GUI  -> same shared feedback services later
```

CLI handlers do not patch raw review dictionaries.

Feedback mutations continue through the existing services for:

* standard-feedback options;
* custom comments;
* reusable-comment selection;
* composition completion;
* reusable-comment persistence and usage tracking.

## `feedback show`

`feedback show` is strictly read-only.

It reports:

* class ID;
* assignment ID;
* student ID;
* canonical submission-manifest path;
* canonical review-record path;
* review-record existence;
* current review state;
* rating-completion status;
* feedback-composition status;
* configured Focus Standard count;
* configured and missing standard-feedback records;
* stale feedback records;
* total and included comments;
* selected observations;
* global feedback-inclusion flags.

Focus Standards appear in assignment order.

For each Focus Standard, the command displays:

* current overall rating and label;
* current rationale;
* overall-rating feedback eligibility;
* current standard-feedback options;
* selected observation IDs;
* eligible observation candidates;
* stored feedback comments;
* compatible reusable comments.

The command exposes the comment-set and comment identifiers needed by `use-reusable-comment`.

It does not dump raw review JSON.

## Missing Review Behavior

When a valid canonical submission exists but `review.json` does not, `feedback show` reports:

* review state: `not_started`;
* no configured feedback records;
* no comments;
* no selected observations;
* each assignment Focus Standard as unconfigured.

The command returns successfully without creating a review record, directories, or reusable-comment files.

Malformed or identity-mismatched review records fail clearly rather than being treated as empty.

## Focus Standard Validation

All standard-specific write commands require the supplied standard to appear in:

```text
assignment.focus_standard_ids
```

A standard is not accepted merely because it exists in the shared standards library or stale review data.

Invalid Focus Standards fail without writing.

## Feedback Options

`feedback set-options` creates or replaces the feedback-selection options for one Focus Standard.

Both direct-CLI choices are explicit:

* include the overall rating;
* include the overall rationale.

The optional observation list is parsed as an ordered comma-separated collection.

Parsing rejects:

* blank elements;
* duplicate IDs;
* unknown IDs;
* IDs belonging to another Focus Standard;
* observations whose own `include_in_feedback` value is false.

Omitting `--observation-ids` clears the selected observation list for that standard.

Updating options preserves existing comments attached to the standard.

The shared service recomputes the global review-unit observation inclusion flag from the resulting standard selections.

## Observation Eligibility

The shared feedback service now prevents direct callers from selecting an observation that was excluded in the observation workflow.

An observation may be selected only when it:

* exists in the current review;
* belongs to the selected Focus Standard;
* has `include_in_feedback: true`.

The CLI cannot bypass that service-level rule.

The teacher must first change an excluded observation through the observation workflow before selecting it for feedback.

## Custom Comments

`feedback add-comment` appends one teacher-authored comment to a Focus Standard.

The implementation preserves the teacher’s approved text rather than:

* rewriting it;
* correcting it;
* summarizing it;
* personalizing it automatically;
* generating alternative feedback.

Review-local comment IDs remain sequential and unique across the review:

```text
feedback_comment_0001
feedback_comment_0002
```

The teacher explicitly controls whether the comment is included in student-facing feedback.

Adding a custom comment does not export feedback.

## Saving Comments for Reuse

Without `--save-for-reuse`, the command changes only the student review record.

With `--save-for-reuse`, the command may also create or update the service-selected canonical reusable-comment set.

The reusable workflow supports:

* a required reusable label;
* separately approved reusable text;
* canonical purposes;
* normalized teacher tags;
* optional current-rating tagging.

The student-specific review comment and reusable text may differ.

This permits the review to preserve student-specific feedback while the shared comment store receives separately approved reusable language without student-specific details.

## Canonical Reusable Purposes

Supported purposes are:

* `praise`
* `next_step`
* `clarification`
* `evidence`
* `reasoning`
* `organization`
* `style`
* `conventions`
* `revision`
* `general`

The unsupported value `strength` is rejected.

## Teacher Tags

Teacher tags are normalized through the shared reusable-comment service.

Normalization includes:

* trimming;
* lowercase snake-case conversion;
* deduplication;
* preservation of first-occurrence order.

Tags remain teacher-facing organizational metadata.

They do not cause automatic scoring, feedback generation, or comment selection.

## Reusable Comment Selection

`feedback use-reusable-comment` validates the selected reusable comment against:

* the assignment’s standards profile;
* the assignment writing type;
* the selected Focus Standard;
* the current overall rating under existing lookup semantics;
* active status;
* student-facing status;
* the supplied comment-set ID;
* the supplied comment ID.

Invalid or incompatible comments fail without being copied.

On success, the reusable text is copied into the review as a stable snapshot.

The review record stores:

* a new sequential feedback-comment ID;
* source `reusable_focus_standard_comment`;
* the reusable comment ID;
* the comment-set ID;
* the exact selected text;
* the explicit feedback-inclusion choice;
* the creation timestamp.

Later changes to the reusable source do not alter the review snapshot.

## Reusable Usage Metadata

Each successful reusable-comment selection increments usage exactly once.

The selected reusable comment’s metadata is updated with:

* incremented `times_used`;
* updated `last_used_at`;
* updated comment timestamp;
* updated comment-set timestamp.

Failed comment lookup or compatibility validation does not increment usage.

## Feedback-Edit State Behavior

Feedback edits preserve the existing shared state transition:

* `feedback_composed` -> `ratings_complete`
* `ready_for_export` -> `ratings_complete`
* `exported` -> `ratings_complete`
* earlier non-returned states remain unchanged

This applies to:

* option changes;
* custom comments;
* reusable-comment selections.

The transition requires the teacher to mark feedback composed again after changing downstream feedback data.

Existing feedback exports and export metadata are not automatically deleted.

## `feedback mark-composed`

Feedback composition is completed explicitly with:

```text
quillan feedback mark-composed <class_id> <assignment_id> <student_id> --yes
```

`--yes` is required.

The command does not prompt when confirmation is omitted and does not write.

Completion reports warnings when:

* ratings are incomplete;
* ratings are missing;
* standard-feedback records are missing;
* no comments are included;
* no observations are selected;
* no student-facing content is currently configured.

These warnings remain advisory.

Explicit completion is permitted despite missing content, matching the existing menu workflow.

A successful completion sets:

```text
review_state = "feedback_composed"
```

It does not create missing ratings, comments, observations, or feedback records.

## Returned-Without-Full-Review Behavior

Records in:

```text
returned_without_full_review
```

remain displayable for audit purposes.

All feedback-composition write commands reject those records:

* `set-options`
* `add-comment`
* `use-reusable-comment`
* `mark-composed`

The minimum-requirements outcome must be changed before full standards-based feedback composition can continue.

Rejected operations do not generate feedback or exports.

## Composition and Export Separation

None of the new feedback commands automatically exports student-facing feedback.

They do not create or replace:

```text
exports/feedback.md
exports/feedback.pdf
```

They do not call the Markdown or PDF export services.

They do not automatically update feedback export metadata.

The existing export command remains the only way to generate feedback artifacts.

Marking feedback composed is not equivalent to exporting it.

## Write Boundaries

### `feedback show`

Writes nothing.

### `feedback set-options`

May modify only:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
```

### Ordinary `feedback add-comment`

May modify only canonical `review.json`.

### `feedback add-comment --save-for-reuse`

May modify:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
shared/focus_standard_comments/<service-selected-comment-set-id>.json
```

### `feedback use-reusable-comment`

May modify:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
shared/focus_standard_comments/<comment_set_id>.json
```

The reusable-comment-set mutation is limited to usage and timestamp metadata.

### `feedback mark-composed`

May modify only canonical `review.json`.

The implementation does not modify:

* `assignment.json`;
* `submission.json`;
* class rosters;
* class metadata;
* routed or retained evidence;
* PDFs or images;
* standards libraries;
* unrelated reusable-comment sets;
* feedback export files;
* assignment reports;
* PDS Core data;
* ScoreForm data.

## Preserved Review Data

Feedback operations preserve unrelated review data, including:

* minimum-requirement checks;
* minimum-requirement outcomes;
* review units;
* observations;
* overall Focus Standard ratings;
* unrelated standard-feedback records;
* existing comments;
* exports;
* private notes;
* top-level module metadata;
* original creation timestamp.

Changing options preserves comments for the selected standard.

Adding comments preserves existing standard options and prior comments.

Marking feedback composed preserves the entire feedback structure.

## No Automated Feedback

Confirmed that the implementation does not:

* inspect evidence;
* parse PDFs;
* inspect images;
* run OCR;
* perform handwriting recognition;
* use AI;
* generate comment text;
* rewrite teacher text;
* select reusable comments automatically;
* select observations automatically;
* infer ratings;
* infer rationales;
* calculate grades;
* calculate scores;
* export feedback automatically.

All feedback text is teacher-authored or teacher-selected.

## Files Changed

New files include:

* `quillan/feedback_management.py`
* `quillan/cli_app/handlers/feedback.py`
* `tests/test_cli_feedback.py`

The implementation also updates:

* CLI parser registration;
* teacher-facing output formatters;
* the shared feedback service;
* shared-service tests;
* four relevant documentation contracts.

## Documentation

Updated documentation covers:

* the complete `feedback` command namespace;
* read-only feedback inspection;
* Focus Standard validation;
* observation eligibility;
* feedback-option replacement behavior;
* teacher-authored comments;
* reusable-text privacy guidance;
* canonical reusable purposes;
* teacher-tag normalization;
* current-rating tagging;
* reusable compatibility;
* stable snapshots;
* usage increments;
* feedback-edit state transitions;
* explicit completion;
* warning-only completion behavior;
* multi-record write boundaries;
* separation between composition and export;
* the prohibition on AI-generated feedback.

## Safety

Confirmed:

* bare namespace help does not resolve the workspace;
* handlers are non-interactive;
* no menu functions are called;
* display is read-only;
* missing reviews are not created by display;
* standards must belong to the assignment;
* invalid observations fail cleanly;
* excluded observations cannot be selected;
* teacher-authored text is preserved;
* reusable comments are compatibility-checked;
* reusable selections create stable snapshots;
* usage increments on successful selection;
* completion requires `--yes`;
* completion warnings are advisory;
* returned-without-full-review records cannot be modified;
* no feedback export occurs automatically;
* assignment and submission records remain unchanged;
* unrelated comment sets remain unchanged;
* PDS Core was not modified;
* ScoreForm was not modified;
* no workspace or real student data was added;
* no generated feedback or export artifacts were added.

## Validation

* Focused feedback service and CLI tests: `24 passed`
* Feedback and reusable-comment regressions: `87 passed`
* Broader CLI and review regressions: `580 passed`
* Full pytest suite: `1199 passed`
* Ruff: passed
* mypy: passed, `159` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* No workspace data, real student data, or generated feedback/export artifacts present

Closes #305
