### PR TITLE
Add submission page management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ quillan route-scan <source-folder> --decode-qr
 quillan decode-scan <source-file> [--hide-payload]
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+quillan pages list <class_id> <assignment_id> <student_id>
+quillan pages exclude <class_id> <assignment_id> <student_id> --page N --yes
+quillan pages restore <class_id> <assignment_id> <student_id> --page N --yes
+quillan pages mark-needs-rescan <class_id> <assignment_id> <student_id> --page N --yes
 quillan open-evidence <workspace-relative-evidence-path>
 quillan open-submission <class_id> <assignment_id> <student_id> [--page N]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -208,6 +208,10 @@ quillan list-scan-review [--include-resolved] [--limit N]
 quillan resolve-scan-review <failure_id> --action <action> [--message "..."] [--evidence-path <workspace-relative-path>]
 quillan assemble-submissions <class_id> <assignment_id> [--expected-pages N] [--overwrite]
 quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+quillan pages list <class_id> <assignment_id> <student_id>
+quillan pages exclude <class_id> <assignment_id> <student_id> --page N --yes
+quillan pages restore <class_id> <assignment_id> <student_id> --page N --yes
+quillan pages mark-needs-rescan <class_id> <assignment_id> <student_id> --page N --yes
 quillan open-evidence <workspace-relative-evidence-path>
 quillan open-submission <class_id> <assignment_id> <student_id> [--page N]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
@@ -237,6 +241,59 @@ and exits successfully without resolving or inspecting the workspace.
 
 Running `quillan observations` without a subcommand prints observation help
 and exits successfully without resolving or inspecting the workspace.
+
+## Direct Submission Page Management
+
+The `pages` namespace exposes the same shared submission-page services used by
+Manage Submission Pages in the teacher menu. Bare `quillan pages` prints
+namespace help and succeeds without resolving a workspace, loading a manifest,
+inspecting routed evidence, creating directories, or writing files.
+
+`pages list` loads only the requested student's canonical
+`submissions/<student_id>/submission.json`. It does not scan sibling students,
+the roster, assignment configuration, or routed evidence. It reports canonical
+identity and path, lightweight submission state, expected page count, manifest
+timestamps, page-state counts, pages lacking selected evidence, and page and
+evidence summaries. Pages are displayed by ascending logical `page_number`;
+evidence remains in stored order. A null selection is displayed as `none` and
+is never inferred or repaired. Listing never opens or stats evidence files and
+does not normalize or rewrite the manifest.
+
+The mutation commands require `--page` with a positive logical page number
+that exists in the manifest and the explicit non-interactive confirmation
+`--yes`. Omission is an argument error; no prompt or implicit confirmation is
+used. These commands do not accept arbitrary manifest paths.
+
+Exclusion retains the page and every evidence record, clears selection, saves
+each evidence record's current role and state as temporary pre-exclusion
+metadata, and marks it excluded from active review. It does not delete files.
+Restore uses that preserved role and state, including a valid prior lack of
+selection. For legacy excluded records without preservation metadata, zero,
+one, and multiple evidence records safely restore to missing, uniquely selected
+present, and unselected duplicate states respectively. No duplicate candidate
+is chosen automatically.
+
+Marking needs rescan retains every evidence record, clears selection, and makes
+the records candidates needing rescan; an empty page remains evidence-less.
+Changing an excluded page to needs rescan removes obsolete exclusion-transition
+metadata so a later exclude/restore cycle returns to the current rescan state.
+Page state and top-level `submission_state` are distinct: page management never
+changes the latter.
+
+A valid plain-paper manual manifest lists successfully as zero digital pages;
+the physical paper remains outside Quillan. Page mutations fail because no
+digital page exists. A missing manifest is not treated as plain paper: every
+command fails with submission-assembly guidance and never assembles or creates
+a manifest or review record.
+
+The sole write boundary is the selected student's canonical `submission.json`,
+validated in full and atomically replaced. Created timestamps, evidence paths,
+retained-source provenance, and unrelated module metadata are preserved;
+successful changes update only the manifest update timestamp and page-management
+metadata. Review records, assignments, rosters, routed and retained files,
+ratings, observations, feedback, exports, and reports remain untouched. These
+commands perform no evidence inspection, OCR, handwriting recognition, AI,
+grading, scoring, feedback composition, or export work.
 
 ## Direct Focus Standard Feedback Composition
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -49,6 +49,15 @@ They describe routed evidence, retained-source provenance, page state, selected
 evidence, duplicate/missing evidence conditions, and lightweight submission
 state. They do not store teacher ratings, comments, feedback, or reports.
 
+Page-management transitions retain excluded pages and evidence rather than
+deleting them. Exclusion temporarily preserves each evidence role and state so
+restoration can recover the prior selection (including no selection); older
+excluded records use a conservative legacy fallback. Page state is independent
+of top-level lightweight `submission_state`, which page management preserves.
+A plain-paper manual manifest has `expected_pages: null` and no digital page
+records because the physical evidence remains outside Quillan. Both the direct
+`pages` CLI and teacher menu use the same shared page-management service.
+
 ### Review Record
 
 The active teacher-review artifact is schema version `2` `review.json`:

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -188,6 +188,14 @@ Updating submission review state is an explicit workflow status change.
 Quillan does not infer review state from observations, ratings, notes,
 feedback, or exports.
 
+Submission page management is an evidence-metadata workflow separate from
+teacher judgment. The menu and direct `pages` commands share one service for
+listing, excluding, restoring, and marking pages as needing rescan. Excluded
+pages and their routed evidence are retained, not deleted. Restoration recovers
+preserved evidence roles and states when available and uses a conservative
+legacy fallback otherwise. These changes do not update top-level submission
+state or mutate review records, ratings, observations, feedback, or exports.
+
 ## Related Docs
 
 * [`data_contracts.md`](data_contracts.md)

