### PR TITLE
Add observation completion CLI

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -218,6 +218,7 @@ quillan review-units set <class_id> <assignment_id> <student_id> --count <positi
 quillan review-units set <class_id> <assignment_id> <student_id> --units <units.json>
 quillan observations list <class_id> <assignment_id> <student_id>
 quillan observations set <class_id> <assignment_id> <student_id> --unit-id <unit_id> --standard-id <standard_id> --applicable true|false [--evidence-present true|false] [--rating <integer>] [--rationale <text>] [--include-in-feedback true|false]
+quillan observations mark-complete <class_id> <assignment_id> <student_id> --yes
 quillan ratings list <class_id> <assignment_id> <student_id>
 quillan ratings set <class_id> <assignment_id> <student_id> --standard-id <standard_id> --rating <integer> [--rationale <text>] --include-in-feedback true|false
 quillan ratings mark-complete <class_id> <assignment_id> <student_id> --yes
@@ -431,7 +432,7 @@ remain intact.
 ### `observations` commands
 
 The `observations` namespace exposes review-unit Focus Standard observations
-as direct, non-interactive commands. Both commands validate the canonical
+as direct, non-interactive commands. All commands validate the canonical
 assignment, require an existing valid canonical `submission.json`, and validate
 an existing `review.json` rather than treating a malformed or mismatched record
 as empty. Routed evidence is not assembled automatically. A valid plain-paper
@@ -478,13 +479,33 @@ shared observation service performs review-state transitions and refuses to
 modify `returned_without_full_review` records until the minimum-requirements
 outcome changes.
 
-List writes nothing. Set may modify only
+`observations mark-complete` is an explicit teacher-controlled phase transition.
+It requires `--yes`, never prompts, and calls the same shared completion service
+as the teacher menu. A valid existing review with at least one review unit is
+required. A missing review is not created, and missing units produce guidance to
+define review units first. The returned-without-full-review guard also applies;
+the minimum-requirement outcome must change before completion can proceed.
+
+Complete observation coverage is not required. Some, most, or every configured
+unit-standard pair may remain unobserved, including when the review has zero
+observations. The command still sets `review_state` to `observations_complete`
+and updates `updated_at`. It reports the exact missing-pair count returned by the
+shared service and, when that count is nonzero, warns that completion occurred
+with unobserved pairs and that no observations were created. It does not infer
+or fill applicability, evidence presence, ratings, rationales, or feedback
+choices.
+
+List writes nothing. Set and mark-complete may modify only
 `classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json`
-through the shared validated atomic writer. Neither command opens evidence,
-parses PDFs or images, runs OCR, handwriting recognition, or AI, infers any
-teacher judgment, calculates overall ratings, grades, or scores, marks review
-complete, composes feedback, or modifies assignments, submissions, rosters,
-evidence, exports, reports, Core data, or ScoreForm data.
+through the shared validated atomic writer. Completion changes only
+`review_state` and `updated_at`; it preserves units, observations, minimum-
+requirement data, overall ratings, feedback and comments, private notes, export
+metadata, module details, array ordering, and `created_at`. No observation
+command opens evidence, parses PDFs or images, decodes QR codes, runs OCR,
+handwriting recognition, or AI, infers any teacher judgment, calculates overall
+ratings, mastery, percentages, grades, or scores, assembles submissions, mutates
+pages, composes feedback, generates exports, or modifies assignments,
+submissions, rosters, evidence, reports, Core data, or ScoreForm data.
 
 ### `ratings` commands
 

--- a/quillan/cli_app/handlers/observations.py
+++ b/quillan/cli_app/handlers/observations.py
@@ -6,7 +6,10 @@ import argparse
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
-from quillan.cli_app.output import print_updated_review_unit_observation
+from quillan.cli_app.output import (
+    print_completed_review_unit_observations,
+    print_updated_review_unit_observation,
+)
 from quillan.observation_management import (
     ObservationContext,
     ObservationManagementError,
@@ -15,6 +18,7 @@ from quillan.observation_management import (
 )
 from quillan.review_observations import (
     ReviewObservationError,
+    mark_observations_complete,
     set_review_unit_observation,
 )
 
@@ -65,6 +69,27 @@ def handle_observations_set(args: argparse.Namespace) -> int:
             include_in_feedback=args.include_in_feedback,
         )
         print_updated_review_unit_observation(updated)
