### PR TITLE
Add reusable Focus Standard comment CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -47,6 +47,77 @@ quillan [command] [arguments]
 Calling `quillan.cli.main()` from Python is useful for tests, but it is not a
 separate public Python API contract.
 
+## Direct Reusable Focus Standard Comments
+
+The non-interactive `comments` namespace manages teacher-authored shared
+reusable source material without requiring a class, assignment, student,
+submission, review record, rating, or feedback-composition context:
+
+```powershell
+quillan comments list [--profile-id <profile_id>] [--writing-type <type>] [--standard-id <standard_id>] [--rating-value <number>]
+quillan comments show <comment_set_id>
+quillan comments create <comment_set_id> --profile-id <profile_id> --writing-type <type> --standard-id <standard_id> --label <label> --text <text> [--purpose <purpose>] [--rating-values <number,...>] [--teacher-tags <tag,...>]
+```
+
+Running `quillan comments` without a subcommand prints namespace help and
+returns success. It does not resolve the workspace, scan comment files, create
+directories, or write data.
+
+`comments list` reads every JSON file beneath
+`shared/focus_standard_comments` in case-insensitive filename order and keeps
+comment order within each set. It shows only active, student-facing comments.
+Optional filters are combined with logical AND: profile and standard IDs match
+exactly; a supplied writing type must satisfy both set-level and comment-level
+restrictions, where an empty array means all writing types; and a supplied
+finite numeric rating matches either an unrestricted empty array or an array
+containing that value. With no rating filter, rating-specific comments remain
+visible. Purpose and teacher tags never affect compatibility. Valid results
+are still printed when another file is invalid, followed by invalid-file
+diagnostics and a nonzero status. An absent directory or no matches is a
+successful empty result and creates nothing.
+
+`comments show` resolves only a canonical comment-set ID, never an arbitrary
+path. It displays complete set metadata and every stored comment in order,
+including inactive and teacher-only comments, source provenance, usage data,
+timestamps, and module details. Listing and showing are byte-for-byte
+read-only; showing a missing or invalid set fails rather than treating it as
+empty. The displayed file is current reusable source material, while existing
+student reviews retain their earlier copied snapshots.
+
+`comments create` creates one active, student-facing manual reusable comment
+through the same validated append and atomic-write service used by feedback
+composition. A missing set is created with schema version `1`, the supplied
+profile and writing type, a generated title, a source-neutral description,
+`grade_band: null`, and empty top-level module details. A compatible existing
+set is appended without rebuilding it; profile or writing-type incompatibility
+and malformed existing data fail before any replacement. The label supplies a
+generated ID, with `_2`, `_3`, and later suffixes used for collisions.
+
+Purpose defaults to `general` and accepts only `praise`, `next_step`,
+`clarification`, `evidence`, `reasoning`, `organization`, `style`,
+`conventions`, `revision`, and `general`. Rating values preserve order and may
+be integers, finite floats, zero, or negative; blank elements, duplicates,
+non-numbers, NaN, and infinities fail. Omission means all ratings. Teacher tags
+are trimmed and normalized to unique ASCII-safe lowercase snake case in first
+occurrence order; omission stores no required tag key. Tags remain display and
+organization metadata only.
+
+Manual source provenance uses `source.type: manual`, the creation timestamp as
+`saved_at`, and null class, assignment, student, review, and feedback-comment
+fields. Creation does not increment usage. Surrounding whitespace is trimmed
+from required teacher-facing strings, but internal text, capitalization,
+punctuation, and line structure are preserved exactly. Teachers must not put
+student names, student IDs, assignment-specific private details, or other
+identifying information in reusable text.
+
+The create write boundary is exactly one selected
+`shared/focus_standard_comments/<comment_set_id>.json` file. It does not touch
+assignments, submissions, reviews, rosters, evidence, scans, exports, reports,
+standards libraries, other reusable sets, legacy comment banks, Core, or
+ScoreForm. This namespace does not provide editing, activation, deactivation,
+deletion, migration, import, raw JSON patching, AI generation, inference,
+automatic selection, scoring, grading, or feedback export.
+
 ## Direct Minimum-Requirement Review
 
 The `requirements` namespace exposes the teacher-facing minimum-requirement
@@ -119,6 +190,9 @@ quillan feedback set-options <class_id> <assignment_id> <student_id> --standard-
 quillan feedback add-comment <class_id> <assignment_id> <student_id> --standard-id <standard_id> --text <text> --include-in-feedback true|false [--save-for-reuse --reusable-label <label> [--reusable-text <text>] [--purpose <purpose>] [--teacher-tags <tag,...>] [--tag-current-rating true|false]]
 quillan feedback use-reusable-comment <class_id> <assignment_id> <student_id> --standard-id <standard_id> --comment-set-id <comment_set_id> --comment-id <comment_id> --include-in-feedback true|false
 quillan feedback mark-composed <class_id> <assignment_id> <student_id> --yes
+quillan comments list [--profile-id <profile_id>] [--writing-type <type>] [--standard-id <standard_id>] [--rating-value <number>]
+quillan comments show <comment_set_id>
+quillan comments create <comment_set_id> --profile-id <profile_id> --writing-type <type> --standard-id <standard_id> --label <label> --text <text> [--purpose <purpose>] [--rating-values <number,...>] [--teacher-tags <tag,...>]
 quillan roster create <class_id> --input <roster.csv> [--school-year YYYY-YYYY] [--overwrite] (--yes | --dry-run)
 quillan roster show <class_id>
 quillan roster validate <class_id>

--- a/docs/focus_standard_comment_contract.md
+++ b/docs/focus_standard_comment_contract.md
@@ -3,7 +3,8 @@
 ## Purpose and Boundary
 
 Reusable Focus Standard comments are teacher-authored feedback language for
-Quillan's v0.8.6 standards-based review workflow.
+Quillan's v0.8.6 standards-based review workflow. They may be authored
+directly as shared material or saved from feedback composition.
 
 They replace generic prebuilt comment banks as the active reusable feedback
 model for standards-based review.
@@ -37,6 +38,21 @@ no rating restriction. `feedback use-reusable-comment` applies the existing
 profile, writing-type, standard, rating, active, and student-facing lookup
 rules, then increments `times_used` and updates `last_used_at` exactly once
 after a successful selection.
+
+The direct `comments create` workflow accepts reusable metadata explicitly and
+uses the same schema validation, ID generation, append logic, compatibility
+checks, and atomic writer. It has no assignment or student context and creates
+manual provenance with all student and review fields null. Generated comment
+set descriptions are therefore source-neutral:
+
+```text
+Reusable teacher-authored Focus Standard comments managed by Quillan.
+```
+
+The management CLI also lists active student-facing comments and inspects full
+sets. These read operations do not rewrite invalid files. This management
+surface does not add editing, deletion, activation, deactivation, migration,
+or any other lifecycle policy.
 
 ## Status
 