--- a/quillan/cli_app/handlers/pages.py
+++ b/quillan/cli_app/handlers/pages.py
@@ -1,0 +1,73 @@
+"""Direct, non-interactive submission page-management handlers."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.cli_app.output import (
+    print_managed_submission_page,
+    print_submission_page_context,
+)
+from quillan.submission_page_management import (
+    ManagedSubmissionPage,
+    SubmissionPageManagementError,
+    exclude_submission_page,
+    load_submission_page_context,
+    mark_submission_page_needs_rescan,
+    restore_excluded_submission_page,
+)
+
+
+def handle_pages_list(args: argparse.Namespace) -> int:
+    """List one canonical submission's page state without writing."""
+    try:
+        context = load_submission_page_context(
+            resolve_workspace_root(),
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+        )
+    except (WorkspaceRootError, SubmissionPageManagementError, OSError) as error:
+        print(f"Error: could not list submission pages: {error}")
+        return 1
+    print_submission_page_context(context)
+    return 0
+
+
+def handle_pages_exclude(args: argparse.Namespace) -> int:
+    """Exclude one page from active review through the shared service."""
+    return _mutate(args, exclude_submission_page)
+
+
+def handle_pages_restore(args: argparse.Namespace) -> int:
+    """Restore one excluded page through the shared service."""
+    return _mutate(args, restore_excluded_submission_page)
+
+
+def handle_pages_mark_needs_rescan(args: argparse.Namespace) -> int:
+    """Mark one page as needing rescan through the shared service."""
+    return _mutate(args, mark_submission_page_needs_rescan)
+
+
+PageMutation = Callable[[str | Path, str, str, str, int], ManagedSubmissionPage]
+
+
+def _mutate(args: argparse.Namespace, service: PageMutation) -> int:
+    try:
+        workspace_root = resolve_workspace_root()
+        result = service(
+            workspace_root,
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            args.page,
+        )
+    except (WorkspaceRootError, SubmissionPageManagementError, OSError) as error:
+        print(f"Error: page change was not saved: {error}")
+        return 1
+    print_managed_submission_page(result, workspace_root)
+    return 0

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -43,6 +43,10 @@ from quillan.student_performance_summary_export import (
 )
 from quillan.submission_review_opening import OpenedSubmissionReview
 from quillan.submission_review_state import UpdatedSubmissionReviewState
+from quillan.submission_page_management import (
+    ManagedSubmissionPage,
+    SubmissionPageContext,
+)
 from quillan.submission_status import AssignmentSubmissionStatus
 
 
