### PR TITLE
Add review workflow state CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The selected-student review menu is:
 6. Compose Focus Standard feedback
 7. Manage submission pages
 8. Add teacher note
-9. Update submission review state
+9. Update review workflow state
 10. Export student feedback
 11. Refresh summary
 12. Back
@@ -244,6 +244,7 @@ quillan pages mark-needs-rescan <class_id> <assignment_id> <student_id> --page N
 quillan open-evidence <workspace-relative-evidence-path>
 quillan open-submission <class_id> <assignment_id> <student_id> [--page N]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+quillan review-workflow set-state <class_id> <assignment_id> <student_id> --state <state> --yes
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan export-feedback <class_id> <assignment_id> <student_id> [--format markdown|pdf|both] [--overwrite]
 quillan export-student-performance-summary <class_id> <assignment_id> [--overwrite]

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -1000,7 +1000,7 @@ The selected-student review menu provides:
 6. Compose Focus Standard feedback
 7. Manage submission pages
 8. Add teacher note
-9. Update submission review state
+9. Update review workflow state
 10. Export student feedback
 11. Refresh summary
 12. Back
@@ -1046,13 +1046,14 @@ as the direct commands:
 ```powershell
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
+quillan review-workflow set-state <class_id> <assignment_id> <student_id> --state <state> --yes
 ```
 
 The generic structured-tag, comment-bank, rubric, and criterion-score runtime
 workflows have been removed. Quillan does not create, import, edit, retire,
 reactivate, or authoritatively validate pds-core standards from review mode.
 
-`Update submission review state` displays the allowed states with
+`Update review workflow state` displays the allowed states with
 teacher-facing descriptions and requires confirmation before saving. This is
 an explicit workflow status change, not a grade, and is not inferred from
 notes, tags, comments, scores, or exports.
@@ -1371,7 +1372,17 @@ Both commands are read-only. They do not inspect content, select evidence,
 score work, tag work, create review records, generate feedback, or update
 review state.
 
-## Submission Review State
+## Two State Models
+
+Quillan deliberately keeps two independent state fields. They are never
+automatically synchronized:
+
+* lightweight submission state is stored in `submission.json.submission_state`;
+* standards-based review workflow state is stored in `review.json.review_state`.
+
+Changing either field leaves the other record unchanged.
+
+## Lightweight Submission State
 
 ```powershell
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
@@ -1386,9 +1397,54 @@ needs_rescan
 reviewed
 ```
 
-This command updates only `submission_state` and `updated_at` in the validated
-manifest. It does not open or inspect evidence or make an automatic review
-decision.
+This compatibility command updates only `submission_state` and `updated_at` in
+the validated `submission.json`. It does not open or inspect evidence, make an
+automatic review decision, or change `review.json.review_state`.
+
+## Review Workflow State
+
+```powershell
+quillan review-workflow set-state <class_id> <assignment_id> <student_id> --state <state> --yes
+```
+
+Bare `quillan review-workflow` prints namespace help successfully without
+resolving a workspace or reading or creating records. The nine ordered workflow
+states are:
+
+```text
+not_started
+requirements_checked
+returned_without_full_review
+observations_in_progress
+observations_complete
+ratings_complete
+feedback_composed
+ready_for_export
+exported
+```
+
+`--yes` is mandatory and is parsed before workspace resolution. This is a
+manual teacher override: forward, backward, nonadjacent, and same-state updates
+are allowed, and same-state saves refresh `updated_at`. The command does not
+infer, require, remove, or create phase artifacts, feedback, ratings, exports,
+evidence, or submission assemblies.
+
+After validating the canonical assignment and submission, a missing
+`review.json` may be created as an empty schema-version-2 record for a
+non-returned state. This includes valid evidence-less plain-paper submissions
+and historical submissions for students no longer on the roster. Existing
+records preserve every field except `review_state` and `updated_at`.
+
+Returned-without-full-review status remains controlled by `requirements
+set-outcome`: the generic command cannot enter that state without a coherent
+returned outcome, and cannot leave a coherent returned outcome until the
+minimum-requirement outcome is changed. A legacy record whose workflow state is
+returned but whose outcome is not marked returned may be repaired by moving to
+a non-returned state.
+
+The exact write boundary is the selected canonical `review.json` only. The
+command never changes `submission.json.submission_state`, roster data,
+assignment data, evidence, sibling records, exports, or reports.
 
 ## Quick Teacher Notes
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -72,6 +72,10 @@ A plain-paper manual manifest has `expected_pages: null` and no digital page
 records because the physical evidence remains outside Quillan. Both the direct
 `pages` CLI and teacher menu use the same shared page-management service.
 
+The lightweight submission state in `submission.json.submission_state` is
+separate from the standards-based review workflow state in
+`review.json.review_state`. Neither field is synchronized to the other.
+
 ### Review Record
 
 The active teacher-review artifact is schema version `2` `review.json`:

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -82,6 +82,19 @@ associated `assignment.json` remains the source of truth for student prompt,
 writing type, standards profile, Focus Standards, review-unit labels, rating
 scale, basic requirements, and minimum-requirement policy.
 
+## Two State Models
+
+`submission.json.submission_state` is the lightweight submission state used to
+manage evidence readiness (`unreviewed`, `in_progress`, `needs_rescan`, or
+`reviewed`). `review.json.review_state` is the nine-value standards-based review
+workflow state. They are independent and are not synchronized automatically.
+
+Teachers may explicitly override the review workflow state through the shared
+menu/service or `quillan review-workflow set-state ... --state ... --yes`.
+That override changes only `review_state` and `updated_at`; it does not infer or
+create observations, ratings, feedback, or exports. Returned-without-full-review
+entry and exit remain coupled to the minimum-requirement outcome workflow.
+
 ## Minimum Requirements
 
 Minimum-requirement checks document teacher-entered decisions about basic

