### PR TITLE
Add printable response packet CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ Assignment creation requires an existing roster and writes:
 <workspace_root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
 ```
 
+Printable response packets can also be generated non-interactively:
+
+```powershell
+quillan printable-responses generate <class_id> <assignment_id> --dry-run
+quillan printable-responses generate <class_id> <assignment_id> --pages-per-student 2 --yes
+```
+
+The CLI and menu share the same canonical assignment/roster planning and packet
+generation service. The CLI writes only the assignment-local
+`templates/printable_response_pages.pdf`, protects existing packets unless
+`--overwrite --yes` is supplied, and never opens the generated file.
+
 The v0.8.6 creation workflow prompts for class, title, assignment ID, writing
 type, student prompt, pds-core standards profile, Focus Standards, review-unit
 settings, rating scale, basic requirements, and minimum-requirement policy.

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -236,6 +236,7 @@ quillan roster validate <class_id>
 quillan roster add-student <class_id> --student-id <student_id> --last-name <name> --first-name <name> --period <period> [--field <column=value> ...] (--yes | --dry-run)
 quillan roster update-student <class_id> <student_id> [--last-name <name>] [--first-name <name>] [--period <period>] [--field <column=value> ...] (--yes | --dry-run)
 quillan roster remove-student <class_id> <student_id> (--yes | --dry-run)
+quillan printable-responses generate <class_id> <assignment_id> [--pages-per-student N] [--overwrite] (--yes | --dry-run)
 quillan validate-assignment <path>
 quillan route-scan <source-file> --payload "<already-decoded PDS1 payload>"
 quillan route-scan <source-image> --decode-qr
@@ -273,11 +274,49 @@ exits successfully; it does not inspect or modify the workspace.
 Running `quillan roster` without a subcommand prints roster help and exits
 successfully without resolving or inspecting the workspace.
 
+Running `quillan printable-responses` without a subcommand prints namespace
+help and exits successfully without resolving the workspace, loading an
+assignment or roster, checking an output target, or creating directories.
+
 Running `quillan review-units` without a subcommand prints review-unit help
 and exits successfully without resolving or inspecting the workspace.
 
 Running `quillan observations` without a subcommand prints observation help
 and exits successfully without resolving or inspecting the workspace.
+
+## Direct Printable Response Packet Generation
+
+`printable-responses generate` creates the same one-file class packet available
+through Assignment Management's Printable Response Pages workflow. It requires
+the requested canonical `assignment.json` and shared class `roster.csv`, keeps
+students in stored roster order, and defaults to one numbered response page per
+student. The command reports aggregate student, per-student page, and total PDF
+page counts; it does not list student identities.
+
+Exactly one of `--yes` and `--dry-run` is required. Dry-run validates identifier
+syntax, assignment schema and path identity, assignment class membership,
+roster structure and class identity, a nonempty student collection, the page
+count, canonical output route, and existing-target state. It does not call the
+renderer, create `templates/`, generate QR images or temporary files, touch an
+existing PDF, or write any file. `--overwrite` requires `--yes`; an existing
+packet otherwise fails unchanged with guidance to use `--overwrite --yes`.
+
+Actual generation may create the selected assignment's `templates/` directory
+and create or replace only:
+
+```text
+classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
+```
+
+All displayed paths are workspace-relative POSIX paths. The direct command
+does not accept alternate output paths or filenames and does not open the PDF
+or its folder. It uses the shared application planning/generation service also
+used by the menu, whose low-level renderer remains
+`generate_printable_responses_for_roster(...)`. Assignment, roster, class,
+submission, review, evidence, scan, reusable-comment, feedback, and report data
+remain unchanged. Generation performs no scan processing, QR decoding, OCR,
+handwriting recognition, AI, inference, assembly, review, grading, feedback,
+or export work.
 
 ## Direct Submission Page Management
 

--- a/docs/printable_response_template.md
+++ b/docs/printable_response_template.md
@@ -196,7 +196,13 @@ without inspecting PDF drawing coordinates.
 `generate_printable_responses_for_roster()` loads shared `pds-core` roster
 records with `class_id`, `student_id`, `last_name`, `first_name`, and `period`.
 Student IDs remain strings so leading zeros are preserved. This API support
-is complemented by a teacher-facing Roster Management menu.
+is used through one shared packet planning and generation service by both the
+teacher-facing Printable Response Pages menu and the direct
+`quillan printable-responses generate` command. The shared service validates
+canonical assignment and roster inputs and enforces overwrite policy; the
+low-level renderer remains `generate_printable_responses_for_roster()`.
+The CLI adds no alternate layout and does not change this page or PDS1 payload
+contract.
 
 ## Privacy and Synthetic Data
 
@@ -251,8 +257,7 @@ This contract does not implement or define:
 * teacher scoring areas;
 * assignment, submission, or standards model redesign;
 * requirements checking, tagging, scoring, feedback, or reporting;
-* AI tagging, scoring, feedback, or automatic grading; or
-* a dedicated printable-response CLI or menu workflow;
+* AI tagging, scoring, feedback, or automatic grading;
 * assignment creation workflows; or
 * workspace configuration workflows.
 

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -125,14 +125,16 @@ generation.
 ### `templates/`
 
 A shared assignment-local directory for generated or teacher-facing printable
-materials. The Python API and Printable Response Pages menu create
+materials. The Python API, Printable Response Pages menu, and direct
+`quillan printable-responses generate` command create
 `templates/printable_response_pages.pdf` as one combined class packet of
-roster-aware writing-response pages. The menu requires an existing canonical
-roster and assignment config and protects replacement with exact `OVERWRITE`
-confirmation. Generation does not rewrite either source file. Generated PDFs
-are local workspace artifacts and should not be committed. A dedicated
-printable-response CLI is not implemented. The response-page contract is
-defined in
+roster-aware writing-response pages. Both entry points share packet planning
+and generation services and require an existing canonical roster and assignment
+config. The menu protects replacement with exact `OVERWRITE` confirmation; the
+non-interactive CLI requires `--overwrite --yes`. CLI dry-run performs full
+preflight validation without creating the directory or PDF. Generation does
+not rewrite either source file. Generated PDFs are local workspace artifacts
+and should not be committed. The response-page contract is defined in
 [`printable_response_template.md`](printable_response_template.md).
 
 ### Workspace `scans/source/YYYY-MM-DD/`

--- a/quillan/cli_app/handlers/printable_responses.py
+++ b/quillan/cli_app/handlers/printable_responses.py
@@ -1,0 +1,53 @@
+"""Direct, non-interactive printable response packet handler."""
+
+from __future__ import annotations
+
+import argparse
+
+from pds_core.rosters import RosterError
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.assignments import AssignmentConfigError
+from quillan.cli_app.output import (
+    print_generated_printable_response_packet,
+    print_printable_response_packet_plan,
+)
+from quillan.printable_response_packet import (
+    generate_printable_response_packet,
+    plan_printable_response_packet,
+)
+
+
+def handle_printable_responses_generate(args: argparse.Namespace) -> int:
+    """Validate, report, or generate one canonical combined class packet."""
+    if args.overwrite and not args.yes:
+        return _error(ValueError("--overwrite requires --yes."))
+    if not args.yes and not args.dry_run:
+        return _error(ValueError("use --yes to confirm or --dry-run."))
+
+    try:
+        plan = plan_printable_response_packet(
+            resolve_workspace_root(),
+            args.class_id,
+            args.assignment_id,
+            pages_per_student=args.pages_per_student,
+        )
+        if args.dry_run:
+            print_printable_response_packet_plan(plan)
+            return 0
+        result = generate_printable_response_packet(plan, overwrite=args.overwrite)
+        print_generated_printable_response_packet(result)
+        return 0
+    except (
+        AssignmentConfigError,
+        OSError,
+        RosterError,
+        ValueError,
+        WorkspaceRootError,
+    ) as error:
+        return _error(error)
+
+
+def _error(error: Exception) -> int:
+    print(f"Error: {error}")
+    return 1

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -19,6 +19,10 @@ from quillan.comment_management import (
 from quillan.evidence_filing import EvidenceFilingError, RoutedEvidenceFile
 from quillan.feedback_export import ExportedFeedback, ExportedFeedbackPdf
 from quillan.focus_standard_comments import SavedReusableFocusStandardComment
+from quillan.printable_response_packet import (
+    GeneratedPrintableResponsePacket,
+    PrintableResponsePacketPlan,
+)
 from quillan.review_feedback import (
     AddedFeedbackComment,
     CompletedFeedbackComposition,
@@ -50,6 +54,40 @@ from quillan.submission_page_management import (
     SubmissionPageContext,
 )
 from quillan.submission_status import AssignmentSubmissionStatus
+
+
+def print_printable_response_packet_plan(
+    plan: PrintableResponsePacketPlan,
+) -> None:
+    """Print a stable, aggregate-only printable packet dry-run summary."""
+    print("Printable response packet dry run:")
+    print(f"Class: {plan.class_id}")
+    print(f"Assignment: {plan.assignment_id} - {plan.assignment_title}")
+    print(f"Students: {plan.student_count}")
+    print(f"Pages per student: {plan.pages_per_student}")
+    print(f"Total packet pages: {plan.total_page_count}")
+    print(f"Assignment config: {plan.assignment_relative_path}")
+    print(f"Roster: {plan.roster_relative_path}")
+    print(f"Would write: {plan.output_relative_path}")
+    print(f"Existing target: {format_bool(plan.target_exists)}")
+    if plan.target_exists:
+        print("Replacement requires --overwrite --yes during actual generation.")
+    print("No files were written.")
+
+
+def print_generated_printable_response_packet(
+    result: GeneratedPrintableResponsePacket,
+) -> None:
+    """Print a stable, aggregate-only printable packet generation summary."""
+    print("Generated printable response packet:")
+    print(f"Class: {result.class_id}")
+    print(f"Assignment: {result.assignment_id} - {result.assignment_title}")
+    print(f"Students: {result.student_count}")
+    print(f"Pages per student: {result.pages_per_student}")
+    print(f"Total packet pages: {result.total_page_count}")
+    action = "replaced existing packet" if result.replaced_existing else "created"
+    print(f"Action: {action}")
+    print(f"PDF: {result.output_relative_path}")
 
 
 def print_reusable_comment_inventory(inventory: ReusableCommentInventory) -> None:

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -52,6 +52,9 @@ from quillan.cli_app.handlers.pages import (
     handle_pages_mark_needs_rescan,
     handle_pages_restore,
 )
+from quillan.cli_app.handlers.printable_responses import (
+    handle_printable_responses_generate,
+)
 from quillan.cli_app.handlers.ratings import (
     handle_ratings_list,
     handle_ratings_mark_complete,
@@ -220,6 +223,48 @@ def build_parser() -> argparse.ArgumentParser:
     _add_assignment_identity_arguments(assignment_validate_parser)
     assignment_validate_parser.set_defaults(
         handler=handle_canonical_assignment_validate
+    )
+
+    printable_responses_parser = subparsers.add_parser(
+        "printable-responses",
+        help="Generate canonical printable response class packets.",
+    )
+    printable_responses_parser.set_defaults(
+        handler=partial(_print_parser_help, printable_responses_parser)
+    )
+    printable_responses_subparsers = printable_responses_parser.add_subparsers(
+        dest="printable_responses_command"
+    )
+    printable_responses_generate_parser = printable_responses_subparsers.add_parser(
+        "generate",
+        help="Generate one combined packet from a canonical assignment and roster.",
+    )
+    _add_assignment_identity_arguments(printable_responses_generate_parser)
+    printable_responses_generate_parser.add_argument(
+        "--pages-per-student",
+        type=positive_integer,
+        default=1,
+        metavar="N",
+        help="Number of numbered response pages per roster student (default: 1).",
+    )
+    printable_responses_generate_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace the existing canonical packet; requires --yes.",
+    )
+    printable_confirmation = (
+        printable_responses_generate_parser.add_mutually_exclusive_group(required=True)
+    )
+    printable_confirmation.add_argument(
+        "--yes", action="store_true", help="Confirm PDF generation."
+    )
+    printable_confirmation.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and report without writing files.",
+    )
+    printable_responses_generate_parser.set_defaults(
+        handler=handle_printable_responses_generate
     )
 
     requirements_parser = subparsers.add_parser(

--- a/quillan/printable_response_packet.py
+++ b/quillan/printable_response_packet.py
@@ -1,0 +1,138 @@
+"""Application services for canonical printable response class packets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from quillan.assignment_setup import load_canonical_assignment
+from quillan.printable_response import (
+    PRINTABLE_RESPONSE_FILENAME,
+    generate_printable_responses_for_roster,
+)
+from quillan.roster_management import load_canonical_roster
+from quillan.storage import assignment_templates_dir
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponsePacketPlan:
+    """Validated, non-writing inputs for one combined class packet."""
+
+    workspace_root: Path
+    class_id: str
+    assignment_id: str
+    assignment_title: str
+    assignment_path: Path
+    assignment_relative_path: str
+    roster_path: Path
+    roster_relative_path: str
+    output_path: Path
+    output_relative_path: str
+    pages_per_student: int
+    student_count: int
+    total_page_count: int
+    target_exists: bool
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratedPrintableResponsePacket:
+    """Stable result of generating one combined class packet."""
+
+    class_id: str
+    assignment_id: str
+    assignment_title: str
+    output_path: Path
+    output_relative_path: str
+    pages_per_student: int
+    student_count: int
+    total_page_count: int
+    replaced_existing: bool
+
+
+def plan_printable_response_packet(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    *,
+    pages_per_student: int = 1,
+) -> PrintableResponsePacketPlan:
+    """Validate canonical packet inputs without creating directories or files."""
+    _validate_pages_per_student(pages_per_student)
+    root = Path(workspace_root).resolve(strict=False)
+    assignment = load_canonical_assignment(root, class_id, assignment_id)
+    loaded_roster = load_canonical_roster(root, class_id)
+    student_count = len(loaded_roster.roster.students)
+    if student_count == 0:
+        raise ValueError(
+            "canonical roster must contain at least one student to generate a packet."
+        )
+
+    output_path = (
+        assignment_templates_dir(root, class_id, assignment_id)
+        / PRINTABLE_RESPONSE_FILENAME
+    )
+    return PrintableResponsePacketPlan(
+        workspace_root=root,
+        class_id=class_id,
+        assignment_id=assignment_id,
+        assignment_title=cast(str, assignment.assignment["title"]),
+        assignment_path=assignment.path,
+        assignment_relative_path=_relative_posix(assignment.path, root),
+        roster_path=loaded_roster.roster_path,
+        roster_relative_path=_relative_posix(loaded_roster.roster_path, root),
+        output_path=output_path,
+        output_relative_path=_relative_posix(output_path, root),
+        pages_per_student=pages_per_student,
+        student_count=student_count,
+        total_page_count=student_count * pages_per_student,
+        target_exists=output_path.exists(),
+    )
+
+
+def generate_printable_response_packet(
+    plan: PrintableResponsePacketPlan,
+    *,
+    overwrite: bool = False,
+) -> GeneratedPrintableResponsePacket:
+    """Enforce target protection and render one validated canonical packet."""
+    target_exists = plan.output_path.exists()
+    if target_exists and not overwrite:
+        raise FileExistsError(
+            f"printable response packet already exists at "
+            f"{plan.output_relative_path}; use --overwrite --yes to replace it."
+        )
+
+    generated_path = generate_printable_responses_for_roster(
+        plan.workspace_root,
+        assignment_path=plan.assignment_path,
+        roster_path=plan.roster_path,
+        pages_per_student=plan.pages_per_student,
+        class_label=plan.class_id,
+    )
+    if generated_path.resolve(strict=False) != plan.output_path.resolve(strict=False):
+        raise ValueError(
+            "printable response renderer returned an unexpected output path: "
+            f"{generated_path}"
+        )
+
+    return GeneratedPrintableResponsePacket(
+        class_id=plan.class_id,
+        assignment_id=plan.assignment_id,
+        assignment_title=plan.assignment_title,
+        output_path=plan.output_path,
+        output_relative_path=plan.output_relative_path,
+        pages_per_student=plan.pages_per_student,
+        student_count=plan.student_count,
+        total_page_count=plan.total_page_count,
+        replaced_existing=target_exists,
+    )
+
+
+def _validate_pages_per_student(value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("pages_per_student must be a positive integer.")
+
+
+def _relative_posix(path: Path, workspace_root: Path) -> str:
+    return path.resolve(strict=False).relative_to(workspace_root).as_posix()

--- a/quillan/printable_response_workflows.py
+++ b/quillan/printable_response_workflows.py
@@ -12,14 +12,16 @@ from pds_core.routes import class_assignments_dir
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
 from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.cli_app.output import print_generated_printable_response_packet
 from quillan.generated_output_opening import (
     GeneratedOutputOpeningError,
     open_generated_output_file,
     open_generated_output_folder,
 )
-from quillan.printable_response import (
-    PRINTABLE_RESPONSE_FILENAME,
-    generate_printable_responses_for_roster,
+from quillan.printable_response import PRINTABLE_RESPONSE_FILENAME
+from quillan.printable_response_packet import (
+    generate_printable_response_packet,
+    plan_printable_response_packet,
 )
 from quillan.storage import assignment_templates_dir
 
@@ -266,42 +268,41 @@ def prompt_generate_class_packet() -> int:
         print(f"Error: {error}")
         return 1
 
-    output_path = expected_printable_packet_path(
-        workspace_root,
-        class_folder.class_id,
-        assignment.assignment_id,
-    )
-    if output_path.exists():
-        print(f"Printable response packet already exists:\n{output_path}")
+    try:
+        plan = plan_printable_response_packet(
+            workspace_root,
+            class_folder.class_id,
+            assignment.assignment_id,
+            pages_per_student=pages_per_student,
+        )
+    except (AssignmentConfigError, RosterError, OSError, ValueError) as error:
+        print(f"Error: {error}")
+        return 1
+
+    overwrite = False
+    if plan.target_exists:
+        print(f"Printable response packet already exists:\n{plan.output_path}")
         confirmation = input(
             "Type OVERWRITE to replace the existing printable response packet: "
         ).strip()
         if confirmation != "OVERWRITE":
             print("Canceled: existing printable response packet was not changed.")
             return 1
+        overwrite = True
 
     print("Output mode: one class packet PDF")
     try:
-        generated_path = generate_printable_responses_for_roster(
-            workspace_root,
-            assignment_path=assignment.path,
-            roster_path=class_folder.roster_path,
-            pages_per_student=pages_per_student,
-            class_label=class_folder.class_id,
+        generated = generate_printable_response_packet(
+            plan,
+            overwrite=overwrite,
         )
     except (AssignmentConfigError, RosterError, OSError, ValueError) as error:
         print(f"Error: {error}")
         return 1
 
-    assignment_label = assignment.assignment_id
-    if assignment.title:
-        assignment_label = f"{assignment.assignment_id} - {assignment.title}"
-    print("Generated printable response packet:")
-    print(generated_path)
-    print(f"Class: {class_folder.class_id}")
-    print(f"Assignment: {assignment_label}")
-    print(f"Pages per student: {pages_per_student}")
-    _prompt_open_generated_packet(workspace_root, generated_path)
+    print_generated_printable_response_packet(generated)
+    print(f"Saved at: {generated.output_path}")
+    _prompt_open_generated_packet(workspace_root, generated.output_path)
     return 0
 
 

--- a/tests/test_cli_printable_responses.py
+++ b/tests/test_cli_printable_responses.py
@@ -1,0 +1,182 @@
+"""Tests for the direct printable response packet CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pypdf import PdfReader
+import pytest
+
+from quillan.cli import main
+import quillan.cli_app.handlers.printable_responses as handlers
+from tests.test_printable_response_packet import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    write_packet_workspace,
+)
+
+
+def command(*extra: str) -> list[str]:
+    return ["printable-responses", "generate", CLASS_ID, ASSIGNMENT_ID, *extra]
+
+
+def test_help_surface_and_bare_namespace_do_not_resolve_workspace(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def unexpected_resolution() -> Path:
+        raise AssertionError("bare namespace resolved the workspace")
+
+    monkeypatch.setattr(handlers, "resolve_workspace_root", unexpected_resolution)
+    assert main(["printable-responses"]) == 0
+    assert "generate" in capsys.readouterr().out
+
+    for argv, expected in [
+        (["--help"], "printable-responses"),
+        (["printable-responses", "--help"], "generate"),
+        (["printable-responses", "generate", "--help"], "--pages-per-student"),
+    ]:
+        with pytest.raises(SystemExit) as error:
+            main(argv)
+        assert error.value.code == 0
+        assert expected in capsys.readouterr().out
+
+
+def test_confirmation_and_page_count_are_parser_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_resolution() -> Path:
+        raise AssertionError("invalid options resolved the workspace")
+
+    monkeypatch.setattr(handlers, "resolve_workspace_root", unexpected_resolution)
+    for argv in [
+        command(),
+        command("--yes", "--dry-run"),
+        command("--yes", "--pages-per-student", "0"),
+        ["printable-responses", "generate", CLASS_ID, "--yes"],
+    ]:
+        with pytest.raises(SystemExit) as error:
+            main(argv)
+        assert error.value.code != 0
+
+    assert main(command("--overwrite", "--dry-run")) == 1
+
+
+def test_dry_run_is_full_preflight_with_no_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    write_packet_workspace(tmp_path)
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+
+    def no_render(*_args: object, **_kwargs: object) -> Path:
+        raise AssertionError("dry run called the renderer")
+
+    monkeypatch.setattr(
+        "quillan.printable_response_packet.generate_printable_responses_for_roster",
+        no_render,
+    )
+    assert main(command("--pages-per-student", "2", "--dry-run")) == 0
+
+    output = capsys.readouterr().out
+    assert "Printable response packet dry run:" in output
+    assert "Students: 2" in output
+    assert "Pages per student: 2" in output
+    assert "Total packet pages: 4" in output
+    assert "Existing target: no" in output
+    assert "No files were written." in output
+    assert str(tmp_path) not in output
+    assert not (
+        tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "templates"
+    ).exists()
+
+
+def test_dry_run_reports_existing_target_without_touching_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    write_packet_workspace(tmp_path)
+    packet = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "templates"
+        / "printable_response_pages.pdf"
+    )
+    packet.parent.mkdir(parents=True)
+    packet.write_bytes(b"existing synthetic bytes")
+    before = packet.stat().st_mtime_ns
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(command("--dry-run")) == 0
+    output = capsys.readouterr().out
+    assert "Existing target: yes" in output
+    assert "--overwrite --yes" in output
+    assert packet.read_bytes() == b"existing synthetic bytes"
+    assert packet.stat().st_mtime_ns == before
+
+
+def test_generation_is_noninteractive_and_uses_default_page_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assignment_path, roster_path = write_packet_workspace(tmp_path)
+    inputs_before = (assignment_path.read_bytes(), roster_path.read_bytes())
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("direct command prompted for input")
+        ),
+    )
+
+    assert main(command("--yes")) == 0
+    packet = assignment_path.parent / "templates" / "printable_response_pages.pdf"
+    assert packet.read_bytes().startswith(b"%PDF")
+    assert len(PdfReader(str(packet)).pages) == 2
+    assert (assignment_path.read_bytes(), roster_path.read_bytes()) == inputs_before
+    output = capsys.readouterr().out
+    assert "Pages per student: 1" in output
+    assert "Total packet pages: 2" in output
+    assert "Action: created" in output
+    assert f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/templates/" in output
+    assert str(tmp_path) not in output
+
+
+def test_existing_target_error_and_successful_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assignment_path, _ = write_packet_workspace(tmp_path)
+    packet = assignment_path.parent / "templates" / "printable_response_pages.pdf"
+    packet.parent.mkdir(parents=True)
+    packet.write_bytes(b"old synthetic packet")
+    before = packet.stat().st_mtime_ns
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(command("--yes")) == 1
+    output = capsys.readouterr().out
+    assert "Error:" in output
+    assert "--overwrite --yes" in output
+    assert packet.read_bytes() == b"old synthetic packet"
+    assert packet.stat().st_mtime_ns == before
+
+    assert main(command("--overwrite", "--yes")) == 0
+    assert packet.read_bytes().startswith(b"%PDF")
+    assert "Action: replaced existing packet" in capsys.readouterr().out
+
+
+def test_missing_assignment_fails_without_creating_templates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    assert main(command("--dry-run")) == 1
+    assert "Error:" in capsys.readouterr().out
+    assert not list(tmp_path.rglob("templates"))

--- a/tests/test_printable_response_packet.py
+++ b/tests/test_printable_response_packet.py
@@ -1,0 +1,203 @@
+"""Tests for shared printable response packet application services."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pds_core.classes import write_class_roster
+from pds_core.rosters import RosterError, create_roster
+from pypdf import PdfReader
+import pytest
+
+from quillan.printable_response_packet import (
+    generate_printable_response_packet,
+    plan_printable_response_packet,
+)
+
+CLASS_ID = "synthetic_english_p3"
+ASSIGNMENT_ID = "synthetic_response"
+
+
+def write_packet_workspace(root: Path) -> tuple[Path, Path]:
+    roster_path = write_class_roster(
+        root,
+        create_roster(
+            CLASS_ID,
+            [
+                {
+                    "student_id": "00107",
+                    "last_name": "Zulu",
+                    "first_name": "Avery",
+                    "period": "3",
+                },
+                {
+                    "student_id": "00002",
+                    "last_name": "Alpha",
+                    "first_name": "Morgan",
+                    "period": "3",
+                },
+            ],
+        ),
+    )
+    assignment_path = (
+        root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    )
+    assignment_path.parent.mkdir(parents=True, exist_ok=True)
+    assignment_path.write_text(json.dumps(valid_assignment()), encoding="utf-8")
+    return assignment_path, roster_path
+
+
+def valid_assignment() -> dict[str, object]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Synthetic Writing Response",
+        "class_ids": [CLASS_ID],
+        "writing_type": "synthetic_response",
+        "student_prompt": "Private synthetic directions must not be printed.",
+        "standards_profile_id": "missing_but_not_needed_for_printing",
+        "focus_standard_ids": ["synthetic:W.SYN.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "synthetic_scale",
+            "levels": [
+                {"value": 1, "label": "Developing", "description": "Synthetic."},
+                {"value": 2, "label": "Meeting", "description": "Synthetic."},
+            ],
+        },
+        "basic_requirements": {},
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+        "created_at": "2026-07-13T00:00:00+00:00",
+        "updated_at": "2026-07-13T00:00:00+00:00",
+        "module_details": {},
+    }
+
+
+def test_plan_validates_without_writing_and_reports_canonical_paths(
+    tmp_path: Path,
+) -> None:
+    assignment_path, roster_path = write_packet_workspace(tmp_path)
+    plan = plan_printable_response_packet(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, pages_per_student=3
+    )
+
+    assert plan.student_count == 2
+    assert plan.pages_per_student == 3
+    assert plan.total_page_count == 6
+    assert plan.assignment_path == assignment_path
+    assert plan.roster_path == roster_path
+    assert plan.assignment_relative_path.endswith("/assignment.json")
+    assert plan.roster_relative_path.endswith("/roster.csv")
+    assert plan.output_relative_path == (
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/templates/"
+        "printable_response_pages.pdf"
+    )
+    assert not plan.target_exists
+    assert not plan.output_path.parent.exists()
+
+
+def test_generate_reuses_renderer_and_rejects_unexpected_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_packet_workspace(tmp_path)
+    plan = plan_printable_response_packet(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    unexpected = tmp_path / "unexpected.pdf"
+    monkeypatch.setattr(
+        "quillan.printable_response_packet.generate_printable_responses_for_roster",
+        lambda *_args, **_kwargs: unexpected,
+    )
+
+    with pytest.raises(ValueError, match="unexpected output path"):
+        generate_printable_response_packet(plan)
+
+
+def test_generation_counts_pages_and_preserves_inputs(tmp_path: Path) -> None:
+    assignment_path, roster_path = write_packet_workspace(tmp_path)
+    untouched_paths = [
+        tmp_path / "classes" / CLASS_ID / "class.json",
+        tmp_path / "classes" / CLASS_ID / "assignments" / "sibling" / "assignment.json",
+        assignment_path.parent / "submissions" / "synthetic_student" / "submission.json",
+        assignment_path.parent / "submissions" / "synthetic_student" / "review.json",
+        assignment_path.parent / "scans" / "synthetic_evidence.txt",
+        assignment_path.parent / "exports" / "synthetic_report.csv",
+        tmp_path / "shared" / "focus_standard_comments" / "synthetic.json",
+        tmp_path / "scans" / "review" / "synthetic.json",
+    ]
+    for index, path in enumerate(untouched_paths):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"synthetic sentinel {index}".encode())
+    untouched_bytes = {path: path.read_bytes() for path in untouched_paths}
+    assignment_bytes = assignment_path.read_bytes()
+    roster_bytes = roster_path.read_bytes()
+    plan = plan_printable_response_packet(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, pages_per_student=2
+    )
+
+    result = generate_printable_response_packet(plan)
+
+    assert result.total_page_count == 4
+    assert result.output_path.read_bytes().startswith(b"%PDF")
+    reader = PdfReader(str(result.output_path))
+    assert len(reader.pages) == 4
+    first_student_text = reader.pages[0].extract_text()
+    second_student_text = reader.pages[2].extract_text()
+    assert "Avery Zulu" in first_student_text
+    assert "Student ID: 00107" in first_student_text
+    assert "Morgan Alpha" in second_student_text
+    assert "Student ID: 00002" in second_student_text
+    assert "Synthetic Writing Response" in first_student_text
+    assert f"Assignment ID: {ASSIGNMENT_ID}" in first_student_text
+    assert all(
+        "Private synthetic directions" not in page.extract_text()
+        for page in reader.pages
+    )
+    assert assignment_path.read_bytes() == assignment_bytes
+    assert roster_path.read_bytes() == roster_bytes
+    assert {path: path.read_bytes() for path in untouched_paths} == untouched_bytes
+
+
+def test_existing_packet_requires_explicit_overwrite(tmp_path: Path) -> None:
+    write_packet_workspace(tmp_path)
+    plan = plan_printable_response_packet(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    plan.output_path.parent.mkdir(parents=True)
+    plan.output_path.write_bytes(b"existing synthetic packet")
+    original_stat = plan.output_path.stat()
+
+    with pytest.raises(FileExistsError, match="--overwrite --yes"):
+        generate_printable_response_packet(plan)
+
+    assert plan.output_path.read_bytes() == b"existing synthetic packet"
+    assert plan.output_path.stat().st_mtime_ns == original_stat.st_mtime_ns
+    replaced = generate_printable_response_packet(plan, overwrite=True)
+    assert replaced.replaced_existing
+    assert plan.output_path.read_bytes().startswith(b"%PDF")
+
+
+def test_empty_roster_fails_before_templates_directory(tmp_path: Path) -> None:
+    write_packet_workspace(tmp_path)
+    roster_path = tmp_path / "classes" / CLASS_ID / "roster.csv"
+    roster_path.write_text(
+        "class_id,student_id,last_name,first_name,period\n", encoding="utf-8"
+    )
+
+    with pytest.raises(RosterError, match="at least one student"):
+        plan_printable_response_packet(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+    assert not (
+        tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "templates"
+    ).exists()
+
+
+@pytest.mark.parametrize("value", [0, -1, True])
+def test_plan_rejects_invalid_page_counts(tmp_path: Path, value: int) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        plan_printable_response_packet(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, pages_per_student=value
+        )


### PR DESCRIPTION
## Summary

* Add a direct, non-interactive command for generating printable response class packets:

  ```text
  quillan printable-responses generate \
    <class_id> <assignment_id> \
    [--pages-per-student N] \
    [--overwrite] \
    (--yes | --dry-run)
  ```

* Add immutable shared planning and generation services used by both the direct CLI and teacher menu.

* Add a true no-write dry-run path that validates all prerequisites without rendering pages, generating QR codes, or creating directories.

* Preserve the existing combined class-packet format, ReportLab renderer, QR payload contract, roster ordering, and canonical output path.

* Protect existing packets unless replacement is explicitly authorized with `--overwrite --yes`.

* Keep generated-file and folder opening as menu-only conveniences.

## Command Surface

```text
quillan printable-responses generate \
  <class_id> <assignment_id> \
  [--pages-per-student N] \
  [--overwrite] \
  (--yes | --dry-run)