@@ -170,6 +174,104 @@ def print_updated_submission_review_state(
     print(f"Previous state: {updated.previous_state}")
     print(f"New state: {updated.new_state}")
     print(f"Manifest: {updated.manifest_relative_path}")
+
+
+def print_submission_page_context(context: SubmissionPageContext) -> None:
+    """Print manifest-only status for one selected student's pages."""
+    print("Submission pages:")
+    print(f"Class: {context.class_id}")
+    print(f"Assignment: {context.assignment_id}")
+    print(f"Student: {context.student_id}")
+    print(f"Manifest: {context.manifest_relative_path}")
+    print(f"Submission state: {context.submission_state}")
+    print(
+        "Expected pages: "
+        f"{context.expected_pages if context.expected_pages is not None else 'not specified'}"
+    )
+    print(f"Plain-paper submission: {format_bool(context.plain_paper)}")
+    if context.plain_paper:
+        print(f"Entry method: {context.plain_paper_entry_method or 'plain-paper manual'}")
+        print("Physical paper remains outside Quillan; there are zero digital pages.")
+    print(f"Total pages: {len(context.pages)}")
+    print(f"Present pages: {context.present_count}")
+    print(f"Missing pages: {context.missing_count}")
+    print(f"Duplicate pages: {context.duplicate_count}")
+    print(f"Needs-rescan pages: {context.needs_rescan_count}")
+    print(f"Excluded pages: {context.excluded_count}")
+    print(
+        "Pages lacking selected evidence: "
+        f"{format_page_numbers(context.pages_without_selected_evidence) or 'none'}"
+    )
+    print(f"Created: {context.created_at}")
+    print(f"Updated: {context.updated_at}")
+    if not context.pages:
+        print("Digital pages: none")
+        return
+    for page in context.pages:
+        print()
+        print(f"Page {page.page_number}:")
+        print(f"  State: {_teacher_page_state(page.page_state)}")
+        print(f"  Selected evidence: {page.selected_evidence_id or 'none'}")
+        print(f"  Evidence count: {len(page.evidence)}")
+        for evidence in page.evidence:
+            print(f"  Evidence {evidence.evidence_id}:")
+            print(f"    Role: {evidence.evidence_role}")
+            print(f"    State: {evidence.evidence_state}")
+            print(f"    Routed path: {evidence.routed_evidence_path}")
+            print(
+                "    Duplicate number: "
+                f"{evidence.duplicate_number if evidence.duplicate_number is not None else 'none'}"
+            )
+            print(
+                "    Retained source present: "
+                f"{format_bool(evidence.retained_source_present)}"
+            )
+            if (
+                evidence.pre_exclusion_role is not None
+                or evidence.pre_exclusion_state is not None
+            ):
+                print(
+                    "    Pre-exclusion role: "
+                    f"{evidence.pre_exclusion_role or 'none'}"
+                )
+                print(
+                    "    Pre-exclusion state: "
+                    f"{evidence.pre_exclusion_state or 'none'}"
+                )
+
+
+def print_managed_submission_page(
+    result: ManagedSubmissionPage, workspace_root: Path
+) -> None:
+    """Print one successful page-management mutation."""
+    print("Submission page updated:")
+    print(f"Class: {result.class_id}")
+    print(f"Assignment: {result.assignment_id}")
+    print(f"Student: {result.student_id}")
+    print(f"Action: {result.action}")
+    print(f"Page: {result.page_number}")
+    print(f"Previous state: {_teacher_page_state(result.previous_page_state)}")
+    print(f"Resulting state: {_teacher_page_state(result.page_state)}")
+    print(
+        "Previous selected evidence: "
+        f"{result.previous_selected_evidence_id or 'none'}"
+    )
+    print(f"Resulting selected evidence: {result.selected_evidence_id or 'none'}")
+    print(f"Evidence records preserved: {result.evidence_count}")
+    if result.restore_source is not None:
+        print(f"Restore source: {result.restore_source}")
+    print(
+        "Manifest: "
+        f"{workspace_relative_display(result.manifest_path, workspace_root)}"
+    )
+    print(f"Updated: {result.updated_at}")
+
+
+def _teacher_page_state(state: str) -> str:
+    return {
+        "excluded": "excluded from active review",
+        "needs_rescan": "needs rescan",
+    }.get(state, state)
 
 
 def print_added_review_note(added: AddedReviewNote) -> None:

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -42,6 +42,12 @@ from quillan.cli_app.handlers.observations import (
     handle_observations_list,
     handle_observations_set,
 )
+from quillan.cli_app.handlers.pages import (
+    handle_pages_exclude,
+    handle_pages_list,
+    handle_pages_mark_needs_rescan,
+    handle_pages_restore,
+)
 from quillan.cli_app.handlers.ratings import (
     handle_ratings_list,
     handle_ratings_mark_complete,
@@ -701,6 +707,57 @@ def build_parser() -> argparse.ArgumentParser:
         help="Validate and report target paths without writing files.",
     )
     plain_paper_parser.set_defaults(handler=handle_create_plain_paper_submission)
+
+    pages_parser = subparsers.add_parser(
+        "pages",
+        help="Inspect or change one student's canonical submission pages.",
+        description=(
+            "List or explicitly change page-management state in one canonical "
+            "submission manifest. Evidence files and review data are not changed."
+        ),
+    )
+    pages_parser.set_defaults(handler=partial(_print_parser_help, pages_parser))
+    pages_subparsers = pages_parser.add_subparsers(dest="pages_command")
+
+    pages_list_parser = pages_subparsers.add_parser(
+        "list", help="List manifest page and evidence state without writing."
+    )
+    _add_submission_identity_arguments(pages_list_parser)
+    pages_list_parser.set_defaults(handler=handle_pages_list)
+
+    page_mutations = (
+        (
+            "exclude",
+            "Exclude a page from active review without deleting evidence.",
+            handle_pages_exclude,
+        ),
+        (
+            "restore",
+            "Restore an excluded page using preserved state or safe fallback.",
+            handle_pages_restore,
+        ),
+        (
+            "mark-needs-rescan",
+            "Mark a page as requiring corrected evidence.",
+            handle_pages_mark_needs_rescan,
+        ),
+    )
+    for command, help_text, handler in page_mutations:
+        mutation_parser = pages_subparsers.add_parser(command, help=help_text)
+        _add_submission_identity_arguments(mutation_parser)
+        mutation_parser.add_argument(
+            "--page",
+            required=True,
+            type=positive_integer,
+            help="Positive logical page number in the current manifest.",
+        )
+        mutation_parser.add_argument(
+            "--yes",
+            required=True,
+            action="store_true",
+            help="Explicitly confirm this manifest-only page change.",
+        )
+        mutation_parser.set_defaults(handler=handler)
 
     status_parser = subparsers.add_parser(
         "list-submissions",

--- a/quillan/submission_page_management.py
+++ b/quillan/submission_page_management.py
@@ -20,6 +20,8 @@ from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
 )
+from quillan.plain_paper_submission import is_plain_paper_submission
+from quillan.submission_guidance import missing_submission_guidance
 
 _PRESERVED_EXCLUSION_KEY = "quillan_before_page_exclusion"
 
@@ -37,9 +39,118 @@ class ManagedSubmissionPage:
     assignment_id: str
     student_id: str
     page_number: int
+    action: str
+    previous_page_state: str
     page_state: str
+    previous_selected_evidence_id: str | None
     selected_evidence_id: str | None
     evidence_count: int
+    updated_at: str
+    restore_source: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionEvidenceStatus:
+    """Immutable manifest-only status for one evidence record."""
+
+    evidence_id: str
+    evidence_role: str
+    evidence_state: str
+    routed_evidence_path: str
+    duplicate_number: int | None
+    retained_source_present: bool
+    pre_exclusion_role: str | None
+    pre_exclusion_state: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionPageStatus:
+    """Immutable manifest-only status for one logical submission page."""
+
+    page_number: int
+    page_state: str
+    selected_evidence_id: str | None
+    evidence: tuple[SubmissionEvidenceStatus, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionPageContext:
+    """Read-only page-management context for one canonical submission."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    manifest_path: Path
+    manifest_relative_path: str
+    submission_state: str
+    expected_pages: int | None
+    plain_paper: bool
+    plain_paper_entry_method: str | None
+    created_at: str
+    updated_at: str
+    pages: tuple[SubmissionPageStatus, ...]
+    present_count: int
+    missing_count: int
+    duplicate_count: int
+    needs_rescan_count: int
+    excluded_count: int
+    pages_without_selected_evidence: tuple[int, ...]
+
+
+def load_submission_page_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> SubmissionPageContext:
+    """Load one student's canonical manifest without inspecting evidence files."""
+    path, manifest = _load_manifest(
+        workspace_root, class_id, assignment_id, student_id
+    )
+    pages = tuple(
+        SubmissionPageStatus(
+            page_number=int(page["page_number"]),
+            page_state=str(page["page_state"]),
+            selected_evidence_id=(
+                str(page["selected_evidence_id"])
+                if page["selected_evidence_id"] is not None
+                else None
+            ),
+            evidence=tuple(_evidence_status(item) for item in _evidence_items(page)),
+        )
+        for page in sorted(
+            cast(list[dict[str, Any]], manifest["pages"]),
+            key=lambda item: int(item["page_number"]),
+        )
+    )
+    root = Path(workspace_root).resolve(strict=False)
+    try:
+        relative_path = path.resolve(strict=False).relative_to(root).as_posix()
+    except (OSError, ValueError):
+        relative_path = str(path)
+    details = cast(dict[str, Any], manifest["module_details"])
+    return SubmissionPageContext(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        manifest_path=path,
+        manifest_relative_path=relative_path,
+        submission_state=str(manifest["submission_state"]),
+        expected_pages=cast(int | None, manifest["expected_pages"]),
+        plain_paper=is_plain_paper_submission(manifest),
+        plain_paper_entry_method=cast(str | None, details.get("submission_entry_method")),
+        created_at=str(manifest["created_at"]),
+        updated_at=str(manifest["updated_at"]),
+        pages=pages,
+        present_count=_state_count(pages, "present"),
+        missing_count=_state_count(pages, "missing"),
+        duplicate_count=_state_count(pages, "duplicate"),
+        needs_rescan_count=_state_count(pages, "needs_rescan"),
+        excluded_count=_state_count(pages, "excluded"),
+        pages_without_selected_evidence=tuple(
+            page.page_number for page in pages if page.selected_evidence_id is None
+        ),
+    )
 
 
 def exclude_submission_page(
@@ -64,7 +175,9 @@ def exclude_submission_page(
     updated_page["selected_evidence_id"] = None
     for evidence in _evidence_items(updated_page):
         _preserve_evidence_state_before_exclusion(evidence)
-    return _write_result(manifest_path, updated, updated_page)
+    return _write_result(
+        manifest_path, updated, updated_page, previous_page=page, action="excluded"
+    )
 
 
 def restore_excluded_submission_page(
@@ -86,6 +199,7 @@ def restore_excluded_submission_page(
     updated = deepcopy(manifest)
     updated_page = _page_by_number(updated, page_number)
     evidence = _evidence_items(updated_page)
+    used_preserved_state = any(_has_preserved_state(item) for item in evidence)
     updated_page["selected_evidence_id"] = None
     if not evidence:
         updated_page["page_state"] = "missing"
@@ -109,7 +223,18 @@ def restore_excluded_submission_page(
             selected_ids[0] if selected_ids else None
         )
         updated_page["page_state"] = _restored_page_state(evidence)
-    return _write_result(manifest_path, updated, updated_page)
+    return _write_result(
+        manifest_path,
+        updated,
+        updated_page,
+        previous_page=page,
+        action="restored",
+        restore_source=(
+            "preserved pre-exclusion metadata"
+            if used_preserved_state
+            else "legacy fallback"
+        ),
+    )
 
 
 def mark_submission_page_needs_rescan(
@@ -133,9 +258,16 @@ def mark_submission_page_needs_rescan(
     updated_page["page_state"] = "needs_rescan"
     updated_page["selected_evidence_id"] = None
     for evidence in _evidence_items(updated_page):
+        _module_details(evidence).pop(_PRESERVED_EXCLUSION_KEY, None)
         evidence["evidence_role"] = "candidate"
         evidence["evidence_state"] = "needs_rescan"
-    return _write_result(manifest_path, updated, updated_page)
+    return _write_result(
+        manifest_path,
+        updated,
+        updated_page,
+        previous_page=page,
+        action="marked needs rescan",
+    )
 
 
 def _load_page(
@@ -152,14 +284,26 @@ def _load_page(
         or page_number < 1
     ):
         raise SubmissionPageManagementError("Page number must be a positive integer.")
-    path = submission_manifest_path(
+    path, manifest = _load_manifest(
         workspace_root, class_id, assignment_id, student_id
     )
+    return path, manifest, _page_by_number(manifest, page_number)
+
+
+def _load_manifest(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> tuple[Path, dict[str, Any]]:
+    _validate_identity(class_id, assignment_id, student_id)
+    path = submission_manifest_path(workspace_root, class_id, assignment_id, student_id)
     try:
         manifest = load_submission_manifest(path)
     except (SubmissionManifestError, OSError) as error:
+        guidance = f" {missing_submission_guidance()}" if not path.exists() else ""
         raise SubmissionPageManagementError(
-            f"Could not load submission record: {error}"
+            f"Could not load submission record: {error}{guidance}"
         ) from error
     if (
         manifest["class_id"] != class_id
@@ -169,7 +313,7 @@ def _load_page(
         raise SubmissionPageManagementError(
             "Submission record identity does not match the selected student."
         )
-    return path, manifest, _page_by_number(manifest, page_number)
+    return path, manifest
 
 
 def _page_by_number(manifest: dict[str, Any], page_number: int) -> dict[str, Any]:
@@ -188,13 +332,10 @@ def _evidence_items(page: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _preserve_evidence_state_before_exclusion(evidence: dict[str, Any]) -> None:
     module_details = _module_details(evidence)
-    module_details.setdefault(
-        _PRESERVED_EXCLUSION_KEY,
-        {
-            "evidence_role": evidence["evidence_role"],
-            "evidence_state": evidence["evidence_state"],
-        },
-    )
+    module_details[_PRESERVED_EXCLUSION_KEY] = {
+        "evidence_role": evidence["evidence_role"],
+        "evidence_state": evidence["evidence_state"],
+    }
     evidence["evidence_role"] = "excluded"
     evidence["evidence_state"] = "excluded"
 
@@ -224,6 +365,34 @@ def _module_details(evidence: dict[str, Any]) -> dict[str, Any]:
     return module_details
 
 
+def _has_preserved_state(evidence: dict[str, Any]) -> bool:
+    preserved = evidence.get("module_details", {}).get(_PRESERVED_EXCLUSION_KEY)
+    return isinstance(preserved, dict) and (
+        isinstance(preserved.get("evidence_role"), str)
+        or isinstance(preserved.get("evidence_state"), str)
+    )
+
+
+def _evidence_status(evidence: dict[str, Any]) -> SubmissionEvidenceStatus:
+    details = cast(dict[str, Any], evidence["module_details"])
+    preserved = details.get(_PRESERVED_EXCLUSION_KEY)
+    preserved_dict = preserved if isinstance(preserved, dict) else {}
+    return SubmissionEvidenceStatus(
+        evidence_id=str(evidence["evidence_id"]),
+        evidence_role=str(evidence["evidence_role"]),
+        evidence_state=str(evidence["evidence_state"]),
+        routed_evidence_path=str(evidence["routed_evidence_path"]),
+        duplicate_number=cast(int | None, evidence["duplicate_number"]),
+        retained_source_present=evidence["retained_source"] is not None,
+        pre_exclusion_role=cast(str | None, preserved_dict.get("evidence_role")),
+        pre_exclusion_state=cast(str | None, preserved_dict.get("evidence_state")),
+    )
+
+
+def _state_count(pages: tuple[SubmissionPageStatus, ...], state: str) -> int:
+    return sum(page.page_state == state for page in pages)
+
+
 def _restored_page_state(evidence: list[dict[str, Any]]) -> str:
     evidence_states = {item["evidence_state"] for item in evidence}
     if evidence_states & {"needs_rescan", "damaged"}:
@@ -234,7 +403,13 @@ def _restored_page_state(evidence: list[dict[str, Any]]) -> str:
 
 
 def _write_result(
-    manifest_path: Path, manifest: dict[str, Any], page: dict[str, Any]
+    manifest_path: Path,
+    manifest: dict[str, Any],
+    page: dict[str, Any],
+    *,
+    previous_page: dict[str, Any],
+    action: str,
+    restore_source: str | None = None,
 ) -> ManagedSubmissionPage:
     manifest["updated_at"] = datetime.now(UTC).isoformat()
     try:
@@ -250,13 +425,22 @@ def _write_result(
         assignment_id=str(manifest["assignment_id"]),
         student_id=str(manifest["student_id"]),
         page_number=int(page["page_number"]),
+        action=action,
+        previous_page_state=str(previous_page["page_state"]),
         page_state=str(page["page_state"]),
+        previous_selected_evidence_id=(
+            str(previous_page["selected_evidence_id"])
+            if previous_page["selected_evidence_id"] is not None
+            else None
+        ),
         selected_evidence_id=(
             str(page["selected_evidence_id"])
             if page["selected_evidence_id"] is not None
             else None
         ),
         evidence_count=len(page["evidence"]),
+        updated_at=str(manifest["updated_at"]),
+        restore_source=restore_source,
     )
 
 

--- a/tests/test_cli_pages.py
+++ b/tests/test_cli_pages.py
@@ -1,0 +1,281 @@
+"""Direct CLI coverage for canonical submission page management."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import quillan.cli_app.handlers.pages as page_handlers
+from quillan.cli_app.main import main
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+STUDENT_ID = "stu_0001"
+TIMESTAMP = "2026-07-13T12:00:00+00:00"
+
+
+def _evidence(evidence_id: str, page_number: int, role: str) -> dict[str, Any]:
+    return {
+        "evidence_id": evidence_id,
+        "routed_evidence_path": (
+            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+            f"response_{STUDENT_ID}_pg_{page_number:03d}.pdf"
+        ),
+        "evidence_role": role,
+        "evidence_state": "active",
+        "duplicate_number": None,
+        "created_at": TIMESTAMP,
+        "retained_source": None,
+        "module_details": {},
+    }
+
+
+def _manifest(*, plain_paper: bool = False) -> dict[str, Any]:
+    pages: list[dict[str, Any]] = []
+    expected_pages: int | None = None
+    details: dict[str, Any] = {
+        "submission_entry_method": "plain_paper_manual"
+    }
+    if not plain_paper:
+        expected_pages = 3
+        details = {}
+        pages = [
+            {
+                "page_number": 3,
+                "page_state": "missing",
+                "selected_evidence_id": None,
+                "evidence": [],
+            },
+            {
+                "page_number": 1,
+                "page_state": "present",
+                "selected_evidence_id": "evidence_001",
+                "evidence": [_evidence("evidence_001", 1, "selected")],
+            },
+            {
+                "page_number": 2,
+                "page_state": "duplicate",
+                "selected_evidence_id": None,
+                "evidence": [
+                    _evidence("evidence_002a", 2, "candidate"),
+                    _evidence("evidence_002b", 2, "candidate"),
+                ],
+            },
+        ]
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": expected_pages,
+        "submission_state": "reviewed",
+        "pages": pages,
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": details,
+    }
+
+
+def _write(root: Path, *, plain_paper: bool = False) -> Path:
+    path = submission_manifest_path(root, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    return write_submission_manifest(path, _manifest(plain_paper=plain_paper))
+
+
+def _configure_workspace(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr(page_handlers, "resolve_workspace_root", lambda: root)
+
+
+def test_help_lists_pages_namespace_and_all_subcommands(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as top_help:
+        main(["--help"])
+    assert top_help.value.code == 0
+    assert "pages" in capsys.readouterr().out
+
+    assert main(["pages"]) == 0
+    namespace_help = capsys.readouterr().out
+    assert "list" in namespace_help
+    assert "exclude" in namespace_help
+    assert "restore" in namespace_help
+    assert "mark-needs-rescan" in namespace_help
+
+    for command in ("list", "exclude", "restore", "mark-needs-rescan"):
+        with pytest.raises(SystemExit) as subcommand_help:
+            main(["pages", command, "--help"])
+        assert subcommand_help.value.code == 0
+        capsys.readouterr()
+
+
+def test_bare_pages_does_not_resolve_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        page_handlers,
+        "resolve_workspace_root",
+        lambda: pytest.fail("bare namespace resolved workspace"),
+    )
+    assert main(["pages"]) == 0
+
+
+def test_list_is_read_only_and_orders_pages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write(tmp_path)
+    before = path.read_bytes()
+    _configure_workspace(monkeypatch, tmp_path)
+
+    assert main(["pages", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+
+    output = capsys.readouterr().out
+    assert output.index("Page 1:") < output.index("Page 2:") < output.index("Page 3:")
+    assert "Selected evidence: none" in output
+    assert "Present pages: 1" in output
+    assert "Missing pages: 1" in output
+    assert "Duplicate pages: 1" in output
+    assert "Pages lacking selected evidence: 2,3" in output
+    assert "Routed path:" in output
+    assert path.read_bytes() == before
+
+
+def test_plain_paper_lists_zero_pages_and_mutations_fail_without_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write(tmp_path, plain_paper=True)
+    before = path.read_bytes()
+    _configure_workspace(monkeypatch, tmp_path)
+
+    assert main(["pages", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
+    output = capsys.readouterr().out
+    assert "Plain-paper submission: yes" in output
+    assert "zero digital pages" in output
+    assert "Digital pages: none" in output
+
+    for command in ("exclude", "restore", "mark-needs-rescan"):
+        assert main(
+            [
+                "pages",
+                command,
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--page",
+                "1",
+                "--yes",
+            ]
+        ) == 1
+        assert "Page 1 is not in this submission record" in capsys.readouterr().out
+        assert path.read_bytes() == before
+
+
+def test_missing_manifest_reports_assembly_guidance_without_creating_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_workspace(monkeypatch, tmp_path)
+    path = submission_manifest_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+
+    assert main(["pages", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 1
+    assert "Assemble submissions" in capsys.readouterr().out
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.parametrize("command", ["exclude", "restore", "mark-needs-rescan"])
+def test_mutations_require_yes_and_positive_page(
+    command: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as missing_yes:
+        main(
+            [
+                "pages",
+                command,
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--page",
+                "1",
+            ]
+        )
+    assert missing_yes.value.code != 0
+    assert "--yes" in capsys.readouterr().err
+
+    with pytest.raises(SystemExit) as invalid_page:
+        main(
+            [
+                "pages",
+                command,
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--page",
+                "0",
+                "--yes",
+            ]
+        )
+    assert invalid_page.value.code != 0
+    assert "positive integer" in capsys.readouterr().err
+
+
+def test_cli_mutations_report_transition_and_preserve_submission_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write(tmp_path)
+    review = path.with_name("review.json")
+    review.write_bytes(b'{"review_state":"in_progress"}\n')
+    review_before = review.read_bytes()
+    _configure_workspace(monkeypatch, tmp_path)
+    args = [CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--page", "1", "--yes"]
+
+    assert main(["pages", "exclude", *args]) == 0
+    excluded_output = capsys.readouterr().out
+    assert "Action: excluded" in excluded_output
+    assert "Previous state: present" in excluded_output
+    assert "Resulting state: excluded from active review" in excluded_output
+
+    assert main(["pages", "restore", *args]) == 0
+    restored_output = capsys.readouterr().out
+    assert "Action: restored" in restored_output
+    assert "Restore source: preserved pre-exclusion metadata" in restored_output
+
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    assert manifest["submission_state"] == "reviewed"
+    assert manifest["created_at"] == TIMESTAMP
+    assert review.read_bytes() == review_before
+
+
+def test_rescan_transition_discards_obsolete_exclusion_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write(tmp_path)
+    _configure_workspace(monkeypatch, tmp_path)
+    args = [CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--page", "1", "--yes"]
+
+    assert main(["pages", "exclude", *args]) == 0
+    assert main(["pages", "mark-needs-rescan", *args]) == 0
+    assert main(["pages", "exclude", *args]) == 0
+    assert main(["pages", "restore", *args]) == 0
+
+    page = json.loads(path.read_text(encoding="utf-8"))["pages"][1]
+    evidence = page["evidence"][0]
+    assert page["page_state"] == "needs_rescan"
+    assert page["selected_evidence_id"] is None
+    assert evidence["evidence_role"] == "candidate"
+    assert evidence["evidence_state"] == "needs_rescan"
+    assert "quillan_before_page_exclusion" not in evidence["module_details"]


### PR DESCRIPTION
## Summary

* Add direct CLI commands for inspecting and managing submission pages:

  * `quillan pages list`
  * `quillan pages exclude`
  * `quillan pages restore`
  * `quillan pages mark-needs-rescan`
* Add an immutable selected-student page and evidence context.
* Route all mutations through the existing shared submission-page management services.
* Preserve routed evidence, retained-source provenance, review records, exports, assignments, rosters, and unrelated workspace data.
* Keep all page-management mutations confined to the selected student’s canonical `submission.json`.

## Command Surface

```text
quillan pages list <class_id> <assignment_id> <student_id>

quillan pages exclude <class_id> <assignment_id> <student_id> \
  --page <positive_integer> \
  --yes

quillan pages restore <class_id> <assignment_id> <student_id> \
  --page <positive_integer> \
  --yes

quillan pages mark-needs-rescan <class_id> <assignment_id> <student_id> \
  --page <positive_integer> \
  --yes
```

Running:

```text
quillan pages
```

without a subcommand prints pages-command help and exits successfully without resolving or inspecting the workspace.

All commands are direct and non-interactive. They do not call `input()` or invoke menu functions.

## Shared Architecture

Added thin direct CLI handlers in:

* `quillan/cli_app/handlers/pages.py`

Extended the shared submission-page service in:

* `quillan/submission_page_management.py`

Updated command registration and teacher-facing output in:

* `quillan/cli_app/parser.py`
* `quillan/cli_app/output.py`

The implementation preserves the intended boundary:

```text
menu       -> shared submission-page services
direct CLI -> same shared submission-page services
future GUI -> same shared submission-page services
```

CLI handlers do not patch raw manifest dictionaries or write manifests directly.

## Read-Only Page Context

The shared service now exposes an immutable selected-student page and evidence context containing:

* canonical submission identity;
* canonical manifest path;
* submission state;
* expected page count;
* plain-paper status;
* manifest timestamps;
* total page count;
* page-state counts;
* pages without selected evidence;
* ordered page summaries;
* ordered evidence summaries.

The context loads only the requested student’s canonical manifest.

It does not scan every submission in the assignment, so an unrelated malformed sibling manifest cannot prevent inspection of the selected student’s valid record.

## `pages list`

`pages list` is strictly read-only.

It reports:

* class ID;
* assignment ID;
* student ID;
* canonical workspace-relative manifest path;
* submission state;
* expected page count;
* plain-paper status;
* total page count;
* present-page count;
* missing-page count;
* duplicate-page count;
* needs-rescan-page count;
* excluded-page count;
* pages lacking selected evidence;
* manifest creation timestamp;
* manifest update timestamp.

Pages are displayed in ascending logical page-number order.

Evidence records retain their stored order.

For each page, output includes:

* page number;
* page state;
* selected evidence ID or `none`;
* evidence-record count.

For each evidence record, output includes:

* evidence ID;
* evidence role;
* evidence state;
* routed evidence path;
* duplicate number;
* retained-source presence;
* preserved pre-exclusion role and state when present.

The command does not dump raw JSON, inspect evidence contents, open PDFs or images, or stat routed evidence files.

## Null Evidence Selections

Pages whose:

```text
selected_evidence_id = null
```

are displayed explicitly as having no selected evidence.

Listing does not:

* choose an evidence candidate;
* repair the manifest;
* normalize stored page order;
* modify timestamps;
* assemble submissions;
* create a review record.

## Plain-Paper Submissions

A valid plain-paper manual submission is handled separately from a missing manifest.

For a manifest containing no digital pages, `pages list`:

* succeeds;
* identifies the plain-paper workflow;
* reports zero digital pages;
* explains that the physical paper remains outside Quillan;
* writes nothing.

Mutation commands against a nonexistent digital page fail without:

* synthesizing a page;
* changing plain-paper metadata;
* changing `review.json`;
* creating routed evidence.

## Missing Manifest Behavior

When canonical `submission.json` does not exist:

* list and mutation commands fail clearly;
* existing submission-assembly guidance is displayed;
* no manifest is created;
* no review record is created;
* routed evidence is not assembled automatically;
* routed evidence remains unchanged.

A missing manifest is never treated as an empty or plain-paper submission.

## Page Validation

Mutation commands require:

```text
--page <positive_integer>
```

The implementation rejects:

* missing page values;
* zero;
* negative values;
* noninteger text;
* positive page numbers absent from the manifest.

The logical `page_number` field is authoritative.

Array position is not treated as page identity.

## Explicit Confirmation

All mutation commands require:

```text
--yes
```

When confirmation is omitted:

* the command does not prompt;
* no service mutation occurs;
* no files are changed;
* normal argument validation returns nonzero.

The read-only list command requires no confirmation.

## Excluding Pages

`pages exclude` calls the existing shared:

```text
exclude_submission_page(...)
```

service.

A successful exclusion sets:

```text
page_state = "excluded"
selected_evidence_id = null
```

For every evidence record, the service preserves the current:

* evidence role;
* evidence state;

under:

```text
module_details.quillan_before_page_exclusion
```

before changing the active values to:

```text
evidence_role = "excluded"
evidence_state = "excluded"
```

The operation preserves:

* evidence IDs;
* routed evidence paths;
* duplicate numbers;
* evidence creation timestamps;
* retained-source provenance;
* unrelated module metadata;
* evidence files.

An already excluded page is rejected without writing.

## Exclusion Without Selected Evidence

Pages without selected evidence can be excluded safely.

This includes:

* duplicate pages;
* unselected present pages;
* missing pages without evidence.

The service preserves every candidate’s current role and state and does not select a candidate before exclusion.

An empty missing page remains an empty page record after exclusion.

## Restoring Excluded Pages

`pages restore` calls:

```text
restore_excluded_submission_page(...)
```

Only an excluded page may be restored.

The service first attempts to restore each evidence record from its preserved pre-exclusion role and state.

After restoration, the temporary exclusion metadata is removed while unrelated module metadata remains intact.

## Preserved-State Restoration

When reliable preservation metadata exists:

* formerly selected evidence returns to its selected role;
* candidate evidence remains candidate;
* replacement roles remain replacement;
* active evidence remains active;
* damaged evidence remains damaged;
* needs-rescan evidence remains needs rescan;
* prior null page selection remains null when valid.

The service does not automatically select a lone candidate merely because it is the only evidence record when preserved metadata shows that it was previously unselected.

If restoration would result in multiple selected evidence records, the operation fails without writing.

## Restored Page State

After evidence state restoration:

* no evidence restores to `missing`;
* damaged or needs-rescan evidence produces `needs_rescan`;
* multiple evidence records produce `duplicate`;
* otherwise the page becomes `present`.

The selected evidence ID is reconstructed only when exactly one evidence record has the selected role.

## Legacy Restore Fallback

Excluded manifests created before pre-exclusion metadata remain supported.

When preserved metadata is absent:

* no evidence restores to `missing`;
* one evidence record restores to `present` and becomes selected and active;
* multiple evidence records restore to `duplicate`, candidate, active, and unselected.

The service does not choose among multiple legacy candidates.

Successful output identifies whether restoration used:

* preserved pre-exclusion metadata; or
* legacy fallback.

## Marking Pages as Needing Rescan

`pages mark-needs-rescan` calls:

```text
mark_submission_page_needs_rescan(...)
```

A successful mutation sets:

```text
page_state = "needs_rescan"
selected_evidence_id = null
```

Every existing evidence record becomes:

```text
evidence_role = "candidate"
evidence_state = "needs_rescan"
```

The service preserves all evidence records and files.

A missing page without evidence may also be marked as needing rescan, producing:

```text
page_state = "needs_rescan"
selected_evidence_id = null
evidence = []
```

No placeholder evidence record is created.

A page already marked as needing rescan is rejected without writing.

## Exclusion Metadata Consistency

The implementation fixes stale exclusion metadata during an explicit:

```text
excluded -> needs_rescan
```

transition.

When an excluded page is marked as needing rescan, obsolete:

```text
module_details.quillan_before_page_exclusion
```

metadata is removed.

This prevents a later exclude-and-restore cycle from restoring evidence state from before the earlier exclusion.

The resulting transition remains consistent:

```text
exclude
mark needs rescan
exclude again
restore
```

restores the current candidate/needs-rescan state rather than an obsolete earlier state.

This correction is implemented in the shared service, so menu and direct CLI behavior remain aligned.

## Top-Level Submission State

Page-management actions preserve the manifest’s existing:

```text
submission_state
```

They do not automatically change it to:

* `needs_rescan`;
* `in_progress`;
* `unreviewed`;
* `reviewed`.

Page state and top-level submission state remain separate explicit concepts.

## Timestamp Behavior

Successful mutations:

* preserve manifest `created_at`;
* update manifest `updated_at`;
* preserve evidence `created_at`;
* preserve retained-source provenance and timestamps;
* leave review and export timestamps unchanged.

Failed or unconfirmed operations do not alter timestamps.

## Mutation Results

Shared mutation results now include:

* action;
* class ID;
* assignment ID;
* student ID;
* page number;
* previous page state;
* resulting page state;
* previous selected evidence ID;
* resulting selected evidence ID;
* evidence-record count;
* canonical manifest path;
* update timestamp;
* restoration source when applicable.

The CLI prints concise teacher-facing status rather than raw manifest JSON.

## Complete Validation Before Write

Every successful mutation follows this sequence:

1. validate identifiers;
2. resolve the canonical manifest path;
3. load and validate the current manifest;
4. validate manifest identity;
5. verify the requested page exists;
6. apply the mutation to a deep copy;
7. validate the complete resulting manifest;
8. atomically replace canonical `submission.json`.

The complete manifest is validated, not only the selected page.

Malformed unrelated page or evidence data therefore causes the operation to fail without automatically repairing or partially rewriting the record.

## Atomic Writing

All writes continue through the existing canonical atomic submission-manifest writer.

Write failures are wrapped as page-management errors.

Tests verify that a failed write:

* preserves original manifest bytes;
* leaves no partial canonical mutation;
* leaves evidence files unchanged;
* leaves review files unchanged.

## Exact Write Boundary

Mutation commands may modify only:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
```

`pages list` writes nothing.

The implementation does not modify:

* another student’s manifest;
* `review.json`;
* minimum-requirement data;
* review units;
* observations;
* overall ratings;
* feedback options;
* feedback comments;
* private notes;
* review state;
* export metadata;
* feedback Markdown or PDF;
* assignment reports;
* assignment configuration;
* rosters;
* class metadata;
* reusable comment sets;
* scan-review records;
* Core data;
* ScoreForm data.

## Evidence Preservation

Page management changes manifest metadata only.

It does not:

* delete evidence;
* rename evidence;
* move evidence;
* copy evidence;
* overwrite evidence;
* inspect evidence contents;
* change evidence-file bytes;
* change evidence-file timestamps.

Routed evidence paths remain unchanged.

## Retained-Source Preservation

Retained-source provenance remains unchanged, including:

* source scan ID;
* source filename;
* source SHA-256;
* retained-source path;
* source page number.

Retained source files are not opened or modified.

## Review and Export Preservation

Existing `review.json` records remain byte-for-byte unchanged.

This includes:

* minimum-requirement checks and outcomes;
* review units;
* Focus Standard observations;
* overall Focus Standard ratings;
* feedback composition;
* reusable-comment snapshots;
* private notes;
* review state;
* export metadata;
* review timestamps.

Existing generated exports and reports remain unchanged.

Page exclusion or rescan status does not trigger rescoring, rating changes, feedback recomposition, or export regeneration.

## Menu Regression Safety

The teacher-facing Manage Submission Pages menu continues to:

* explain that excluded pages are preserved;
* explain that exclusion does not delete files;
* list current pages;
* exclude pages;
* restore excluded pages;
* mark pages as needing rescan;
* require confirmation;
* call the shared page-management services;
* report resulting state;
* report preserved evidence counts;
* leave review data unchanged.

The CLI does not introduce separate transition rules.

## No Automated Processing

Confirmed that the implementation does not:

* assemble submissions;
* route scans;
* decode QR payloads;
* open evidence;
* inspect PDFs;
* inspect images;
* run OCR;
* perform handwriting recognition;
* use AI;
* select evidence;
* resolve duplicates;
* score work;
* grade work;
* calculate mastery;
* modify observations;
* modify ratings;
* compose feedback;
* export feedback;
* update review state.

## Files Changed

Nine intended Quillan source, test, and documentation files were modified or added:

* `README.md`
* `docs/cli_contract.md`
* `docs/data_contracts.md`
* `docs/teacher_review_model.md`
* `quillan/cli_app/output.py`
* `quillan/cli_app/parser.py`
* `quillan/submission_page_management.py`
* `quillan/cli_app/handlers/pages.py`
* `tests/test_cli_pages.py`

## Documentation

Updated documentation covers:

* the `pages` namespace;
* bare namespace help;
* read-only page listing;
* positive logical page numbers;
* explicit `--yes` confirmation;
* exclusion behavior;
* preserved role and state metadata;
* restoration behavior;
* legacy restoration fallback;
* needs-rescan behavior;
* null selected-evidence handling;
* plain-paper submissions;
* missing-manifest guidance;
* separation between page state and submission state;
* exact write boundaries;
* evidence and retained-source preservation;
* the absence of OCR, AI, scoring, and feedback mutation.

## Safety

Confirmed:

* bare namespace help does not resolve the workspace;
* direct handlers are non-interactive;
* list is manifest-only and read-only;
* page order is deterministic;
* evidence order is preserved;
* plain-paper submissions remain evidence-less;
* missing manifests are not created automatically;
* mutation commands require positive page numbers;
* mutation commands require `--yes`;
* excluded pages are preserved rather than deleted;
* evidence roles, states, and provenance are preserved;
* legacy excluded manifests remain restorable;
* stale exclusion metadata is removed on needs-rescan transitions;
* top-level submission state remains unchanged;
* only the selected canonical manifest may change;
* routed evidence and retained scans remain unchanged;
* review records and exports remain unchanged;
* PDS Core remains unchanged;
* ScoreForm remains unchanged;
* no real student data or generated artifacts were added.

## Validation

* Focused page-management CLI tests: `18 passed`
* Page, submission, and menu regressions: `378 passed`, `847 deselected`
* Broader CLI regressions: `250 passed`, `975 deselected`
* Full pytest suite: `1225 passed`
* Ruff: passed
* mypy: passed, `164` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* Git status contains only the nine intended Quillan changes
* No student data, workspace records, routed evidence, retained scans, or generated review/export artifacts present

Closes #307