--- a/quillan/cli_app/handlers/review_workflow.py
+++ b/quillan/cli_app/handlers/review_workflow.py
@@ -1,0 +1,30 @@
+"""Review workflow state command handlers."""
+
+from __future__ import annotations
+
+import argparse
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.cli_app.output import print_updated_review_workflow_state
+from quillan.review_workflow_state import (
+    ReviewWorkflowStateError,
+    set_review_workflow_state,
+)
+
+
+def handle_review_workflow_set_state(args: argparse.Namespace) -> int:
+    """Apply one confirmed, non-interactive review workflow state override."""
+    try:
+        updated = set_review_workflow_state(
+            resolve_workspace_root(),
+            args.class_id,
+            args.assignment_id,
+            args.student_id,
+            args.state,
+        )
+    except (WorkspaceRootError, ReviewWorkflowStateError) as error:
+        print(f"Error: could not update review workflow state: {error}")
+        return 1
+    print_updated_review_workflow_state(updated)
+    return 0

--- a/quillan/cli_app/handlers/submissions.py
+++ b/quillan/cli_app/handlers/submissions.py
@@ -149,7 +149,7 @@ def handle_open_submission(args: argparse.Namespace) -> int:
 
 
 def handle_set_review_state(args: argparse.Namespace) -> int:
-    """Update one canonical submission's lightweight review state."""
+    """Update one canonical manifest's lightweight submission state."""
     try:
         workspace_root = resolve_workspace_root()
         updated = update_submission_review_state(
@@ -160,7 +160,7 @@ def handle_set_review_state(args: argparse.Namespace) -> int:
             args.state,
         )
     except (WorkspaceRootError, SubmissionReviewStateError) as error:
-        print(f"Error: could not update submission review state: {error}")
+        print(f"Error: could not update lightweight submission state: {error}")
         return 1
 
     print_updated_submission_review_state(updated)

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -35,6 +35,8 @@ from quillan.review_ratings import (
     CompletedOverallStandardRatings,
     UpdatedOverallStandardRating,
 )
+from quillan.review_status_display import review_status_label
+from quillan.review_workflow_state import UpdatedReviewWorkflowState
 from quillan.route_planning import RouteFailure
 from quillan.routing_review import RoutingReviewRecord
 from quillan.standards_summary_export import ExportedStandardsSummary
@@ -166,14 +168,32 @@ def print_opened_submission_review(opened: OpenedSubmissionReview) -> None:
 def print_updated_submission_review_state(
     updated: UpdatedSubmissionReviewState,
 ) -> None:
-    """Print a concise teacher-facing review-state update."""
-    print("Updated submission review state:")
+    """Print a concise lightweight submission-state update."""
+    print("Updated lightweight submission state:")
     print(f"Class: {updated.class_id}")
     print(f"Assignment: {updated.assignment_id}")
     print(f"Student: {updated.student_id}")
-    print(f"Previous state: {updated.previous_state}")
-    print(f"New state: {updated.new_state}")
-    print(f"Manifest: {updated.manifest_relative_path}")
+    print(f"Previous submission state: {updated.previous_state}")
+    print(f"New submission state: {updated.new_state}")
+    print(f"Submission manifest: {updated.manifest_relative_path}")
+
+
+def print_updated_review_workflow_state(
+    updated: UpdatedReviewWorkflowState,
+) -> None:
+    """Print a stable teacher-facing review workflow state summary."""
+    print("Updated review workflow state:")
+    print(f"Class: {updated.class_id}")
+    print(f"Assignment: {updated.assignment_id}")
+    print(f"Student: {updated.student_id}")
+    action = "created review record" if updated.review_was_created else "updated existing review"
+    previous = updated.previous_state or "no review record"
+    print(f"Action: {action}")
+    print(f"Previous workflow state: {previous}")
+    print(f"New workflow state: {updated.new_state}")
+    print(f"Review: {review_status_label({'review_state': updated.new_state})}")
+    print(f"Review record: {updated.review_record_relative_path}")
+    print(f"Updated: {updated.updated_at}")
 
 
 def print_submission_page_context(context: SubmissionPageContext) -> None:

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -14,6 +14,7 @@ from quillan.cli_app.handlers.comments import (
 )
 from quillan.cli_app.handlers.dashboard import handle_review_dashboard
 from quillan.cli_app.handlers.review_status import handle_review_status
+from quillan.cli_app.handlers.review_workflow import handle_review_workflow_set_state
 from quillan.cli_app.handlers.exports import (
     handle_export_class_summary,
     handle_export_feedback,
@@ -91,6 +92,7 @@ from quillan.cli_app.handlers.workspace import (
     handle_workspace_validate,
 )
 from quillan.focus_standard_comments import ALLOWED_PURPOSES
+from quillan.review_workflow_state import REVIEW_WORKFLOW_STATES
 
 APP_DESCRIPTION = "Quillan: standards-based writing evidence capture"
 
@@ -131,6 +133,46 @@ def build_parser() -> argparse.ArgumentParser:
         help="Standard-output representation (default: text).",
     )
     review_status_parser.set_defaults(handler=handle_review_status)