@@ -590,6 +606,11 @@ Development` to `scene_development`. Tags are optional; consumers must tolerate
 their absence, and existing schema version `1` comments with empty
 `module_details` remain valid. Consumers must not require teacher tags for
 lookup or automatic selection.
+
+Direct management accepts comma-separated tags and delegates normalization to
+the shared service. Tags remain noncompatibility metadata: they do not affect
+profile, writing-type, standard, or rating matching; automatic selection;
+usage; scoring; or reporting.
 
 ## Source and Provenance
 

--- a/quillan/cli_app/handlers/comments.py
+++ b/quillan/cli_app/handlers/comments.py
@@ -1,0 +1,126 @@
+"""Direct, non-interactive reusable-comment management handlers."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.cli_app.output import (
+    print_created_manual_reusable_comment,
+    print_reusable_comment_inventory,
+    print_reusable_comment_set,
+)
+from quillan.comment_management import (
+    create_manual_reusable_comment,
+    list_reusable_comments,
+    show_reusable_comment_set,
+)
+from quillan.focus_standard_comments import FocusStandardCommentError
+
+
+def handle_comments_list(args: argparse.Namespace) -> int:
+    """List active, student-facing reusable comments."""
+    try:
+        inventory = list_reusable_comments(
+            resolve_workspace_root(),
+            standards_profile_id=_optional_trimmed(args.profile_id, "profile ID"),
+            writing_type=_optional_trimmed(args.writing_type, "writing type"),
+            standard_id=_optional_trimmed(args.standard_id, "standard ID"),
+            rating_value=(
+                _number(args.rating_value, "rating value")
+                if args.rating_value is not None
+                else None
+            ),
+        )
+        print_reusable_comment_inventory(inventory)
+        return 1 if inventory.invalid_files else 0
+    except (OSError, ValueError, WorkspaceRootError, FocusStandardCommentError) as error:
+        return _error(error)
+
+
+def handle_comments_show(args: argparse.Namespace) -> int:
+    """Show one complete reusable comment set."""
+    try:
+        result = show_reusable_comment_set(resolve_workspace_root(), args.comment_set_id)
+        print_reusable_comment_set(result)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, FocusStandardCommentError) as error:
+        return _error(error)
+
+
+def handle_comments_create(args: argparse.Namespace) -> int:
+    """Create one manually authored reusable comment."""
+    try:
+        result = create_manual_reusable_comment(
+            resolve_workspace_root(),
+            comment_set_id=args.comment_set_id,
+            standards_profile_id=args.profile_id,
+            writing_type=args.writing_type,
+            standard_id=args.standard_id,
+            label=args.label,
+            text=args.text,
+            purpose=args.purpose,
+            rating_values=_number_list(args.rating_values, "rating values"),
+            teacher_tags=_tag_list(args.teacher_tags),
+        )
+        print_created_manual_reusable_comment(result)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, FocusStandardCommentError) as error:
+        return _error(error)
+
+
+def _number_list(value: str | None, label: str) -> list[int | float]:
+    if value is None:
+        return []
+    items = value.split(",")
+    if any(not item.strip() for item in items):
+        raise FocusStandardCommentError(f"{label} must not contain blank elements.")
+    numbers = [_number(item.strip(), label) for item in items]
+    seen: set[int | float] = set()
+    for number in numbers:
+        if number in seen:
+            raise FocusStandardCommentError(f"{label} contains duplicate {number!r}.")
+        seen.add(number)
+    return numbers
+
+
+def _number(value: str, label: str) -> int | float:
+    try:
+        number: int | float
+        if re.fullmatch(r"[+-]?\d+", value):
+            number = int(value)
+        else:
+            number = float(value)
+    except ValueError as error:
+        raise FocusStandardCommentError(f"{label} must contain finite numbers.") from error
+    if isinstance(number, float) and not math.isfinite(number):
+        raise FocusStandardCommentError(f"{label} must contain finite numbers.")
+    return number
+
+
+def _tag_list(value: str | None) -> list[str] | None:
+    if value is None:
+        return None
+    items = value.split(",")
+    if any(not item.strip() for item in items):
+        raise FocusStandardCommentError(
+            "teacher tags must not contain blank elements."
+        )
+    return [item.strip() for item in items]
+
+
+def _optional_trimmed(value: str | None, label: str) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        raise FocusStandardCommentError(f"{label} must not be blank.")
+    return normalized
+
+
+def _error(error: Exception) -> int:
+    print(f"Error: {error}")
+    return 1

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -10,6 +10,12 @@ from quillan.assignment_submission_assembly import (
     AssignmentSubmissionAssemblyResult,
 )
 from quillan.class_summary_export import ExportedClassSummary
+from quillan.comment_management import (
+    CreatedManualReusableComment,
+    ReusableCommentInventory,
+    ReusableCommentSetStatus,
+    ReusableCommentStatus,
+)
 from quillan.evidence_filing import EvidenceFilingError, RoutedEvidenceFile
 from quillan.feedback_export import ExportedFeedback, ExportedFeedbackPdf
 from quillan.focus_standard_comments import SavedReusableFocusStandardComment
@@ -38,6 +44,103 @@ from quillan.student_performance_summary_export import (
 from quillan.submission_review_opening import OpenedSubmissionReview
 from quillan.submission_review_state import UpdatedSubmissionReviewState
 from quillan.submission_status import AssignmentSubmissionStatus
+
+
+def print_reusable_comment_inventory(inventory: ReusableCommentInventory) -> None:
+    """Print deterministic reusable-comment list results and invalid files."""
+    if not inventory.comments:
+        print("No reusable Focus Standard comments matched.")
+    for index, comment in enumerate(inventory.comments, start=1):
+        if index > 1:
+            print()
+        print(f"Reusable comment {index}:")
+        _print_reusable_comment(comment, include_inspection_fields=False)
+    if inventory.invalid_files:
+        print("\nInvalid reusable Focus Standard comment sets:")
+        for invalid in inventory.invalid_files:
+            print(f"- {invalid.relative_path}: {invalid.error}")
+
+
+def print_reusable_comment_set(result: ReusableCommentSetStatus) -> None:
+    """Print one complete reusable-comment source set."""
+    print("Reusable Focus Standard comment set:")
+    print(f"Comment set ID: {result.comment_set_id}")
+    print(f"Title: {result.title}")
+    print(f"Description: {result.description}")
+    print(f"Standards profile ID: {result.standards_profile_id}")
+    print(f"Writing types: {_values(result.writing_types, 'all')}")
+    print(f"Grade band: {result.grade_band or 'none'}")
+    print(f"Comment count: {len(result.comments)}")
+    print(f"Created: {result.created_at}")
+    print(f"Updated: {result.updated_at}")
+    print(f"Path: {result.relative_path}")
+    print(f"Module details: {result.module_details}")
+    if not result.comments:
+        print("\nComments: none")
+    for index, comment in enumerate(result.comments, start=1):
+        print(f"\nComment {index}:")
+        _print_reusable_comment(comment, include_inspection_fields=True)
+
+
+def print_created_manual_reusable_comment(
+    result: CreatedManualReusableComment,
+) -> None:
+    """Print the result of creating one manual reusable comment."""
+    print("Created manual reusable Focus Standard comment:")
+    print(f"Comment set ID: {result.comment_set_id}")
+    print(f"Comment ID: {result.comment_id}")
+    print(f"Comment set: {'created' if result.set_was_created else 'already existed'}")
+    print(f"Standards profile ID: {result.standards_profile_id}")
+    print(f"Writing type: {result.writing_type}")
+    print(f"Standard ID: {result.standard_id}")
+    print(f"Label: {result.label}")
+    print(f"Purpose: {result.purpose}")
+    print(f"Rating values: {_values(result.rating_values, 'all')}")
+    print(f"Teacher tags: {_values(result.teacher_tags, 'none')}")
+    print(f"Active: {format_bool(result.active)}")
+    print(f"Student-facing: {format_bool(result.student_facing)}")
+    print(f"Usage count: {result.times_used}")
+    print(f"Path: {result.relative_path}")
+    print(f"Created: {result.created_at}")
+
+
+def _print_reusable_comment(
+    comment: ReusableCommentStatus, *, include_inspection_fields: bool
+) -> None:
+    print(f"Comment set ID: {comment.comment_set_id}")
+    print(f"Comment set title: {comment.comment_set_title}")
+    print(f"Standards profile ID: {comment.standards_profile_id}")
+    print(f"Comment ID: {comment.comment_id}")
+    print(f"Standard ID: {comment.standard_id}")
+    print(f"Label: {comment.label}")
+    print(f"Text: {comment.text}")
+    print(f"Purpose: {comment.purpose}")
+    print(f"Writing types: {_values(comment.writing_types, 'all')}")
+    print(f"Rating values: {_values(comment.rating_values, 'all')}")
+    print(f"Teacher tags: {_values(comment.teacher_tags, 'none')}")
+    print(f"Usage count: {comment.times_used}")
+    print(f"Last used: {comment.last_used_at or 'never'}")
+    print(f"Path: {comment.relative_path}")
+    if include_inspection_fields:
+        print(f"Student-facing: {format_bool(comment.student_facing)}")
+        print(f"Active: {format_bool(comment.active)}")
+        print(f"Source type: {comment.source.type}")
+        print(f"Source class ID: {comment.source.class_id or 'none'}")
+        print(f"Source assignment ID: {comment.source.assignment_id or 'none'}")
+        print(f"Source student ID: {comment.source.student_id or 'none'}")
+        print(f"Source review path: {comment.source.review_path or 'none'}")
+        print(
+            "Source feedback comment ID: "
+            f"{comment.source.feedback_comment_id or 'none'}"
+        )
+        print(f"Source saved: {comment.source.saved_at}")
+        print(f"Created: {comment.created_at}")
+        print(f"Updated: {comment.updated_at}")
+        print(f"Module details: {comment.module_details}")
+
+
+def _values(values: tuple[object, ...], empty: str) -> str:
+    return ", ".join(str(value) for value in values) if values else empty
 
 
 def print_opened_submission_review(opened: OpenedSubmissionReview) -> None:

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -7,6 +7,11 @@ from functools import partial
 from pathlib import Path
 
 from quillan.cli_app.arguments import nonnegative_integer, positive_integer
+from quillan.cli_app.handlers.comments import (
+    handle_comments_create,
+    handle_comments_list,
+    handle_comments_show,
+)
 from quillan.cli_app.handlers.exports import (
     handle_export_class_summary,
     handle_export_feedback,
@@ -76,6 +81,7 @@ from quillan.cli_app.handlers.workspace import (
     handle_workspace_show,
     handle_workspace_validate,
 )
+from quillan.focus_standard_comments import ALLOWED_PURPOSES
 
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
 
@@ -865,6 +871,52 @@ def build_parser() -> argparse.ArgumentParser:
     export_standards_summary_parser.set_defaults(
         handler=handle_export_standards_summary
     )
+
+    comments_parser = subparsers.add_parser(
+        "comments",
+        help="List, inspect, and create reusable Focus Standard comments.",
+        description=(
+            "Manage teacher-authored reusable Focus Standard comments without an "
+            "assignment or student context. Text is stored as supplied; do not include "
+            "student names, IDs, or assignment-specific private details."
+        ),
+    )
+    comments_parser.set_defaults(handler=partial(_print_parser_help, comments_parser))
+    comments_subparsers = comments_parser.add_subparsers(dest="comments_command")
+    comments_list_parser = comments_subparsers.add_parser(
+        "list", help="List active, student-facing reusable comments."
+    )
+    comments_list_parser.add_argument("--profile-id")
+    comments_list_parser.add_argument("--writing-type")
+    comments_list_parser.add_argument("--standard-id")
+    comments_list_parser.add_argument("--rating-value")
+    comments_list_parser.set_defaults(handler=handle_comments_list)
+    comments_show_parser = comments_subparsers.add_parser(
+        "show", help="Show every comment and all metadata in one comment set."
+    )
+    comments_show_parser.add_argument("comment_set_id")
+    comments_show_parser.set_defaults(handler=handle_comments_show)
+    comments_create_parser = comments_subparsers.add_parser(
+        "create",
+        help="Create one manually authored reusable comment.",
+        description=(
+            "Create one student-facing reusable comment. The text is preserved, not "
+            "generated or rewritten. Do not include student names, IDs, or private "
+            "assignment-specific details."
+        ),
+    )
+    comments_create_parser.add_argument("comment_set_id")
+    comments_create_parser.add_argument("--profile-id", required=True)
+    comments_create_parser.add_argument("--writing-type", required=True)
+    comments_create_parser.add_argument("--standard-id", required=True)
+    comments_create_parser.add_argument("--label", required=True)
+    comments_create_parser.add_argument("--text", required=True)
+    comments_create_parser.add_argument(
+        "--purpose", choices=sorted(ALLOWED_PURPOSES), default="general"
+    )
+    comments_create_parser.add_argument("--rating-values")
+    comments_create_parser.add_argument("--teacher-tags")
+    comments_create_parser.set_defaults(handler=handle_comments_create)
 
     workspace_parser = subparsers.add_parser(
         "workspace",

--- a/quillan/comment_management.py
+++ b/quillan/comment_management.py
@@ -1,0 +1,266 @@
+"""Read-oriented management services for reusable Focus Standard comments."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.focus_standard_comments import (
+    FocusStandardCommentError,
+    append_saved_comment,
+    comment_matches_compatibility,
+    focus_standard_comment_set_path,
+    list_focus_standard_comment_set_files,
+    load_comment_set,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ReusableCommentSource:
+    type: str
+    class_id: str | None
+    assignment_id: str | None
+    student_id: str | None
+    review_path: str | None
+    feedback_comment_id: str | None
+    saved_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReusableCommentStatus:
+    comment_set_id: str
+    comment_set_title: str
+    standards_profile_id: str
+    comment_id: str
+    standard_id: str
+    label: str
+    text: str
+    purpose: str
+    writing_types: tuple[str, ...]
+    rating_values: tuple[int | float, ...]
+    student_facing: bool
+    active: bool
+    teacher_tags: tuple[str, ...]
+    source: ReusableCommentSource
+    times_used: int
+    last_used_at: str | None
+    created_at: str
+    updated_at: str
+    module_details: str
+    relative_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReusableCommentSetStatus:
+    comment_set_id: str
+    title: str
+    description: str
+    standards_profile_id: str
+    writing_types: tuple[str, ...]
+    grade_band: str | None
+    created_at: str
+    updated_at: str
+    module_details: str
+    relative_path: str
+    comments: tuple[ReusableCommentStatus, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class InvalidReusableCommentSet:
+    relative_path: str
+    error: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReusableCommentInventory:
+    comments: tuple[ReusableCommentStatus, ...]
+    invalid_files: tuple[InvalidReusableCommentSet, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CreatedManualReusableComment:
+    comment_set_id: str
+    comment_id: str
+    set_was_created: bool
+    standards_profile_id: str
+    writing_type: str
+    standard_id: str
+    label: str
+    purpose: str
+    rating_values: tuple[int | float, ...]
+    teacher_tags: tuple[str, ...]
+    active: bool
+    student_facing: bool
+    times_used: int
+    relative_path: str
+    created_at: str
+
+
+def list_reusable_comments(
+    workspace_root: str | Path,
+    *,
+    standards_profile_id: str | None = None,
+    writing_type: str | None = None,
+    standard_id: str | None = None,
+    rating_value: int | float | None = None,
+) -> ReusableCommentInventory:
+    """List matching comments while retaining invalid-file diagnostics."""
+    root = Path(workspace_root)
+    matches: list[ReusableCommentStatus] = []
+    invalid: list[InvalidReusableCommentSet] = []
+    for discovered in list_focus_standard_comment_set_files(root):
+        if not discovered.is_valid:
+            invalid.append(
+                InvalidReusableCommentSet(
+                    _relative_path(discovered.path, root),
+                    discovered.error or "Unknown validation error.",
+                )
+            )
+            continue
+        comment_set = discovered.comment_set
+        if comment_set is None:
+            continue
+        for comment in comment_set["comments"]:
+            if comment_matches_compatibility(
+                comment_set,
+                comment,
+                standards_profile_id=standards_profile_id,
+                writing_type=writing_type,
+                standard_id=standard_id,
+                rating_value=rating_value,
+            ):
+                matches.append(_comment_status(comment_set, comment, discovered.path, root))
+    return ReusableCommentInventory(tuple(matches), tuple(invalid))
+
+
+def show_reusable_comment_set(
+    workspace_root: str | Path, comment_set_id: str
+) -> ReusableCommentSetStatus:
+    """Load one canonical reusable comment set for complete inspection."""
+    root = Path(workspace_root)
+    path = focus_standard_comment_set_path(root, comment_set_id)
+    data = load_comment_set(path)
+    return ReusableCommentSetStatus(
+        comment_set_id=data["comment_set_id"],
+        title=data["title"],
+        description=data["description"],
+        standards_profile_id=data["standards_profile_id"],
+        writing_types=tuple(data["writing_types"]),
+        grade_band=data["grade_band"],
+        created_at=data["created_at"],
+        updated_at=data["updated_at"],
+        module_details=_metadata(data["module_details"]),
+        relative_path=_relative_path(path, root),
+        comments=tuple(
+            _comment_status(data, comment, path, root) for comment in data["comments"]
+        ),
+    )
+
+
+def create_manual_reusable_comment(
+    workspace_root: str | Path,
+    *,
+    comment_set_id: str,
+    standards_profile_id: str,
+    writing_type: str,
+    standard_id: str,
+    label: str,
+    text: str,
+    purpose: str = "general",
+    rating_values: list[int | float] | None = None,
+    teacher_tags: list[str] | None = None,
+    created_at: datetime | str | None = None,
+) -> CreatedManualReusableComment:
+    """Create one manual comment through the canonical append service."""
+    root = Path(workspace_root)
+    path = focus_standard_comment_set_path(root, comment_set_id)
+    set_was_created = not path.exists()
+    timestamp: datetime | str = (
+        datetime.now(timezone.utc) if created_at is None else created_at
+    )
+    saved = append_saved_comment(
+        root,
+        comment_set_id=comment_set_id,
+        standards_profile_id=standards_profile_id,
+        writing_type=writing_type,
+        standard_id=standard_id,
+        label=label,
+        text=text,
+        purpose=purpose,
+        rating_values=rating_values,
+        teacher_tags=teacher_tags,
+        created_at=timestamp,
+        source={
+            "type": "manual",
+            "class_id": None,
+            "assignment_id": None,
+            "student_id": None,
+            "review_path": None,
+            "feedback_comment_id": None,
+            "saved_at": timestamp.isoformat() if isinstance(timestamp, datetime) else timestamp,
+        },
+    )
+    data = load_comment_set(saved.path)
+    comment = next(item for item in data["comments"] if item["comment_id"] == saved.comment_id)
+    tags = comment["module_details"].get("teacher_tags", [])
+    return CreatedManualReusableComment(
+        comment_set_id=saved.comment_set_id,
+        comment_id=saved.comment_id,
+        set_was_created=set_was_created,
+        standards_profile_id=data["standards_profile_id"],
+        writing_type=comment["writing_types"][0],
+        standard_id=comment["standard_id"],
+        label=comment["label"],
+        purpose=comment["purpose"],
+        rating_values=tuple(comment["rating_values"]),
+        teacher_tags=tuple(tags),
+        active=comment["active"],
+        student_facing=comment["student_facing"],
+        times_used=comment["usage"]["times_used"],
+        relative_path=_relative_path(saved.path, root),
+        created_at=comment["created_at"],
+    )
+
+
+def _comment_status(
+    comment_set: dict[str, Any], comment: dict[str, Any], path: Path, root: Path
+) -> ReusableCommentStatus:
+    source = comment["source"]
+    return ReusableCommentStatus(
+        comment_set_id=comment_set["comment_set_id"],
+        comment_set_title=comment_set["title"],
+        standards_profile_id=comment_set["standards_profile_id"],
+        comment_id=comment["comment_id"],
+        standard_id=comment["standard_id"],
+        label=comment["label"],
+        text=comment["text"],
+        purpose=comment["purpose"],
+        writing_types=tuple(comment["writing_types"]),
+        rating_values=tuple(comment["rating_values"]),
+        student_facing=comment["student_facing"],
+        active=comment["active"],
+        teacher_tags=tuple(comment["module_details"].get("teacher_tags", [])),
+        source=ReusableCommentSource(**source),
+        times_used=comment["usage"]["times_used"],
+        last_used_at=comment["usage"]["last_used_at"],
+        created_at=comment["created_at"],
+        updated_at=comment["updated_at"],
+        module_details=_metadata(comment["module_details"]),
+        relative_path=_relative_path(path, root),
+    )
+
+
+def _metadata(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True) if value else "none"
+
+
+def _relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(root.resolve(strict=False)).as_posix()
+    except ValueError as error:
+        raise FocusStandardCommentError(
+            f"Comment set path is outside the active workspace: {path}"
+        ) from error

--- a/quillan/focus_standard_comments.py
+++ b/quillan/focus_standard_comments.py
@@ -171,7 +171,7 @@ def load_comment_set(path: str | Path) -> dict[str, Any]:
         raise FocusStandardCommentError(
             f"Focus Standard comment set not found: {comment_set_path}"
         ) from error
-    except json.JSONDecodeError as error:
+    except (json.JSONDecodeError, UnicodeError) as error:
         raise FocusStandardCommentError(
             f"Focus Standard comment set is not valid JSON: {comment_set_path}"
         ) from error
@@ -253,14 +253,11 @@ def lookup_comments(
         comment_set = file.comment_set
         if comment_set is None:
             continue
-        if comment_set["standards_profile_id"] != standards_profile_id:
-            continue
-        set_writing_types = comment_set["writing_types"]
-        if set_writing_types and writing_type not in set_writing_types:
-            continue
         for comment in comment_set["comments"]:
-            if not _comment_matches(
+            if not comment_matches_compatibility(
+                comment_set,
                 comment,
+                standards_profile_id=standards_profile_id,
                 standard_id=standard_id,
                 writing_type=writing_type,
                 rating_value=rating_value,
@@ -299,10 +296,15 @@ def append_saved_comment(
 ) -> SavedReusableFocusStandardComment:
     """Append a teacher-approved reusable comment, creating a default set if needed."""
     normalized_created_at = _normalize_timestamp(created_at)
+    normalized_profile_id = _normalize_required_string(
+        standards_profile_id, "standards_profile_id"
+    )
+    normalized_writing_type = _normalize_required_string(writing_type, "writing_type")
+    normalized_standard_id = _normalize_required_string(standard_id, "standard_id")
     normalized_set_id = (
         _validate_identifier(comment_set_id, "comment_set_id")
         if comment_set_id is not None
-        else _default_comment_set_id(standards_profile_id, writing_type)
+        else _default_comment_set_id(normalized_profile_id, normalized_writing_type)
     )
     normalized_comment_id = (
         _validate_identifier(comment_id, "comment_id")
@@ -319,21 +321,24 @@ def append_saved_comment(
     path = focus_standard_comment_set_path(workspace_root, normalized_set_id)
     if path.exists():
         comment_set = load_comment_set(path)
-        if comment_set["standards_profile_id"] != standards_profile_id:
+        if comment_set["standards_profile_id"] != normalized_profile_id:
             raise FocusStandardCommentError(
                 "Existing Focus Standard comment set standards_profile_id does not "
-                f"match {standards_profile_id!r}."
+                f"match {normalized_profile_id!r}."
             )
-        if comment_set["writing_types"] and writing_type not in comment_set["writing_types"]:
+        if (
+            comment_set["writing_types"]
+            and normalized_writing_type not in comment_set["writing_types"]
+        ):
             raise FocusStandardCommentError(
                 "Existing Focus Standard comment set does not include writing_type "
-                f"{writing_type!r}."
+                f"{normalized_writing_type!r}."
             )
     else:
         comment_set = _build_default_comment_set(
             comment_set_id=normalized_set_id,
-            standards_profile_id=standards_profile_id,
-            writing_type=writing_type,
+            standards_profile_id=normalized_profile_id,
+            writing_type=normalized_writing_type,
             created_at=normalized_created_at,
         )
 
@@ -341,8 +346,8 @@ def append_saved_comment(
     normalized_comment_id = _unique_identifier(normalized_comment_id, existing_ids)
     comment = {
         "comment_id": normalized_comment_id,
-        "standard_id": _normalize_required_string(standard_id, "standard_id"),
-        "writing_types": [writing_type],
+        "standard_id": normalized_standard_id,
+        "writing_types": [normalized_writing_type],
         "rating_values": normalized_rating_values,
         "label": normalized_label,
         "text": normalized_text,
@@ -361,16 +366,16 @@ def append_saved_comment(
     }
     comment_set["comments"].append(comment)
     if not comment_set["writing_types"]:
-        comment_set["writing_types"] = [writing_type]
-    elif writing_type not in comment_set["writing_types"]:
-        comment_set["writing_types"].append(writing_type)
+        comment_set["writing_types"] = [normalized_writing_type]
+    elif normalized_writing_type not in comment_set["writing_types"]:
+        comment_set["writing_types"].append(normalized_writing_type)
     comment_set["updated_at"] = normalized_created_at
     write_comment_set(workspace_root, comment_set, overwrite=path.exists())
     return SavedReusableFocusStandardComment(
         comment_set_id=normalized_set_id,
         comment_id=normalized_comment_id,
         path=path,
-        standard_id=standard_id,
+        standard_id=normalized_standard_id,
         label=normalized_label,
         text=normalized_text,
         purpose=normalized_purpose,
@@ -509,19 +514,30 @@ def _comment_sets_dir(workspace_root: str | Path) -> Path:
     return Path(workspace_root) / "shared" / "focus_standard_comments"
 
 
-def _comment_matches(
+def comment_matches_compatibility(
+    comment_set: dict[str, Any],
     comment: dict[str, Any],
     *,
-    standard_id: str,
-    writing_type: str,
-    rating_value: int | float | None,
+    standards_profile_id: str | None = None,
+    standard_id: str | None = None,
+    writing_type: str | None = None,
+    rating_value: int | float | None = None,
 ) -> bool:
-    if comment["standard_id"] != standard_id:
+    """Return whether a validated comment satisfies shared compatibility filters."""
+    if (
+        standards_profile_id is not None
+        and comment_set["standards_profile_id"] != standards_profile_id
+    ):
+        return False
+    if standard_id is not None and comment["standard_id"] != standard_id:
         return False
     if not comment["active"] or not comment["student_facing"]:
         return False
-    if comment["writing_types"] and writing_type not in comment["writing_types"]:
-        return False
+    if writing_type is not None:
+        if comment_set["writing_types"] and writing_type not in comment_set["writing_types"]:
+            return False
+        if comment["writing_types"] and writing_type not in comment["writing_types"]:
+            return False
     if rating_value is not None and comment["rating_values"]:
         return rating_value in comment["rating_values"]
     return True
@@ -621,10 +637,7 @@ def _build_default_comment_set(
         "record_type": "focus_standard_comment_set",
         "comment_set_id": comment_set_id,
         "title": title,
-        "description": (
-            "Reusable teacher-authored Focus Standard comments saved from "
-            "Quillan feedback composition."
-        ),
+        "description": "Reusable teacher-authored Focus Standard comments managed by Quillan.",
         "standards_profile_id": standards_profile_id,
         "writing_types": [writing_type],
         "grade_band": None,

--- a/tests/test_cli_comments.py
+++ b/tests/test_cli_comments.py
@@ -1,0 +1,347 @@
+"""Tests for direct reusable Focus Standard comment management commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.cli_app.handlers.comments as cli_comments
+from quillan.cli import main
+from quillan.comment_management import create_manual_reusable_comment
+from quillan.focus_standard_comments import (
+    FocusStandardCommentError,
+    focus_standard_comment_set_path,
+    load_comment_set,
+)
+
+TIMESTAMP = "2026-07-13T12:00:00+00:00"
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(cli_comments, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _create(
+    workspace: Path,
+    *,
+    comment_set_id: str = "argument_comments",
+    profile_id: str = "profile_a",
+    writing_type: str = "argument",
+    standard_id: str = "W.1",
+    label: str = "Explain evidence",
+    text: str = "Explain how the evidence supports your claim.",
+    purpose: str = "next_step",
+    ratings: list[int | float] | None = None,
+    tags: list[str] | None = None,
+) -> None:
+    create_manual_reusable_comment(
+        workspace,
+        comment_set_id=comment_set_id,
+        standards_profile_id=profile_id,
+        writing_type=writing_type,
+        standard_id=standard_id,
+        label=label,
+        text=text,
+        purpose=purpose,
+        rating_values=ratings,
+        teacher_tags=tags,
+        created_at=TIMESTAMP,
+    )
+
+
+def test_comments_help_and_bare_namespace_do_not_resolve_workspace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fail_if_called() -> Path:
+        raise AssertionError("workspace resolution must not run for namespace help")
+
+    monkeypatch.setattr(cli_comments, "resolve_workspace_root", fail_if_called)
+
+    assert main(["comments"]) == 0
+    namespace_help = capsys.readouterr().out
+    assert all(command in namespace_help for command in ("list", "show", "create"))
+    for arguments in (
+        ["--help"],
+        ["comments", "--help"],
+        ["comments", "list", "--help"],
+        ["comments", "show", "--help"],
+        ["comments", "create", "--help"],
+    ):
+        with pytest.raises(SystemExit) as result:
+            main(arguments)
+        assert result.value.code == 0
+
+
+def test_empty_list_is_successful_and_does_not_create_directory(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    directory = workspace / "shared" / "focus_standard_comments"
+
+    assert main(["comments", "list"]) == 0
+
+    assert "No reusable Focus Standard comments matched." in capsys.readouterr().out
+    assert not directory.exists()
+
+
+def test_show_missing_set_fails_without_creating_files(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["comments", "show", "missing_set"]) == 1
+    assert "Error:" in capsys.readouterr().out
+    assert not (workspace / "shared").exists()
+
+
+def test_create_new_set_preserves_text_and_normalizes_metadata(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(
+        [
+            "comments",
+            "create",
+            "argument_comments",
+            "--profile-id",
+            " profile_a ",
+            "--writing-type",
+            " argument ",
+            "--standard-id",
+            " W.1 ",
+            "--label",
+            " Explain Evidence ",
+            "--text",
+            "  Keep THIS punctuation!\nAnd this line.  ",
+            "--purpose",
+            "evidence",
+            "--rating-values=-1,0,2.5",
+            "--teacher-tags",
+            "Scene Development,Dialogue,scene development",
+        ]
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Comment set: created" in output
+    assert "Comment ID: explain_evidence" in output
+    assert "Rating values: -1, 0, 2.5" in output
+    assert "Teacher tags: scene_development, dialogue" in output
+    path = focus_standard_comment_set_path(workspace, "argument_comments")
+    data = load_comment_set(path)
+    comment = data["comments"][0]
+    assert data["description"] == (
+        "Reusable teacher-authored Focus Standard comments managed by Quillan."
+    )
+    assert data["standards_profile_id"] == "profile_a"
+    assert data["writing_types"] == ["argument"]
+    assert data["grade_band"] is None
+    assert comment["text"] == "Keep THIS punctuation!\nAnd this line."
+    assert comment["source"] == {
+        "type": "manual",
+        "class_id": None,
+        "assignment_id": None,
+        "student_id": None,
+        "review_path": None,
+        "feedback_comment_id": None,
+        "saved_at": comment["created_at"],
+    }
+    assert comment["active"] is True
+    assert comment["student_facing"] is True
+    assert comment["usage"] == {"times_used": 0, "last_used_at": None}
+    assert sorted(path.parent.iterdir()) == [path]
+
+
+def test_create_appends_collision_safe_id_and_preserves_existing_data(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _create(workspace)
+    path = focus_standard_comment_set_path(workspace, "argument_comments")
+    before = load_comment_set(path)
+
+    assert main(
+        [
+            "comments",
+            "create",
+            "argument_comments",
+            "--profile-id",
+            "profile_a",
+            "--writing-type",
+            "argument",
+            "--standard-id",
+            "W.1",
+            "--label",
+            "Explain evidence",
+            "--text",
+            "A second reusable comment.",
+        ]
+    ) == 0
+
+    assert "Comment ID: explain_evidence_2" in capsys.readouterr().out
+    after = load_comment_set(path)
+    assert after["comments"][0] == before["comments"][0]
+    assert after["created_at"] == before["created_at"]
+    assert len(after["comments"]) == 2
+
+
+@pytest.mark.parametrize(
+    ("option", "value", "message"),
+    [
+        ("--profile-id", "other_profile", "standards_profile_id"),
+        ("--writing-type", "narrative", "writing_type"),
+    ],
+)
+def test_incompatible_append_is_byte_for_byte_unchanged(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    option: str,
+    value: str,
+    message: str,
+) -> None:
+    _create(workspace)
+    path = focus_standard_comment_set_path(workspace, "argument_comments")
+    before = path.read_bytes()
+    arguments = [
+        "comments",
+        "create",
+        "argument_comments",
+        "--profile-id",
+        "profile_a",
+        "--writing-type",
+        "argument",
+        "--standard-id",
+        "W.1",
+        "--label",
+        "Another",
+        "--text",
+        "Another comment.",
+    ]
+    arguments[arguments.index(option) + 1] = value
+
+    assert main(arguments) == 1
+
+    assert message in capsys.readouterr().out
+    assert path.read_bytes() == before
+
+
+def test_list_filters_visibility_order_and_reports_invalid_files(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _create(
+        workspace,
+        comment_set_id="z_set",
+        ratings=[2.5],
+        tags=["Evidence"],
+        text="Z text.",
+    )
+    _create(
+        workspace,
+        comment_set_id="a_set",
+        ratings=[],
+        text="A first text.",
+    )
+    _create(
+        workspace,
+        comment_set_id="a_set",
+        label="Second stored",
+        text="A second text.",
+    )
+    a_path = focus_standard_comment_set_path(workspace, "a_set")
+    data: dict[str, Any] = json.loads(a_path.read_text(encoding="utf-8"))
+    data["comments"][1]["active"] = False
+    a_path.write_text(json.dumps(data), encoding="utf-8")
+    invalid_path = a_path.parent / "broken.json"
+    invalid_path.write_text("{", encoding="utf-8")
+    before = {path: path.read_bytes() for path in a_path.parent.iterdir()}
+
+    assert main(
+        [
+            "comments",
+            "list",
+            "--profile-id",
+            "profile_a",
+            "--writing-type",
+            "argument",
+            "--standard-id",
+            "W.1",
+            "--rating-value",
+            "2.5",
+        ]
+    ) == 1
+
+    output = capsys.readouterr().out
+    assert output.index("Comment set ID: a_set") < output.index("Comment set ID: z_set")
+    assert "A first text." in output
+    assert "A second text." not in output
+    assert "Z text." in output
+    assert "Purpose: next_step" in output
+    assert "Teacher tags: evidence" in output
+    assert "Usage count: 0" in output
+    assert "shared/focus_standard_comments/z_set.json" in output
+    assert "Invalid reusable Focus Standard comment sets:" in output
+    assert "broken.json" in output
+    assert {path: path.read_bytes() for path in a_path.parent.iterdir()} == before
+
+
+def test_show_includes_inactive_teacher_only_and_is_read_only(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _create(workspace)
+    path = focus_standard_comment_set_path(workspace, "argument_comments")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["comments"][0]["active"] = False
+    data["comments"][0]["student_facing"] = False
+    path.write_text(json.dumps(data), encoding="utf-8")
+    before = path.read_bytes()
+
+    assert main(["comments", "show", "argument_comments"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Description:" in output
+    assert "Comment count: 1" in output
+    assert "Student-facing: no" in output
+    assert "Active: no" in output
+    assert "Source type: manual" in output
+    assert "Source student ID: none" in output
+    assert "Usage count: 0" in output
+    assert "Module details:" in output
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "rating_values", ["1,1", "1,,2", "text", "NaN", "inf", "-inf"]
+)
+def test_create_rejects_invalid_rating_lists_without_writing(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    rating_values: str,
+) -> None:
+    result = main(
+        [
+            "comments",
+            "create",
+            "argument_comments",
+            "--profile-id",
+            "profile_a",
+            "--writing-type",
+            "argument",
+            "--standard-id",
+            "W.1",
+            "--label",
+            "Label",
+            "--text",
+            "Text",
+            f"--rating-values={rating_values}",
+        ]
+    )
+
+    assert result == 1
+    assert "Error:" in capsys.readouterr().out
+    assert not (workspace / "shared").exists()
+
+
+def test_manual_service_rejects_blank_and_unusable_values(tmp_path: Path) -> None:
+    with pytest.raises(FocusStandardCommentError, match="label"):
+        _create(tmp_path, label=" ")
+    with pytest.raises(FocusStandardCommentError, match="letters or numbers"):
+        _create(tmp_path, tags=["---"])


### PR DESCRIPTION
## Summary

* Add direct CLI commands for listing, inspecting, and creating reusable Focus Standard comments:

  * `quillan comments list`
  * `quillan comments show`
  * `quillan comments create`
* Add immutable shared management services for reusable-comment inventory and creation.
* Reuse the existing schema validation, compatibility matching, comment-ID generation, teacher-tag normalization, and atomic-write paths.
* Preserve the existing reusable Focus Standard comment-set schema.
* Keep lifecycle management intentionally limited: no editing, deactivation, or deletion is introduced.

## Command Surface

```
quillan comments list \
  [--profile-id <standards_profile_id>] \
  [--writing-type <writing_type>] \
  [--standard-id <standard_id>] \
  [--rating-value <number>]

