### PR TITLE
Add student review status CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Quillan
 
+For a compact, read-only diagnostic of one student's submission and review
+workflow, use `quillan review-status <class_id> <assignment_id> <student_id>`;
+add `--format json` for the stable versioned structured contract.
+
 Quillan is a local-first, teacher-controlled review tool for written student
 work. It helps a teacher move from student evidence to review units, Focus
 Standards, teacher judgment, feedback, and assignment-local reporting.

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -1,5 +1,21 @@
 # Quillan CLI Contract
 
+## Direct Student Review Status
+
+`quillan review-status <class_id> <assignment_id> <student_id> [--format text|json]`
+prints compact record conditions, workflow state, aggregate review counts, and
+feedback-export freshness for one student. Text is the default; JSON follows
+the versioned [student review status contract](review_status_contract.md).
+Missing, invalid, identity-mismatched, and orphaned selected records are
+successful diagnostics. Plain-paper manifests are valid zero-digital-page
+submissions. Fatal assignment/workspace errors are concise and nonzero.
+
+This command is strictly read-only and performs no automated judgment. It does
+not inspect evidence or student writing, assemble submissions, create reviews,
+mutate workflow, or generate exports. It excludes teacher-entered and student
+prose. Current Review Details remains the content-oriented teacher view;
+`review-dashboard` remains the assignment-wide overview.
+
 ## Purpose and Status
 
 This document defines Quillan's command-line contract during pre-1.0

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -1,5 +1,10 @@
 # Quillan Data Contracts
 
+The versioned, read-only selected-student diagnostic is defined separately in
+[`review_status_contract.md`](review_status_contract.md). It composes canonical
+assignment, submission-manifest, and review-record data without changing any of
+those source schemas.
+
 Quillan stores structured evidence and teacher review data in local files under
 the teacher-selected Paper Data Suite workspace.
 

--- a/docs/review_status_contract.md
+++ b/docs/review_status_contract.md
@@ -1,0 +1,55 @@
+# Student Review Status Contract
+
+`quillan review-status <class_id> <assignment_id> <student_id> [--format text|json]`
+is a direct, non-interactive, read-only diagnostic for one student. Text is the
+default. JSON emits one newline-terminated document with `schema_version: "1"`
+and `record_type: "quillan_student_review_status"`.
+
+The required top-level keys, in order, are `schema_version`, `record_type`,
+`class_id`, `assignment_id`, `student_id`, `assignment`, `student`,
+`routed_evidence`, `submission`, `review`, and `warnings`. Paths are canonical,
+workspace-relative POSIX strings. Warnings are deduplicated code strings in
+deterministic discovery order.
+
+## Fixed Sections and Null Semantics
+
+Assignment context includes title, writing type, standards profile, configured
+Focus Standard and minimum-requirement counts, and path. Student context uses
+`rostered`, `unrostered`, or `roster_unavailable`. Routed evidence reports
+availability, presence, selected-student file count, and assembly need.
+
+Submission and review status is `missing`, `valid`, `invalid`, or
+`identity_mismatch`; review separately reports `orphaned`. Fixed nested groups
+cover pages, evidence, progress, requirements, units, observations, overall
+ratings, feedback, private-note count, and PDF/Markdown exports. A valid
+zero-page or plain-paper manifest has available integer zero counts. Missing,
+invalid, or mismatched manifests use unavailable groups and JSON `null` counts.
+Missing reviews have known zero stored-artifact counts and assignment-derived
+configured/missing counts. Invalid or mismatched reviews use `available: false`
+and `null` review-derived counts. Zero never means unreadable.
+
+Export objects include path, metadata/file presence, `present`, `stale`,
+`missing`, or `unknown` status, stale boolean, and metadata timestamps. Their
+summary counts both formats.
+
+## Warnings, Privacy, and Compatibility
+
+Stable warnings cover unavailable/unrostered context, routed assembly need,
+missing/invalid/mismatched records, orphaned reviews, stale or unconfigured
+review artifacts, and feedback-export file, freshness, and metadata conditions.
+These are successful diagnostics. Invalid identifiers, missing/invalid or
+identity-mismatched assignments, class incompatibility, and workspace failures
+are fatal and emit no partial JSON.
+
+The command reads only the canonical assignment, optional roster, assignment
+scan filenames, the selected canonical submission and review, and selected
+export file presence. It does not inspect siblings or evidence content. It emits
+no assignment prompt, student writing, evidence, notes, rationales, feedback
+text/identifiers, reusable-comment data, or private-note content/identifiers.
+It creates and modifies nothing and performs no assembly, OCR, QR decoding, AI,
+inference, grading, workflow mutation, scan resolution, or export.
+
+Within schema version `"1"`, required keys and types, null/zero meaning, status
+semantics, privacy exclusions, ordering, and path formatting are stable.
+Breaking changes require a new schema version; additions must be documented and
+contract-tested.

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -1,5 +1,10 @@
 # Quillan Teacher-Review Model
 
+The direct `review-status` command is a compact conditions-and-counts view. It
+does not replace Current Review Details, which remains the content-oriented view
+of teacher-entered review details, or `review-dashboard`, which remains the
+assignment-wide overview. See [`review_status_contract.md`](review_status_contract.md).
+
 ## Overview
 
 Quillan's review model is teacher-controlled. It preserves student evidence,