+
+    review_workflow_parser = subparsers.add_parser(
+        "review-workflow",
+        help="Manage standards-based review workflow state in review.json.",
+        description=(
+            "Manage review.json.review_state. This is separate from the lightweight "
+            "submission.json.submission_state model."
+        ),
+    )
+    review_workflow_parser.set_defaults(
+        handler=partial(_print_parser_help, review_workflow_parser)
+    )
+    review_workflow_subparsers = review_workflow_parser.add_subparsers(
+        dest="review_workflow_command"
+    )
+    review_workflow_set_state_parser = review_workflow_subparsers.add_parser(
+        "set-state",
+        help="Manually override one student's review workflow state.",
+        description=(
+            "Manually override review.json.review_state without changing "
+            "submission.json.submission_state. This workflow-only change does not "
+            "infer or create review artifacts appropriate to the selected phase."
+        ),
+    )
+    _add_submission_identity_arguments(review_workflow_set_state_parser)
+    review_workflow_set_state_parser.add_argument(
+        "--state",
+        required=True,
+        choices=REVIEW_WORKFLOW_STATES,
+        help="Requested standards-based review workflow state.",
+    )
+    review_workflow_set_state_parser.add_argument(
+        "--yes",
+        required=True,
+        action="store_true",
+        help="Explicitly confirm this review.json workflow-state write.",
+    )
+    review_workflow_set_state_parser.set_defaults(
+        handler=handle_review_workflow_set_state
+    )
 
     assignment_parser = subparsers.add_parser(
         "assignment", help="Create, show, and validate canonical assignments."
@@ -880,16 +922,20 @@ def build_parser() -> argparse.ArgumentParser:
 
     review_state_parser = subparsers.add_parser(
         "set-review-state",
-        help="Update one student submission's lightweight review state.",
+        help="Update one student's lightweight submission state.",
         description=(
-            "Update only submission_state and updated_at in one canonical "
-            "student submission manifest."
+            "Update only submission.json.submission_state and updated_at in one "
+            "canonical student submission manifest. This does not change "
+            "review.json.review_state."
         ),
     )
     _add_submission_identity_arguments(review_state_parser)
     review_state_parser.add_argument(
         "state",
-        help=("Review state: unreviewed, in_progress, needs_rescan, or reviewed."),
+        help=(
+            "Lightweight submission state stored in submission.json: unreviewed, "
+            "in_progress, needs_rescan, or reviewed."
+        ),
     )
     review_state_parser.set_defaults(handler=handle_set_review_state)
 

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -39,6 +38,7 @@ from quillan.cli_app.output import (
     print_updated_overall_standard_rating,
     print_updated_review_unit_observation,
     print_updated_review_units,
+    print_updated_review_workflow_state,
 )
 from quillan.feedback_export import (
     FeedbackExportError,
@@ -94,16 +94,16 @@ from quillan.review_feedback import (
     summarize_standard_feedback,
 )
 from quillan.review_record import (
-    ALLOWED_REVIEW_STATES,
     ReviewRecordError,
-    build_empty_review_record,
     load_review_record,
-    validate_review_record,
 )
 from quillan.review_record_paths import (
-    ReviewRecordPathError,
     review_record_path,
-    write_review_record,
+)
+from quillan.review_workflow_state import (
+    REVIEW_WORKFLOW_STATES,
+    ReviewWorkflowStateError,
+    set_review_workflow_state,
 )
 from quillan.review_dashboard import (
     AssignmentReviewDashboard,
@@ -548,7 +548,7 @@ def _launch_selected_student_review(
             )
             input("Press Enter to continue...")
         elif choice == "9":
-            _menu_update_submission_review_state(
+            _menu_update_review_workflow_state(
                 workspace_root,
                 class_id,
                 assignment_id,
@@ -708,95 +708,79 @@ def _load_assignment_for_review(
         return None
 
 
-def _menu_update_submission_review_state(
+def _menu_update_review_workflow_state(
     workspace_root: Path,
     class_id: str,
     assignment_id: str,
     student_id: str,
 ) -> None:
     _print_review_action_header(
-        "Update Review State", class_id, assignment_id, student_id
+        "Update Review Workflow State", class_id, assignment_id, student_id
     )
     print("Use this to update the teacher-review workflow. This is not a grade.")
     print()
     path = review_record_path(workspace_root, class_id, assignment_id, student_id)
-    if not path.exists():
-        timestamp = datetime.now(timezone.utc).isoformat()
-        record = build_empty_review_record(
-            class_id=class_id,
-            assignment_id=assignment_id,
-            student_id=student_id,
-            created_at=timestamp,
-        )
-    else:
+    record = None
+    if path.exists():
         try:
             record = load_review_record(path)
         except (OSError, ReviewRecordError) as error:
             print(f"Error: could not load review record: {error}")
             return
-    current_state = str(record["review_state"])
-    print(f"Current state: {current_state}")
+    current_state = "not_started" if record is None else str(record["review_state"])
+    print(f"Current review workflow state: {current_state}")
     print()
-    states = (
-        "not_started",
-        "requirements_checked",
-        "returned_without_full_review",
-        "observations_in_progress",
-        "observations_complete",
-        "ratings_complete",
-        "feedback_composed",
-        "ready_for_export",
-        "exported",
-    )
     descriptions = {
         state: review_status_label({"review_state": state}).capitalize()
-        for state in states
+        for state in REVIEW_WORKFLOW_STATES
     }
-    for index, state_opt in enumerate(states, start=1):
+    for index, state_opt in enumerate(REVIEW_WORKFLOW_STATES, start=1):
         print(f"{index}. {state_opt} - {descriptions[state_opt]}")
     print("B. Back")
     print()
 
     selection = input("Select review workflow state: ").strip()
     if not selection or selection.casefold() == "b":
-        print("Update review state canceled.")
+        print("Update review workflow state canceled.")
         return
 
     selected_state: str | None = None
     if selection.isdigit():
         index = int(selection) - 1
-        selected_state = states[index] if 0 <= index < len(states) else None
+        selected_state = (
+            REVIEW_WORKFLOW_STATES[index]
+            if 0 <= index < len(REVIEW_WORKFLOW_STATES)
+            else None
+        )
     else:
         selected_state = selection
 
-    if selected_state not in ALLOWED_REVIEW_STATES:
+    if selected_state not in REVIEW_WORKFLOW_STATES:
         print(
-            "Update review state canceled. Invalid state selection. "
-            f"Allowed values: {', '.join(states)}."
+            "Update review workflow state canceled. Invalid state selection. "
+            f"Allowed values: {', '.join(REVIEW_WORKFLOW_STATES)}."
         )
         return
 
     print()
-    print(f"Change review state to {selected_state}?")
+    print(f"Change review workflow state to {selected_state}?")
     print()
     print("1. Save")
     print("2. Back")
     print()
     if input("Select an option: ").strip() != "1":
-        print("Update review state canceled.")
+        print("Update review workflow state canceled.")
         return
 
     try:
-        updated_record = dict(record)
-        updated_record["review_state"] = selected_state
-        updated_record["updated_at"] = datetime.now(timezone.utc).isoformat()
-        validate_review_record(updated_record)
-        write_review_record(path, updated_record, overwrite=True)
-    except (ReviewRecordError, ReviewRecordPathError, OSError) as error:
+        updated = set_review_workflow_state(
+            workspace_root, class_id, assignment_id, student_id, selected_state
+        )
+    except ReviewWorkflowStateError as error:
         print(f"Error: could not update review workflow state: {error}")
         return
 
-    print(f"Review: {review_status_label(updated_record)}")
+    print_updated_review_workflow_state(updated)
 
 
 def _prompt_yes_no_default_no(prompt: str) -> bool:

--- a/quillan/review_workflow_state.py
+++ b/quillan/review_workflow_state.py
@@ -1,0 +1,206 @@
+"""Teacher-controlled review workflow state updates."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from quillan.minimum_requirement_review import (
+    allows_return_without_full_review,
+    configured_requirements,
+)
+from quillan.review_record import (
+    ALLOWED_REVIEW_STATES,
+    ReviewRecordError,
+    build_empty_review_record,
+    validate_review_record,
+)
+from quillan.review_record_paths import ReviewRecordPathError, write_review_record
+from quillan.review_unit_management import (
+    ReviewUnitManagementError,
+    load_review_unit_context,
+)
+
+REVIEW_WORKFLOW_STATES = (
+    "not_started",
+    "requirements_checked",
+    "returned_without_full_review",
+    "observations_in_progress",
+    "observations_complete",
+    "ratings_complete",
+    "feedback_composed",
+    "ready_for_export",
+    "exported",
+)
+
+if frozenset(REVIEW_WORKFLOW_STATES) != ALLOWED_REVIEW_STATES:
+    raise RuntimeError("Ordered review workflow states do not match the review schema.")
+
+
+class ReviewWorkflowStateError(ValueError):
+    """Raised when a review workflow state cannot be updated safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class UpdatedReviewWorkflowState:
+    """Immutable result of one canonical review workflow state update."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    review_record_path: Path
+    review_record_relative_path: str
+    previous_state: str | None
+    new_state: str
+    review_was_created: bool
+    updated_at: str
+
+
+def set_review_workflow_state(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    state: str,
+    *,
+    updated_at: datetime | str | None = None,
+) -> UpdatedReviewWorkflowState:
+    """Set only ``review_state`` and ``updated_at`` in one canonical review."""
+    if state not in REVIEW_WORKFLOW_STATES:
+        allowed = ", ".join(REVIEW_WORKFLOW_STATES)
+        raise ReviewWorkflowStateError(
+            f"Invalid review workflow state {state!r}. Allowed states: {allowed}."
+        )
+
+    try:
+        context = load_review_unit_context(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except ReviewUnitManagementError as error:
+        raise ReviewWorkflowStateError(str(error)) from error
+
+    normalized_updated_at = _normalize_timestamp(updated_at)
+    review = context.review
+    if state == "returned_without_full_review":
+        if review is None or not _has_coherent_returned_outcome(
+            review, context.assignment
+        ):
+            raise ReviewWorkflowStateError(
+                "Returned-without-full-review status must be set through "
+                "'requirements set-outcome --outcome returned_without_full_review' first."
+            )
+    elif review is not None and bool(
+        review["minimum_requirement_outcome"]["returned_without_full_review"]
+    ):
+        raise ReviewWorkflowStateError(
+            "Change the minimum-requirement outcome through 'requirements set-outcome' "
+            "before leaving returned-without-full-review status."
+        )
+
+    if review is None:
+        updated_review = build_empty_review_record(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            submission_manifest_path=context.submission_manifest_relative_path,
+            assignment_path=_relative(context.assignment_path, context.workspace_root),
+            created_at=normalized_updated_at,
+        )
+        previous_state = None
+        review_was_created = True
+    else:
+        _ensure_not_before_created_at(normalized_updated_at, review["created_at"])
+        updated_review = copy.deepcopy(review)
+        previous_state = str(review["review_state"])
+        review_was_created = False
+
+    updated_review["review_state"] = state
+    updated_review["updated_at"] = normalized_updated_at
+    try:
+        validate_review_record(updated_review)
+        write_review_record(
+            context.review_record_path,
+            updated_review,
+            overwrite=not review_was_created,
+        )
+    except (ReviewRecordError, ReviewRecordPathError, OSError, ValueError) as error:
+        raise ReviewWorkflowStateError(f"Could not write review record: {error}") from error
+
+    return UpdatedReviewWorkflowState(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        review_record_path=context.review_record_path,
+        review_record_relative_path=context.review_record_relative_path,
+        previous_state=previous_state,
+        new_state=state,
+        review_was_created=review_was_created,
+        updated_at=normalized_updated_at,
+    )
+
+
+def _has_coherent_returned_outcome(
+    review: dict[str, Any], assignment: dict[str, Any]
+) -> bool:
+    outcome = review["minimum_requirement_outcome"]
+    assert isinstance(outcome, dict)
+    note = outcome["teacher_note"]
+    configured_keys = {item.key for item in configured_requirements(assignment)}
+    checks = review["minimum_requirement_checks"]
+    assert isinstance(checks, list)
+    has_configured_unmet_check = any(
+        isinstance(check, dict)
+        and check.get("requirement_key") in configured_keys
+        and check.get("met") is False
+        for check in checks
+    )
+    return (
+        review["review_state"] == "returned_without_full_review"
+        and outcome["status"] == "returned_without_full_review"
+        and outcome["returned_without_full_review"] is True
+        and isinstance(note, str)
+        and bool(note.strip())
+        and allows_return_without_full_review(assignment)
+        and has_configured_unmet_check
+    )
+
+
+def _normalize_timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        value = datetime.now(timezone.utc)
+    if isinstance(value, datetime):
+        parsed = value
+        normalized = value.isoformat()
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError as error:
+            raise ReviewWorkflowStateError(
+                "updated_at must be a timezone-aware ISO 8601 timestamp."
+            ) from error
+        normalized = value
+    else:
+        raise ReviewWorkflowStateError(
+            "updated_at must be a timezone-aware datetime or ISO 8601 string."
+        )
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ReviewWorkflowStateError("updated_at must be timezone-aware.")
+    return normalized
+
+
+def _ensure_not_before_created_at(updated_at: str, created_at: object) -> None:
+    assert isinstance(created_at, str)
+    if datetime.fromisoformat(updated_at) < datetime.fromisoformat(created_at):
+        raise ReviewWorkflowStateError("updated_at must not precede created_at.")
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return path.resolve(strict=False).relative_to(root).as_posix()
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ReviewWorkflowStateError(
+            f"Canonical path is outside the workspace: {path}"
+        ) from error

--- a/quillan/submission_review_state.py
+++ b/quillan/submission_review_state.py
@@ -1,4 +1,4 @@
-"""Teacher-controlled lightweight submission review-state updates."""
+"""Teacher-controlled lightweight submission-state updates."""
 
 from __future__ import annotations
 
@@ -23,12 +23,12 @@ from quillan.submission_guidance import missing_submission_guidance
 
 
 class SubmissionReviewStateError(Exception):
-    """Raised when a submission review state cannot be updated safely."""
+    """Raised when a lightweight submission state cannot be updated safely."""
 
 
 @dataclass(frozen=True, slots=True)
 class UpdatedSubmissionReviewState:
-    """Information about a submission review-state update."""
+    """Information about a lightweight submission-state update."""
 
     class_id: str
     assignment_id: str
@@ -49,11 +49,11 @@ def update_submission_review_state(
     *,
     updated_at: datetime | str | None = None,
 ) -> UpdatedSubmissionReviewState:
-    """Update only the lightweight review state for one student submission."""
+    """Update only the lightweight state for one student submission."""
     if state not in ALLOWED_SUBMISSION_STATES:
         allowed = ", ".join(sorted(ALLOWED_SUBMISSION_STATES))
         raise SubmissionReviewStateError(
-            f"Invalid submission review state {state!r}. Allowed states: {allowed}."
+            f"Invalid lightweight submission state {state!r}. Allowed states: {allowed}."
         )
 
     try:

--- a/tests/test_cli_review_workflow.py
+++ b/tests/test_cli_review_workflow.py
@@ -1,0 +1,64 @@
+"""CLI parser and handler coverage for review workflow state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quillan.cli import main
+from quillan.cli_app.handlers import review_workflow as handlers
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [["--help"], ["review-workflow", "--help"], ["review-workflow", "set-state", "--help"]],
+)
+def test_review_workflow_help_succeeds(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(argv)
+    assert error.value.code == 0
+
+
+def test_bare_namespace_prints_help_without_resolving_workspace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: pytest.fail("resolved"))
+    assert main(["review-workflow"]) == 0
+    assert "set-state" in capsys.readouterr().out
+
+
+def test_yes_is_required_before_workspace_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: pytest.fail("resolved"))
+    with pytest.raises(SystemExit) as error:
+        main([
+            "review-workflow", "set-state", "class_1", "assignment_1", "student_1",
+            "--state", "not_started",
+        ])
+    assert error.value.code == 2
+
+
+def test_handler_is_direct_and_prints_service_result(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from quillan.review_workflow_state import UpdatedReviewWorkflowState
+
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: Path("workspace"))
+    monkeypatch.setattr(
+        handlers,
+        "set_review_workflow_state",
+        lambda *args: UpdatedReviewWorkflowState(
+            "class_1", "assignment_1", "student_1", Path("review.json"),
+            "classes/class_1/review.json", None, "not_started", True,
+            "2026-07-13T13:00:00+00:00",
+        ),
+    )
+    assert main([
+        "review-workflow", "set-state", "class_1", "assignment_1", "student_1",
+        "--state", "not_started", "--yes",
+    ]) == 0
+    output = capsys.readouterr().out
+    assert "Updated review workflow state:" in output
+    assert "Previous workflow state: no review record" in output

--- a/tests/test_review_workflow_state.py
+++ b/tests/test_review_workflow_state.py
@@ -1,0 +1,144 @@
+"""Focused coverage for canonical review workflow state updates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from quillan.review_record import ALLOWED_REVIEW_STATES, build_empty_review_record
+from quillan.review_record_paths import review_record_path, write_review_record
+from quillan.review_workflow_state import (
+    REVIEW_WORKFLOW_STATES,
+    ReviewWorkflowStateError,
+    set_review_workflow_state,
+)
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+
+CLASS_ID = "english10_p2"
+ASSIGNMENT_ID = "argument_01"
+STUDENT_ID = "00107"
+CREATED = "2026-07-13T12:00:00+00:00"
+UPDATED = "2026-07-13T13:00:00+00:00"
+
+
+def _assignment() -> dict[str, Any]:
+    return {
+        "schema_version": "2", "module": "quillan", "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID, "title": "Argument", "class_ids": [CLASS_ID],
+        "writing_type": "argument", "student_prompt": "Make an argument.",
+        "standards_profile_id": "ela", "focus_standard_ids": ["W.1"],
+        "review_unit": {"type": "paragraph", "singular_label": "paragraph", "plural_label": "paragraphs"},
+        "rating_scale": {"scale_id": "two", "levels": [{"value": 1, "label": "Developing", "description": "Developing."}]},
+        "basic_requirements": {"paragraphs_min": 3, "required_elements": []},
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+        "created_at": CREATED, "updated_at": CREATED, "module_details": {},
+    }
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "1", "module": "quillan", "record_type": "submission_manifest",
+        "class_id": CLASS_ID, "assignment_id": ASSIGNMENT_ID, "student_id": STUDENT_ID,
+        "expected_pages": None, "submission_state": "unreviewed", "pages": [],
+        "created_at": CREATED, "updated_at": CREATED,
+        "module_details": {"submission_entry_method": "plain_paper_manual"},
+    }
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    assignment_path = tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment_path.parent.mkdir(parents=True)
+    assignment_path.write_text(json.dumps(_assignment()), encoding="utf-8")
+    write_submission_manifest(
+        submission_manifest_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID),
+        _manifest(),
+    )
+    return tmp_path
+
+
+def _review() -> dict[str, Any]:
+    review = build_empty_review_record(
+        class_id=CLASS_ID, assignment_id=ASSIGNMENT_ID, student_id=STUDENT_ID,
+        created_at=CREATED,
+    )
+    review["private_notes"] = [{
+        "private_note_id": "private_note_0001", "text": "Keep this.",
+        "created_at": CREATED, "updated_at": CREATED, "module_details": {},
+    }]
+    return review
+
+
+def test_ordered_states_match_schema() -> None:
+    assert frozenset(REVIEW_WORKFLOW_STATES) == ALLOWED_REVIEW_STATES
+
+
+@pytest.mark.parametrize("state", ["not_started", "observations_in_progress", "exported"])
+def test_missing_review_is_created_without_changing_plain_paper_manifest(
+    workspace: Path, state: str
+) -> None:
+    manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    before = manifest_path.read_bytes()
+    result = set_review_workflow_state(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, state, updated_at=UPDATED
+    )
+    review = json.loads(result.review_record_path.read_text(encoding="utf-8"))
+    assert result.review_was_created is True
+    assert result.previous_state is None
+    assert review["review_state"] == state
+    assert review["created_at"] == review["updated_at"] == UPDATED
+    assert review["exports"] == {"feedback_pdf": None, "feedback_markdown": None}
+    assert manifest_path.read_bytes() == before
+
+
+def test_existing_update_preserves_every_field_except_state_and_timestamp(workspace: Path) -> None:
+    path = write_review_record(review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID), _review())
+    before = json.loads(path.read_text(encoding="utf-8"))
+    result = set_review_workflow_state(
+        workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "feedback_composed", updated_at=UPDATED
+    )
+    after = json.loads(path.read_text(encoding="utf-8"))
+    assert result.previous_state == "not_started"
+    for key in before:
+        if key not in {"review_state", "updated_at"}:
+            assert after[key] == before[key]
+
+
+def test_returned_entry_and_coherent_exit_are_guarded(workspace: Path) -> None:
+    path = write_review_record(review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID), _review())
+    before = path.read_bytes()
+    with pytest.raises(ReviewWorkflowStateError, match="requirements set-outcome"):
+        set_review_workflow_state(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "returned_without_full_review", updated_at=UPDATED)
+    assert path.read_bytes() == before
+
+    returned = _review()
+    returned["minimum_requirement_checks"] = [{
+        "requirement_check_id": "requirement_check_0001", "requirement_key": "paragraphs_min",
+        "label": "Minimum paragraphs", "expected": 3, "met": False,
+        "updated_at": CREATED, "module_details": {},
+    }]
+    returned["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review", "returned_without_full_review": True,
+        "teacher_note": "Please revise.", "updated_at": CREATED,
+    }
+    returned["review_state"] = "returned_without_full_review"
+    write_review_record(path, returned, overwrite=True)
+    before = path.read_bytes()
+    with pytest.raises(ReviewWorkflowStateError, match="minimum-requirement outcome"):
+        set_review_workflow_state(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "not_started", updated_at=UPDATED)
+    assert path.read_bytes() == before
+
+
+def test_invalid_and_naive_timestamps_write_nothing(workspace: Path) -> None:
+    path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+    with pytest.raises(ReviewWorkflowStateError, match="Allowed states"):
+        set_review_workflow_state(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "bogus")
+    with pytest.raises(ReviewWorkflowStateError, match="timezone-aware"):
+        set_review_workflow_state(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "not_started", updated_at="2026-07-13T13:00:00")
+    assert not path.exists()

--- a/tests/test_submission_review_state.py
+++ b/tests/test_submission_review_state.py
@@ -392,13 +392,13 @@ def test_cli_success_prints_teacher_context(
         == 0
     )
     assert capsys.readouterr().out == (
-        "Updated submission review state:\n"
+        "Updated lightweight submission state:\n"
         f"Class: {CLASS_ID}\n"
         f"Assignment: {ASSIGNMENT_ID}\n"
         f"Student: {STUDENT_ID}\n"
-        "Previous state: unreviewed\n"
-        "New state: in_progress\n"
-        f"Manifest: {relative_path}\n"
+        "Previous submission state: unreviewed\n"
+        "New submission state: in_progress\n"
+        f"Submission manifest: {relative_path}\n"
     )
 
 
@@ -431,6 +431,6 @@ def test_cli_failure_returns_one(
         == 1
     )
     assert capsys.readouterr().out == (
-        "Error: could not update submission review state: "
+        "Error: could not update lightweight submission state: "
         "manifest is unavailable\n"
     )


### PR DESCRIPTION
## Summary

* Add a direct, non-interactive command for changing one student’s standards-based review workflow state:

  ```text
  quillan review-workflow set-state \
    <class_id> <assignment_id> <student_id> \
    --state <state> \
    --yes
  ```

* Add a shared review-workflow-state service used by both the teacher menu and direct CLI.

* Remove direct `review.json` construction and mutation from the menu workflow.

* Preserve Quillan’s existing lightweight submission-state command for compatibility.

* Clarify throughout the CLI that:

  * `submission.json.submission_state` is the lightweight submission state;
  * `review.json.review_state` is the standards-based review workflow state.

* Preserve manual forward, backward, nonadjacent, and same-state workflow overrides.

* Guard entry into and exit from returned-without-full-review status through the minimum-requirements workflow.

## Command Surface

```text
quillan review-workflow set-state \
  <class_id> <assignment_id> <student_id> \
  --state <state> \
  --yes
```

Supported review workflow states are:

* `not_started`
* `requirements_checked`
* `returned_without_full_review`
* `observations_in_progress`
* `observations_complete`
* `ratings_complete`
* `feedback_composed`
* `ready_for_export`
* `exported`

The command is direct and non-interactive.

`--yes` is required.

## Namespace Behavior

Bare:

```text
quillan review-workflow
```

prints namespace help and returns success.

It does not:

* resolve the workspace;
* load an assignment;
* load a submission manifest;
* load or create a review record;
* write any files.

The following help commands succeed:

```text
quillan --help
quillan review-workflow --help
quillan review-workflow set-state --help
```

## Explicit Confirmation

The `set-state` command requires:

```text
--yes
```

Omitting confirmation fails through argparse before workspace resolution.

The direct command:

* never calls `input()`;
* does not invoke a menu function;
* does not provide an interactive fallback;
* does not assume confirmation from context.

## Shared Service

Added the shared service and immutable result model in:

* `quillan/review_workflow_state.py`

The service owns:

* canonical path handling;
* assignment loading and validation;
* assignment identity validation;
* assignment class-membership validation;
* submission-manifest loading and validation;
* submission identity validation;
* optional review-record loading;
* review identity validation;
* missing-review creation policy;
* allowed-state validation;
* returned-work transition guardrails;
* timestamp normalization;
* full review-record validation;
* canonical atomic writing;
* immutable result construction.

The service does not print or interact with the user.

## Shared Architecture

The workflow now follows:

```text
Teacher menu -> shared review-workflow service
Direct CLI  -> shared review-workflow service
Future GUI  -> shared review-workflow service
```

The CLI handler does not:

* load raw JSON records;
* construct review records;
* mutate dictionaries;
* validate the review schema independently;
* write files directly;
* calculate transition rules.

The teacher menu no longer performs those operations itself for workflow-state updates.

## Teacher Menu Integration

The Selected Student Review menu continues to expose:

```text
Update review workflow state
```

The menu now:

* displays the current workflow state;
* lists the authoritative ordered state sequence;
* collects the teacher’s selection;
* confirms the action;
* calls the shared workflow-state service;
* prints the shared result.

The menu no longer:

* builds an empty review record directly;
* assigns `review_state` directly;
* assigns `updated_at` directly;
* validates the changed record itself;
* writes `review.json` directly.

Menu numbering and surrounding review actions remain unchanged.

## Authoritative State Sequence

One ordered sequence defines the review workflow states used by:

* the parser;
* service validation;
* menu state selection;
* deterministic error messages;
* documentation and tests.

The ordered sequence contains the same values as the review-record schema’s allowed-state set.

## Two Distinct State Models

Quillan continues to maintain two independent state fields.

### Lightweight submission state

Stored in:

```text
submission.json.submission_state
```

Values:

* `unreviewed`
* `in_progress`
* `needs_rescan`
* `reviewed`

Existing command:

```text
quillan set-review-state \
  <class_id> <assignment_id> <student_id> \
  <state>
```

This command changes only `submission.json`.

### Review workflow state

Stored in:

```text
review.json.review_state
```

Values:

* `not_started`
* `requirements_checked`
* `returned_without_full_review`
* `observations_in_progress`
* `observations_complete`
* `ratings_complete`
* `feedback_composed`
* `ready_for_export`
* `exported`

New command:

```text
quillan review-workflow set-state \
  <class_id> <assignment_id> <student_id> \
  --state <state> \
  --yes
```

This command changes only `review.json`.

The two fields are not automatically synchronized.

## Compatibility Command

The existing:

```text
quillan set-review-state ...
```

command remains available with its original positional syntax.

Its help and output now identify the operation as a:

```text
lightweight submission state
```

update.

The compatibility command continues to:

* validate the selected canonical submission manifest;
* change only `submission_state` and the manifest timestamp;
* write only `submission.json`;
* leave `review.json` unchanged.

The new workflow command leaves `submission.json.submission_state` unchanged.

## Assignment Validation

The shared workflow service validates:

* class identifier;
* assignment identifier;
* student identifier;
* canonical assignment path;
* assignment JSON;
* assignment schema;
* assignment ID;
* class membership in `assignment.class_ids`.

Missing, malformed, unsupported, identity-mismatched, or class-incompatible assignments fail without creating or modifying a review.

## Submission Validation

The service requires the selected canonical:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
```

It validates:

* manifest existence;
* manifest JSON and schema;
* class identity;
* assignment identity;
* student identity.

A missing manifest returns existing submission-assembly guidance.

The workflow command does not:

* assemble routed evidence;
* create a submission manifest;
* inspect evidence;
* infer a plain-paper submission.

## Missing Review Creation

When the assignment and submission are valid but canonical `review.json` is absent, the service may create a canonical empty review for a non-returned workflow state.

The created review includes:

* canonical class, assignment, and student identities;
* canonical assignment and submission paths;
* schema-version-2 review metadata;
* empty minimum-requirement checks;
* a `not_checked` minimum-requirement outcome;
* empty review units;
* empty observations;
* empty overall ratings;
* empty feedback;
* empty export metadata;
* empty private notes;
* empty module details.

For a newly created review:

* `created_at` and `updated_at` use the same normalized timestamp;
* the requested state is stored before validation and writing;
* the immutable result reports that the review was created;
* no phase artifacts are synthesized.

A missing review is not created when the requested state is an unsafe returned-work transition.

## Existing Review Updates

When a valid review already exists, a successful workflow-state update changes only:

* `review_state`;
* `updated_at`.

The service preserves:

* `created_at`;
* schema metadata;
* record identity;
* assignment and submission paths;
* minimum-requirement checks;
* minimum-requirement outcome;
* review units;
* observations;
* overall ratings;
* feedback options;
* feedback comments;
* reusable-comment snapshots;
* export metadata;
* private notes;
* module details;
* array ordering.

## Manual Override Semantics

The command remains an explicit teacher-controlled workflow override.

For non-returned states, it permits:

* forward transitions;
* backward transitions;
* nonadjacent transitions;
* same-state updates.

Representative supported transitions include:

```text
not_started -> observations_complete
requirements_checked -> feedback_composed
observations_complete -> ratings_complete
exported -> observations_in_progress
feedback_composed -> ready_for_export
ready_for_export -> exported
```

The command does not require stored review artifacts to substantiate the selected workflow label.

For example:

* `ratings_complete` does not create or require ratings;
* `feedback_composed` does not create or require feedback records;
* `exported` does not create or require export files.

## Same-State Updates

A confirmed request for the currently stored state succeeds.

For an existing review:

* previous and new workflow states are equal;
* `updated_at` is refreshed;
* `created_at` remains unchanged;
* all nested content remains unchanged.

## Returned-Work Entry Guard

`returned_without_full_review` remains coupled to the minimum-requirements workflow.

The generic workflow command does not:

* invent failed requirements;
* create a return note;
* change assignment policy;
* create a returned minimum-requirement outcome.

Attempting to enter returned status without a coherent returned outcome fails and directs the teacher to:

```text
quillan requirements set-outcome \
  <class_id> <assignment_id> <student_id> \
  --outcome returned_without_full_review \
  --note <teacher_note>
```

No review is created or modified by the failed workflow-state request.

## Returned-Work Exit Guard

When the minimum-requirement outcome still indicates:

```text
returned_without_full_review = true
```

the generic workflow command cannot select a non-returned state.

The teacher must first change the minimum-requirement outcome through the requirements workflow.

The service does not silently clear or replace returned-work metadata.

## Coherent Returned Same-State Update

An existing valid review whose workflow state and minimum-requirement outcome coherently indicate returned work follows the implemented same-state policy.

The generic service does not use that action to alter:

* failed requirement checks;
* return notes;
* outcome status;
* assignment policy.

## Legacy Anomalous Returned State

A legacy schema-valid review may contain:

```text
review_state = returned_without_full_review
```

without a returned minimum-requirement outcome.

The shared service allows that anomalous state to be repaired by explicitly selecting a non-returned workflow state.

The repair:

* changes only `review_state`;
* changes `updated_at`;
* preserves the existing non-returned outcome;
* creates no requirement data.

## Plain-Paper Submissions

Valid plain-paper manual submissions are supported.

The workflow service:

* accepts their evidence-less canonical manifests;
* requires no digital pages;
* permits review creation and workflow updates;
* leaves the submission manifest unchanged.

Plain paper is not treated as missing or unassembled.

## Unrostered Historical Submissions

A valid canonical historical submission remains usable when the student is absent from the current roster.

The workflow service:

* does not require roster membership;
* does not load or modify roster data;
* does not add the student to the roster.

## Timestamp Rules

The service accepts an injectable timestamp for deterministic testing.

Timestamps must be:

* timezone-aware;
* valid ISO 8601 values or timezone-aware datetime objects;
* no earlier than the existing review’s `created_at`.

The service rejects:

* naive datetime objects;
* naive timestamp strings;
* malformed timestamps;
* timestamps before `created_at`;
* unsupported value types.

For new reviews:

```text
created_at == updated_at
```

For existing reviews:

* `created_at` is preserved;
* `updated_at` changes.

## Immutable Result and Output

The shared service returns an immutable result containing:

* class ID;
* assignment ID;
* student ID;
* canonical review path;
* workspace-relative review path;
* previous workflow state;
* new workflow state;
* whether the review was created;
* update timestamp.

Teacher-readable output distinguishes between:

* creation of a new review record;
* update of an existing review record;
* previous workflow state;
* new workflow state;
* teacher-facing workflow label;
* canonical review path.

Output consistently uses the phrase:

```text
review workflow state
```

## Exact Write Boundaries

### New workflow command

May create or modify only:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
```

### Compatibility command

Continues to modify only:

```text
classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
```

Neither command changes both records in one invocation.

The new workflow command does not modify:

* assignment configuration;
* submission manifest;
* roster or class metadata;
* routed evidence;
* retained scans;
* submission pages;
* reusable comments;
* feedback exports;
* assignment reports;
* scan-review records;
* sibling student records;
* PDS Core data;
* ScoreForm data.

## No Automated Processing

Confirmed that the shared service and direct command do not:

* open evidence;
* inspect PDFs or images;
* parse student writing;
* decode QR payloads;
* run OCR;
* perform handwriting recognition;
* use AI;
* infer minimum-requirement checks;
* infer minimum-requirement outcomes;
* infer review units;
* infer observations;
* infer ratings;
* infer feedback;
* calculate grades;
* calculate mastery;
* calculate percentages;
* assemble submissions;
* mutate pages;
* compose feedback;
* generate exports;
* create export metadata.

A workflow-state update remains a teacher-controlled status change, not a grade or automated judgment.

## Error Behavior

Expected failures:

* print a concise `Error: ...`;
* return nonzero;
* avoid tracebacks;
* perform no partial write.

Covered failure conditions include:

* workspace-resolution errors;
* invalid identifiers;
* invalid workflow states;
* missing or malformed assignments;
* assignment identity mismatch;
* class absent from assignment;
* missing or invalid submission manifests;
* submission identity mismatch;
* malformed or invalid reviews;
* review identity mismatch;
* noncanonical review references;
* unsafe returned-work transitions;
* invalid timestamps;
* review validation errors;
* review write errors.

## Files Changed

Source areas include:

* `quillan/review_workflow_state.py`
* `quillan/cli_app/handlers/review_workflow.py`
* `quillan/cli_app/parser.py`
* `quillan/review_menu.py`
* `quillan/cli_app/output.py`
* focused service, CLI, menu, and compatibility tests
* CLI and review-workflow documentation

## Documentation

Updated documentation explains:

* the `review-workflow` namespace;
* command syntax;
* explicit confirmation;
* all nine workflow states;
* manual override behavior;
* missing-review creation;
* same-state updates;
* forward and backward transitions;
* returned-work entry and exit rules;
* legacy anomalous-state repair;
* timestamp requirements;
* exact `review.json` write boundary;
* distinction from the lightweight submission-state command.

Documentation now uses:

* “lightweight submission state” for `submission_state`;
* “review workflow state” for `review_state`.

## Test Coverage

Added focused coverage for:

* parser and help behavior;
* bare namespace behavior;
* failure before workspace resolution without `--yes`;
* non-interactive CLI operation;
* shared service state validation;
* every allowed workflow state;
* invalid state rejection;
* missing-review creation;
* existing-review updates;
* forward transitions;
* backward transitions;
* nonadjacent transitions;
* same-state updates;
* returned-state entry guard;
* returned-state exit guard;
* coherent returned-state behavior;
* legacy anomalous returned-state repair;
* assignment and submission failures;
* invalid and mismatched reviews;
* plain-paper submissions;
* unrostered historical submissions;
* timezone-aware timestamp validation;
* exact field preservation;
* exact write boundaries;
* compatibility `set-review-state` behavior;
* menu and CLI service parity;
* absence of automated processing.

## Safety

Confirmed:

* CLI and menu use the same shared service;
* the menu no longer constructs or writes the changed review record;
* non-returned manual overrides remain permissive;
* returned-work invariants cannot be bypassed;
* missing reviews are created only after valid assignment and submission checks;
* only `review_state` and `updated_at` change in existing reviews;
* nested review content is preserved;
* the new command never changes the submission manifest;
* the compatibility command never changes the review record;
* no evidence is opened or inspected;
* no automated judgment or content generation is introduced;
* PDS Core remains unchanged;
* ScoreForm remains unchanged;
* no real student data or generated workspace artifacts were added.

## Validation

* Focused final regression: `66 passed`
* State and menu regression: `91 passed`
* Broader CLI regression: `268 passed`
* Full pytest suite: `1256 passed`
* Ruff: passed
* mypy: passed, `176` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed, including:

  * `1256` tests;
  * Ruff;
  * mypy;
  * whitespace checks
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* No real student data or generated workspace artifacts present

Closes #325