quillan comments show <comment_set_id>

quillan comments create <comment_set_id> \
  --profile-id <standards_profile_id> \
  --writing-type <writing_type> \
  --standard-id <standard_id> \
  --label <label> \
  --text <text> \
  [--purpose <purpose>] \
  [--rating-values <number,number,...>] \
  [--teacher-tags <tag,tag,...>]
```

Running:

```
quillan comments
```

without a subcommand prints namespace help and exits successfully without resolving or inspecting the workspace.

All commands are direct and non-interactive. They do not call `input()` or invoke menu functions.

## Shared Architecture

Added immutable reusable-comment management services in:

* `quillan/comment_management.py`

Added thin direct CLI handlers in:

* `quillan/cli_app/handlers/comments.py`

Updated:

* `quillan/cli_app/parser.py`
* `quillan/cli_app/output.py`

Shared compatibility matching was extracted in:

* `quillan/focus_standard_comments.py`

The implementation preserves the intended boundary:

```
feedback composition -> shared reusable-comment services
direct CLI          -> same shared reusable-comment services
future GUI          -> same shared reusable-comment services
```

CLI handlers do not build or patch raw comment-set dictionaries.

## Canonical Storage

Reusable Focus Standard comment sets remain stored at:

```
shared/focus_standard_comments/<comment_set_id>.json
```

The CLI accepts a validated comment-set identifier, not an arbitrary file path.

The implementation does not inspect or modify legacy generic comment banks under:

```
shared/comment_banks/
```

## `comments list`

`comments list` is strictly read-only.

With no filters, it displays all active, student-facing comments from every valid reusable Focus Standard comment set.

Optional filters are combined with logical AND:

* standards profile;
* writing type;
* standard ID;
* rating value.

### Ordering

Results are deterministic:

1. comment sets are ordered case-insensitively by filename;
2. comments retain their stored order within each set.

The command does not reorder results by:

* usage count;
* label;
* purpose;
* tags.

### Profile and Standard Filters

Profile and standard matching are exact.

The command does not use fuzzy matching or infer related standards.

### Writing-Type Compatibility

Writing-type filtering preserves the existing compatibility rules.

A comment matches when:

* the comment set’s writing-type list is empty or contains the requested type; and
* the individual comment’s writing-type list is empty or contains the requested type.

An empty writing-type list remains unrestricted.

### Rating Compatibility

When a rating filter is supplied:

* comments with an empty rating-value list match because they are unrestricted;
* comments with configured rating values match only when the requested value is present.

When no rating filter is supplied, rating-specific comments remain visible.

The parser supports finite integer and floating-point values, including:

* zero;
* negative values;
* noncontiguous values.

It rejects:

* blank values;
* nonnumeric values;
* duplicate values;
* `NaN`;
* positive infinity;
* negative infinity.

No assignment-owned rating scale is required because reusable-comment management has no assignment context.

### Active and Student-Facing Filtering

Ordinary list results exclude:

* inactive comments;
* comments marked as not student-facing.

Those records remain visible through `comments show`.

### List Output

Each matching result reports:

* comment-set ID;
* comment-set title;
* standards-profile ID;
* comment ID;
* standard ID;
* label;
* full reusable text;
* purpose;
* writing-type restrictions;
* rating restrictions;
* normalized teacher tags;
* usage count;
* last-used timestamp;
* canonical workspace-relative set path.

The command does not dump raw JSON.

## Empty Inventory

When the reusable-comment directory does not exist or no comments match:

* the command reports that no reusable Focus Standard comments matched;
* it returns successfully;
* it does not create the directory.

## Malformed Comment Sets

Listing uses the existing discovery path that reports invalid files individually.

When valid and malformed sets coexist:

* valid matching comments remain visible;
* malformed files are reported separately with their validation errors;
* the command returns nonzero;
* no files are repaired or rewritten.

A malformed set therefore cannot silently disappear from inventory reporting, but it also does not prevent inspection of valid data.

## `comments show`

`comments show` is strictly read-only.

It resolves the requested set through the canonical comment-set path helper and loads it through the existing validator.

The command reports:

* comment-set ID;
* title;
* description;
* standards-profile ID;
* top-level writing types;
* grade band;
* comment count;
* creation timestamp;
* update timestamp;
* canonical workspace-relative path;
* relevant module metadata.

Every stored comment is displayed in its original order, including inactive and teacher-only records.

For each comment, the output includes:

* comment ID;
* standard ID;
* label;
* full text;
* purpose;
* writing types;
* rating values;
* student-facing status;
* active status;
* normalized teacher tags;
* source type;
* source provenance;
* usage count;
* last-used timestamp;
* creation timestamp;
* update timestamp;
* relevant module metadata.

Inactive and teacher-only states are identified clearly.

A missing, malformed, unsupported, or filename-mismatched set fails rather than being treated as empty.

## `comments create`

`comments create` creates one manually authored reusable Focus Standard comment.

It uses the same shared append and validation path used when feedback composition saves a comment for reuse.

The handler does not construct schema records directly.

## New Comment Sets

When the requested comment set does not exist, the shared service creates a schema-version-1 set containing the new comment.

The generated set includes:

* module: `quillan`;
* record type: `focus_standard_comment_set`;
* the supplied comment-set ID;
* the supplied standards-profile ID;
* the supplied writing type;
* a generated teacher-facing title;
* a source-neutral description;
* grade band: `null`;
* initial timestamps;
* empty top-level module metadata.

The source-neutral description accurately supports comments created either manually or through feedback composition.

## Existing Comment Sets

When the set already exists, the service:

* loads and validates the complete file;
* confirms standards-profile compatibility;
* confirms writing-type compatibility;
* appends the new comment;
* preserves existing set metadata;
* preserves existing comments;
* preserves existing provenance and usage data;
* preserves the original set creation timestamp;
* updates the set timestamp.

The existing set is not rebuilt or replaced.

An incompatible or malformed existing set fails without modification.

## Comment IDs

The caller does not supply a comment ID.

The ID is derived from the teacher-facing label through the existing identifier suggestion path.

Collisions are resolved safely:

```
explain_evidence
explain_evidence_2
explain_evidence_3
```

Existing comments are not replaced when a label-derived ID collides.

The successful output reports the actual resulting comment ID.

## Manual Source Provenance

Manually created comments use:

```
source.type = "manual"
```

Student and review provenance fields remain null:

* class ID;
* assignment ID;
* student ID;
* review path;
* feedback-comment ID.

The source timestamp records when the reusable comment was created.

The management command does not request or store student identity.

## Teacher Text Preservation

The reusable comment text is teacher-authored.

Only surrounding whitespace is trimmed.

The implementation preserves internal:

* capitalization;
* punctuation;
* spacing;
* line structure.

It does not:

* rewrite;
* correct;
* summarize;
* personalize;
* generate alternatives.

No AI path is used.

Documentation warns that reusable text must not contain student-identifying or private assignment-specific information.

## Purpose

The optional purpose defaults to:

```
general
```

Canonical supported values are:

* `praise`
* `next_step`
* `clarification`
* `evidence`
* `reasoning`
* `organization`
* `style`
* `conventions`
* `revision`
* `general`

Unsupported values such as `strength` are rejected.

Purpose remains teacher-facing organization metadata and does not change compatibility matching.

## Rating Restrictions

`--rating-values` accepts an ordered comma-separated list of finite numeric values.

When omitted, the comment stores:

```
"rating_values": []
```

An empty list means the comment is not rating restricted.

The implementation preserves integer and floating-point values without assuming a fixed rating scale.

Duplicate, blank, nonnumeric, `NaN`, and infinite values are rejected.

## Teacher Tags

Optional comma-separated teacher tags are normalized through the existing shared service.

Normalization includes:

* surrounding-whitespace trimming;
* lowercase conversion;
* snake-case conversion;
* ASCII-safe normalization;
* deduplication;
* preservation of first-occurrence order.

For example:

```
Scene Development, Dialogue, scene development
```

becomes:

```
scene_development, dialogue
```

Tags are stored under:

```
module_details.teacher_tags
```

Teacher tags remain display and organization metadata only.

They do not affect:

* profile compatibility;
* writing-type compatibility;
* standard compatibility;
* rating compatibility;
* comment selection;
* usage behavior;
* scoring;
* reporting.

## Default Comment State

New manually authored comments use the existing append-service defaults:

```
student_facing: true
active: true
usage.times_used: 0
usage.last_used_at: null
```

Creation does not increment usage.

Usage changes only when a teacher selects the reusable comment for a student review through the feedback workflow.

## Successful Creation Output

Successful creation reports:

* comment-set ID;
* generated comment ID;
* whether the set was newly created or already existed;
* standards-profile ID;
* writing type;
* standard ID;
* label;
* purpose;
* rating restrictions;
* normalized teacher tags;
* active status;
* student-facing status;
* usage count;
* canonical workspace-relative set path;
* creation timestamp.

The output does not dump raw JSON or imply that the comment has already been used in student feedback.

## Write Boundaries

`comments list` writes nothing.

`comments show` writes nothing.

`comments create` may create or update exactly one canonical file:

```
shared/focus_standard_comments/<comment_set_id>.json
```

The commands do not modify:

* assignments;
* submission manifests;
* review records;
* class rosters;
* class metadata;
* evidence;
* scans;
* student feedback exports;
* assignment reports;
* standards-library records;
* unrelated reusable-comment sets;
* legacy generic comment banks;
* PDS Core data;
* ScoreForm data.

No review-state transition occurs.

## Preserved Existing Workflows

The implementation preserves existing behavior for:

* saving comments for reuse during feedback composition;
* separately approved reusable text;
* current-rating tagging;
* default service-selected comment-set IDs;
* compatible reusable-comment lookup;
* stable student-review snapshots;
* usage increments during selection;
* canonical purposes;
* teacher-tag normalization.

The new manual management path does not change student review or feedback composition behavior.

## No Automated Generation or Judgment

Confirmed that the implementation does not:

* inspect student evidence;
* open PDFs;
* inspect images;
* parse student writing;
* run OCR;
* perform handwriting recognition;
* use AI;
* generate feedback language;
* rewrite teacher language;
* infer standards;
* infer writing types;
* infer rating restrictions;
* infer teacher tags;
* create student feedback;
* create observations;
* create ratings;
* calculate grades;
* calculate scores;
* select reusable comments automatically;
* increment usage during listing, inspection, or creation;
* export feedback.

These commands manage teacher-authored shared source material only.

## Lifecycle Boundaries

This issue does not add:

* comment editing;
* relabeling;
* purpose changes;
* rating-filter changes;
* writing-type changes;
* teacher-tag changes;
* activation or deactivation;
* student-facing status changes;
* comment deletion;
* comment-set deletion;
* comment-set renaming;
* comment-set metadata editing;
* usage editing or reset;
* bulk import or export;
* legacy comment-bank migration;
* raw JSON patching.

Those operations require a clearer reusable-comment lifecycle policy.

## Files Changed

Eight intended Quillan source, test, and documentation files were modified or added:

* `quillan/focus_standard_comments.py`
* `quillan/comment_management.py`
* `quillan/cli_app/parser.py`
* `quillan/cli_app/handlers/comments.py`
* `quillan/cli_app/output.py`
* `tests/test_cli_comments.py`
* `docs/cli_contract.md`
* `docs/focus_standard_comment_contract.md`

## Documentation

Updated documentation covers:

* the `comments` namespace;
* bare namespace help;
* inventory filters;
* compatibility semantics;
* active and student-facing filtering;
* malformed-set reporting;
* complete comment-set inspection;
* manual reusable-comment creation;
* source-neutral set creation;
* compatible append behavior;
* generated and collision-safe IDs;
* manual provenance;
* canonical purposes;
* numeric rating restrictions;
* teacher-tag normalization;
* tags remaining outside compatibility matching;
* exact read and write boundaries;
* the absence of editing and deletion;
* the prohibition on AI generation.

## Safety

Confirmed:

* bare namespace help does not resolve the workspace;
* handlers are direct and non-interactive;
* list and show are read-only;
* empty inventory listing creates no directory;
* malformed sets are not repaired automatically;
* valid results remain visible when another set is malformed;
* create uses canonical schema validation;
* create uses the atomic writer;
* incompatible existing sets remain unchanged;
* manual provenance contains no student identity;
* teacher text is preserved;
* tags do not affect compatibility;
* creation does not increment usage;
* only the selected reusable-comment set may change;
* review records remain unchanged;
* assignments and submissions remain unchanged;
* exports are not generated;
* PDS Core remains unchanged;
* ScoreForm remains unchanged;
* no real student data or generated artifacts were added.

## Validation

* Focused reusable-comment and CLI tests: `29 passed`
* Reusable-comment and feedback regressions: `118 passed`
* Broader CLI selection: `240 passed`
* Full pytest suite: `1215 passed`
* Ruff: passed
* mypy: passed, `162` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* Git status contains only the eight intended Quillan changes
* No real student data, review records, generated feedback, or export artifacts present

Closes #306