+        return 0
+    except (OSError, ValueError, WorkspaceRootError, ReviewObservationError) as error:
+        return _error(error)
+
+
+def handle_observations_mark_complete(args: argparse.Namespace) -> int:
+    """Explicitly mark review-unit observations complete without prompting."""
+    try:
+        completed = mark_observations_complete(
+            resolve_workspace_root(),
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+        )
+        print_completed_review_unit_observations(completed)
+        if completed.missing_focus_standard_pairs:
+            print(
+                "Warning: Observations were marked complete with "
+                f"{completed.missing_focus_standard_pairs} unobserved "
+                "unit-standard pair(s); no observations were created."
+            )
         return 0
     except (OSError, ValueError, WorkspaceRootError, ReviewObservationError) as error:
         return _error(error)

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -42,6 +42,7 @@ from quillan.cli_app.handlers.review_units import (
 )
 from quillan.cli_app.handlers.observations import (
     handle_observations_list,
+    handle_observations_mark_complete,
     handle_observations_set,
 )
 from quillan.cli_app.handlers.pages import (
@@ -301,10 +302,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     observations_parser = subparsers.add_parser(
         "observations",
-        help="List and record review-unit Focus Standard observations.",
+        help="List, record, and complete review-unit Focus Standard observations.",
         description=(
-            "List or record explicit teacher-entered Focus Standard observations "
-            "without inspecting evidence or inferring judgments."
+            "List, record, or explicitly complete teacher-entered Focus Standard "
+            "observations without inspecting evidence or inferring judgments."
         ),
     )
     observations_parser.set_defaults(
@@ -339,6 +340,27 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-in-feedback", type=_true_false, metavar="true|false"
     )
     observations_set_parser.set_defaults(handler=handle_observations_set)
+
+    observations_complete_parser = observations_subparsers.add_parser(
+        "mark-complete",
+        help="Explicitly complete observations, including when pairs are unobserved.",
+        description=(
+            "Explicitly mark the observation phase complete for an existing review "
+            "with defined units. Missing observations do not block completion and "
+            "none are created automatically; only canonical review workflow state "
+            "is changed."
+        ),
+    )
+    _add_submission_identity_arguments(observations_complete_parser)
+    observations_complete_parser.add_argument(
+        "--yes",
+        required=True,
+        action="store_true",
+        help="Explicitly confirm completion without prompting.",
+    )
+    observations_complete_parser.set_defaults(
+        handler=handle_observations_mark_complete
+    )
 
     ratings_parser = subparsers.add_parser(
         "ratings",

--- a/tests/test_cli_observations.py
+++ b/tests/test_cli_observations.py
@@ -10,7 +10,10 @@ import pytest
 
 from quillan.cli import main
 from quillan.cli_app.handlers import observations as handlers
-from quillan.review_observations import set_review_units
+from quillan.review_observations import (
+    CompletedReviewUnitObservations,
+    set_review_units,
+)
 from quillan.review_record import build_empty_review_record
 from quillan.review_record_paths import review_record_path, write_review_record
 from quillan.submission_manifest_paths import (
@@ -108,6 +111,17 @@ def _set_args(*extra: str) -> list[str]:
     ]
 
 
+def _complete_args(*extra: str) -> list[str]:
+    return [
+        "observations",
+        "mark-complete",
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        *extra,
+    ]
+
+
 @pytest.mark.parametrize(
     "argv",
     [
@@ -115,6 +129,7 @@ def _set_args(*extra: str) -> list[str]:
         ["observations", "--help"],
         ["observations", "list", "--help"],
         ["observations", "set", "--help"],
+        ["observations", "mark-complete", "--help"],
     ],
 )
 def test_observation_help_exits_successfully(argv: list[str]) -> None:
@@ -132,7 +147,20 @@ def test_bare_namespace_prints_help_without_resolving_workspace(
         lambda: pytest.fail("bare namespace resolved the workspace"),
     )
     assert main(["observations"]) == 0
-    assert "{list,set}" in capsys.readouterr().out
+    assert "{list,set,mark-complete}" in capsys.readouterr().out
+
+
+def test_mark_complete_requires_yes_before_resolving_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        handlers,
+        "resolve_workspace_root",
+        lambda: pytest.fail("missing --yes resolved the workspace"),
+    )
+    with pytest.raises(SystemExit) as error:
+        main(_complete_args())
+    assert error.value.code == 2
 
 
 def test_list_without_review_is_read_only_and_reports_setup_guidance(
@@ -337,4 +365,183 @@ def test_returned_review_can_be_listed_but_not_changed(
     assert "Review state: returned_without_full_review" in capsys.readouterr().out
     assert main(_set_args("--applicable", "true", "--evidence-present", "true")) == 1
     assert "Change the minimum-requirements outcome" in capsys.readouterr().out
+    assert record_path.read_bytes() == before
+
+    assert main(_complete_args("--yes")) == 1
+    assert "Change the minimum-requirements outcome" in capsys.readouterr().out
+    assert record_path.read_bytes() == before
+
+
+def test_mark_complete_reuses_service_result_and_warns_without_prompting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    completed = CompletedReviewUnitObservations(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        review_record_path=tmp_path / "review.json",
+        review_record_relative_path="classes/example/review.json",
+        review_state="observations_complete",
+        unit_count=2,
+        observation_count=1,
+        missing_focus_standard_pairs=3,
+        updated_at=TIMESTAMP,
+    )
+    calls: list[tuple[Path, str, str, str]] = []
+
+    def complete(
+        root: Path, class_id: str, assignment_id: str, student_id: str
+    ) -> CompletedReviewUnitObservations:
+        calls.append((root, class_id, assignment_id, student_id))
+        return completed
+
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(handlers, "mark_observations_complete", complete)
+    monkeypatch.setattr("builtins.input", lambda *_args: pytest.fail("CLI prompted"))
+
+    assert main(_complete_args("--yes")) == 0
+
+    output = capsys.readouterr().out
+    assert calls == [(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)]
+    assert "Unobserved unit-standard pairs: 3" in output
+    assert (
+        "Warning: Observations were marked complete with 3 unobserved "
+        "unit-standard pair(s); no observations were created."
+    ) in output
+
+
+def test_mark_complete_allows_zero_observations_and_preserves_review_content(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    set_review_units(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1, "label": "Opening"}],
+        updated_at=TIMESTAMP,
+    )
+    record_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = json.loads(record_path.read_text(encoding="utf-8"))
+    monkeypatch.setattr("builtins.input", lambda *_args: pytest.fail("CLI prompted"))
+
+    assert main(_complete_args("--yes")) == 0
+
+    after = json.loads(record_path.read_text(encoding="utf-8"))
+    output = capsys.readouterr().out
+    assert after["review_state"] == "observations_complete"
+    assert after["updated_at"] != before["updated_at"]
+    assert after["review_units"][0]["standard_observations"] == []
+    assert after["overall_standard_ratings"] == []
+    assert after["feedback"]["standard_feedback"] == []
+    assert {k: v for k, v in after.items() if k not in {"review_state", "updated_at"}} == {
+        k: v for k, v in before.items() if k not in {"review_state", "updated_at"}
+    }
+    assert "Observations: 0" in output
+    assert "Unobserved unit-standard pairs: 2" in output
+    assert "no observations were created" in output
+
+
+def test_mark_complete_with_partial_coverage_reports_service_count(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    set_review_units(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}, {"sequence": 2}],
+        updated_at=TIMESTAMP,
+    )
+    assert main(
+        _set_args("--applicable", "true", "--evidence-present", "true")
+    ) == 0
+    capsys.readouterr()
+
+    assert main(_complete_args("--yes")) == 0
+
+    output = capsys.readouterr().out
+    review = json.loads(
+        review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert review["review_state"] == "observations_complete"
+    assert len(review["review_units"][0]["standard_observations"]) == 1
+    assert all(
+        not unit["standard_observations"] for unit in review["review_units"][1:]
+    )
+    assert "Unobserved unit-standard pairs: 3" in output
+    assert "marked complete with 3 unobserved" in output
+
+
+def test_mark_complete_with_full_coverage_has_no_warning(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    set_review_units(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=TIMESTAMP,
+    )
+    for standard_id in ("W.1", "L.2"):
+        assert main(
+            [
+                "observations",
+                "set",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                STUDENT_ID,
+                "--unit-id",
+                "paragraph_1",
+                "--standard-id",
+                standard_id,
+                "--applicable",
+                "true",
+                "--evidence-present",
+                "true",
+            ]
+        ) == 0
+    capsys.readouterr()
+
+    assert main(_complete_args("--yes")) == 0
+
+    output = capsys.readouterr().out
+    assert "Unobserved unit-standard pairs: 0" in output
+    assert "Warning:" not in output
+
+
+def test_mark_complete_requires_existing_review_and_units_without_writing(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    record_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    manifest_before = manifest_path.read_bytes()
+
+    assert main(_complete_args("--yes")) == 1
+    assert "Review units must be defined before recording observations" in capsys.readouterr().out
+    assert not record_path.exists()
+    assert manifest_path.read_bytes() == manifest_before
+
+    set_review_units(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        [{"sequence": 1}],
+        updated_at=TIMESTAMP,
+    )
+    review = json.loads(record_path.read_text(encoding="utf-8"))
+    review["review_units"] = []
+    write_review_record(record_path, review, overwrite=True)
+    before = record_path.read_bytes()
+
+    assert main(_complete_args("--yes")) == 1
+    assert "Define review units before marking observations complete" in capsys.readouterr().out
     assert record_path.read_bytes() == before


### PR DESCRIPTION
## Summary

* Add a direct, non-interactive command for completing the Focus Standard observation phase:

  ```text
  quillan observations mark-complete <class_id> <assignment_id> <student_id> --yes
  ```

* Reuse the existing shared `mark_observations_complete(...)` service.

* Reuse the existing `print_completed_review_unit_observations(...)` formatter.

* Preserve the teacher menu’s permissive completion behavior.

* Require explicit `--yes` confirmation through argparse.

* Restrict the write boundary to the selected student’s canonical `review.json`.

## Command Surface

```text
quillan observations list <class_id> <assignment_id> <student_id>

quillan observations set <class_id> <assignment_id> <student_id> ...

quillan observations mark-complete \
  <class_id> <assignment_id> <student_id> \
  --yes
```

Bare:

```text
quillan observations
```

continues to print namespace help and exit successfully without resolving or inspecting the workspace.

## Explicit Confirmation

`--yes` is required by argparse.

When it is omitted:

* argument parsing fails;
* the workspace is not resolved;
* assignment, submission, and review records are not loaded;
* no prompt appears;
* no files are changed.

The command does not call `input()` or provide an interactive fallback.

## Shared Service Reuse

The direct handler calls:

```python
mark_observations_complete(...)
```

The CLI does not independently implement:

* assignment validation;
* submission validation;
* review validation;
* identity checking;
* review-unit prerequisites;
* returned-without-full-review guardrails;
* state mutation;
* missing-pair calculation;
* review writing.

The handler does not manipulate raw review JSON.

## Completion Behavior

A successful command:

* requires an existing valid review record;

* requires at least one defined review unit;

* sets:

  ```text
  review_state = observations_complete
  ```

* updates `updated_at`;

* preserves `created_at`;

* writes through the existing validated canonical review writer.

## Permissive Coverage Rules

Completion remains an explicit teacher-controlled action.

The command succeeds when review units exist with:

* complete observation coverage;
* partial observation coverage;
* zero recorded observations.

Missing unit-standard observations do not block completion.

The command does not create or infer missing observations.

## Missing-Pair Warning

When one or more unit-standard pairs remain unobserved, the command returns success and prints:

```text
Warning: Observations were marked complete with N unobserved unit-standard pair(s); no observations were created.
```

The warning count comes from the shared service result.

The handler does not independently calculate missing coverage.

When no pairs are missing, no warning is printed.

## Output

Successful output uses:

```python
print_completed_review_unit_observations(...)
```

It reports:

* class ID;
* assignment ID;
* student ID;
* review-unit count;
* recorded observation count;
* unobserved unit-standard pair count;
* resulting review state;
* canonical workspace-relative review-record path.

The command does not dump raw JSON.

## Missing Review

When canonical `review.json` does not exist:

* the command returns nonzero;
* guidance explains that review units must be defined first;
* no review record is created;
* the submission manifest remains unchanged.

## Missing Review Units

When a valid review contains no review units:

* the command returns nonzero;
* the review remains byte-for-byte unchanged;
* no units or observations are inferred or created.

## Returned Without Full Review

A review in:

```text
returned_without_full_review
```

cannot be marked observation-complete.

The command:

* returns nonzero;
* explains that the minimum-requirement outcome must change first;
* leaves `review.json` unchanged;
* creates no observations, ratings, or feedback.

## Submission Support

The command continues to support:

* scanned submissions;
* valid plain-paper manual submissions;
* valid historical or unrostered submissions.

A valid plain-paper submission does not require digital pages or evidence.

Current roster membership is not required when a valid canonical submission exists.

## Submission Prerequisite

A valid canonical `submission.json` remains required.

When the manifest is missing:

* the command returns nonzero;
* existing assembly guidance is displayed;
* routed evidence is not assembled;
* no review is created.

Invalid or identity-mismatched assignment, submission, or review records fail without modification.

## Review Preservation

Successful completion preserves all existing review content, including:

* minimum-requirement checks;
* minimum-requirement outcome;
* review units;
* observation records;
* observation IDs;
* applicability;
* evidence-presence values;
* unit-level ratings;
* rationales;
* feedback-inclusion flags;
* overall Focus Standard ratings;
* feedback options;
* feedback comments;
* reusable-comment snapshots;
* export metadata;
* private notes;
* module details;
* original creation timestamp.

Only these intended fields change:

* `review_state`;
* `updated_at`.

## Exact Write Boundary

The only permitted write is:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
```

The implementation does not modify:

* `assignment.json`;
* `submission.json`;
* class roster or metadata;
* routed evidence;
* retained scans;
* page-management metadata;
* scan-review records;
* reusable-comment sets;
* feedback exports;
* assignment reports;
* sibling student records;
* PDS Core data;
* ScoreForm data.

## No Automated Processing

Confirmed that the command does not:

* open evidence;
* inspect PDFs or images;
* parse student writing;
* decode QR payloads;
* run OCR;
* perform handwriting recognition;
* use AI;
* infer review units;
* infer observations;
* infer applicability;
* infer evidence presence;
* infer ratings;
* calculate mastery;
* calculate grades;
* compose feedback;
* generate exports;
* assemble submissions;
* alter submission state.

## Files Changed

Four intended Quillan files were modified:

* `quillan/cli_app/parser.py`
* `quillan/cli_app/handlers/observations.py`
* `tests/test_cli_observations.py`
* `docs/cli_contract.md`

## Documentation

Updated the CLI contract to document:

* the new `observations mark-complete` command;
* required `--yes` confirmation;
* existing-review and review-unit prerequisites;
* permissive completion with incomplete coverage;
* missing-pair warning behavior;
* absence of automatic observation creation;
* resulting `observations_complete` state;
* returned-without-full-review guard;
* exact `review.json` write boundary;
* preservation of ratings, feedback, notes, exports, and metadata.

## Test Coverage

Added or updated tests for:

* top-level help;
* observation namespace help;
* `mark-complete` help;
* bare namespace behavior;
* required `--yes`;
* failure before workspace resolution when confirmation is absent;
* non-interactive behavior;
* complete observation coverage;
* partial observation coverage;
* zero observations with defined units;
* missing review;
* missing review units;
* returned-without-full-review rejection;
* plain-paper submissions;
* unrostered submissions;
* exact missing-pair warning;
* preservation of nested review content;
* exact write boundary;
* absence of unrelated file changes.

## Validation

* Focused observation tests: `29 passed`
* Related regressions: `158 passed`
* Broader CLI regressions: `262 passed`
* Full pytest suite: `1243 passed`
* Ruff: passed
* mypy: passed, `172` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* All requested help commands: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* Quillan working tree contains only the four intended changes
* No real student data or generated artifacts present

Closes #324
