### PR TITLE
Add assignment review dashboard CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Quillan currently supports:
 * basic requirements and minimum-requirement return policy;
 * printable QR paper response packets;
 * QR/paper routing and submission assembly;
-* read-only submission status listing;
+* read-only submission status listing and assignment review dashboards;
 * workspace-safe evidence opening and selected-evidence opening;
 * minimum-requirements review with explicit teacher-entered outcomes;
 * review-unit Focus Standard observations;
@@ -206,6 +206,19 @@ submission manifests, review records, routed evidence, rosters, standards, or
 reusable comments.
 
 ## Direct CLI Commands
+
+The assignment-level review dashboard is available in concise teacher text or
+stable schema-version-1 JSON. Both forms are non-interactive and strictly
+read-only:
+
+```powershell
+quillan review-dashboard <class_id> <assignment_id> [--format text|json]
+```
+
+It combines roster coverage, submissions, routed evidence, page states, review
+workflow, minimum-requirement outcomes, feedback freshness, and assignment-
+filtered scan-review attention. It does not inspect evidence, infer judgments,
+assemble submissions, or write exports or reports.
 
 The direct command surface exposed through argparse is:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -47,6 +47,26 @@ quillan [command] [arguments]
 Calling `quillan.cli.main()` from Python is useful for tests, but it is not a
 separate public Python API contract.
 
+## Assignment Review Dashboard
+
+```powershell
+quillan review-dashboard <class_id> <assignment_id> [--format text|json]
+```
+
+`text` is the default. `json` writes exactly one JSON document to standard
+output using dashboard schema version `1`; it never names or creates an output
+file. The command is direct, non-interactive, deterministic for unchanged
+workspace data, and read-only. It shares its immutable dashboard service and
+text formatter with Assignment Review Actions. See
+[`review_dashboard_contract.md`](review_dashboard_contract.md) for population,
+warning, ordering, read-boundary, and JSON details.
+
+Missing work, malformed student records, stale exports, roster unavailability,
+and active scan-review items are successful diagnostic results. Invalid
+identifiers or assignment configuration, assignment identity/class mismatch,
+unrecoverable routed discovery, and unsafe serialization are fatal and return
+nonzero without a traceback.
+
 ## Direct Reusable Focus Standard Comments
 
 The non-interactive `comments` namespace manages teacher-authored shared

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -14,6 +14,15 @@ has been removed. This index documents the active v0.8.6 contracts.
 
 ## Active Contracts
 
+### Assignment Review Dashboard
+
+The live assignment review dashboard is an immutable derived read model, not a
+stored workspace record. Its versioned JSON representation and exact read-only
+boundary are defined in
+[`review_dashboard_contract.md`](review_dashboard_contract.md). It does not
+change the assignment, submission, review, feedback-export, or scan-review
+schemas.
+
 ### Assignment
 
 Active assignments use schema version `2` and live at:

--- a/docs/review_dashboard_contract.md
+++ b/docs/review_dashboard_contract.md
@@ -1,0 +1,80 @@
+# Assignment Review Dashboard Contract
+
+## Command and boundary
+
+```powershell
+quillan review-dashboard <class_id> <assignment_id> [--format text|json]
+```
+
+Text is the default. The command and Assignment Review Actions menu use the
+same immutable service. JSON is printed only to standard output. A successful
+dashboard may read the canonical assignment, class roster, student submission
+and review records, routed-evidence filenames and routing metadata, feedback
+export metadata and file existence, and scan-review failure and resolution
+metadata. Paths are workspace-relative POSIX strings.
+
+There is no workspace write boundary. The service creates no directories,
+records, manifests, exports, reports, temporary files, locks, caches, scan
+resolutions, or audit entries and changes no timestamps. It does not open or
+inspect student evidence, PDFs, or images; decode QR data; run OCR, handwriting
+recognition, or AI; infer requirements, ratings, grades, mastery, or feedback;
+assemble submissions; resolve scan items; or invoke an export writer.
+
+## Population and diagnostics
+
+Students are ordered as current roster entries in roster order, followed by
+submission-directory students sorted by exact ID, then routed-evidence-only
+students sorted by exact ID. Exact IDs are deduplicated. Roster names display
+as `First Last`; other rows fall back to the student ID. If the roster is
+missing or invalid, assignment-local students remain visible in ID order,
+`roster_available` is false, `rostered` is null, and no complete expected
+population is claimed.
+
+Submission and review files are independently classified as `missing`,
+`valid`, `invalid`, or `identity_mismatch`; a review beside no valid submission
+is `orphaned`. A malformed student file produces student and dashboard warnings
+without hiding other rows. Valid plain-paper manifests are valid submissions
+with zero digital pages. Only valid, identity-matching records contribute
+stored workflow-state counts.
+
+Page states are `present`, `missing`, `duplicate`, `needs_rescan`, and
+`excluded`, plus `present_unselected`. Feedback PDF and Markdown are counted
+separately as `present`, `stale`, `missing`, or `unknown` using canonical export
+metadata freshness rules. Assignment-filtered unresolved and deferred scan
+items are included; resolved items are excluded. Scan discovery failure sets
+`available` false rather than inventing zero availability.
+
+Diagnostic conditions return success once the dashboard is safely built.
+Fatal assignment validation, identifier, discovery, or serialization failures
+return nonzero and no partial dashboard.
+
+## JSON schema version 1
+
+The top-level object always contains, in stable order:
+
+```text
+schema_version, record_type, class_id, assignment_id, assignment, summary,
+students, unassembled_routed_files, unused_duplicate_routed_files,
+skipped_routed_files, scan_review_items, warnings
+```
+
+`schema_version` is `"1"`; `record_type` is
+`"quillan_assignment_review_dashboard"`. `assignment` contains `title`,
+`writing_type`, `standards_profile_id`, `focus_standard_count`, and `path`.
+`summary` always contains `students`, `submissions`, `pages`,
+`routed_evidence`, `reviews`, `minimum_requirements`, `feedback_exports`, and
+`scan_review`. Fixed state groups remain present even when every count is zero.
+
+Each student has stable `student_id`, `display_name`, `roster_status`,
+`routed_evidence_present`, `needs_assembly`, `submission`, `review`, `exports`,
+and `warnings` keys. Submission objects include status, canonical path, stored
+state or null, plain-paper boolean, and all page counts. Review objects include
+status, canonical path, stored state or null, minimum-requirement status or
+null, and returned-without-full-review boolean.
+
+Counts are JSON integers, flags are JSON booleans, genuinely unavailable
+scalars are JSON null, and ordered collections are arrays. Empty arrays are not
+omitted. No execution timestamp, random identifier, absolute path, or `Path`
+representation is emitted, so repeated unchanged invocations are structurally
+identical. Renaming or removing keys, changing their JSON types or meanings, or
+changing path semantics requires a dashboard schema-version change.