```

`--pages-per-student` defaults to `1`.

The command generates one combined PDF containing:

```text
student count × pages per student
```

response pages.

## Namespace Behavior

Bare:

```text
quillan printable-responses
```

prints namespace help and exits successfully.

It does not:

* resolve the workspace;
* load an assignment;
* load a roster;
* inspect the output path;
* create a templates directory;
* render a PDF;
* write any file.

The following help commands succeed:

```text
quillan --help
quillan printable-responses --help
quillan printable-responses generate --help
```

## Confirmation Rules

Exactly one of:

```text
--yes
--dry-run
```

is required.

The command never prompts interactively.

When neither flag is supplied, parsing fails before workspace resolution.

`--overwrite` requires `--yes`.

The combination:

```text
--overwrite --dry-run
```

is rejected.

## Page Count

`--pages-per-student`:

* is optional;
* defaults to `1`;
* accepts only positive integers;
* controls the numbered response pages generated for every roster student.

Invalid values fail before rendering.

The generated result reports:

* student count;
* pages per student;
* total packet-page count.

## Shared Planning Service

Added immutable planning support in:

* `quillan/printable_response_packet.py`

The planning service validates:

* workspace resolution;
* class identifier;
* assignment identifier;
* canonical assignment path;
* assignment JSON and schema;
* assignment path identity;
* assignment class membership;
* canonical class roster;
* roster CSV and schema;
* roster class identity;
* student records;
* nonempty roster;
* positive pages per student;
* canonical output path;
* current target existence.

The plan reports:

* class ID;
* assignment ID;
* assignment title;
* assignment path;
* roster path;
* output path;
* student count;
* pages per student;
* total page count;
* whether the target already exists.

Planning creates no directories or files.

## Shared Generation Service

The shared generation service:

1. accepts a validated immutable plan;
2. rechecks canonical target existence;
3. enforces overwrite policy;
4. calls the existing `generate_printable_responses_for_roster(...)` renderer;
5. verifies that the renderer returned the expected canonical output path;
6. returns an immutable generated-packet result.

Both the teacher menu and direct CLI use this service.

The CLI handler does not:

* parse assignment JSON;
* parse roster CSV;
* create student page contexts;
* build QR payloads;
* invoke ReportLab directly;
* create directories directly;
* write PDF bytes directly.

## True Dry Run

`--dry-run` performs complete preflight validation and reports the planned operation.

It reports:

* class;
* assignment ID and title;
* assignment path;
* roster path;
* student count;
* pages per student;
* total packet pages;
* canonical output path;
* whether the target exists;
* confirmation that no files were written.

Dry-run does not:

* call the PDF renderer;
* invoke ReportLab;
* generate QR images;
* create the `templates` directory;
* create a temporary PDF;
* touch an existing packet;
* alter timestamps;
* write any workspace file.

## Assignment Validation

The command loads only the canonical assignment:

```text
classes/<class_id>/assignments/<assignment_id>/assignment.json
```

It validates:

* identifier syntax;
* canonical path;
* JSON syntax;
* assignment schema;
* assignment ID;
* requested class membership in `class_ids`.

Missing, malformed, unsupported, identity-mismatched, or class-incompatible assignments fail without writes.

Printable packet generation does not require the workspace standards library when the assignment itself is structurally valid.

## Roster Validation

The command loads the selected class’s canonical shared roster.

It validates:

* roster existence;
* roster structure;
* roster class identity;
* student records;
* student identifiers;
* display-name data;
* nonempty student collection.

The command does not accept arbitrary roster paths.

An empty roster fails before rendering or directory creation.

## Student Ordering

Packet pages preserve the canonical roster’s stored student order.

The direct CLI does not:

* alphabetize students;
* reorder students;
* deduplicate records independently;
* skip valid students silently.

For each student, response pages are generated in page-number order from:

```text
1..N
```

## Student Identifier Preservation

Student IDs remain strings throughout generation.

Leading-zero IDs such as:

```text
00107
00002
```

remain unchanged in:

* human-readable PDF identity text;
* canonical PDS1 QR payloads;
* page-generation context.

No numeric conversion is performed.

## Packet Format

The implementation continues to generate one combined class packet:

```text
printable_response_pages.pdf
```

Each response page remains:

* US Letter;
* portrait;
* lined for handwriting;
* identified by assignment, class, student, and page number;
* encoded with one canonical Quillan response QR payload.

The printable-page layout and PDS1 payload contract are unchanged.

## Canonical Output Path

The generated packet remains at:

```text
classes/<class_id>/assignments/<assignment_id>/
  templates/printable_response_pages.pdf