--- a/quillan/cli_app/handlers/review_status.py
+++ b/quillan/cli_app/handlers/review_status.py
@@ -1,0 +1,33 @@
+"""Direct selected-student review status command handler."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.student_review_status import (
+    StudentReviewStatusError,
+    build_student_review_status,
+    format_student_review_status,
+    student_review_status_to_dict,
+)
+
+
+def handle_review_status(args: argparse.Namespace) -> int:
+    """Print exactly one read-only selected-student status result."""
+    try:
+        status = build_student_review_status(
+            resolve_workspace_root(), args.class_id, args.assignment_id, args.student_id
+        )
+        output = (
+            json.dumps(student_review_status_to_dict(status), indent=2, ensure_ascii=False)
+            if args.format == "json"
+            else format_student_review_status(status)
+        )
+    except (WorkspaceRootError, StudentReviewStatusError, OSError, TypeError) as error:
+        print(f"Error: could not build student review status: {error}")
+        return 1
+    print(output)
+    return 0

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -13,6 +13,7 @@ from quillan.cli_app.handlers.comments import (
     handle_comments_show,
 )
 from quillan.cli_app.handlers.dashboard import handle_review_dashboard
+from quillan.cli_app.handlers.review_status import handle_review_status
 from quillan.cli_app.handlers.exports import (
     handle_export_class_summary,
     handle_export_feedback,
@@ -114,6 +115,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Standard-output representation (default: text).",
     )
     dashboard_parser.set_defaults(handler=handle_review_dashboard)
+
+    review_status_parser = subparsers.add_parser(
+        "review-status",
+        help="Show compact read-only review status for one student.",
+        description=(
+            "Inspect one student's assignment, roster, routed evidence, submission, "
+            "review workflow, artifact counts, and feedback-export freshness without writing files."
+        ),
+    )
+    _add_submission_identity_arguments(review_status_parser)
+    review_status_parser.add_argument(
+        "--format", choices=("text", "json"), default="text",
+        help="Standard-output representation (default: text).",
+    )
+    review_status_parser.set_defaults(handler=handle_review_status)
 
     assignment_parser = subparsers.add_parser(
         "assignment", help="Create, show, and validate canonical assignments."

--- a/quillan/student_review_status.py
+++ b/quillan/student_review_status.py
@@ -1,0 +1,529 @@
+"""Compact, immutable, read-only status for one student's assignment review."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, TypeAlias, cast
+
+from pds_core.classes import load_class_roster
+from pds_core.identifiers import validate_identifier
+from pds_core.rosters import RosterError, student_display_name
+
+from quillan.assignment_submission_assembly import discover_assignment_routed_evidence_status
+from quillan.assignment_summary_context import feedback_status, relative_path_for
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.feedback_export import feedback_export_path, feedback_pdf_export_path
+from quillan.minimum_requirement_review import configured_requirements
+from quillan.plain_paper_submission import is_plain_paper_submission
+from quillan.review_record import ReviewRecordError, load_review_record
+from quillan.review_status_display import review_progress_status
+from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
+
+REVIEW_STATUS_SCHEMA_VERSION: Final = "1"
+REVIEW_STATUS_RECORD_TYPE: Final = "quillan_student_review_status"
+PAGE_STATES: Final = ("present", "missing", "duplicate", "needs_rescan", "excluded")
+EXPORT_KEYS: Final = ("feedback_pdf", "feedback_markdown")
+
+FrozenValue: TypeAlias = str | int | bool | None | "FrozenMapping" | tuple["FrozenValue", ...]
+
+
+class StudentReviewStatusError(ValueError):
+    """Raised when the required assignment context cannot be loaded safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenMapping(Mapping[str, FrozenValue]):
+    """A small deterministic immutable mapping used by the public status model."""
+
+    items_tuple: tuple[tuple[str, FrozenValue], ...]
+
+    def __getitem__(self, key: str) -> FrozenValue:
+        for item_key, value in self.items_tuple:
+            if item_key == key:
+                return value
+        raise KeyError(key)
+
+    def __iter__(self) -> Iterator[str]:
+        return (key for key, _ in self.items_tuple)
+
+    def __len__(self) -> int:
+        return len(self.items_tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class StudentReviewStatus:
+    """Immutable status model shared by text and JSON representations."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    assignment: FrozenMapping
+    student: FrozenMapping
+    routed_evidence: FrozenMapping
+    submission: FrozenMapping
+    review: FrozenMapping
+    warnings: tuple[str, ...]
+
+
+def build_student_review_status(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> StudentReviewStatus:
+    """Inspect only the selected student's canonical records without writing."""
+    try:
+        validate_identifier(class_id, "class_id")
+        validate_identifier(assignment_id, "assignment_id")
+        validate_identifier(student_id, "student_id")
+    except ValueError as error:
+        raise StudentReviewStatusError(str(error)) from error
+
+    root = Path(workspace_root).resolve(strict=False)
+    assignment_path = root / "classes" / class_id / "assignments" / assignment_id / "assignment.json"
+    try:
+        assignment = load_assignment_config(assignment_path)
+    except (OSError, AssignmentConfigError) as error:
+        raise StudentReviewStatusError(f"Could not load assignment: {error}") from error
+    if assignment["assignment_id"] != assignment_id:
+        raise StudentReviewStatusError(
+            f"Assignment identity mismatch: expected {assignment_id!r}, found {assignment['assignment_id']!r}."
+        )
+    if class_id not in assignment["class_ids"]:
+        raise StudentReviewStatusError(
+            f"Assignment {assignment_id!r} is not configured for class {class_id!r}."
+        )
+
+    warnings: list[str] = []
+    display_name = student_id
+    roster_status = "roster_unavailable"
+    try:
+        roster = load_class_roster(root, class_id)
+    except (OSError, RosterError):
+        warnings.append("roster_unavailable")
+    else:
+        roster_status = "unrostered"
+        for student in roster.students:
+            if student.student_id == student_id:
+                display_name = student_display_name(student)
+                roster_status = "rostered"
+                break
+        if roster_status == "unrostered":
+            warnings.append("unrostered_student")
+
+    routed_available = True
+    routed_count: int | None
+    try:
+        routed = discover_assignment_routed_evidence_status(root, class_id, assignment_id)
+        routed_count = len(routed.evidence_by_student.get(student_id, ()))
+    except (OSError, ValueError):
+        routed_available = False
+        routed_count = None
+        warnings.append("routed_evidence_unavailable")
+
+    student_dir = assignment_path.parent / "submissions" / student_id
+    manifest_path = student_dir / "submission.json"
+    review_path = student_dir / "review.json"
+    manifest, submission_status = _load_record(
+        manifest_path,
+        load_submission_manifest,
+        class_id,
+        assignment_id,
+        student_id,
+        "submission",
+        warnings,
+    )
+    review, review_status = _load_record(
+        review_path,
+        load_review_record,
+        class_id,
+        assignment_id,
+        student_id,
+        "review",
+        warnings,
+    )
+    needs_assembly = None if routed_count is None else bool(routed_count) and manifest is None
+    if needs_assembly:
+        warnings.append("routed_evidence_needs_assembly")
+    if submission_status == "missing":
+        warnings.append("missing_submission")
+    if review_status == "missing":
+        warnings.append("missing_review")
+    orphaned = review_path.is_file() and manifest is None
+    if orphaned:
+        warnings.append("review_without_valid_submission")
+
+    requirements = configured_requirements(assignment)
+    focus_ids = tuple(str(value) for value in assignment["focus_standard_ids"])
+    submission_section = _submission_section(manifest, submission_status, manifest_path, root)
+    review_section, review_warnings = _review_section(
+        root, class_id, assignment_id, student_id, review, review_status, review_path,
+        orphaned, requirements, focus_ids,
+    )
+    warnings.extend(review_warnings)
+
+    return StudentReviewStatus(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        assignment=_freeze({
+            "title": assignment["title"],
+            "writing_type": assignment["writing_type"],
+            "standards_profile_id": assignment["standards_profile_id"],
+            "focus_standard_count": len(focus_ids),
+            "configured_requirement_count": len(requirements),
+            "path": relative_path_for(assignment_path, root),
+        }),
+        student=_freeze({"display_name": display_name, "roster_status": roster_status}),
+        routed_evidence=_freeze({
+            "available": routed_available,
+            "present": None if routed_count is None else routed_count > 0,
+            "file_count": routed_count,
+            "needs_assembly": needs_assembly,
+        }),
+        submission=_freeze(submission_section),
+        review=_freeze(review_section),
+        warnings=tuple(dict.fromkeys(warnings)),
+    )
+
+
+def _load_record(
+    path: Path,
+    loader: Any,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    kind: str,
+    warnings: list[str],
+) -> tuple[dict[str, Any] | None, str]:
+    if not path.is_file():
+        return None, "missing"
+    try:
+        record = loader(path)
+    except (OSError, SubmissionManifestError, ReviewRecordError):
+        warnings.append(f"invalid_{kind}")
+        return None, "invalid"
+    if any(record[key] != expected for key, expected in (
+        ("class_id", class_id), ("assignment_id", assignment_id), ("student_id", student_id)
+    )):
+        warnings.append(f"{kind}_identity_mismatch")
+        return None, "identity_mismatch"
+    return cast(dict[str, Any], record), "valid"
+
+
+def _submission_section(
+    manifest: dict[str, Any] | None, status: str, path: Path, root: Path
+) -> dict[str, Any]:
+    unavailable_pages = {
+        "available": False, "total": None,
+        "states": {state: None for state in PAGE_STATES},
+        "present_unselected": None, "with_selected_evidence": None,
+        "without_selected_evidence": None,
+    }
+    unavailable_evidence = {"available": False, "total": None, "selected": None}
+    if manifest is None:
+        return {
+            "status": status, "path": relative_path_for(path, root), "state": None,
+            "plain_paper": None, "expected_pages": None, "created_at": None,
+            "updated_at": None, "pages": unavailable_pages, "evidence": unavailable_evidence,
+        }
+    plain_paper = is_plain_paper_submission(manifest)
+    pages = manifest["pages"]
+    page_states = Counter(str(page["page_state"]) for page in pages)
+    evidence_total = sum(len(page["evidence"]) for page in pages)
+    selected = sum(page["selected_evidence_id"] is not None for page in pages)
+    present = [page for page in pages if page["page_state"] == "present"]
+    return {
+        "status": "valid", "path": relative_path_for(path, root),
+        "state": manifest["submission_state"], "plain_paper": plain_paper,
+        "expected_pages": manifest["expected_pages"], "created_at": manifest["created_at"],
+        "updated_at": manifest["updated_at"],
+        "pages": {
+            "available": True, "total": len(pages),
+            "states": {state: page_states[state] for state in PAGE_STATES},
+            "present_unselected": sum(page["selected_evidence_id"] is None for page in present),
+            "with_selected_evidence": selected,
+            "without_selected_evidence": len(pages) - selected,
+        },
+        "evidence": {"available": True, "total": evidence_total, "selected": selected},
+    }
+
+
+def _review_section(
+    root: Path, class_id: str, assignment_id: str, student_id: str,
+    review: dict[str, Any] | None, status: str, path: Path, orphaned: bool,
+    requirements: tuple[Any, ...], focus_ids: tuple[str, ...],
+) -> tuple[dict[str, Any], list[str]]:
+    warnings: list[str] = []
+    configured = set(focus_ids)
+    usable = status in {"valid", "missing"}
+    missing = status == "missing"
+    available = usable
+    if review is None and not missing:
+        stored: int | None = None
+        unavailable_minimum = {
+            "available": False, "configured": len(requirements), "stored": None,
+            "current": None, "unchecked": None, "met": None, "unmet": None,
+            "stale": None, "outcome": None, "returned_without_full_review": None,
+            "outcome_note_present": None,
+        }
+        return _empty_review_section(
+            root, class_id, assignment_id, student_id, status, path, orphaned,
+            unavailable_minimum, stored,
+        ), warnings
+
+    checks = [] if review is None else review["minimum_requirement_checks"]
+    requirement_keys = {item.key for item in requirements}
+    current_checks = [check for check in checks if check["requirement_key"] in requirement_keys]
+    stale_checks = len(checks) - len(current_checks)
+    if stale_checks:
+        warnings.append("stale_requirement_checks")
+    outcome = None if review is None else review["minimum_requirement_outcome"]
+    minimum: dict[str, Any] = {
+        "available": True, "configured": len(requirements), "stored": len(checks),
+        "current": len(current_checks), "unchecked": len(requirements) - len(current_checks),
+        "met": sum(check["met"] is True for check in current_checks),
+        "unmet": sum(check["met"] is False for check in current_checks), "stale": stale_checks,
+        "outcome": "not_checked" if outcome is None else outcome["status"],
+        "returned_without_full_review": False if outcome is None else outcome["returned_without_full_review"],
+        "outcome_note_present": False if outcome is None else bool(outcome["teacher_note"]),
+    }
+    units = [] if review is None else review["review_units"]
+    observations = [observation for unit in units for observation in unit["standard_observations"]]
+    represented = {str(item["standard_id"]) for item in observations} & configured
+    stale_observations = sum(str(item["standard_id"]) not in configured for item in observations)
+    if stale_observations:
+        warnings.append("observations_for_unconfigured_standard")
+    ratings = [] if review is None else review["overall_standard_ratings"]
+    current_ratings = [item for item in ratings if str(item["standard_id"]) in configured]
+    stale_ratings = len(ratings) - len(current_ratings)
+    if stale_ratings:
+        warnings.append("ratings_for_unconfigured_standard")
+    standard_feedback = [] if review is None else review["feedback"]["standard_feedback"]
+    current_feedback = [item for item in standard_feedback if str(item["standard_id"]) in configured]
+    stale_feedback = len(standard_feedback) - len(current_feedback)
+    if stale_feedback:
+        warnings.append("feedback_for_unconfigured_standard")
+    comments = [comment for item in standard_feedback for comment in item["comments"]]
+    feedback = {} if review is None else review["feedback"]
+    progress = review_progress_status(review)
+    returned = bool(minimum["returned_without_full_review"]) or progress.is_returned_without_full_review
+
+    exports, export_warnings = _exports(root, class_id, assignment_id, student_id, review)
+    warnings.extend(export_warnings)
+    section = {
+        "status": status, "path": relative_path_for(path, root), "orphaned": orphaned,
+        "state": None if review is None else review["review_state"],
+        "state_label": "no review record" if review is None else progress.review_state_label,
+        "created_at": None if review is None else review["created_at"],
+        "updated_at": None if review is None else review["updated_at"],
+        "progress": {
+            "returned_without_full_review": returned,
+            "observations_complete": False if review is None else progress.observations_complete,
+            "ratings_complete": False if review is None else progress.ratings_complete,
+            "feedback_composed": False if review is None else progress.feedback_composed,
+            "ready_for_export": False if review is None else progress.ready_for_export,
+            "exported": False if review is None else progress.exported,
+        },
+        "minimum_requirements": minimum,
+        "review_units": {
+            "available": available, "total": len(units),
+            "with_page_targets": sum(unit.get("page_number") is not None for unit in units),
+            "with_evidence_ids": sum(unit.get("evidence_id") is not None for unit in units),
+            "empty": sum(not unit["standard_observations"] for unit in units),
+            "with_observations": sum(bool(unit["standard_observations"]) for unit in units),
+        },
+        "observations": {
+            "available": available, "total": len(observations),
+            "applicable": sum(item["applicable"] is True for item in observations),
+            "not_applicable": sum(item["applicable"] is False for item in observations),
+            "evidence_present": sum(item["evidence_present"] is True for item in observations),
+            "evidence_missing": sum(item["evidence_present"] is False for item in observations),
+            "evidence_not_applicable": sum(item["evidence_present"] is None for item in observations),
+            "with_rating": sum(item["rating"] is not None for item in observations),
+            "with_rationale": sum(bool(item["rationale"]) for item in observations),
+            "included_for_feedback": sum(item["include_in_feedback"] is True for item in observations),
+            "configured_standards_represented": len(represented), "unconfigured": stale_observations,
+        },
+        "overall_ratings": {
+            "available": available, "configured": len(focus_ids), "stored": len(ratings),
+            "current": len(current_ratings), "missing": len(focus_ids) - len({str(x['standard_id']) for x in current_ratings}),
+            "stale": stale_ratings,
+            "included_in_feedback": sum(item["include_in_feedback"] is True for item in ratings),
+            "with_rationale": sum(bool(item["rationale"]) for item in ratings),
+        },
+        "feedback": {
+            "available": available, "stored_records": len(standard_feedback),
+            "current_records": len(current_feedback),
+            "missing_configured_records": len(focus_ids) - len({str(x['standard_id']) for x in current_feedback}),
+            "stale_records": stale_feedback,
+            "selected_observation_references": sum(len(item["included_observation_ids"]) for item in standard_feedback),
+            "include_overall_rating_records": sum(item["include_overall_rating"] is True for item in standard_feedback),
+            "include_overall_rationale_records": sum(item["include_overall_rationale"] is True for item in standard_feedback),
+            "comments_total": len(comments),
+            "comments_included": sum(item["include_in_feedback"] is True for item in comments),
+            "comments_excluded": sum(item["include_in_feedback"] is False for item in comments),
+            "custom_comments": sum(item["source"] == "custom" for item in comments),
+            "reusable_snapshots": sum(item["source"] == "reusable_focus_standard_comment" for item in comments),
+            "save_for_reuse": sum(item["save_for_reuse"] is True for item in comments),
+            "include_review_unit_observations": bool(feedback.get("include_review_unit_observations", False)),
+            "include_overall_standard_ratings": bool(feedback.get("include_overall_standard_ratings", False)),
+        },
+        "private_notes": {"available": available, "total": 0 if review is None else len(review["private_notes"])},
+        "exports": exports,
+    }
+    return section, warnings
+
+
+def _empty_review_section(
+    root: Path, class_id: str, assignment_id: str, student_id: str, status: str,
+    path: Path, orphaned: bool, minimum: dict[str, Any], value: int | None,
+) -> dict[str, Any]:
+    def group(keys: tuple[str, ...]) -> dict[str, Any]:
+        return {"available": False, **{key: value for key in keys}}
+    exports, _ = _exports(root, class_id, assignment_id, student_id, None)
+    return {
+        "status": status, "path": relative_path_for(path, root), "orphaned": orphaned,
+        "state": None, "state_label": None, "created_at": None, "updated_at": None,
+        "progress": {key: None for key in ("returned_without_full_review", "observations_complete", "ratings_complete", "feedback_composed", "ready_for_export", "exported")},
+        "minimum_requirements": minimum,
+        "review_units": group(("total", "with_page_targets", "with_evidence_ids", "empty", "with_observations")),
+        "observations": group(("total", "applicable", "not_applicable", "evidence_present", "evidence_missing", "evidence_not_applicable", "with_rating", "with_rationale", "included_for_feedback", "configured_standards_represented", "unconfigured")),
+        "overall_ratings": group(("configured", "stored", "current", "missing", "stale", "included_in_feedback", "with_rationale")),
+        "feedback": group(("stored_records", "current_records", "missing_configured_records", "stale_records", "selected_observation_references", "include_overall_rating_records", "include_overall_rationale_records", "comments_total", "comments_included", "comments_excluded", "custom_comments", "reusable_snapshots", "save_for_reuse", "include_review_unit_observations", "include_overall_standard_ratings")),
+        "private_notes": {"available": False, "total": value}, "exports": exports,
+    }
+
+
+def _exports(
+    root: Path, class_id: str, assignment_id: str, student_id: str,
+    review: dict[str, Any] | None,
+) -> tuple[dict[str, Any], list[str]]:
+    results: dict[str, Any] = {}
+    warnings: list[str] = []
+    defaults = {
+        "feedback_pdf": feedback_pdf_export_path(root, class_id, assignment_id, student_id),
+        "feedback_markdown": feedback_export_path(root, class_id, assignment_id, student_id),
+    }
+    for key in EXPORT_KEYS:
+        relative, status, stale_text, codes = feedback_status(root, review, key, defaults[key])
+        metadata = None if review is None else review["exports"].get(key)
+        results[key] = {
+            "path": relative, "metadata_present": isinstance(metadata, dict),
+            "file_present": (root / relative).is_file(), "status": status,
+            "stale": stale_text == "true",
+            "generated_at": metadata.get("generated_at") if isinstance(metadata, dict) else None,
+            "source_review_updated_at": metadata.get("source_review_updated_at") if isinstance(metadata, dict) else None,
+        }
+        warnings.extend(codes)
+    counts = Counter(str(results[key]["status"]) for key in EXPORT_KEYS)
+    results["summary"] = {
+        "current": counts["present"], "stale": counts["stale"],
+        "missing": counts["missing"], "unknown": counts["unknown"],
+        "metadata_present": sum(bool(results[key]["metadata_present"]) for key in EXPORT_KEYS),
+    }
+    return results, warnings
+
+
+def student_review_status_to_dict(status: StudentReviewStatus) -> dict[str, object]:
+    """Serialize the immutable model to the stable schema-version-1 object."""
+    return {
+        "schema_version": REVIEW_STATUS_SCHEMA_VERSION,
+        "record_type": REVIEW_STATUS_RECORD_TYPE,
+        "class_id": status.class_id,
+        "assignment_id": status.assignment_id,
+        "student_id": status.student_id,
+        "assignment": _thaw(status.assignment),
+        "student": _thaw(status.student),
+        "routed_evidence": _thaw(status.routed_evidence),
+        "submission": _thaw(status.submission),
+        "review": _thaw(status.review),
+        "warnings": list(status.warnings),
+    }
+
+
+def format_student_review_status(status: StudentReviewStatus) -> str:
+    """Render compact teacher-readable status without review prose."""
+    d = student_review_status_to_dict(status)
+    assignment = cast(dict[str, Any], d["assignment"])
+    student = cast(dict[str, Any], d["student"])
+    routed = cast(dict[str, Any], d["routed_evidence"])
+    submission = cast(dict[str, Any], d["submission"])
+    review = cast(dict[str, Any], d["review"])
+    pages, evidence = submission["pages"], submission["evidence"]
+    minimum = review["minimum_requirements"]
+    units, observations = review["review_units"], review["observations"]
+    ratings, feedback = review["overall_ratings"], review["feedback"]
+    lines = [
+        "Student Review Status", "",
+        f"Class: {status.class_id}",
+        f"Assignment: {assignment['title']} ({status.assignment_id})",
+        f"Student: {student['display_name']} ({status.student_id})",
+        f"Roster status: {student['roster_status']}", "",
+        "Routed evidence:",
+        f"- Available: {_yes_no(routed['available'])}",
+        f"- Files: {_value(routed['file_count'])}",
+        f"- Needs assembly: {_yes_no(routed['needs_assembly'])}", "",
+        "Submission:", f"- Record: {submission['status']}",
+        f"- State: {_value(submission['state'])}",
+        f"- Plain-paper submission: {_yes_no(submission['plain_paper'])}",
+        f"- Expected pages: {_value(submission['expected_pages'])}",
+        f"- Digital pages: {_value(pages['total'])}",
+        f"- Evidence records: {_value(evidence['total'])}",
+        f"- Selected evidence: {_value(evidence['selected'])}",
+        f"- Manifest: {submission['path']}",
+    ]
+    if submission["plain_paper"] is True:
+        lines.append("- Physical paper remains outside Quillan")
+    lines.extend([
+        "", "Review:", f"- Record: {review['status']}",
+        f"- Orphaned: {_yes_no(review['orphaned'])}",
+        f"- State: {_value(review['state_label'])}", f"- Review record: {review['path']}",
+        "", "Minimum requirements:",
+        f"- Configured: {minimum['configured']}", f"- Checked: {_value(minimum['current'])}",
+        f"- Met: {_value(minimum['met'])}", f"- Unmet: {_value(minimum['unmet'])}",
+        f"- Stale checks: {_value(minimum['stale'])}", f"- Outcome: {_value(minimum['outcome'])}",
+        "", "Review artifacts:",
+        f"- Review units: {_value(units['total'])}", f"- Observations: {_value(observations['total'])}",
+        f"- Observations included for feedback: {_value(observations['included_for_feedback'])}",
+        f"- Overall ratings: {_value(ratings['current'])}/{ratings['configured']}",
+        f"- Feedback records: {_value(feedback['current_records'])}/{assignment['focus_standard_count']}",
+        f"- Feedback comments: {_value(feedback['comments_total'])} total; {_value(feedback['comments_included'])} included",
+        f"- Private notes: {_value(review['private_notes']['total'])}", "", "Feedback exports:",
+        f"- PDF: {review['exports']['feedback_pdf']['status']} — {review['exports']['feedback_pdf']['path']}",
+        f"- Markdown: {review['exports']['feedback_markdown']['status']} — {review['exports']['feedback_markdown']['path']}",
+        "", "Warnings:",
+    ])
+    lines.extend(f"- {code}" for code in status.warnings)
+    if not status.warnings:
+        lines.append("- none")
+    return "\n".join(lines)
+
+
+def _freeze(value: Mapping[str, Any]) -> FrozenMapping:
+    def one(item: Any) -> FrozenValue:
+        if isinstance(item, Mapping):
+            return FrozenMapping(tuple((str(key), one(child)) for key, child in item.items()))
+        if isinstance(item, (list, tuple)):
+            return tuple(one(child) for child in item)
+        return cast(str | int | bool | None, item)
+    return cast(FrozenMapping, one(value))
+
+
+def _thaw(value: FrozenValue) -> Any:
+    if isinstance(value, FrozenMapping):
+        return {key: _thaw(child) for key, child in value.items_tuple}
+    if isinstance(value, tuple):
+        return [_thaw(child) for child in value]
+    return value
+
+
+def _value(value: object) -> str:
+    return "unavailable" if value is None else str(value)
+
+
+def _yes_no(value: object) -> str:
+    return "unavailable" if value is None else "yes" if value is True else "no"

--- a/tests/test_cli_review_status.py
+++ b/tests/test_cli_review_status.py
@@ -1,0 +1,34 @@
+"""CLI registration and representation tests for review-status."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quillan.cli import main
+from quillan.cli_app.handlers import review_status as cli_review_status
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID
+from tests.test_class_summary_export import _write_assignment
+
+
+def test_help_is_registered(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["review-status", "--help"])
+    assert exit_info.value.code == 0
+    assert "student_id" in capsys.readouterr().out
+
+
+def test_json_is_one_document(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(cli_review_status, "resolve_workspace_root", lambda: tmp_path)
+    assert main(["review-status", CLASS_ID, ASSIGNMENT_ID, "00100", "--format", "json"]) == 0
+    assert json.loads(capsys.readouterr().out)["record_type"] == "quillan_student_review_status"
+
+
+def test_text_is_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(cli_review_status, "resolve_workspace_root", lambda: tmp_path)
+    assert main(["review-status", CLASS_ID, ASSIGNMENT_ID, "00100"]) == 0
+    assert capsys.readouterr().out.startswith("Student Review Status\n")

--- a/tests/test_student_review_status.py
+++ b/tests/test_student_review_status.py
@@ -1,0 +1,80 @@
+"""Focused contract tests for selected-student review status."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from quillan.student_review_status import (
+    build_student_review_status,
+    format_student_review_status,
+    student_review_status_to_dict,
+)
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID, _manifest, _review
+from tests.test_class_summary_export import _student_dir, _write_assignment, _write_json, _write_roster
+
+
+def _snapshot(root: Path) -> dict[str, bytes]:
+    return {p.relative_to(root).as_posix(): p.read_bytes() for p in root.rglob("*") if p.is_file()}
+
+
+def _document(root: Path, student_id: str = "00100") -> dict[str, Any]:
+    status = build_student_review_status(root, CLASS_ID, ASSIGNMENT_ID, student_id)
+    return cast(dict[str, Any], student_review_status_to_dict(status))
+
+
+def test_missing_records_have_null_and_zero_semantics_and_are_read_only(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_roster(tmp_path)
+    before = _snapshot(tmp_path)
+    document = _document(tmp_path)
+    assert document["schema_version"] == "1"
+    assert document["record_type"] == "quillan_student_review_status"
+    assert document["submission"]["status"] == "missing"
+    assert document["submission"]["pages"] == {
+        "available": False,
+        "total": None,
+        "states": {state: None for state in ("present", "missing", "duplicate", "needs_rescan", "excluded")},
+        "present_unselected": None,
+        "with_selected_evidence": None,
+        "without_selected_evidence": None,
+    }
+    assert document["review"]["status"] == "missing"
+    assert document["review"]["state"] is None
+    assert document["review"]["review_units"]["total"] == 0
+    assert document["review"]["overall_ratings"]["missing"] == 2
+    assert _snapshot(tmp_path) == before
+
+
+def test_valid_review_counts_notes_without_exposing_prose(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    manifest = copy.deepcopy(_manifest("00100"))
+    review = copy.deepcopy(_review("feedback_composed", "00100"))
+    secret = "DISTINCTIVE_PRIVATE_SECRET"
+    review["private_notes"] = [{"private_note_id": "note_1", "text": secret, "created_at": review["created_at"], "updated_at": review["updated_at"], "module_details": {}}]
+    _write_json(_student_dir(tmp_path, "00100") / "submission.json", manifest)
+    _write_json(_student_dir(tmp_path, "00100") / "review.json", review)
+    status = build_student_review_status(tmp_path, CLASS_ID, ASSIGNMENT_ID, "00100")
+    document = cast(dict[str, Any], student_review_status_to_dict(status))
+    rendered = json.dumps(document) + format_student_review_status(status)
+    assert document["review"]["private_notes"]["total"] == 1
+    assert secret not in rendered
+    assert "private_note_id" not in rendered
+
+
+def test_invalid_sibling_is_isolated_and_output_is_deterministic(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_json(_student_dir(tmp_path, "00999") / "review.json", "not a record")
+    assert _document(tmp_path) == _document(tmp_path)
+    assert "invalid_review" not in _document(tmp_path)["warnings"]
+
+
+def test_orphaned_review_is_validated_independently(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_json(_student_dir(tmp_path, "00100") / "review.json", _review("not_started", "00100"))
+    document = _document(tmp_path)
+    assert document["review"]["status"] == "valid"
+    assert document["review"]["orphaned"] is True
+    assert "review_without_valid_submission" in document["warnings"]


### PR DESCRIPTION
## Summary

* Add a compact, direct, read-only status command for one student’s submission and review workflow:

  * `quillan review-status <class_id> <assignment_id> <student_id>`
  * `quillan review-status <class_id> <assignment_id> <student_id> --format text`
  * `quillan review-status <class_id> <assignment_id> <student_id> --format json`
* Add one immutable selected-student status model shared by text and JSON output.
* Add a versioned JSON contract for future GUI consumption.
* Report submission, review, workflow, artifact-count, and export-freshness status without exposing private review prose.
* Support scanned submissions, plain-paper submissions, missing records, invalid records, identity mismatches, and orphaned reviews.
* Keep the command entirely read-only and isolated to the selected student.

## Command Surface

```
quillan review-status <class_id> <assignment_id> <student_id>

quillan review-status <class_id> <assignment_id> <student_id> \
  --format text

quillan review-status <class_id> <assignment_id> <student_id> \
  --format json
```

Text is the default format.

The command is direct and non-interactive. It does not call `input()` or invoke menu functions.

`--format` controls standard-output representation only. It does not create a status or export file.

## Shared Architecture

Added the immutable selected-student status service in:

* `quillan/student_review_status.py`

Added the thin direct CLI handler in:

* `quillan/cli_app/handlers/review_status.py`

Registered the command in:

* `quillan/cli_app/parser.py`

The implementation preserves the intended boundary:

```
Direct CLI -> immutable selected-student status builder
           -> text or versioned JSON formatter

Future GUI -> same immutable model or JSON contract
```

The handler does not:

* load raw workspace JSON directly;
* calculate review counts;
* patch submission or review records;
* invoke the interactive menu;
* invoke the whole assignment dashboard;
* call report or feedback exporters.

## Relationship to Existing Review Views

The new command remains distinct from the existing content-oriented Current Review Details view.

`review-status` reports:

* record conditions;
* workflow states;
* counts;
* paths;
* timestamps;
* booleans;
* warning codes;
* export freshness.

It does not display:

* requirement teacher notes;
* outcome teacher notes;
* observation rationales;
* overall-rating rationales;
* feedback-comment text;
* private-note text;
* student writing.

The existing detailed teacher review view remains available for inspecting teacher-entered review content.

## Selected-Student Isolation

The status builder inspects only the requested student’s relevant records.

It does not construct the complete assignment dashboard or load sibling student reviews.

A malformed record belonging to another student therefore does not prevent status for the selected student.

The command may read:

* the canonical assignment configuration;
* roster metadata for the selected student;
* selected-student routed-evidence metadata;
* selected canonical `submission.json`;
* selected canonical `review.json`;
* selected student’s expected feedback export files.

It does not inspect other students’ submission or review records.

## Assignment Validation

The command validates:

* class identifier syntax;
* assignment identifier syntax;
* student identifier syntax;
* canonical assignment path;
* assignment JSON;
* assignment schema;
* assignment identity;
* requested class membership in `assignment.class_ids`.

Fatal assignment or workspace failures return nonzero with a concise error.

Fatal failures do not emit a partial successful JSON object or create workspace records.

The status reports assignment context including:

* assignment ID;
* title;
* writing type;
* standards-profile ID;
* configured Focus Standard count;
* configured minimum-requirement count;
* canonical workspace-relative assignment path.

The full student prompt is not emitted.

## Student and Roster Context

The command reports:

* student ID;
* roster-derived display name when available;
* roster status:

  * `rostered`;
  * `unrostered`;
  * `roster_unavailable`.

Current roster membership is not required when valid historical submission or review records exist.

When the roster is missing or invalid:

* status construction continues;
* the student ID is used as a display fallback;
* a deterministic warning is included;
* the command does not falsely classify the student as unrostered.

## Routed-Evidence Context

The command reports selected-student routed-evidence diagnostics:

* discovery availability;
* routed-evidence presence;
* routed-file count;
* whether submission assembly appears necessary.

Assembly is needed only when routed evidence exists without a valid canonical submission manifest.

Routed-evidence discovery remains diagnostic only.

The implementation does not:

* assemble submissions;
* open routed files;
* inspect PDFs or images;
* decode QR payloads;
* repair routing metadata.

A routed-evidence discovery failure remains nonfatal when assignment and canonical record status can still be determined.

Unavailable routed-evidence information is represented explicitly rather than being reported as a false zero.

## Submission Record Status

The command inspects only:

```
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
```

Submission records are classified as:

* `missing`;
* `valid`;
* `invalid`;
* `identity_mismatch`.

Invalid records are not treated as missing.

Identity-mismatched records are not treated as valid records for the requested student.

The canonical workspace-relative path is reported even when the file is missing.

## Missing Submission

A missing manifest is a successful diagnostic result.

The command reports:

* submission status: `missing`;
* canonical target path;
* routed-evidence presence;
* routed-file count when available;
* whether assembly appears necessary;
* adjacent review status for orphan diagnostics.

It does not:

* create a submission manifest;
* create a review record;
* assemble routed evidence;
* infer a submission state;
* invent page or evidence counts.

Page and evidence details are marked unavailable rather than represented as valid zero counts.

## Invalid or Identity-Mismatched Submission

Malformed or schema-invalid manifests produce:

* submission status: `invalid`;
* a deterministic warning;
* unavailable page and evidence counts.

Schema-valid manifests whose identity does not match their canonical path produce:

* submission status: `identity_mismatch`;
* a deterministic warning;
* unavailable page, evidence, and submission-state details.

Partial or incorrectly attributed manifest data is not exposed.

Neither condition causes the command to modify or repair the manifest.

## Valid Scanned Submissions

For valid digital submissions, the command reports:

* stored submission state;
* expected page count;
* digital page count;
* evidence-record count;
* selected-evidence count;
* manifest creation timestamp;
* manifest update timestamp;
* page counts by canonical state:

  * `present`;
  * `missing`;
  * `duplicate`;
  * `needs_rescan`;
  * `excluded`;
* present-but-unselected pages;
* pages with selected evidence;
* pages without selected evidence.

Evidence contents are not opened or inspected.

## Plain-Paper Submissions

Valid plain-paper submissions are identified explicitly.

They report:

* submission status: `valid`;
* plain-paper flag: `true`;
* expected pages: `null`;
* digital page count: `0`;
* evidence-record count: `0`;
* selected-evidence count: `0`;
* physical paper remaining outside Quillan.

Plain-paper submissions are not reported as:

* missing;
* unassembled;
* invalid because they lack digital evidence.

No digital pages or evidence records are synthesized.

## Null Versus Zero Semantics

The status model distinguishes known zero values from unavailable values.

Examples:

* valid plain-paper submission:

  * page and evidence counts are available and equal zero;
* missing or invalid submission:

  * page and evidence counts are unavailable;
* missing review:

  * stored artifact counts are known to be zero;
  * assignment-derived missing requirements and ratings can still be calculated;
* invalid or identity-mismatched review:

  * review-derived counts are unavailable.

JSON uses `null` for unavailable scalar values rather than conflating unreadable data with zero activity.

## Review Record Status

The command inspects:

```
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
```

Review records are classified as:

* `missing`;
* `valid`;
* `invalid`;
* `identity_mismatch`.

The status also reports whether the review is orphaned.

A review is orphaned when it exists without a valid identity-matching adjacent submission.

Existing reviews are validated independently for diagnostics even when the manifest is missing or invalid.

The command does not delete, repair, or normalize orphaned reviews.

## Missing Review

A missing review is a successful diagnostic result.

The command reports:

* review status: `missing`;
* review state: `null`;
* canonical review path;
* stored review artifact counts of zero;
* assignment-derived configured requirement count;
* assignment-derived missing rating count;
* assignment-derived missing feedback-record count.

Text output distinguishes:

* no review record;
* a valid stored review whose state is `not_started`.

No review record is created.

## Valid `not_started` Review

A valid review whose stored state is:

```
not_started
```

remains distinct from a missing review file.

For a valid record, the command reports:

* review status: `valid`;
* review state: `not_started`;
* stored timestamps;
* stored empty artifact counts;
* centralized workflow-progress interpretation.

This distinction is preserved in JSON.

## Invalid and Identity-Mismatched Reviews

An invalid review produces:

* review status: `invalid`;
* a deterministic warning;
* unavailable review-derived counts.

A schema-valid review with the wrong class, assignment, or student identity produces:

* review status: `identity_mismatch`;
* a deterministic warning;
* unavailable workflow and artifact details.

The command does not use partial malformed data or attribute a mismatched record to the selected student.

## Orphaned Reviews

An existing review without a valid adjacent submission is identified as orphaned.

The command can still report whether the review itself is:

* valid;
* invalid;
* identity-mismatched.

A valid orphaned review may expose compact stored counts for diagnostic purposes, but it is not represented as an ordinary review-ready student record.

The command does not create the missing submission or alter the review.

## Review Workflow Status

For valid reviews, workflow interpretation uses the centralized review-status service.

The command reports:

* stored review state;
* teacher-facing state label;
* returned-without-full-review status;
* observations-complete status;
* ratings-complete status;
* feedback-composed status;
* ready-for-export status;
* exported workflow status;
* review creation timestamp;
* review update timestamp.

Workflow thresholds are not reimplemented in the CLI handler.

## Returned Without Full Review

Returned work is identified clearly.

The command reports:

* returned without full standards review;
* observations not applicable to the completed workflow;
* ratings not applicable to the completed workflow;
* feedback composition not applicable to the completed workflow.

Stored artifact counts remain available for audit when the review itself is valid.

The command does not delete or suppress residual stored records.

## Minimum-Requirement Status

Configured requirements are derived from the current assignment.

The command reports:

* configured requirements;
* raw stored checks;
* checks matching current assignment configuration;
* unchecked configured requirements;
* met checks;
* unmet checks;
* stale or no-longer-configured checks;
* stored outcome status;
* returned-without-full-review status;
* whether an outcome teacher note exists.

Teacher-note text is not emitted.

Stale checks remain visible for diagnostics but do not satisfy current assignment requirement coverage.

## Review-Unit Counts

For valid reviews, the command reports:

* total review units;
* units with page targets;
* units with evidence IDs;
* units containing observations;
* empty units without observations.

Unit labels, page targets, and evidence identifiers are not exposed in structured output.

## Focus Standard Observation Counts

The command counts observations nested within review units and reports:

* total observations;
* applicable observations;
* not-applicable observations;
* evidence-present observations;
* evidence-missing observations;
* observations whose evidence status is not applicable;
* observations with a unit-level rating;
* observations with a rationale;
* observations marked for feedback;
* configured Focus Standards represented;
* observations for standards no longer configured by the assignment.

Observation rationales and evidence contents are not emitted.

Stale observations remain countable for audit but do not satisfy current assignment coverage.

## Overall Focus Standard Rating Counts

The current assignment’s `focus_standard_ids` remains the authority for rating coverage.

The command reports:

* configured Focus Standards;
* raw stored ratings;
* current configured standards rated;
* configured standards missing ratings;
* stale or unconfigured ratings;
* ratings included in feedback;
* ratings with rationales.

Stale ratings do not satisfy current assignment completion.

Rating rationales and rating distributions are not emitted.

## Feedback-Composition Counts

For valid reviews, the command reports:

* raw standard-feedback records;
* current configured standards with feedback records;
* configured standards missing feedback records;
* stale feedback records;
* selected observation-reference count;
* records including overall ratings;
* records including overall rationales;
* total feedback comments;
* included comments;
* excluded comments;
* custom comments;
* reusable-comment snapshots;
* comments marked for reuse;
* global review-unit-observation inclusion;
* global overall-rating inclusion.

The command does not emit:

* feedback-comment text;
* reusable-comment text;
* feedback-comment IDs;
* reusable-comment IDs;
* comment-set IDs;
* selected observation IDs.

## Private Notes

Only the private-note count is reported.

The command does not emit:

* private-note text;
* private-note IDs;
* note previews;
* note timestamps.

This privacy boundary applies to both text and JSON output.

## Feedback Export Freshness

PDF and Markdown are evaluated independently through the shared export-freshness rules.

For each format, the command reports:

* workspace-relative path;
* metadata presence;
* file presence;
* status:

  * `present`;
  * `stale`;
  * `missing`;
  * `unknown`;
* stale boolean;
* generated timestamp when canonical metadata exists;
* source-review update timestamp when canonical metadata exists;
* related warning codes.

The command distinguishes:

* a current export;
* an export generated from an earlier review state;
* missing output;
* metadata pointing to a missing file;
* a file present without usable canonical metadata.

It does not create export directories, regenerate feedback, or modify review export metadata.

## Warning Codes

Warnings are:

* deterministic;
* deduplicated;
* stable in order;
* included in text output;
* included in JSON.

Supported diagnostics include conditions such as:

* unavailable roster;
* unrostered student;
* unavailable routed-evidence discovery;
* routed evidence needing assembly;
* missing or invalid submission;
* submission identity mismatch;
* missing or invalid review;
* review identity mismatch;
* orphaned review;
* stale requirement checks;
* observations for unconfigured standards;
* ratings for unconfigured standards;
* feedback for unconfigured standards;
* stale or missing feedback export files;
* export files without canonical metadata.

Conditions requiring teacher attention do not automatically cause command failure.

## Text Output

The default text output is compact and status-oriented.

It includes:

* class, assignment, and student identity;
* roster status;
* routed-evidence availability and assembly need;
* submission record status;
* plain-paper status;
* page and evidence counts;
* review record status;
* orphaned status;
* review workflow state;
* requirement progress;
* unit and observation counts;
* rating coverage;
* feedback counts;
* private-note count;
* PDF and Markdown status;
* warnings.

It does not dump raw assignment, submission, or review JSON.

It does not display private review prose.

## JSON Output

`--format json` emits exactly one valid JSON document to standard output.

The JSON does not include:

* headings before the document;
* progress messages;
* warnings outside the document;
* Python object representations;
* absolute workspace paths;
* terminal formatting.

The output ends with one newline.

## JSON Contract

The command introduces a dedicated status schema:

```
"schema_version": "1"
"record_type": "quillan_student_review_status"
```

The schema is independent of:

* assignment schema versions;
* submission-manifest schema versions;
* review-record schema versions;
* assignment-dashboard schema versions.

Required top-level fields include:

* `schema_version`;
* `record_type`;
* `class_id`;
* `assignment_id`;
* `student_id`;
* `assignment`;
* `student`;
* `routed_evidence`;
* `submission`;
* `review`;
* `warnings`.

Fixed sections remain present even when the corresponding workspace record is missing or unreadable.

## JSON Types

The JSON serializer uses:

* integers for available counts;
* booleans for true and false;
* null for unavailable scalar values;
* strings for IDs, statuses, timestamps, labels, and paths;
* arrays for ordered warnings;
* objects for named status and count groups.

Booleans and counts are not encoded as strings.

Paths are explicitly serialized as workspace-relative POSIX strings.

The implementation does not use `default=str` or expose `Path(...)` representations.

## JSON Privacy Boundary

The structured output does not contain:

* the assignment prompt;
* student writing;
* evidence contents;
* retained-scan contents;
* requirement teacher-note text;
* outcome teacher-note text;
* observation rationale text;
* overall-rating rationale text;
* feedback-comment text;
* reusable-comment snapshots;
* private-note text.

It may contain:

* student display name;
* identifiers;
* counts;
* workflow states;
* booleans;
* warning codes;
* canonical paths;
* record timestamps;
* export timestamps.

## JSON Determinism

Repeated calls against an unchanged workspace produce equivalent parsed JSON objects.

The serializer does not add:

* execution timestamps;
* generated-at timestamps;
* random identifiers;
* process-specific values;
* environment-dependent values.

Ordering is deterministic for:

* warning codes;
* count groups;
* state groups;
* configured assignment fields.

All paths remain workspace-relative and POSIX-style.

## JSON Stability Policy

Within schema version `"1"`:

* required keys are not renamed;
* required keys are not removed;
* key types remain stable;
* status meanings remain stable;
* fixed sections remain present;
* private review prose remains excluded;
* null-versus-zero semantics remain stable;
* path formatting remains stable;
* breaking changes require a schema-version change.

## Success and Exit Behavior

The following remain successful diagnostic results:

* valid scanned submission;
* valid plain-paper submission;
* missing manifest;
* routed evidence awaiting assembly;
* invalid manifest;
* submission identity mismatch;
* missing review;
* invalid review;
* review identity mismatch;
* orphaned review;
* stale export;
* missing export;
* unrostered student;
* unavailable roster;
* unavailable routed-evidence diagnostics.

These conditions are represented through status fields and warnings.

Nonzero exit status is reserved for failures that prevent safe status construction, such as:

* unresolved workspace;
* invalid identifiers;
* missing or malformed assignment;
* unsupported assignment schema;
* assignment identity mismatch;
* class not configured for the assignment;
* unrecoverable path or serialization failure.

Expected fatal errors are reported without tracebacks.

## Exact Read Boundary

The command may read:

* canonical assignment configuration;
* selected-student roster metadata;
* selected-student routed-evidence metadata;
* selected canonical submission manifest;
* selected canonical review record;
* selected student’s feedback PDF and Markdown file existence.

It does not read:

* student evidence contents;
* retained-source contents;
* student writing;
* other students’ reviews;
* reusable-comment source files;
* assignment report contents.

## No Workspace Write Boundary

The command writes no workspace files.

It does not create:

* directories;
* submission manifests;
* review records;
* exports;
* reports;
* temporary workspace files;
* caches;
* locks;
* scan-review resolutions.

It does not modify:

* assignment configuration;
* roster;
* submission manifest;
* review record;
* routed evidence;
* retained scans;
* reusable comments;
* feedback exports;
* report exports;
* scan-review metadata;
* PDS Core data;
* ScoreForm data.

Standard-output text or JSON is the only output.

## No Automated Processing or Judgment

Confirmed that the command does not:

* open evidence;
* inspect PDFs;
* inspect images;
* parse student writing;
* decode QR payloads;
* run OCR;
* perform handwriting recognition;
* use AI;
* infer requirement checks;
* infer requirement outcomes;
* infer observations;
* infer ratings;
* infer feedback;
* calculate grades;
* calculate percentages;
* calculate mastery;
* average ratings;
* assemble submissions;
* select evidence;
* resolve duplicates;
* change workflow state;
* compose feedback;
* generate exports.

All reported values derive from stored records and assignment configuration.

## Files Changed

Ten intended Quillan source, test, and documentation files were modified or added:

* `quillan/student_review_status.py`
* `quillan/cli_app/handlers/review_status.py`
* `quillan/cli_app/parser.py`
* `tests/test_student_review_status.py`
* `tests/test_cli_review_status.py`
* `docs/review_status_contract.md`
* `docs/cli_contract.md`
* `docs/data_contracts.md`
* `docs/teacher_review_model.md`
* `README.md`

## Documentation

Added the focused review-status contract in:

* `docs/review_status_contract.md`

Updated documentation covers:

* command syntax;
* text and JSON output;
* selected-student isolation;
* scanned and plain-paper submissions;
* missing, invalid, and identity-mismatched records;
* orphaned review behavior;
* requirement, unit, observation, rating, feedback, note, and export counts;
* null-versus-zero semantics;
* warning versus fatal behavior;
* JSON schema version;
* deterministic ordering;
* path formatting;
* privacy exclusions;
* exact read-only boundary;
* absence of inference and automated processing.

## Test Coverage

Added coverage for:

* command registration and help;
* text default;
* explicit text and JSON formats;
* assignment and identifier failures;
* rostered and unrostered students;
* unavailable roster;
* selected-student routed-evidence status;
* scanned submissions;
* plain-paper submissions;
* missing manifests;
* invalid manifests;
* identity-mismatched manifests;
* missing reviews;
* valid `not_started` reviews;
* invalid reviews;
* identity-mismatched reviews;
* orphaned reviews;
* configured and stale requirement checks;
* review-unit counts;
* observation counts;
* configured and stale ratings;
* feedback-record and comment counts;
* private-note privacy;
* PDF and Markdown freshness;
* warning ordering;
* JSON shape and types;
* null-versus-zero behavior;
* workspace-relative paths;
* JSON determinism;
* selected-student isolation;
* complete read-only workspace snapshots;
* privacy regression strings.

## Safety

Confirmed:

* the handler is thin and non-interactive;
* text and JSON share one immutable status model;
* only the selected student is inspected;
* missing and invalid records remain diagnostic successes;
* missing review remains distinct from stored `not_started`;
* plain-paper submissions remain valid without digital evidence;
* unreadable data is not represented as zero;
* private review prose is not emitted;
* all paths are workspace-relative;
* no files or directories are created;
* no existing file is modified;
* no evidence is opened;
* no submission is assembled;
* no review or export is generated;
* PDS Core remains unchanged;
* ScoreForm remains unchanged;
* no real student data or generated artifacts were added.

## Validation

* Focused review-status tests: `7 passed`
* Related review and dashboard tests: `50 passed`
* Broader CLI regressions: `255 passed`
* Full pytest suite: `1236 passed`
* Ruff: passed
* mypy: passed, `172` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* No temporary test directories, real student data, or generated artifacts present

Closes #309