--- a/quillan/cli_app/handlers/dashboard.py
+++ b/quillan/cli_app/handlers/dashboard.py
@@ -1,0 +1,38 @@
+"""Direct assignment review dashboard command handler."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.review_dashboard import (
+    ReviewDashboardError,
+    assignment_review_dashboard_to_dict,
+    build_assignment_review_dashboard,
+    format_assignment_review_dashboard,
+)
+
+
+def handle_review_dashboard(args: argparse.Namespace) -> int:
+    """Print one read-only assignment dashboard as text or JSON."""
+    try:
+        root = resolve_workspace_root()
+        dashboard = build_assignment_review_dashboard(
+            root, args.class_id, args.assignment_id
+        )
+        output = (
+            json.dumps(
+                assignment_review_dashboard_to_dict(dashboard),
+                indent=2,
+                ensure_ascii=False,
+            )
+            if args.format == "json"
+            else format_assignment_review_dashboard(dashboard)
+        )
+    except (WorkspaceRootError, ReviewDashboardError, OSError, TypeError) as error:
+        print(f"Error: could not build assignment review dashboard: {error}")
+        return 1
+    print(output)
+    return 0

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -12,6 +12,7 @@ from quillan.cli_app.handlers.comments import (
     handle_comments_list,
     handle_comments_show,
 )
+from quillan.cli_app.handlers.dashboard import handle_review_dashboard
 from quillan.cli_app.handlers.exports import (
     handle_export_class_summary,
     handle_export_feedback,
@@ -97,6 +98,23 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=APP_DESCRIPTION)
     subparsers = parser.add_subparsers(dest="command")
 
+    dashboard_parser = subparsers.add_parser(
+        "review-dashboard",
+        help="Show a read-only assignment review dashboard.",
+        description=(
+            "Combine roster, submission, page, review, feedback-export, routed-"
+            "evidence, and scan-review status without creating or modifying files."
+        ),
+    )
+    _add_assignment_identity_arguments(dashboard_parser)
+    dashboard_parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Standard-output representation (default: text).",
+    )
+    dashboard_parser.set_defaults(handler=handle_review_dashboard)
+
     assignment_parser = subparsers.add_parser(
         "assignment", help="Create, show, and validate canonical assignments."
     )
@@ -115,7 +133,9 @@ def build_parser() -> argparse.ArgumentParser:
     assignment_create_parser.add_argument("--review-unit-type", default="paragraph")
     assignment_create_parser.add_argument("--review-unit-singular", default="paragraph")
     assignment_create_parser.add_argument("--review-unit-plural", default="paragraphs")
-    assignment_create_parser.add_argument("--rating-scale", choices=("default",), default="default")
+    assignment_create_parser.add_argument(
+        "--rating-scale", choices=("default",), default="default"
+    )
     assignment_create_parser.add_argument("--paragraphs-min", type=nonnegative_integer)
     assignment_create_parser.add_argument("--paragraphs-max", type=nonnegative_integer)
     assignment_create_parser.add_argument("--word-count-min", type=nonnegative_integer)
@@ -139,7 +159,9 @@ def build_parser() -> argparse.ArgumentParser:
         "validate", help="Validate a canonical assignment and workspace standards."
     )
     _add_assignment_identity_arguments(assignment_validate_parser)
-    assignment_validate_parser.set_defaults(handler=handle_canonical_assignment_validate)
+    assignment_validate_parser.set_defaults(
+        handler=handle_canonical_assignment_validate
+    )
 
     requirements_parser = subparsers.add_parser(
         "requirements",
@@ -380,10 +402,16 @@ def build_parser() -> argparse.ArgumentParser:
     _add_submission_identity_arguments(feedback_options_parser)
     feedback_options_parser.add_argument("--standard-id", required=True)
     feedback_options_parser.add_argument(
-        "--include-overall-rating", required=True, type=_true_false, metavar="true|false"
+        "--include-overall-rating",
+        required=True,
+        type=_true_false,
+        metavar="true|false",
     )
     feedback_options_parser.add_argument(
-        "--include-overall-rationale", required=True, type=_true_false, metavar="true|false"
+        "--include-overall-rationale",
+        required=True,
+        type=_true_false,
+        metavar="true|false",
     )
     feedback_options_parser.add_argument(
         "--observation-ids",
@@ -392,7 +420,8 @@ def build_parser() -> argparse.ArgumentParser:
     feedback_options_parser.set_defaults(handler=handle_feedback_set_options)
 
     feedback_comment_parser = feedback_subparsers.add_parser(
-        "add-comment", help="Add one exact teacher-authored feedback comment.",
+        "add-comment",
+        help="Add one exact teacher-authored feedback comment.",
         description=(
             "Add exact teacher-authored text. When saving for reuse, remove all "
             "student-specific details from the separately approved reusable text."
@@ -433,7 +462,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_submission_identity_arguments(feedback_complete_parser)
     feedback_complete_parser.add_argument(
-        "--yes", action="store_true", help="Explicitly confirm completion without prompting."
+        "--yes",
+        action="store_true",
+        help="Explicitly confirm completion without prompting.",
     )
     feedback_complete_parser.set_defaults(handler=handle_feedback_mark_composed)
 
@@ -558,9 +589,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Path to the selected source scan file, or a folder with --decode-qr.",
     )
-    payload_group = route_scan_parser.add_mutually_exclusive_group(
-        required=True
-    )
+    payload_group = route_scan_parser.add_mutually_exclusive_group(required=True)
     payload_group.add_argument(
         "--payload",
         help="Already-decoded canonical PDS1 payload text.",
@@ -822,9 +851,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_submission_identity_arguments(review_state_parser)
     review_state_parser.add_argument(
         "state",
-        help=(
-            "Review state: unreviewed, in_progress, needs_rescan, or reviewed."
-        ),
+        help=("Review state: unreviewed, in_progress, needs_rescan, or reviewed."),
     )
     review_state_parser.set_defaults(handler=handle_set_review_state)
 
@@ -979,9 +1006,7 @@ def build_parser() -> argparse.ArgumentParser:
         "workspace",
         help="Manage the shared Paper Data Suite workspace.",
     )
-    workspace_subparsers = workspace_parser.add_subparsers(
-        dest="workspace_command"
-    )
+    workspace_subparsers = workspace_parser.add_subparsers(dest="workspace_command")
     workspace_show_parser = workspace_subparsers.add_parser(
         "show",
         help="Show the active Paper Data Suite workspace status.",
@@ -1024,7 +1049,9 @@ def _add_assignment_identity_arguments(
     parser.add_argument("assignment_id", help="Assignment identifier.")
 
 
-def _print_parser_help(parser: argparse.ArgumentParser, _args: argparse.Namespace) -> int:
+def _print_parser_help(
+    parser: argparse.ArgumentParser, _args: argparse.Namespace
+) -> int:
     parser.print_help()
     return 0
 

--- a/quillan/review_dashboard.py
+++ b/quillan/review_dashboard.py
@@ -1,0 +1,895 @@
+"""Immutable, read-only assignment review dashboard composition."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from pds_core.classes import load_class_roster
+from pds_core.identifiers import validate_identifier
+from pds_core.rosters import RosterError, student_display_name
+
+from quillan.assignment_submission_assembly import (
+    discover_assignment_routed_evidence_status,
+)
+from quillan.assignment_summary_context import feedback_status, relative_path_for
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.feedback_export import feedback_export_path, feedback_pdf_export_path
+from quillan.plain_paper_submission import is_plain_paper_submission
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.review_status_display import review_progress_status
+from quillan.scan_review_resolution import (
+    ScanReviewResolutionError,
+    discover_scan_review_items,
+)
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+
+DASHBOARD_SCHEMA_VERSION: Final = "1"
+DASHBOARD_RECORD_TYPE: Final = "quillan_assignment_review_dashboard"
+SUBMISSION_STATES: Final = ("unreviewed", "in_progress", "needs_rescan", "reviewed")
+PAGE_STATES: Final = ("present", "missing", "duplicate", "needs_rescan", "excluded")
+REVIEW_STATES: Final = (
+    "not_started",
+    "requirements_checked",
+    "returned_without_full_review",
+    "observations_in_progress",
+    "observations_complete",
+    "ratings_complete",
+    "feedback_composed",
+    "ready_for_export",
+    "exported",
+)
+MINIMUM_REQUIREMENT_STATES: Final = (
+    "not_checked",
+    "met",
+    "unmet_continue_review",
+    "returned_without_full_review",
+)
+EXPORT_STATES: Final = ("present", "stale", "missing", "unknown")
+
+
+class ReviewDashboardError(ValueError):
+    """Raised when an assignment dashboard cannot be built safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class DashboardWarning:
+    code: str
+    message: str
+    path: str | None = None
+    student_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DashboardStudentStatus:
+    student_id: str
+    display_name: str
+    roster_status: str
+    routed_evidence_present: bool
+    needs_assembly: bool
+    submission_status: str
+    submission_path: str
+    submission_state: str | None
+    plain_paper: bool
+    evidence_file_count: int
+    page_counts: tuple[tuple[str, int], ...]
+    review_status: str
+    review_path: str
+    review_state: str | None
+    minimum_requirement_status: str | None
+    returned_without_full_review: bool
+    feedback_pdf_status: str
+    feedback_markdown_status: str
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DashboardScanReviewItem:
+    failure_id: str
+    status: str
+    failure_category: str
+    failure_message: str
+    source_filename: str
+    source_page_number: int | None
+    student_id: str | None
+    failure_metadata_path: str
+    retained_source_path: str | None
+    created_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class AssignmentReviewDashboard:
+    class_id: str
+    assignment_id: str
+    assignment_title: str
+    writing_type: str
+    standards_profile_id: str
+    focus_standard_count: int
+    assignment_path: str
+    roster_available: bool
+    rostered_count: int | None
+    students: tuple[DashboardStudentStatus, ...]
+    submission_counts: tuple[tuple[str, int], ...]
+    submission_state_counts: tuple[tuple[str, int], ...]
+    page_counts: tuple[tuple[str, int], ...]
+    page_student_counts: tuple[tuple[str, int], ...]
+    routed_counts: tuple[tuple[str, int], ...]
+    review_counts: tuple[tuple[str, int], ...]
+    review_state_counts: tuple[tuple[str, int], ...]
+    minimum_requirement_counts: tuple[tuple[str, int], ...]
+    workflow_counts: tuple[tuple[str, int], ...]
+    feedback_pdf_counts: tuple[tuple[str, int], ...]
+    feedback_markdown_counts: tuple[tuple[str, int], ...]
+    scan_review_available: bool
+    scan_review_counts: tuple[tuple[str, int], ...]
+    scan_review_categories: tuple[tuple[str, int], ...]
+    unassembled_routed_files: tuple[str, ...]
+    unused_duplicate_routed_files: tuple[str, ...]
+    skipped_routed_files: tuple[tuple[str, str], ...]
+    scan_review_items: tuple[DashboardScanReviewItem, ...]
+    warnings: tuple[DashboardWarning, ...]
+
+
+def build_assignment_review_dashboard(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> AssignmentReviewDashboard:
+    """Build a deterministic dashboard using only existing workspace records."""
+    try:
+        validate_identifier(class_id, "class_id")
+        validate_identifier(assignment_id, "assignment_id")
+    except ValueError as error:
+        raise ReviewDashboardError(str(error)) from error
+    root = Path(workspace_root).resolve(strict=False)
+    assignment_path = (
+        root / "classes" / class_id / "assignments" / assignment_id / "assignment.json"
+    )
+    try:
+        assignment = load_assignment_config(assignment_path)
+    except (OSError, AssignmentConfigError) as error:
+        raise ReviewDashboardError(f"Could not load assignment: {error}") from error
+    if assignment["assignment_id"] != assignment_id:
+        raise ReviewDashboardError(
+            f"Assignment identity mismatch: expected {assignment_id!r}, "
+            f"found {assignment['assignment_id']!r}."
+        )
+    if class_id not in assignment["class_ids"]:
+        raise ReviewDashboardError(
+            f"Assignment {assignment_id!r} is not configured for class {class_id!r}."
+        )
+
+    warnings: list[DashboardWarning] = []
+    roster_students: tuple[Any, ...] | None
+    try:
+        roster_students = load_class_roster(root, class_id).students
+    except (OSError, RosterError) as error:
+        roster_students = None
+        warnings.append(DashboardWarning("roster_unavailable", str(error)))
+
+    submissions_dir = assignment_path.parent / "submissions"
+    submission_ids = _directory_ids(submissions_dir)
+    try:
+        routed = discover_assignment_routed_evidence_status(
+            root, class_id, assignment_id
+        )
+    except (OSError, ValueError) as error:
+        raise ReviewDashboardError(
+            f"Could not discover routed evidence: {error}"
+        ) from error
+    routed_ids = set(routed.evidence_by_student)
+    ordered_ids, display_names, roster_ids = _student_population(
+        roster_students, submission_ids, routed_ids
+    )
+
+    students: list[DashboardStudentStatus] = []
+    valid_manifests: dict[str, dict[str, Any]] = {}
+    assembled_paths: set[Path] = set()
+    submission_files_present = 0
+    review_files_present = 0
+    orphaned_reviews = 0
+    for student_id in ordered_ids:
+        student_dir = submissions_dir / student_id
+        manifest_path = student_dir / "submission.json"
+        review_path = student_dir / "review.json"
+        manifest_relative = relative_path_for(manifest_path, root)
+        review_relative = relative_path_for(review_path, root)
+        student_warnings: list[str] = []
+        manifest: dict[str, Any] | None = None
+        submission_status = "missing"
+        if manifest_path.is_file():
+            submission_files_present += 1
+            try:
+                loaded = load_submission_manifest(manifest_path)
+            except (OSError, SubmissionManifestError) as error:
+                submission_status = "invalid"
+                student_warnings.append("invalid_submission")
+                warnings.append(
+                    DashboardWarning(
+                        "invalid_submission", str(error), manifest_relative, student_id
+                    )
+                )
+            else:
+                if _identity_mismatch(loaded, class_id, assignment_id, student_id):
+                    submission_status = "identity_mismatch"
+                    student_warnings.append("submission_identity_mismatch")
+                    warnings.append(
+                        DashboardWarning(
+                            "submission_identity_mismatch",
+                            "Submission identity does not match its canonical path.",
+                            manifest_relative,
+                            student_id,
+                        )
+                    )
+                else:
+                    submission_status = "valid"
+                    manifest = loaded
+                    valid_manifests[student_id] = loaded
+                    assembled_paths.update(_manifest_evidence_paths(root, loaded))
+        elif student_id in roster_ids:
+            student_warnings.append("missing_submission")
+
+        review: dict[str, Any] | None = None
+        review_status = "missing" if manifest is not None else "unavailable"
+        if review_path.is_file():
+            review_files_present += 1
+            if manifest is None:
+                review_status = "orphaned"
+                orphaned_reviews += 1
+                student_warnings.append("review_without_valid_submission")
+                warnings.append(
+                    DashboardWarning(
+                        "review_without_valid_submission",
+                        "Review record exists without a valid adjacent submission.",
+                        review_relative,
+                        student_id,
+                    )
+                )
+            else:
+                try:
+                    loaded_review = load_review_record(review_path)
+                except (OSError, ReviewRecordError) as error:
+                    review_status = "invalid"
+                    student_warnings.append("invalid_review")
+                    warnings.append(
+                        DashboardWarning(
+                            "invalid_review", str(error), review_relative, student_id
+                        )
+                    )
+                else:
+                    if _identity_mismatch(
+                        loaded_review, class_id, assignment_id, student_id
+                    ):
+                        review_status = "identity_mismatch"
+                        student_warnings.append("review_identity_mismatch")
+                        warnings.append(
+                            DashboardWarning(
+                                "review_identity_mismatch",
+                                "Review identity does not match its canonical path.",
+                                review_relative,
+                                student_id,
+                            )
+                        )
+                    else:
+                        review_status = "valid"
+                        review = loaded_review
+        elif manifest is not None:
+            student_warnings.append("missing_review")
+
+        page_counts = Counter({state: 0 for state in PAGE_STATES})
+        present_unselected = 0
+        if manifest is not None:
+            for page in manifest["pages"]:
+                page_counts[page["page_state"]] += 1
+                if (
+                    page["page_state"] == "present"
+                    and page["selected_evidence_id"] is None
+                ):
+                    present_unselected += 1
+            page_counts["present_unselected"] = present_unselected
+
+        pdf_default = feedback_pdf_export_path(
+            root, class_id, assignment_id, student_id
+        )
+        md_default = feedback_export_path(root, class_id, assignment_id, student_id)
+        _, pdf_status, _, pdf_warnings = feedback_status(
+            root, review, "feedback_pdf", pdf_default
+        )
+        _, md_status, _, md_warnings = feedback_status(
+            root, review, "feedback_markdown", md_default
+        )
+        student_warnings.extend(pdf_warnings)
+        student_warnings.extend(md_warnings)
+        for code in (*pdf_warnings, *md_warnings):
+            warnings.append(
+                DashboardWarning(code, _warning_message(code), student_id=student_id)
+            )
+
+        routed_present = student_id in routed_ids
+        needs_assembly = routed_present and manifest is None
+        if needs_assembly:
+            student_warnings.append("routed_evidence_needs_assembly")
+        if student_id not in roster_ids and roster_students is not None:
+            student_warnings.append("unrostered_student")
+        minimum = (
+            None if review is None else review["minimum_requirement_outcome"]["status"]
+        )
+        returned = bool(
+            review is not None
+            and review["minimum_requirement_outcome"]["returned_without_full_review"]
+        )
+        students.append(
+            DashboardStudentStatus(
+                student_id=student_id,
+                display_name=display_names.get(student_id, student_id),
+                roster_status=(
+                    "rostered"
+                    if student_id in roster_ids
+                    else "roster_unavailable"
+                    if roster_students is None
+                    else "unrostered"
+                ),
+                routed_evidence_present=routed_present,
+                needs_assembly=needs_assembly,
+                submission_status=submission_status,
+                submission_path=manifest_relative,
+                submission_state=None
+                if manifest is None
+                else manifest["submission_state"],
+                plain_paper=manifest is not None
+                and is_plain_paper_submission(manifest),
+                evidence_file_count=(
+                    0
+                    if manifest is None
+                    else sum(len(page["evidence"]) for page in manifest["pages"])
+                ),
+                page_counts=_fixed_counts(
+                    page_counts, (*PAGE_STATES, "present_unselected")
+                ),
+                review_status=review_status,
+                review_path=review_relative,
+                review_state=None if review is None else review["review_state"],
+                minimum_requirement_status=minimum,
+                returned_without_full_review=returned,
+                feedback_pdf_status=pdf_status,
+                feedback_markdown_status=md_status,
+                warnings=tuple(dict.fromkeys(student_warnings)),
+            )
+        )
+
+    unassembled, unused_duplicates = _routed_file_status(
+        root, routed.evidence_by_student, valid_manifests, assembled_paths
+    )
+    scan_available = True
+    scan_items: tuple[DashboardScanReviewItem, ...] = ()
+    scan_warning_count = 0
+    try:
+        scan_discovery = discover_scan_review_items(
+            root, class_id=class_id, assignment_id=assignment_id, include_resolved=False
+        )
+        scan_warning_count = len(scan_discovery.warnings)
+        for message in scan_discovery.warnings:
+            warnings.append(DashboardWarning("scan_review_metadata_warning", message))
+        scan_items = tuple(
+            DashboardScanReviewItem(
+                failure_id=item.failure_id,
+                status=item.display_status,
+                failure_category=item.failure_category,
+                failure_message=item.failure_message,
+                source_filename=item.source_filename,
+                source_page_number=item.source_page_number,
+                student_id=item.student_id,
+                failure_metadata_path=item.failure_metadata_relative_path,
+                retained_source_path=item.retained_source_path,
+                created_at=item.created_at,
+            )
+            for item in scan_discovery.items
+        )
+    except (OSError, ScanReviewResolutionError, ValueError) as error:
+        scan_available = False
+        warnings.append(DashboardWarning("scan_review_unavailable", str(error)))
+
+    return _dashboard(
+        root=root,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        assignment=assignment,
+        roster_students=roster_students,
+        roster_ids=roster_ids,
+        students=tuple(students),
+        submission_files_present=submission_files_present,
+        review_files_present=review_files_present,
+        orphaned_reviews=orphaned_reviews,
+        routed_ids=routed_ids,
+        unassembled=unassembled,
+        unused_duplicates=unused_duplicates,
+        skipped=tuple(
+            (relative_path_for(item.path, root), item.reason)
+            for item in routed.skipped_files
+        ),
+        scan_available=scan_available,
+        scan_warning_count=scan_warning_count,
+        scan_items=scan_items,
+        warnings=tuple(warnings),
+    )
+
+
+def _dashboard(**values: Any) -> AssignmentReviewDashboard:
+    students: tuple[DashboardStudentStatus, ...] = values["students"]
+    roster_ids: set[str] = values["roster_ids"]
+    submission_statuses = Counter(student.submission_status for student in students)
+    submission_states = Counter(
+        student.submission_state
+        for student in students
+        if student.submission_state is not None
+    )
+    page_counts: Counter[str] = Counter()
+    page_student_counts: Counter[str] = Counter()
+    for student in students:
+        counts = dict(student.page_counts)
+        page_counts.update(counts)
+        for state in (*PAGE_STATES, "present_unselected"):
+            if counts[state]:
+                page_student_counts[f"students_with_{state}"] += 1
+    review_statuses = Counter(student.review_status for student in students)
+    review_states = Counter(
+        student.review_state for student in students if student.review_state is not None
+    )
+    minimum_states = Counter(
+        student.minimum_requirement_status
+        for student in students
+        if student.minimum_requirement_status is not None
+    )
+    pdf_states = Counter(student.feedback_pdf_status for student in students)
+    md_states = Counter(student.feedback_markdown_status for student in students)
+    progress: Counter[str] = Counter()
+    for student in students:
+        if student.review_state is None:
+            continue
+        status = review_progress_status({"review_state": student.review_state})
+        progress["observations_complete"] += status.observations_complete
+        progress["ratings_complete"] += status.ratings_complete
+        progress["feedback_composed"] += status.feedback_composed
+        progress["ready_for_export"] += student.review_state in {
+            "ready_for_export",
+            "exported",
+        }
+        progress["exported"] += student.review_state == "exported"
+    scan_items: tuple[DashboardScanReviewItem, ...] = values["scan_items"]
+    scan_statuses = Counter(item.status for item in scan_items)
+    categories = Counter(item.failure_category for item in scan_items)
+    assignment = values["assignment"]
+    roster_students = values["roster_students"]
+    return AssignmentReviewDashboard(
+        class_id=values["class_id"],
+        assignment_id=values["assignment_id"],
+        assignment_title=assignment["title"],
+        writing_type=assignment["writing_type"],
+        standards_profile_id=assignment["standards_profile_id"],
+        focus_standard_count=len(assignment["focus_standard_ids"]),
+        assignment_path=relative_path_for(
+            values["root"]
+            / "classes"
+            / values["class_id"]
+            / "assignments"
+            / values["assignment_id"]
+            / "assignment.json",
+            values["root"],
+        ),
+        roster_available=roster_students is not None,
+        rostered_count=None if roster_students is None else len(roster_students),
+        students=students,
+        submission_counts=(
+            ("manifest_files_present", values["submission_files_present"]),
+            ("valid", submission_statuses["valid"]),
+            ("missing", submission_statuses["missing"]),
+            ("invalid", submission_statuses["invalid"]),
+            ("identity_mismatch", submission_statuses["identity_mismatch"]),
+            ("plain_paper", sum(s.plain_paper for s in students)),
+            (
+                "rostered_students_missing_submission",
+                sum(
+                    s.student_id in roster_ids and s.submission_status != "valid"
+                    for s in students
+                ),
+            ),
+        ),
+        submission_state_counts=_fixed_counts(submission_states, SUBMISSION_STATES),
+        page_counts=(
+            ("total", sum(page_counts[s] for s in PAGE_STATES)),
+            *((state, page_counts[state]) for state in PAGE_STATES),
+            ("present_unselected", page_counts["present_unselected"]),
+        ),
+        page_student_counts=_fixed_counts(
+            page_student_counts,
+            tuple(f"students_with_{s}" for s in (*PAGE_STATES, "present_unselected")),
+        ),
+        routed_counts=(
+            ("students_with_routed_evidence", len(values["routed_ids"])),
+            ("students_needing_assembly", sum(s.needs_assembly for s in students)),
+            ("unassembled_files", len(values["unassembled"])),
+            ("unused_duplicate_files", len(values["unused_duplicates"])),
+            ("skipped_files", len(values["skipped"])),
+            (
+                "unrostered_students_discovered",
+                sum(s.roster_status == "unrostered" for s in students),
+            ),
+        ),
+        review_counts=(
+            ("files_present", values["review_files_present"]),
+            ("valid", review_statuses["valid"]),
+            ("missing", review_statuses["missing"]),
+            ("invalid", review_statuses["invalid"]),
+            ("identity_mismatch", review_statuses["identity_mismatch"]),
+            ("orphaned", values["orphaned_reviews"]),
+        ),
+        review_state_counts=_fixed_counts(review_states, REVIEW_STATES),
+        minimum_requirement_counts=_fixed_counts(
+            minimum_states, MINIMUM_REQUIREMENT_STATES
+        ),
+        workflow_counts=_fixed_counts(
+            progress,
+            (
+                "observations_complete",
+                "ratings_complete",
+                "feedback_composed",
+                "ready_for_export",
+                "exported",
+            ),
+        ),
+        feedback_pdf_counts=_fixed_counts(pdf_states, EXPORT_STATES),
+        feedback_markdown_counts=_fixed_counts(md_states, EXPORT_STATES),
+        scan_review_available=values["scan_available"],
+        scan_review_counts=(
+            ("attention_items", len(scan_items)),
+            ("unresolved", scan_statuses["unresolved"]),
+            ("deferred", scan_statuses["deferred"]),
+            ("metadata_warning_count", values["scan_warning_count"]),
+        ),
+        scan_review_categories=tuple(sorted(categories.items())),
+        unassembled_routed_files=values["unassembled"],
+        unused_duplicate_routed_files=values["unused_duplicates"],
+        skipped_routed_files=values["skipped"],
+        scan_review_items=scan_items,
+        warnings=values["warnings"],
+    )
+
+
+def assignment_review_dashboard_to_dict(
+    dashboard: AssignmentReviewDashboard,
+) -> dict[str, object]:
+    """Serialize dashboard schema version 1 using JSON-native values."""
+    return {
+        "schema_version": DASHBOARD_SCHEMA_VERSION,
+        "record_type": DASHBOARD_RECORD_TYPE,
+        "class_id": dashboard.class_id,
+        "assignment_id": dashboard.assignment_id,
+        "assignment": {
+            "title": dashboard.assignment_title,
+            "writing_type": dashboard.writing_type,
+            "standards_profile_id": dashboard.standards_profile_id,
+            "focus_standard_count": dashboard.focus_standard_count,
+            "path": dashboard.assignment_path,
+        },
+        "summary": {
+            "students": {
+                "dashboard_total": len(dashboard.students),
+                "roster_available": dashboard.roster_available,
+                "rostered": dashboard.rostered_count,
+                "unrostered_discovered": dict(dashboard.routed_counts)[
+                    "unrostered_students_discovered"
+                ],
+            },
+            "submissions": {
+                **dict(dashboard.submission_counts),
+                "states": dict(dashboard.submission_state_counts),
+            },
+            "pages": {
+                **dict(dashboard.page_counts),
+                **dict(dashboard.page_student_counts),
+            },
+            "routed_evidence": dict(dashboard.routed_counts),
+            "reviews": {
+                **dict(dashboard.review_counts),
+                "states": dict(dashboard.review_state_counts),
+                "workflow": dict(dashboard.workflow_counts),
+            },
+            "minimum_requirements": dict(dashboard.minimum_requirement_counts),
+            "feedback_exports": {
+                "pdf": dict(dashboard.feedback_pdf_counts),
+                "markdown": dict(dashboard.feedback_markdown_counts),
+            },
+            "scan_review": {
+                "available": dashboard.scan_review_available,
+                **dict(dashboard.scan_review_counts),
+                "categories": dict(dashboard.scan_review_categories),
+            },
+        },
+        "students": [_student_to_dict(student) for student in dashboard.students],
+        "unassembled_routed_files": list(dashboard.unassembled_routed_files),
+        "unused_duplicate_routed_files": list(dashboard.unused_duplicate_routed_files),
+        "skipped_routed_files": [
+            {"path": path, "reason": reason}
+            for path, reason in dashboard.skipped_routed_files
+        ],
+        "scan_review_items": [
+            _scan_item_to_dict(item) for item in dashboard.scan_review_items
+        ],
+        "warnings": [_warning_to_dict(warning) for warning in dashboard.warnings],
+    }
+
+
+def format_assignment_review_dashboard(
+    dashboard: AssignmentReviewDashboard,
+    *,
+    show_unused_duplicate_files: bool = True,
+) -> str:
+    """Return concise deterministic teacher-facing dashboard text."""
+    submissions, pages = dict(dashboard.submission_counts), dict(dashboard.page_counts)
+    routed, reviews = dict(dashboard.routed_counts), dict(dashboard.review_counts)
+    lines = [
+        "Assignment Review Dashboard",
+        "",
+        f"Submission status for assignment {dashboard.assignment_id}",
+        "",
+        f"Class: {dashboard.class_id}",
+        f"Assignment: {dashboard.assignment_title} ({dashboard.assignment_id})",
+        f"Writing type: {dashboard.writing_type}",
+        f"Focus Standards: {dashboard.focus_standard_count}",
+        "",
+        "Student coverage:",
+        f"- Roster available: {'yes' if dashboard.roster_available else 'no'}",
+        f"- Rostered students: {dashboard.rostered_count if dashboard.rostered_count is not None else 'unknown'}",
+        f"- Dashboard students: {len(dashboard.students)}",
+        f"- Unrostered records: {routed['unrostered_students_discovered']}",
+        "",
+        "Submission intake:",
+        f"- Valid manifests: {submissions['valid']}",
+        f"- Rostered students missing submissions: {submissions['rostered_students_missing_submission']}",
+        f"- Routed-evidence students needing assembly: {routed['students_needing_assembly']}",
+        f"- Invalid manifests: {submissions['invalid']}",
+        f"- Identity mismatches: {submissions['identity_mismatch']}",
+        f"- Plain-paper submissions: {submissions['plain_paper']}",
+        f"- Unassembled routed files: {routed['unassembled_files']}",
+        f"- Skipped routed files: {routed['skipped_files']}",
+        "",
+        "Submission states:",
+    ]
+    lines.extend(
+        f"- {key}: {value}" for key, value in dashboard.submission_state_counts
+    )
+    lines.extend(["", "Page states:"])
+    lines.extend(f"- {key.replace('_', ' ')}: {pages[key]}" for key in PAGE_STATES)
+    lines.append(f"- present but unselected: {pages['present_unselected']}")
+    lines.extend(
+        [
+            "",
+            "Review progress:",
+            f"- Valid reviews: {reviews['valid']}",
+            f"- Missing reviews: {reviews['missing']}",
+            f"- Invalid reviews: {reviews['invalid']}",
+            f"- Identity mismatches: {reviews['identity_mismatch']}",
+            f"- Orphaned reviews: {reviews['orphaned']}",
+        ]
+    )
+    lines.extend(f"- {key}: {value}" for key, value in dashboard.review_state_counts)
+    lines.extend(["", "Minimum requirements:"])
+    lines.extend(
+        f"- {key}: {value}" for key, value in dashboard.minimum_requirement_counts
+    )
+    lines.extend(["", "Feedback exports:"])
+    lines.extend(
+        f"- PDF {key}: {value}" for key, value in dashboard.feedback_pdf_counts
+    )
+    lines.extend(
+        f"- Markdown {key}: {value}"
+        for key, value in dashboard.feedback_markdown_counts
+    )
+    scan = dict(dashboard.scan_review_counts)
+    lines.extend(
+        [
+            "",
+            "Scan review:",
+            f"- Available: {'yes' if dashboard.scan_review_available else 'no'}",
+            f"- Attention items: {scan['attention_items']}",
+            f"- Unresolved: {scan['unresolved']}",
+            f"- Deferred: {scan['deferred']}",
+            f"- Metadata warnings: {scan['metadata_warning_count']}",
+        ]
+    )
+    lines.extend(["", "Students:"])
+    for student in dashboard.students:
+        page_detail = ",".join(f"{k}:{v}" for k, v in student.page_counts if v)
+        lines.append(
+            f"- {student.display_name} ({student.student_id}):"
+            if student.display_name != student.student_id
+            else f"- {student.student_id}:"
+        )
+        lines.append(
+            f"  submission={student.submission_state or student.submission_status}; pages={page_detail or 'none'}; "
+            f"review={student.review_state or student.review_status}; pdf={student.feedback_pdf_status}; "
+            f"markdown={student.feedback_markdown_status}"
+        )
+    attention = [s for s in dashboard.students if s.warnings]
+    if attention or dashboard.scan_review_items or dashboard.warnings:
+        lines.extend(["", "Needs attention:"])
+        for student in attention:
+            lines.append(f"- {student.display_name}: {', '.join(student.warnings)}")
+        for item in dashboard.scan_review_items:
+            lines.append(
+                f"- Scan {item.failure_id}: {item.status}; {item.failure_category}; {item.failure_message}"
+            )
+        for warning in dashboard.warnings:
+            if warning.student_id is None:
+                lines.append(f"- {warning.code}: {warning.message}")
+    if dashboard.skipped_routed_files:
+        lines.extend(["", "Skipped routed files:"])
+        lines.extend(
+            f"- {path} — {reason}" for path, reason in dashboard.skipped_routed_files
+        )
+    if dashboard.unassembled_routed_files:
+        lines.extend(
+            [
+                "",
+                "Unassembled routed files:",
+                *(f"- {p}" for p in dashboard.unassembled_routed_files),
+            ]
+        )
+    if show_unused_duplicate_files and dashboard.unused_duplicate_routed_files:
+        lines.extend(
+            [
+                "",
+                "Duplicate routed files not used:",
+                *(f"- {p}" for p in dashboard.unused_duplicate_routed_files),
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _student_population(
+    roster: tuple[Any, ...] | None, submission_ids: set[str], routed_ids: set[str]
+) -> tuple[tuple[str, ...], dict[str, str], set[str]]:
+    roster_ids: set[str] = set()
+    display: dict[str, str] = {}
+    ordered: list[str] = []
+    if roster is not None:
+        for student in roster:
+            roster_ids.add(student.student_id)
+            ordered.append(student.student_id)
+            display[student.student_id] = student_display_name(student)
+    ordered.extend(sorted(submission_ids - roster_ids))
+    ordered.extend(sorted(routed_ids - set(ordered)))
+    return tuple(ordered), display, roster_ids
+
+
+def _directory_ids(path: Path) -> set[str]:
+    try:
+        return {entry.name for entry in path.iterdir() if entry.is_dir()}
+    except (FileNotFoundError, NotADirectoryError):
+        return set()
+    except OSError as error:
+        raise ReviewDashboardError(
+            f"Could not discover submission directories: {error}"
+        ) from error
+
+
+def _identity_mismatch(
+    record: dict[str, Any], class_id: str, assignment_id: str, student_id: str
+) -> bool:
+    return any(
+        record[field] != expected
+        for field, expected in (
+            ("class_id", class_id),
+            ("assignment_id", assignment_id),
+            ("student_id", student_id),
+        )
+    )
+
+
+def _manifest_evidence_paths(root: Path, manifest: dict[str, Any]) -> set[Path]:
+    return {
+        (root / item["routed_evidence_path"]).resolve(strict=False)
+        for page in manifest["pages"]
+        for item in page["evidence"]
+    }
+
+
+def _routed_file_status(
+    root: Path,
+    evidence_by_student: dict[str, list[Any]],
+    manifests: dict[str, dict[str, Any]],
+    assembled: set[Path],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    represented = {
+        student_id: {
+            page["page_number"] for page in manifest["pages"] if page["evidence"]
+        }
+        for student_id, manifest in manifests.items()
+    }
+    unassembled: list[str] = []
+    duplicates: list[str] = []
+    for student_id, items in evidence_by_student.items():
+        for item in items:
+            path = Path(item.routed_evidence_path)
+            resolved = (root / path).resolve(strict=False)
+            if resolved in assembled:
+                continue
+            relative = relative_path_for(resolved, root)
+            if (
+                item.duplicate_number is not None
+                and item.page_number in represented.get(student_id, set())
+            ):
+                duplicates.append(relative)
+            else:
+                unassembled.append(relative)
+    return tuple(sorted(unassembled, key=str.casefold)), tuple(
+        sorted(duplicates, key=str.casefold)
+    )
+
+
+def _fixed_counts(
+    counter: Counter[Any], keys: tuple[str, ...]
+) -> tuple[tuple[str, int], ...]:
+    return tuple((key, int(counter[key])) for key in keys)
+
+
+def _student_to_dict(student: DashboardStudentStatus) -> dict[str, object]:
+    return {
+        "student_id": student.student_id,
+        "display_name": student.display_name,
+        "roster_status": student.roster_status,
+        "routed_evidence_present": student.routed_evidence_present,
+        "needs_assembly": student.needs_assembly,
+        "submission": {
+            "status": student.submission_status,
+            "path": student.submission_path,
+            "state": student.submission_state,
+            "plain_paper": student.plain_paper,
+            "pages": dict(student.page_counts),
+        },
+        "review": {
+            "status": student.review_status,
+            "path": student.review_path,
+            "state": student.review_state,
+            "minimum_requirement_status": student.minimum_requirement_status,
+            "returned_without_full_review": student.returned_without_full_review,
+        },
+        "exports": {
+            "feedback_pdf": student.feedback_pdf_status,
+            "feedback_markdown": student.feedback_markdown_status,
+        },
+        "warnings": list(student.warnings),
+    }
+
+
+def _scan_item_to_dict(item: DashboardScanReviewItem) -> dict[str, object]:
+    return {
+        "failure_id": item.failure_id,
+        "status": item.status,
+        "failure_category": item.failure_category,
+        "failure_message": item.failure_message,
+        "source_filename": item.source_filename,
+        "source_page_number": item.source_page_number,
+        "student_id": item.student_id,
+        "failure_metadata_path": item.failure_metadata_path,
+        "retained_source_path": item.retained_source_path,
+        "created_at": item.created_at,
+    }
+
+
+def _warning_to_dict(warning: DashboardWarning) -> dict[str, object]:
+    return {
+        "code": warning.code,
+        "message": warning.message,
+        "path": warning.path,
+        "student_id": warning.student_id,
+    }
+
+
+def _warning_message(code: str) -> str:
+    return code.replace("_", " ").capitalize() + "."

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -1,4 +1,4 @@
-﻿"""Teacher-facing review navigation menu skeleton."""
+"""Teacher-facing review navigation menu skeleton."""
 
 from __future__ import annotations
 
@@ -24,7 +24,6 @@ from quillan.class_summary_export import (
 )
 from quillan.cli_app.output import (
     print_added_review_note,
-    print_assignment_submission_status,
     print_exported_class_summary,
     print_exported_feedback,
     print_exported_feedback_pdf,
@@ -106,6 +105,13 @@ from quillan.review_record_paths import (
     review_record_path,
     write_review_record,
 )
+from quillan.review_dashboard import (
+    AssignmentReviewDashboard,
+    DashboardStudentStatus,
+    ReviewDashboardError,
+    build_assignment_review_dashboard,
+    format_assignment_review_dashboard,
+)
 from quillan.review_status_display import (
     feedback_export_status,
     review_progress_status,
@@ -124,7 +130,10 @@ from quillan.submission_review_opening import (
     open_student_submission_for_review,
     selected_submission_evidence_pages,
 )
-from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    load_submission_manifest,
+)
 from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
@@ -258,11 +267,25 @@ def _load_submission_status(
         return None
 
 
+def _load_review_dashboard(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> AssignmentReviewDashboard | None:
+    try:
+        return build_assignment_review_dashboard(
+            workspace_root, class_id, assignment_id
+        )
+    except (ReviewDashboardError, OSError) as error:
+        print(f"Error: could not build assignment review dashboard: {error}")
+        return None
+
+
 def _prompt_student_id(
     workspace_root: Path,
     class_id: str,
     assignment_id: str,
-    status: AssignmentSubmissionStatus,
+    status: AssignmentSubmissionStatus | AssignmentReviewDashboard,
 ) -> str | None:
     from quillan.menu import clear_screen, print_menu_header
 
@@ -277,10 +300,12 @@ def _prompt_student_id(
     print(f"Assignment: {assignment_id}")
     print()
 
-    status_by_student = {
-        student_status.student_id: student_status
-        for student_status in status.student_statuses
-    }
+    status_items = (
+        status.students
+        if isinstance(status, AssignmentReviewDashboard)
+        else status.student_statuses
+    )
+    status_by_student = {item.student_id: item for item in status_items}
     student_labels = student_display_lookup(workspace_root, class_id)
     print("Select student/submission:")
     for index, student_id in enumerate(student_ids, start=1):
@@ -310,7 +335,7 @@ def _prompt_student_id(
 def _student_choices(
     workspace_root: Path,
     class_id: str,
-    status: AssignmentSubmissionStatus,
+    status: AssignmentSubmissionStatus | AssignmentReviewDashboard,
 ) -> tuple[str, ...]:
     ordered: list[str] = []
     seen: set[str] = set()
@@ -324,7 +349,12 @@ def _student_choices(
             ordered.append(student.student_id)
             seen.add(student.student_id)
 
-    for student_status in status.student_statuses:
+    status_items = (
+        status.students
+        if isinstance(status, AssignmentReviewDashboard)
+        else status.student_statuses
+    )
+    for student_status in status_items:
         if student_status.student_id not in seen:
             ordered.append(student_status.student_id)
             seen.add(student_status.student_id)
@@ -332,22 +362,36 @@ def _student_choices(
     return tuple(ordered)
 
 
-def _student_status_label(status: StudentSubmissionStatus | None) -> str:
+def _student_status_label(
+    status: StudentSubmissionStatus | DashboardStudentStatus | None,
+) -> str:
     if status is None:
         return "no manifest; no routed evidence"
+    if isinstance(status, DashboardStudentStatus):
+        if status.submission_status != "valid":
+            if status.submission_status == "missing" and not status.routed_evidence_present:
+                return "no manifest; no routed evidence"
+            return (
+                "routed evidence exists; no manifest"
+                if status.needs_assembly
+                else status.submission_status.replace("_", " ")
+            )
+        if status.plain_paper:
+            return "plain-paper manual submission; no digital evidence"
+        return (
+            f"{status.submission_state}; manifest exists; "
+            f"evidence files={status.evidence_file_count}"
+        )
     if status.manifest_path is None:
         return "routed evidence exists; no manifest"
     try:
-        if is_plain_paper_submission(
-            load_submission_manifest(status.manifest_path)
-        ):
+        if is_plain_paper_submission(load_submission_manifest(status.manifest_path)):
             return "plain-paper manual submission; no digital evidence"
     except (OSError, SubmissionManifestError):
         pass
     evidence_count = sum(page.evidence_count for page in status.pages)
     return (
-        f"{status.submission_state}; manifest exists; "
-        f"evidence files={evidence_count}"
+        f"{status.submission_state}; manifest exists; evidence files={evidence_count}"
     )
 
 
@@ -401,8 +445,7 @@ def _launch_selected_student_review(
                 "submission record has not been assembled yet."
             )
             print(
-                "Assemble submissions before reviewing, tagging, scoring, "
-                "or exporting."
+                "Assemble submissions before reviewing, tagging, scoring, or exporting."
             )
             print()
             print("1. Assemble this assignment now")
@@ -602,7 +645,9 @@ def _menu_view_current_review_details(
     _print_review_action_header(
         "Current Review Details", class_id, assignment_id, student_id
     )
-    print(current_review_details_text(workspace_root, class_id, assignment_id, student_id))
+    print(
+        current_review_details_text(workspace_root, class_id, assignment_id, student_id)
+    )
 
 
 def _format_secondary_id(value: object) -> str:
@@ -856,12 +901,15 @@ def _count_included_review_unit_observations(record: dict[str, Any]) -> int:
         return 0
     total = 0
     for unit in units:
-        observations = unit.get("standard_observations") if isinstance(unit, dict) else None
+        observations = (
+            unit.get("standard_observations") if isinstance(unit, dict) else None
+        )
         if isinstance(observations, list):
             total += sum(
                 1
                 for observation in observations
-                if isinstance(observation, dict) and observation.get("include_in_feedback")
+                if isinstance(observation, dict)
+                and observation.get("include_in_feedback")
             )
     return total
 
@@ -923,9 +971,13 @@ def _print_observation_entry_header(
     if unit is not None:
         print(f"Review unit: {unit['label']}")
     if standard_id is not None:
-        print(f"Focus Standard: {_format_standard_display(workspace_root, standard_id)}")
+        print(
+            f"Focus Standard: {_format_standard_display(workspace_root, standard_id)}"
+        )
     if current_observation is not None:
-        status = "applicable" if current_observation.get("applicable") else "not applicable"
+        status = (
+            "applicable" if current_observation.get("applicable") else "not applicable"
+        )
         print(f"Current observation: {status}")
         evidence_present = current_observation.get("evidence_present")
         if evidence_present is not None:
@@ -947,7 +999,10 @@ def _unit_standard_observation(
     if not isinstance(observations, list):
         return None
     for observation in observations:
-        if isinstance(observation, dict) and observation.get("standard_id") == standard_id:
+        if (
+            isinstance(observation, dict)
+            and observation.get("standard_id") == standard_id
+        ):
             return observation
     return None
 
@@ -967,7 +1022,9 @@ def _print_rating_entry_header(
     )
     print(f"Step: {step}")
     if standard_id is not None:
-        print(f"Focus Standard: {_format_standard_display(workspace_root, standard_id)}")
+        print(
+            f"Focus Standard: {_format_standard_display(workspace_root, standard_id)}"
+        )
     if current_rating is not None:
         print(f"Current rating: {current_rating['rating']}")
         print(
@@ -1021,10 +1078,7 @@ def _print_review_summary(
     print()
     print(f"Class: {class_id}")
     print(f"Assignment: {assignment_id}")
-    print(
-        f"Student: "
-        f"{student_review_label(workspace_root, class_id, student_id)}"
-    )
+    print(f"Student: {student_review_label(workspace_root, class_id, student_id)}")
 
     status = _load_submission_status(workspace_root, class_id, assignment_id)
     student_status = None
@@ -1109,7 +1163,9 @@ def _print_review_record_summary(
         workspace_root,
         class_id,
         assignment_id,
-        _current_requirement_checks(workspace_root, class_id, assignment_id, student_id),
+        _current_requirement_checks(
+            workspace_root, class_id, assignment_id, student_id
+        ),
         record["minimum_requirement_outcome"],
     )
 
@@ -1137,7 +1193,9 @@ def _count_review_unit_observations(record: dict[str, Any]) -> int:
         return 0
     total = 0
     for unit in units:
-        observations = unit.get("standard_observations") if isinstance(unit, dict) else None
+        observations = (
+            unit.get("standard_observations") if isinstance(unit, dict) else None
+        )
         if isinstance(observations, list):
             total += len(observations)
     return total
@@ -1145,7 +1203,9 @@ def _count_review_unit_observations(record: dict[str, Any]) -> int:
 
 def _count_feedback_comments(record: dict[str, Any]) -> int:
     feedback = record.get("feedback")
-    standard_feedback = feedback.get("standard_feedback") if isinstance(feedback, dict) else None
+    standard_feedback = (
+        feedback.get("standard_feedback") if isinstance(feedback, dict) else None
+    )
     if not isinstance(standard_feedback, list):
         return 0
     total = 0
@@ -1165,9 +1225,7 @@ def _print_requirement_check_summary(
 ) -> None:
     assignment = _load_assignment_for_summary(workspace_root, class_id, assignment_id)
     requirements = (
-        _requirement_items_from_assignment(assignment)
-        if assignment is not None
-        else []
+        _requirement_items_from_assignment(assignment) if assignment is not None else []
     )
     if not requirements:
         print("Minimum requirements: none configured")
@@ -1339,8 +1397,7 @@ def _choose_submission_evidence_page(
     print("Selected evidence pages:")
     for index, page in enumerate(pages, start=1):
         print(
-            f"{index}. Page {page.page_number} - {page.page_state} - "
-            f"{page.evidence_id}"
+            f"{index}. Page {page.page_number} - {page.page_state} - {page.evidence_id}"
         )
     print_navigation_options(all_items=True)
     print()
@@ -1422,7 +1479,9 @@ def _menu_define_review_units(
     review_unit = assignment["review_unit"]
     unit_type = str(review_unit["type"])
     plural_label = str(review_unit["plural_label"])
-    existing = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+    existing = _current_review_record(
+        workspace_root, class_id, assignment_id, student_id
+    )
     existing_units = existing.get("review_units", []) if existing is not None else []
     print(f"Assignment review unit type: {unit_type}")
     print(f"Focus Standards: {len(assignment['focus_standard_ids'])}")
@@ -1525,7 +1584,9 @@ def _record_review_unit_observation(
         step="Select Focus Standard",
         unit=unit,
     )
-    standard_id = _prompt_focus_standard(workspace_root, assignment["focus_standard_ids"])
+    standard_id = _prompt_focus_standard(
+        workspace_root, assignment["focus_standard_ids"]
+    )
     if standard_id is None:
         print("Observation entry canceled.")
         return
@@ -1634,7 +1695,9 @@ def _menu_mark_observations_complete(
     if record is None or not record.get("review_units"):
         print("Define review units before marking observations complete.")
         return
-    print("Observations may be marked complete without observing every unit-standard pair.")
+    print(
+        "Observations may be marked complete without observing every unit-standard pair."
+    )
     print("1. Mark observations complete")
     print("2. Back")
     print()
@@ -1650,8 +1713,7 @@ def _menu_mark_observations_complete(
         return
     if completed.missing_focus_standard_pairs:
         print(
-            "Unobserved unit-standard pairs: "
-            f"{completed.missing_focus_standard_pairs}"
+            f"Unobserved unit-standard pairs: {completed.missing_focus_standard_pairs}"
         )
     print_completed_review_unit_observations(completed)
 
@@ -1675,7 +1737,9 @@ def _menu_overall_focus_standard_ratings(
         if assignment is None:
             input("Press Enter to continue...")
             return
-        record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+        record = _current_review_record(
+            workspace_root, class_id, assignment_id, student_id
+        )
         _print_overall_rating_status(assignment, record)
         _print_overall_rating_warnings(record)
         print()
@@ -1727,7 +1791,9 @@ def _menu_compose_focus_standard_feedback(
         if assignment is None:
             input("Press Enter to continue...")
             return
-        record = _current_review_record(workspace_root, class_id, assignment_id, student_id)
+        record = _current_review_record(
+            workspace_root, class_id, assignment_id, student_id
+        )
         _print_feedback_composer_status(
             workspace_root, class_id, assignment_id, student_id, assignment, record
         )
@@ -1920,7 +1986,9 @@ def _menu_add_custom_focus_standard_feedback_comment(
     )
     print(f"Comment: {_preview_text(text)}")
     print()
-    include_in_feedback = _prompt_yes_no_default_yes("Include this comment in feedback?")
+    include_in_feedback = _prompt_yes_no_default_yes(
+        "Include this comment in feedback?"
+    )
     _print_feedback_action_header(
         "Add Focus Standard Feedback Comment",
         student_id,
@@ -2111,7 +2179,9 @@ def _menu_select_reusable_focus_standard_feedback_comment(
     print()
     print(selected.text)
     print()
-    include_in_feedback = _prompt_yes_no_default_yes("Include this comment in feedback?")
+    include_in_feedback = _prompt_yes_no_default_yes(
+        "Include this comment in feedback?"
+    )
     _print_feedback_action_header(
         "Reusable Focus Standard Comment",
         student_id,
@@ -2381,7 +2451,9 @@ def _record_overall_focus_standard_rating(
         standard_id=standard_id,
         current_rating=current_rating,
     )
-    include_in_feedback = _prompt_yes_no_default_yes("Include rating/rationale in feedback?")
+    include_in_feedback = _prompt_yes_no_default_yes(
+        "Include rating/rationale in feedback?"
+    )
     _print_rating_entry_header(
         workspace_root,
         class_id,
@@ -2568,7 +2640,9 @@ def _print_feedback_action_header(
     print_menu_header(title)
     print(f"Student: {student_id}")
     if workspace_root is not None and standard_id is not None:
-        print(f"Focus Standard: {_format_standard_display(workspace_root, standard_id)}")
+        print(
+            f"Focus Standard: {_format_standard_display(workspace_root, standard_id)}"
+        )
     print()
 
 
@@ -2619,7 +2693,9 @@ def _print_feedback_comment_context(
     print(f"Included comments: {included_comments}")
 
 
-def _print_current_rating_and_rationale(record: dict[str, Any], standard_id: str) -> None:
+def _print_current_rating_and_rationale(
+    record: dict[str, Any], standard_id: str
+) -> None:
     rating = next(
         (
             item
@@ -2662,8 +2738,7 @@ def _prompt_observation_id_selection(observations: list[dict[str, Any]]) -> list
     if not observations:
         return []
     raw = input(
-        "Select observations to include by number, comma-separated "
-        "(blank for none): "
+        "Select observations to include by number, comma-separated (blank for none): "
     ).strip()
     if not raw:
         return []
@@ -2853,9 +2928,7 @@ def _print_rating_scale(assignment: dict[str, Any]) -> None:
 
 
 def _prompt_rating_value(assignment: dict[str, Any]) -> int | None:
-    valid_values = {
-        level["value"] for level in assignment["rating_scale"]["levels"]
-    }
+    valid_values = {level["value"] for level in assignment["rating_scale"]["levels"]}
     response = input("Enter rating value: ").strip()
     if not response:
         return None
@@ -3056,9 +3129,9 @@ def _menu_finalize_minimum_requirement_outcome(
     if status == "returned_without_full_review":
         teacher_note = input("Return note for student: ").strip()
     else:
-        teacher_note = input(
-            "Outcome note (leave blank if not applicable): "
-        ).strip() or None
+        teacher_note = (
+            input("Outcome note (leave blank if not applicable): ").strip() or None
+        )
     try:
         updated = set_configured_minimum_requirement_outcome(
             workspace_root,
@@ -3114,9 +3187,9 @@ def _prompt_and_set_requirement_check(
         print("Invalid status. Enter 1 for met or 2 for not met.")
         return None
 
-    teacher_note = input(
-        "Teacher note (leave blank if not applicable): "
-    ).strip() or None
+    teacher_note = (
+        input("Teacher note (leave blank if not applicable): ").strip() or None
+    )
     try:
         result = set_configured_requirement_check(
             workspace_root,
@@ -3242,14 +3315,9 @@ def _print_minimum_requirement_summary(
         return
     print(f"Outcome status: {outcome.get('status', 'not_checked')}")
     returned = outcome.get("returned_without_full_review") is True
-    print(
-        "Returned without full standards review: "
-        f"{_format_yes_no(returned)}"
-    )
+    print(f"Returned without full standards review: {_format_yes_no(returned)}")
     if returned:
-        print(
-            "Minimum-requirements outcome: returned without full standards review"
-        )
+        print("Minimum-requirements outcome: returned without full standards review")
     if note := _non_empty(outcome.get("teacher_note")):
         print(f"Outcome teacher note: {note}")
     else:
@@ -3569,8 +3637,12 @@ def _menu_export_student_feedback(
         print("Export canceled.")
         return
 
-    pdf_path = feedback_pdf_export_path(workspace_root, class_id, assignment_id, student_id)
-    markdown_path = feedback_export_path(workspace_root, class_id, assignment_id, student_id)
+    pdf_path = feedback_pdf_export_path(
+        workspace_root, class_id, assignment_id, student_id
+    )
+    markdown_path = feedback_export_path(
+        workspace_root, class_id, assignment_id, student_id
+    )
     selected_paths = {
         "1": [pdf_path],
         "2": [markdown_path],
@@ -3724,16 +3796,20 @@ def _launch_assignment_review_actions(
         clear_screen()
         print_menu_header("Assignment Review Actions")
 
-        status = _load_submission_status(
+        dashboard = _load_review_dashboard(
             workspace_root,
             class_id,
             assignment_id,
         )
-        if status is None:
+        if dashboard is None:
             input("Press Enter to continue...")
             return 1
 
-        print_assignment_submission_status(status, workspace_root)
+        print(
+            format_assignment_review_dashboard(
+                dashboard, show_unused_duplicate_files=False
+            )
+        )
         print()
 
         print("1. Select student/submission")
@@ -3752,7 +3828,7 @@ def _launch_assignment_review_actions(
             return 0
         elif choice == "1":
             student_id = _prompt_student_id(
-                workspace_root, class_id, assignment_id, status
+                workspace_root, class_id, assignment_id, dashboard
             )
             if student_id is not None:
                 _launch_selected_student_review(

--- a/tests/test_cli_review_dashboard.py
+++ b/tests/test_cli_review_dashboard.py
@@ -1,0 +1,49 @@
+"""Direct CLI tests for the read-only review dashboard."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quillan.cli import main
+import quillan.cli_app.handlers.dashboard as cli_dashboard
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID
+from tests.test_class_summary_export import _write_assignment
+
+
+def test_cli_review_dashboard_text_and_json_are_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assignment = _write_assignment(tmp_path)
+    original = assignment.read_bytes()
+    before = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+    monkeypatch.setattr(cli_dashboard, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(["review-dashboard", CLASS_ID, ASSIGNMENT_ID]) == 0
+    assert "Assignment Review Dashboard" in capsys.readouterr().out
+    assert main(["review-dashboard", CLASS_ID, ASSIGNMENT_ID, "--format", "json"]) == 0
+    document = json.loads(capsys.readouterr().out)
+
+    assert document["schema_version"] == "1"
+    assert document["assignment"]["path"].startswith("classes/")
+    assert assignment.read_bytes() == original
+    assert sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*")) == before
+
+
+def test_cli_review_dashboard_help_and_expected_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as help_exit:
+        main(["review-dashboard", "--help"])
+    assert help_exit.value.code == 0
+    assert "--format" in capsys.readouterr().out
+
+    monkeypatch.setattr(cli_dashboard, "resolve_workspace_root", lambda: tmp_path)
+    assert main(["review-dashboard", CLASS_ID, ASSIGNMENT_ID]) == 1
+    assert "Error: could not build" in capsys.readouterr().out

--- a/tests/test_review_dashboard.py
+++ b/tests/test_review_dashboard.py
@@ -1,0 +1,125 @@
+"""Contract tests for the shared assignment review dashboard."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any, cast
+
+from quillan.review_dashboard import (
+    assignment_review_dashboard_to_dict,
+    build_assignment_review_dashboard,
+    format_assignment_review_dashboard,
+)
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID, _manifest, _review
+from tests.test_class_summary_export import (
+    _student_dir,
+    _write_assignment,
+    _write_json,
+    _write_roster,
+)
+
+
+def _snapshot(root: Path) -> dict[str, bytes | None]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes() if path.is_file() else None
+        for path in root.rglob("*")
+    }
+
+
+def test_dashboard_unions_students_isolates_invalid_records_and_is_read_only(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path)
+    _write_roster(tmp_path)
+    manifest = copy.deepcopy(_manifest())
+    manifest["student_id"] = "00100"
+    manifest["submission_state"] = "reviewed"
+    review = copy.deepcopy(_review("feedback_composed"))
+    review["student_id"] = "00100"
+    review["submission_manifest_path"] = (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        "00100/submission.json"
+    )
+    _write_json(_student_dir(tmp_path, "00100") / "submission.json", manifest)
+    _write_json(_student_dir(tmp_path, "00100") / "review.json", review)
+    invalid = _student_dir(tmp_path, "00300") / "submission.json"
+    invalid.parent.mkdir(parents=True)
+    invalid.write_text("{", encoding="utf-8")
+    routed = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "response_00400_pg_001.pdf"
+    )
+    routed.parent.mkdir(parents=True)
+    routed.write_bytes(b"not inspected")
+    before = _snapshot(tmp_path)
+
+    dashboard = build_assignment_review_dashboard(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    document = cast(dict[str, Any], assignment_review_dashboard_to_dict(dashboard))
+
+    assert [student["student_id"] for student in document["students"]] == [
+        "00100",
+        "00200",
+        "00900",
+        "00300",
+        "00400",
+    ]
+    assert document["schema_version"] == "1"
+    assert document["record_type"] == "quillan_assignment_review_dashboard"
+    assert document["summary"]["submissions"]["valid"] == 1
+    assert document["summary"]["submissions"]["invalid"] == 1
+    assert document["summary"]["submissions"]["missing"] == 3
+    assert document["summary"]["reviews"]["missing"] == 0
+    assert document["summary"]["routed_evidence"]["students_needing_assembly"] == 1
+    assert document["students"][0]["display_name"] == "Avery Rivera"
+    assert document["students"][-1]["needs_assembly"] is True
+    assert _snapshot(tmp_path) == before
+
+
+def test_dashboard_json_shape_and_text_have_fixed_empty_groups(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    dashboard = build_assignment_review_dashboard(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    document = cast(dict[str, Any], assignment_review_dashboard_to_dict(dashboard))
+
+    assert list(document) == [
+        "schema_version",
+        "record_type",
+        "class_id",
+        "assignment_id",
+        "assignment",
+        "summary",
+        "students",
+        "unassembled_routed_files",
+        "unused_duplicate_routed_files",
+        "skipped_routed_files",
+        "scan_review_items",
+        "warnings",
+    ]
+    assert list(document["summary"]["submissions"]["states"]) == [
+        "unreviewed",
+        "in_progress",
+        "needs_rescan",
+        "reviewed",
+    ]
+    assert list(document["summary"]["reviews"]["states"]) == [
+        "not_started",
+        "requirements_checked",
+        "returned_without_full_review",
+        "observations_in_progress",
+        "observations_complete",
+        "ratings_complete",
+        "feedback_composed",
+        "ready_for_export",
+        "exported",
+    ]
+    assert document["students"] == []
+    text = format_assignment_review_dashboard(dashboard)
+    assert "Assignment Review Dashboard" in text
+    assert "Submission intake:" in text
+    assert "Review progress:" in text
+    assert "Scan review:" in text


### PR DESCRIPTION
## Summary

* Add a direct, read-only assignment review dashboard:

  * `quillan review-dashboard <class_id> <assignment_id>`
  * `quillan review-dashboard <class_id> <assignment_id> --format text`
  * `quillan review-dashboard <class_id> <assignment_id> --format json`
* Add one immutable shared dashboard model for:

  * direct CLI text output;
  * versioned JSON output;
  * the Assignment Review Actions menu;
  * future GUI consumption.
* Aggregate assignment-level submission intake, review workflow, feedback-export, and scan-review status without generating or modifying workspace records.
* Preserve the existing Assignment Review Actions choices and student-selection workflow.

## Command Surface

```text
quillan review-dashboard <class_id> <assignment_id>

quillan review-dashboard <class_id> <assignment_id> --format text

quillan review-dashboard <class_id> <assignment_id> --format json
```

Text is the default format.

The command is direct and non-interactive. It does not call `input()` or invoke the interactive menu.

`--format` controls standard-output representation only. It does not create an export file.

## Shared Architecture

Added the immutable shared dashboard service and JSON serializer in:

* `quillan/review_dashboard.py`

Added the thin direct CLI handler in:

* `quillan/cli_app/handlers/dashboard.py`

The implementation preserves the intended application boundary:

```text
Assignment Review Actions menu -> shared dashboard builder and text formatter
Direct CLI                    -> same builder and text/JSON formatters
Future GUI                    -> same model or versioned JSON representation
```

The CLI handler does not:

* calculate dashboard counts;
* load student records independently;
* parse menu output;
* call report-export functions;
* mutate workspace records.

## Assignment Review Actions Integration

The Assignment Review Actions menu now uses the same dashboard builder and teacher-readable text formatter as the direct command.

Existing menu actions and selection behavior remain available:

1. Select student/submission
2. Assemble routed submissions
3. Export Comprehensive Class Summary
4. Export Standards Summary
5. Export Student Performance Summary
6. Back

The dashboard is refreshed when the menu redraws.

The menu and direct text command therefore report the same status counts for the same unchanged workspace.

## Assignment Validation

The dashboard validates:

* class identifier syntax;
* assignment identifier syntax;
* canonical assignment path;
* assignment JSON;
* assignment schema;
* assignment identity;
* class membership in `assignment.class_ids`.

Fatal assignment failures return nonzero with a concise error.

A fatal failure does not emit a partial dashboard or create any files.

The dashboard reports assignment context including:

* class ID;
* assignment ID;
* assignment title;
* writing type;
* standards-profile ID;
* Focus Standard count;
* canonical workspace-relative assignment path.

## Student Population

The dashboard combines students from:

1. the current class roster;
2. assignment submission records not represented in the roster;
3. routed-evidence-only students not already represented.

Students are deduplicated by exact `student_id`.

Ordering is deterministic:

1. rostered students in roster order;
2. unrostered students with submission records, sorted by student ID;
3. routed-only students, sorted by student ID.

Roster display names are used when available.

Students without roster metadata use student-ID fallback.

Historical and unrostered submission records are not hidden.

## Roster Diagnostics

Roster unavailability is a nonfatal diagnostic when assignment-local records can still be discovered.

The dashboard reports:

* whether roster data is available;
* rostered student count when available;
* dashboard student count;
* discovered unrostered record count;
* a roster warning when roster data cannot be loaded.

When the roster is unavailable, the dashboard does not falsely claim that discovered records represent the complete expected class population.

## Submission Diagnostics

For each student, submission status distinguishes:

* `missing`;
* `valid`;
* `invalid`;
* `identity_mismatch`.

Invalid or identity-mismatched manifests are not treated as missing or valid.

For valid manifests, the dashboard aggregates canonical submission states:

* `unreviewed`;
* `in_progress`;
* `needs_rescan`;
* `reviewed`.

It also reports:

* manifest files present;
* valid manifests;
* missing manifests;
* invalid manifests;
* identity mismatches;
* plain-paper submissions;
* rostered students missing submissions;
* routed-evidence students needing assembly;
* unrostered students discovered.

One invalid student manifest does not prevent valid students from appearing.

## Plain-Paper Submissions

Valid plain-paper submissions count as valid submission manifests.

They report:

* plain-paper status;
* zero digital pages;
* no digital evidence requirement.

They are not marked missing merely because they contain:

```text
expected_pages: null
pages: []
```

## Routed-Evidence Status

The dashboard reuses existing routed-evidence discovery behavior.

It reports:

* students with routed evidence;
* routed-evidence students without manifests;
* students needing assembly;
* unassembled routed files;
* unused duplicate routed files;
* skipped routed files;
* skipped-file reasons.

Paths are represented as deterministic workspace-relative POSIX strings.

Dashboard construction does not:

* assemble submissions;
* move or copy evidence;
* inspect evidence contents;
* decode QR data;
* repair routing metadata.

## Page-State Aggregation

For valid manifests, the dashboard aggregates:

* `present`;
* `missing`;
* `duplicate`;
* `needs_rescan`;
* `excluded`;
* present pages without selected evidence.

It also reports students affected by page-management conditions.

Plain-paper submissions contribute zero digital pages.

Missing or invalid manifests do not contribute invented page records.

Excluded pages are reported as preserved exclusions, not deleted evidence.

## Review Diagnostics

For students with valid submissions, the adjacent review record is classified as:

* `missing`;
* `valid`;
* `invalid`;
* `identity_mismatch`.

The dashboard also identifies orphaned review conditions where a review file exists without a valid adjacent submission.

A missing review is kept distinct from a valid review whose stored state is:

```text
not_started
```

This distinction is preserved in structured JSON.

Invalid review records remain visible as diagnostics and do not prevent valid students from being summarized.

## Review-State Aggregation

For valid review records, the dashboard aggregates every canonical workflow state:

* `not_started`;
* `requirements_checked`;
* `returned_without_full_review`;
* `observations_in_progress`;
* `observations_complete`;
* `ratings_complete`;
* `feedback_composed`;
* `ready_for_export`;
* `exported`.

It separately counts:

* review files present;
* valid reviews;
* missing reviews;
* invalid reviews;
* identity-mismatched reviews;
* orphaned reviews.

The dashboard does not infer a stored review state for a missing record.

## Minimum-Requirement Status

Stored teacher-entered minimum-requirement outcomes are aggregated as:

* `not_checked`;
* `met`;
* `unmet_continue_review`;
* `returned_without_full_review`.

The dashboard reports students returned without full standards review.

It does not inspect evidence or infer whether requirements were actually met.

## Workflow Progress

The dashboard provides lightweight workflow coverage from existing review state:

* observations complete;
* ratings complete;
* feedback composed;
* ready for export;
* exported.

These are workflow-status counts only.

The implementation does not:

* average ratings;
* calculate mastery;
* calculate percentages;
* calculate grades;
* rank students.

Detailed instructional and rating analysis remains the responsibility of the existing assignment-local reports.

## Feedback Export Status

Feedback PDF and Markdown status are evaluated separately using the existing export-freshness rules.

Canonical statuses include:

* `present`;
* `stale`;
* `missing`;
* `unknown`.

The dashboard distinguishes:

* a current export with matching metadata;
* an export whose source-review timestamp is stale;
* a missing export;
* a file that exists without usable canonical metadata;
* metadata that points to a missing file.

Student-level statuses and aggregate counts use the same shared results.

The dashboard does not create export directories, update export metadata, or regenerate exports.

## Scan-Review Attention

The dashboard includes assignment-filtered unresolved and deferred scan-review items.

Resolved items are excluded from ordinary attention counts.

It reports:

* scan-review availability;
* total attention items;
* unresolved count;
* deferred count;
* counts by failure category;
* malformed or unreadable metadata warning count;
* deterministic item details.

Valid attention-item details include:

* failure ID;
* current display status;
* failure category;
* failure message;
* source filename;
* source page number;
* student ID when available;
* failure metadata path;
* retained-source path when available;
* creation timestamp.

Scan-review unavailability remains nonfatal when the rest of the dashboard can be built.

The result distinguishes unavailable discovery from a successfully discovered count of zero.

No scan-review resolution record is written.

## Per-Student Status

Each student result includes:

* student ID;
* display name;
* roster status;
* routed-evidence presence;
* needs-assembly status;
* submission record status;
* submission state;
* plain-paper status;
* page-state counts;
* present-but-unselected count;
* review record status;
* review state;
* minimum-requirement outcome;
* returned-without-full-review status;
* feedback PDF status;
* feedback Markdown status;
* warning codes.

The dashboard intentionally does not expose:

* private teacher-note text;
* observation rationales;
* rating rationales;
* feedback-comment text;
* student writing;
* extracted or OCR text.

## Teacher-Readable Text Output

The default text representation provides a structured teacher-facing view of:

* assignment identity;
* student coverage;
* submission intake;
* routed evidence and assembly needs;
* submission states;
* page states;
* review-record status;
* review workflow states;
* minimum-requirement outcomes;
* feedback export freshness;
* scan-review attention;
* per-student status;
* items needing attention.

The text formatter does not dump raw assignment, submission, or review JSON.

Ordinary early workflow states remain status information rather than being mislabeled as errors.

## JSON Output

`--format json` emits exactly one valid JSON document to standard output.

It does not print:

* headings before the document;
* progress messages;
* warnings outside the document;
* Python object representations;
* absolute workspace paths;
* terminal formatting.

The document ends with a newline.

## JSON Schema

The dashboard uses its own JSON schema version:

```json
"schema_version": "1"
```

The record type identifies the payload as an assignment review dashboard.

The JSON contract includes stable top-level fields for:

* schema version;
* record type;
* class ID;
* assignment ID;
* assignment context;
* summary groups;
* ordered student results;
* unassembled routed files;
* unused duplicate routed files;
* skipped routed files;
* scan-review items;
* warnings.

Empty arrays and fixed summary groups remain present.

## JSON Types

Structured output uses:

* JSON integers for counts;
* JSON booleans for true/false;
* JSON null for unavailable scalar values;
* strings for identifiers, states, paths, and timestamps;
* ordered arrays for collections;
* objects for named count groups.

Booleans and counts are not encoded as strings.

Paths are explicitly serialized as workspace-relative POSIX strings.

No `Path(...)` representations or absolute workspace paths are exposed.

## JSON Determinism

For an unchanged workspace, repeated JSON calls produce equivalent parsed objects.

The serializer does not add:

* an execution timestamp;
* a random identifier;
* a process-specific value;
* a nondeterministic generated-at field.

Ordering is deterministic for:

* students;
* routed files;
* skipped files;
* warning codes;
* state groups;
* scan-review items.

The serializer does not rely on `default=str` or unexamined dataclass serialization.

## JSON Stability Policy

Within dashboard schema version `"1"`:

* keys are not renamed;
* required keys are not removed;
* key types remain stable;
* path formatting remains workspace-relative and POSIX-style;
* collection ordering remains deterministic;
* semantic changes require contract and regression-test updates;
* breaking changes require a dashboard schema-version change.

The dashboard schema is independent of assignment, submission, review, and scan-review record schema versions.

## Diagnostic Warning Behavior

Conditions such as these remain successful dashboard results:

* missing submissions;
* invalid student records;
* missing reviews;
* stale exports;
* unresolved scan-review items;
* unavailable roster;
* malformed supplemental metadata.

These conditions are the subject of the dashboard.

They appear through:

* aggregate counts;
* per-student warning codes;
* attention items;
* dashboard warnings.

The command returns nonzero only when the dashboard itself cannot be built or serialized safely.

## Relationship to Existing Reports

The review dashboard is a live read-only status view.

It does not replace or generate:

* Comprehensive Class Summary;
* Standards Summary;
* Student Performance Summary.

Those remain explicit CSV export workflows.

The dashboard reuses shared loading and status logic without invoking report writers.

## Exact Read Boundary

The dashboard may read:

* canonical assignment configuration;
* class roster;
* submission manifests;
* review records;
* routed-evidence directories and metadata;
* feedback export metadata;
* feedback PDF and Markdown file existence;
* scan-review failure metadata;
* scan-review resolution metadata.

It does not read student evidence contents.

## No Workspace Write Boundary

The command writes no workspace files.

It does not create:

* directories;
* assignments;
* manifests;
* review records;
* exports;
* reports;
* caches;
* lock files;
* temporary workspace files;
* scan-review resolutions.

It does not modify:

* assignment configuration;
* roster;
* submission manifests;
* review records;
* routed evidence;
* retained scans;
* feedback exports;
* report files;
* reusable comments;
* scan-review metadata;
* PDS Core data;
* ScoreForm data.

Standard-output text or JSON is the command’s only output.

## No Automated Processing

Confirmed that the dashboard does not:

* open evidence;
* inspect PDFs;
* inspect images;
* parse student writing;
* decode QR payloads;
* run OCR;
* perform handwriting recognition;
* use AI;
* infer minimum-requirement outcomes;
* infer observations;
* infer ratings;
* calculate grades;
* assemble submissions;
* change workflow states;
* resolve scan-review items;
* compose feedback;
* generate exports.

All reported review information comes from existing stored records.

## Documentation

Added the dashboard and JSON contract documentation in:

* `docs/review_dashboard_contract.md`

Updated relevant CLI and workflow documentation to cover:

* command syntax;
* text and JSON formats;
* student population rules;
* roster-unavailable behavior;
* submission and review diagnostics;
* page and workflow counts;
* export freshness;
* scan-review attention;
* JSON schema version;
* deterministic ordering;
* warning and fatal-error behavior;
* exact read-only boundary;
* absence of automated judgment or generation.

## Test Coverage

Added coverage for:

* parser registration and help;
* text as the default format;
* explicit text and JSON modes;
* fatal assignment errors;
* deterministic student population;
* roster-unavailable behavior;
* routed-only students;
* missing submissions;
* invalid submissions;
* identity mismatches;
* plain-paper submissions;
* page-state aggregation;
* missing and invalid reviews;
* orphaned reviews;
* every canonical review state;
* minimum-requirement outcomes;
* feedback PDF and Markdown freshness;
* scan-review attention and warnings;
* nonfatal diagnostic conditions;
* JSON parsing and required shape;
* JSON boolean, integer, null, string, array, and object types;
* workspace-relative path formatting;
* deterministic JSON output;
* text and menu parity;
* menu action preservation;
* complete workspace read-only snapshots;
* expected-error behavior without tracebacks.

## Safety

Confirmed:

* the direct handler is thin and non-interactive;
* text and JSON use the same immutable dashboard model;
* the menu uses the same dashboard service;
* invalid student records do not hide valid students;
* missing reviews remain distinct from stored `not_started`;
* stale exports are not reported as current;
* unresolved scan-review records remain visible but are not changed;
* no files or directories are created;
* all existing workspace files remain unchanged;
* no evidence is inspected;
* no report or feedback export is generated;
* PDS Core remains unchanged;
* ScoreForm remains unchanged;
* no real student data or generated workspace artifacts were added.

## Validation

* Focused dashboard and menu tests: `56 passed`
* Broader CLI selection: `252 passed`
* Full pytest suite: `1229 passed`
* Ruff: passed
* mypy: passed, `168` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* No real student data or generated workspace artifacts present

Closes #308