```

The CLI does not accept:

* arbitrary output paths;
* alternative filenames;
* output-directory overrides;
* per-student filename templates.

Stable command output reports this path as a workspace-relative POSIX path.

## Existing Packet Protection

When the canonical packet already exists, actual generation without:

```text
--overwrite --yes
```

fails safely.

The command:

* returns nonzero;
* identifies the existing canonical packet;
* explains the required overwrite flags;
* preserves existing PDF bytes;
* preserves the existing modification timestamp;
* creates no alternate packet.

## Explicit Overwrite

With:

```text
--overwrite --yes
```

the command may replace the existing canonical packet.

Successful overwrite output reports that the existing packet was replaced.

The implementation does not automatically create:

* backup packets;
* versioned copies;
* alternate filenames;
* secondary PDFs.

## Generated Output

Successful output reports:

* class ID;
* assignment ID and title;
* student count;
* pages per student;
* total packet-page count;
* whether the action created or replaced the packet;
* canonical workspace-relative PDF path.

The command does not print every roster student’s identity.

## Renderer Reuse

Actual generation continues to call:

```python
generate_printable_responses_for_roster(...)
```

The existing renderer remains responsible for:

* assignment and roster loading required for rendering;
* page-context construction;
* student display-name handling;
* PDS1 response payload construction;
* QR image creation;
* ReportLab page drawing;
* final PDF writing.

No second renderer or QR implementation was added.

## PDS1 Contract

Each page continues to encode:

```text
PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page_number>|doc=response
```

The payload continues to contain stable identifiers rather than student display names.

No PDS1 field, ordering rule, or routing identity changed.

## Assignment Content Boundary

Generated pages include:

* assignment title;
* assignment ID;
* class identity;
* student display name;
* student ID;
* page number.

They do not include:

* the private assignment prompt;
* assignment requirements;
* rating scales;
* rubrics;
* standards summaries;
* teacher review data;
* student submissions;
* feedback;
* grades.

## Menu Integration

The Printable Response Pages menu now uses the same immutable planning and generation services as the direct CLI.

The menu continues to provide:

* interactive class selection;
* interactive assignment selection;
* blank-input page-count default;
* explicit `OVERWRITE` confirmation;
* generated-packet summary;
* optional opening of the generated PDF;
* optional opening of the containing folder.

The menu no longer independently owns:

* generation prerequisite validation;
* student or packet-page count calculation;
* canonical output-path calculation;
* final overwrite enforcement;
* direct low-level rendering calls.

The menu does not invoke the CLI handler.

## File-Opening Boundary

The direct command never:

* opens the generated PDF;
* opens the templates directory;
* launches a PDF viewer;
* invokes shell-opening APIs;
* prompts for a post-generation action.

Opening the generated file or folder remains an interactive menu convenience.

Generation success does not depend on a local PDF viewer.

## Exact Read Boundary

Planning and generation may read:

* canonical assignment configuration;
* canonical class roster;
* canonical output-file existence.

They do not read:

* student submissions;
* review records;
* routed evidence;
* retained scans;
* scan-review records;
* reusable comments;
* feedback exports;
* assignment reports;
* student writing;
* ScoreForm data.

## Exact Write Boundary

Dry-run writes nothing.

Actual generation may:

* create the selected assignment’s `templates` directory;
* create or replace only:

  ```text
  classes/<class_id>/assignments/<assignment_id>/
    templates/printable_response_pages.pdf
  ```

It does not modify:

* `assignment.json`;
* roster CSV;
* class metadata;
* submission manifests;
* review records;
* routed evidence;
* retained scans;
* scan-review records;
* reusable comments;
* feedback exports;
* report exports;
* sibling assignment data;
* PDS Core data;
* ScoreForm data.

## No Review or Automated Judgment

Confirmed that the feature does not:

* inspect student work;
* decode completed response pages;
* route scans;
* assemble submissions;
* create submission manifests;
* create review records;
* inspect evidence;
* run OCR;
* perform handwriting recognition;
* use AI;
* check minimum requirements;
* infer observations;
* infer ratings;
* calculate mastery;
* calculate grades;
* compose feedback;
* generate review or reporting exports.

The PDF remains a blank paper-writing and routing artifact.

## Privacy

Production packets may contain real student names and IDs because they are teacher-controlled local classroom artifacts.

The CLI output reports aggregate counts rather than enumerating students.

Tests, fixtures, documentation, and repository artifacts use synthetic data only.

No generated production packet is committed.

## Files Changed

* `quillan/printable_response_packet.py`
* `quillan/cli_app/handlers/printable_responses.py`
* `quillan/cli_app/parser.py`
* `quillan/cli_app/output.py`
* `quillan/printable_response_workflows.py`
* `tests/test_printable_response_packet.py`
* `tests/test_cli_printable_responses.py`
* `docs/cli_contract.md`
* `docs/printable_response_template.md`
* `docs/workspace_lifecycle.md`
* `README.md`

## Documentation

Updated documentation covers:

* the new `printable-responses` namespace;
* direct generation syntax;
* required confirmation or dry run;
* page-count defaults and validation;
* canonical assignment and roster prerequisites;
* one combined class packet;
* canonical output path;
* dry-run behavior;
* overwrite behavior;
* aggregate count reporting;
* menu and CLI shared services;
* file-opening boundary;
* exact write boundary;
* unchanged printable-page and PDS1 contracts;
* absence of review, OCR, AI, grading, or scan-processing behavior.

Stale documentation claiming no printable-response CLI or menu workflow exists was corrected.

## Test Coverage

Synthetic tests verify:

* parser and namespace help;
* bare namespace behavior;
* no workspace resolution for bare help;
* required `--yes` or `--dry-run`;
* overwrite-option validation;
* positive page counts;
* default page count of one;
* true no-write dry run;
* dry run with an existing target;
* no ReportLab or QR generation during dry run;
* successful multi-student generation;
* actual PDF page count;
* canonical output path;
* workspace-relative POSIX output;
* roster-order preservation;
* leading-zero student IDs;
* assignment title and ID inclusion;
* assignment prompt exclusion;
* empty-roster rejection;
* assignment validation failures;
* roster validation failures;
* existing-target protection;
* successful explicit overwrite;
* menu and CLI service parity;
* exact write boundary;
* unchanged workspace sentinel files;
* absence of file-opening behavior in the CLI;
* reuse of the existing renderer.

A representative generated packet verifies:

```text
2 students × 2 pages = 4 PDF pages
```

## Safety

Confirmed:

* dry-run creates no directory or file;
* existing packets remain byte-for-byte unchanged without explicit overwrite;
* only the canonical packet is created or replaced;
* assignment and roster files remain unchanged;
* submission and review records remain unchanged;
* evidence, scans, comments, feedback, and reports remain unchanged;
* stored roster order is preserved;
* leading-zero student IDs are preserved;
* assignment prompts are excluded;
* the QR/PDS1 contract is unchanged;
* no evidence or completed student work is inspected;
* no automated judgment is introduced;
* PDS Core remains unchanged;
* ScoreForm remains unchanged;
* no real student data or generated production artifacts were added.

## Validation

* Focused printable tests: `50 passed`
* Paper-workflow regressions: `75 passed`
* Broader CLI regressions: `275 passed`
* Full pytest suite: `1271 passed`
* Ruff: passed
* mypy: passed, `180` source files
* `git diff --check`: passed
* `run_tests.ps1`: passed
* PDS Core working tree: clean
* PDS ScoreForm working tree: clean
* Temporary pytest directory removed
* No generated PDFs present in the repository
* No real student data or production artifacts present

Closes #326
