### PR TITLE
Establish PDS Core 0.5 package baseline (#333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,28 +289,38 @@ or compatibility documentation when explicitly labeled that way.
 
 ## Local Setup
 
-`pds-core` is required for local Paper Data Suite development. Check out
-`pds-core` and `pds-quillan` as sibling repositories:
-
-```text
-Paper-Data-Suite/
-  pds-core/
-  pds-quillan/
-```
-
-Create and activate a virtual environment:
+Create and activate a virtual environment, then install Quillan with its
+development extras:
 
 ```powershell
 py -m venv .venv
 .\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install "C:\path\to\pds_core-0.5.x-py3-none-any.whl"
+python -m pip install -e ".[dev]"
+python -m pip check
 ```
 
-Install development dependencies from inside `pds-quillan`:
+The configured package index did not provide a compatible PDS Core distribution
+during the Core 0.5 baseline validation, so install a verified compatible wheel
+first. Pip then confirms that wheel satisfies Quillan's declared
+`pds-core>=0.5,<0.6` runtime dependency. A sibling Core checkout is not required,
+and no neighboring Core source path is used. `requirements-dev.txt` is a
+convenience wrapper around `.[dev]` and may be used instead of the direct
+editable-install command.
+
+To validate clean editable and noneditable installations, run:
 
 ```powershell
-python -m pip install --upgrade pip
-python -m pip install -r requirements-dev.txt
+powershell -ExecutionPolicy Bypass `
+    -File .\scripts\validate_development_install.ps1 `
+    -Python .\.venv\Scripts\python.exe `
+    -PdsCoreWheel "C:\path\to\pds_core-0.5.x-py3-none-any.whl"
 ```
+
+The equivalent `PDS_CORE_WHEEL` environment variable may be used instead of
+`-PdsCoreWheel`; an explicit parameter takes precedence. The isolated validation checks package metadata, editable and noneditable installation, installed import origins, CLI availability, and workspace side effects. During the v0.8.9 migration, all active Quillan runtime surfaces are being converted to PDS2 and module-qualified storage.
+
 
 PDF scan intake uses `pdf2image` and requires Poppler installed on the user's
 machine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "quillan"
 version = "0.1.0"
@@ -11,6 +15,7 @@ authors = [
 dependencies = [
     "numpy<2.5",
     "opencv-python",
+    "pds-core>=0.5,<0.6",
     "pdf2image",
     "qrcode[pil]",
     "reportlab",
@@ -18,6 +23,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "packaging",
     "pytest",
     "pypdf",
     "ruff",
@@ -40,4 +46,13 @@ target-version = "py311"
 python_version = "3.11"
 strict = true
 explicit_package_bases = true
-mypy_path = "../pds-core"
+
+[[tool.mypy.overrides]]
+# Core 0.5 ships inspectable source but no py.typed marker.
+module = ["pds_core", "pds_core.*"]
+follow_untyped_imports = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["quillan*"]
+namespaces = true

--- a/quillan/pds_contract.py
+++ b/quillan/pds_contract.py
@@ -1,0 +1,35 @@
+"""Stable Quillan-owned boundary for future PDS2 integration contracts."""
+
+from typing import Final
+
+from pds_core.module_profiles import CORE_ROUTING_CONTRACT_VERSION
+from pds_core.routing_models import (
+    PDS2_SCHEMA,
+    ROUTE_REGISTRATION_SCHEMA_VERSION,
+)
+
+QUILLAN_MODULE_ID: Final[str] = "quillan"
+QUILLAN_DISPLAY_NAME: Final[str] = "Quillan"
+
+RESPONSE_PAGE_RECORD_KIND: Final[str] = "response_page"
+RESPONSE_PAGE_CONTRACT_VERSION: Final[str] = "1"
+
+SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS: Final[frozenset[str]] = frozenset(
+    {CORE_ROUTING_CONTRACT_VERSION}
+)
+SUPPORTED_QR_SCHEMAS: Final[frozenset[str]] = frozenset({PDS2_SCHEMA})
+SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS: Final[frozenset[str]] = frozenset(
+    {ROUTE_REGISTRATION_SCHEMA_VERSION}
+)
+DISPATCHABLE_ROUTE_STATUSES: Final[frozenset[str]] = frozenset({"active"})
+
+__all__ = [
+    "DISPATCHABLE_ROUTE_STATUSES",
+    "QUILLAN_DISPLAY_NAME",
+    "QUILLAN_MODULE_ID",
+    "RESPONSE_PAGE_CONTRACT_VERSION",
+    "RESPONSE_PAGE_RECORD_KIND",
+    "SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS",
+    "SUPPORTED_QR_SCHEMAS",
+    "SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
--e ../pds-core
+# Development dependencies are authoritative in pyproject.toml.
 -e .[dev]

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,3 +1,7 @@
+param(
+    [string]$Python = "python"
+)
+
 $ErrorActionPreference = "Stop"
 
 function Invoke-Check {
@@ -17,9 +21,21 @@ function Invoke-Check {
     }
 }
 
-Invoke-Check "Running pytest..." { python -m pytest --basetemp .\.pytest-tmp }
-Invoke-Check "Running Ruff..." { python -m ruff check . }
-Invoke-Check "Running mypy..." { python -m mypy . }
+$ResolvedPython = (Get-Command $Python -ErrorAction Stop).Source
+Write-Host "Using Python: $ResolvedPython"
+
+Invoke-Check "Installing Quillan with development extras..." {
+    & $ResolvedPython -m pip install -e ".[dev]"
+}
+Invoke-Check "Checking installed dependencies..." { & $ResolvedPython -m pip check }
+Invoke-Check "Verifying installed imports..." {
+    & $ResolvedPython -c "import pds_core; import quillan.pds_contract; import quillan.cli"
+}
+Invoke-Check "Running pytest..." {
+    & $ResolvedPython -m pytest --basetemp .\.pytest-tmp
+}
+Invoke-Check "Running Ruff..." { & $ResolvedPython -m ruff check . }
+Invoke-Check "Running mypy..." { & $ResolvedPython -m mypy . }
 Invoke-Check "Checking diff whitespace..." { git diff --check }
 
 Write-Host "All checks passed."

--- a/scripts/validate_development_install.ps1
+++ b/scripts/validate_development_install.ps1
@@ -1,0 +1,373 @@
+param(
+    [string]$Python = "python",
+    [string]$PdsCoreWheel
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptPrefix = "pds-quillan-install-"
+$Failures = [System.Collections.Generic.List[string]]::new()
+
+function Invoke-Required {
+    param(
+        [Parameter(Mandatory)] [string]$Description,
+        [Parameter(Mandatory)] [string]$FilePath,
+        [Parameter(Mandatory)] [string[]]$ArgumentList
+    )
+
+    Write-Host $Description
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Invoke-Captured {
+    param(
+        [Parameter(Mandatory)] [string]$Description,
+        [Parameter(Mandatory)] [string]$FilePath,
+        [Parameter(Mandatory)] [string[]]$ArgumentList,
+        [Parameter(Mandatory)] [string]$CaptureDirectory
+    )
+
+    $SafeName = $Description -replace '[^A-Za-z0-9]+', '-'
+    $StdoutPath = Join-Path $CaptureDirectory "$SafeName.stdout.txt"
+    $StderrPath = Join-Path $CaptureDirectory "$SafeName.stderr.txt"
+    $PreviousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & $FilePath @ArgumentList 1> $StdoutPath 2> $StderrPath
+        $ExitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $PreviousErrorActionPreference
+    }
+    $Stdout = Get-Content -LiteralPath $StdoutPath -Raw -ErrorAction SilentlyContinue
+    $Stderr = Get-Content -LiteralPath $StderrPath -Raw -ErrorAction SilentlyContinue
+    Write-Host "$Description exit code: $ExitCode"
+    Write-Host "$Description stdout:"
+    Write-Host $Stdout
+    Write-Host "$Description stderr:"
+    Write-Host $Stderr
+    return [pscustomobject]@{
+        ExitCode = $ExitCode
+        Stdout = $Stdout
+        Stderr = $Stderr
+    }
+}
+
+function Add-Failure {
+    param([Parameter(Mandatory)] [string]$Message)
+    $Failures.Add($Message)
+    Write-Host "FAIL: $Message"
+}
+
+function Assert-WorkspaceAbsent {
+    param(
+        [Parameter(Mandatory)] [string]$Operation,
+        [Parameter(Mandatory)] [string]$WorkspaceRoot
+    )
+    if (Test-Path -LiteralPath $WorkspaceRoot) {
+        Add-Failure "$Operation created the configured workspace: $WorkspaceRoot"
+    }
+    else {
+        Write-Host "$Operation workspace side-effect check: PASS"
+    }
+}
+
+function Remove-ValidatedTemporaryRoot {
+    param(
+        [Parameter(Mandatory)] [string]$TemporaryRoot,
+        [Parameter(Mandatory)] [string]$Repository,
+        [Parameter(Mandatory)] [string]$RepositoryParent,
+        [Parameter(Mandatory)] [string]$OriginalLocation
+    )
+
+    if (-not (Test-Path -LiteralPath $TemporaryRoot)) {
+        return
+    }
+    $ResolvedRoot = (Resolve-Path -LiteralPath $TemporaryRoot).Path.TrimEnd('\')
+    $ResolvedTemp = [System.IO.Path]::GetFullPath(
+        [System.IO.Path]::GetTempPath()
+    ).TrimEnd('\')
+    $Leaf = Split-Path $ResolvedRoot -Leaf
+    $HomePath = [System.IO.Path]::GetFullPath(
+        [Environment]::GetFolderPath('UserProfile')
+    ).TrimEnd('\')
+    $DriveRoot = [System.IO.Path]::GetPathRoot($ResolvedRoot).TrimEnd('\')
+    $Forbidden = @(
+        $Repository.TrimEnd('\'),
+        $RepositoryParent.TrimEnd('\'),
+        $HomePath,
+        $DriveRoot,
+        $OriginalLocation.TrimEnd('\')
+    )
+    if (-not $ResolvedRoot.StartsWith($ResolvedTemp + '\')) {
+        throw "Refusing to delete temporary root outside OS temp: $ResolvedRoot"
+    }
+    if (-not $Leaf.StartsWith($ScriptPrefix)) {
+        throw "Refusing to delete temporary root with unexpected name: $ResolvedRoot"
+    }
+    if ($Forbidden -contains $ResolvedRoot) {
+        throw "Refusing to delete protected path: $ResolvedRoot"
+    }
+    Remove-Item -LiteralPath $ResolvedRoot -Recurse -Force
+    Write-Host "Temporary root cleanup: PASS ($ResolvedRoot)"
+}
+
+$Repository = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$RepositoryParent = (Split-Path $Repository -Parent)
+$OriginalLocation = (Get-Location).Path
+$TemporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "$ScriptPrefix$([guid]::NewGuid().ToString('N'))"
+)
+if (Test-Path -LiteralPath $TemporaryRoot) {
+    throw "Refusing to reuse temporary root: $TemporaryRoot"
+}
+
+$WheelInput = if ($PSBoundParameters.ContainsKey('PdsCoreWheel')) {
+    $PdsCoreWheel
+}
+elseif ($env:PDS_CORE_WHEEL) {
+    $env:PDS_CORE_WHEEL
+}
+else {
+    $null
+}
+$ResolvedCoreWheel = $null
+if ($WheelInput) {
+    $ResolvedCoreWheel = (Resolve-Path -LiteralPath $WheelInput).Path
+    if (-not (Test-Path -LiteralPath $ResolvedCoreWheel -PathType Leaf)) {
+        throw "PDS Core wheel is not a regular file: $ResolvedCoreWheel"
+    }
+    if ([System.IO.Path]::GetExtension($ResolvedCoreWheel) -ne '.whl') {
+        throw "PDS Core wheel must have a .whl extension: $ResolvedCoreWheel"
+    }
+    Write-Host "Core installation source: supplied wheel $ResolvedCoreWheel"
+}
+else {
+    Write-Host "Core installation source: normal pip dependency resolution"
+}
+
+$HadWorkspaceRoot = Test-Path Env:PDS_WORKSPACE_ROOT
+$PreviousWorkspaceRoot = $env:PDS_WORKSPACE_ROOT
+$PreviousPath = $env:PATH
+
+try {
+    New-Item -ItemType Directory -Path $TemporaryRoot -ErrorAction Stop | Out-Null
+    foreach ($Mode in @('editable', 'noneditable')) {
+        Write-Host "=== Validating $Mode installation ==="
+        $ModeRoot = Join-Path $TemporaryRoot $Mode
+        $EnvironmentRoot = Join-Path $ModeRoot 'venv'
+        $WorkingDirectory = Join-Path $ModeRoot 'work'
+        $CaptureDirectory = Join-Path $ModeRoot 'captures'
+        $WorkspaceRoot = Join-Path $ModeRoot 'workspace-must-not-exist'
+        New-Item -ItemType Directory -Path $WorkingDirectory | Out-Null
+        New-Item -ItemType Directory -Path $CaptureDirectory | Out-Null
+        Invoke-Required "Creating $Mode virtual environment" $Python @(
+            '-m', 'venv', $EnvironmentRoot
+        )
+
+        $EnvironmentPython = Join-Path $EnvironmentRoot 'Scripts\python.exe'
+        $EnvironmentScripts = Join-Path $EnvironmentRoot 'Scripts'
+        $QuillanCommand = Join-Path $EnvironmentScripts 'quillan.exe'
+        if ($ResolvedCoreWheel) {
+            Invoke-Required "Installing supplied Core wheel into $Mode environment" `
+                $EnvironmentPython @('-m', 'pip', 'install', '--quiet', $ResolvedCoreWheel)
+        }
+
+        $InstallTarget = "$Repository[dev]"
+        $InstallArguments = @('-m', 'pip', 'install', '--quiet')
+        if ($Mode -eq 'editable') {
+            $InstallArguments += '-e'
+        }
+        $InstallArguments += $InstallTarget
+        Push-Location $WorkingDirectory
+        try {
+            & $EnvironmentPython @InstallArguments
+            $InstallExitCode = $LASTEXITCODE
+        }
+        finally {
+            Pop-Location
+        }
+        if ($InstallExitCode -ne 0) {
+            if (-not $ResolvedCoreWheel) {
+                throw (
+                    "Quillan requires pds-core>=0.5,<0.6, but no compatible " +
+                    "distribution was resolved. Supply a verified Core wheel with " +
+                    "-PdsCoreWheel or PDS_CORE_WHEEL. This script will not fall " +
+                    "back to a neighboring source checkout."
+                )
+            }
+            throw "Installing Quillan in $Mode mode failed with exit code $InstallExitCode."
+        }
+
+        Invoke-Required "Running pip check in $Mode environment" `
+            $EnvironmentPython @('-m', 'pip', 'check')
+
+        $MetadataCheck = @'
+import importlib.metadata as metadata
+import json
+import pathlib
+import sys
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+quillan = metadata.distribution('quillan')
+requirements = [Requirement(value) for value in quillan.requires or []]
+core = [value for value in requirements if value.name == 'pds-core']
+assert len(core) == 1, core
+assert core[0].url is None, core[0]
+assert {str(value) for value in core[0].specifier} == {'>=0.5', '<0.6'}, core[0]
+installed_core = metadata.distribution('pds-core')
+assert Version(installed_core.version) in SpecifierSet('>=0.5,<0.6'), installed_core.version
+scripts = [entry for entry in quillan.entry_points if entry.group == 'console_scripts']
+assert any(entry.name == 'quillan' and entry.value == 'quillan.cli:main' for entry in scripts), scripts
+print(json.dumps({
+    'quillan_version': quillan.version,
+    'quillan_location': str(pathlib.Path(quillan.locate_file('')).resolve()),
+    'core_requirement': str(core[0]),
+    'core_version': installed_core.version,
+    'core_location': str(pathlib.Path(installed_core.locate_file('')).resolve()),
+    'console_script': 'quillan=quillan.cli:main',
+}, indent=2, sort_keys=True))
+'@
+        $MetadataResult = Invoke-Captured "$Mode distribution metadata" `
+            $EnvironmentPython @('-c', $MetadataCheck) $CaptureDirectory
+        if ($MetadataResult.ExitCode -ne 0) {
+            Add-Failure "$Mode distribution metadata validation failed"
+        }
+
+        $env:PDS_WORKSPACE_ROOT = $WorkspaceRoot
+        if (Test-Path -LiteralPath $WorkspaceRoot) {
+            throw "Configured test workspace unexpectedly exists: $WorkspaceRoot"
+        }
+        $CommonImportCheck = @'
+import json
+import pathlib
+import sys
+import pds_core
+import quillan
+import quillan.pds_contract
+
+def locations(module):
+    if getattr(module, '__file__', None):
+        return [str(pathlib.Path(module.__file__).resolve())]
+    return [str(pathlib.Path(value).resolve()) for value in module.__path__]
+
+environment = pathlib.Path(sys.argv[1]).resolve()
+repository = pathlib.Path(sys.argv[2]).resolve()
+mode = sys.argv[3]
+paths = {
+    'pds_core': locations(pds_core),
+    'quillan': locations(quillan),
+    'quillan.pds_contract': locations(quillan.pds_contract),
+}
+assert all(pathlib.Path(value).is_relative_to(environment) for value in paths['pds_core']), paths
+if mode == 'noneditable':
+    for name in ('quillan', 'quillan.pds_contract'):
+        assert all(not pathlib.Path(value).is_relative_to(repository) for value in paths[name]), paths
+print(json.dumps(paths, indent=2, sort_keys=True))
+'@
+        Push-Location $WorkingDirectory
+        try {
+            $ContractResult = Invoke-Captured "$Mode contract import" `
+                $EnvironmentPython @(
+                    '-c', $CommonImportCheck, $EnvironmentRoot, $Repository, $Mode
+                ) $CaptureDirectory
+        }
+        finally {
+            Pop-Location
+        }
+        if ($ContractResult.ExitCode -ne 0) {
+            Add-Failure "$Mode contract import failed"
+        }
+        Assert-WorkspaceAbsent "$Mode contract import" $WorkspaceRoot
+
+        $CliImportCheck = @'
+import json
+import pathlib
+import sys
+import quillan.cli
+
+path = pathlib.Path(quillan.cli.__file__).resolve()
+repository = pathlib.Path(sys.argv[1]).resolve()
+if sys.argv[2] == 'noneditable':
+    assert not path.is_relative_to(repository), path
+print(json.dumps({'quillan.cli': str(path)}, indent=2))
+'@
+        Push-Location $WorkingDirectory
+        try {
+            $CliImportResult = Invoke-Captured "$Mode CLI import" `
+                $EnvironmentPython @('-c', $CliImportCheck, $Repository, $Mode) `
+                $CaptureDirectory
+        }
+        finally {
+            Pop-Location
+        }
+        if ($CliImportResult.ExitCode -ne 0) {
+            Add-Failure "$Mode CLI import failed"
+        }
+        Assert-WorkspaceAbsent "$Mode CLI import" $WorkspaceRoot
+
+        if (-not (Test-Path -LiteralPath $QuillanCommand -PathType Leaf)) {
+            Add-Failure "$Mode absolute console command is missing: $QuillanCommand"
+        }
+        else {
+            Push-Location $WorkingDirectory
+            try {
+                $AbsoluteHelp = Invoke-Captured "$Mode absolute CLI help" `
+                    $QuillanCommand @('--help') $CaptureDirectory
+            }
+            finally {
+                Pop-Location
+            }
+            if (
+                $AbsoluteHelp.ExitCode -ne 0 -or
+                [string]::IsNullOrWhiteSpace($AbsoluteHelp.Stdout) -or
+                $AbsoluteHelp.Stdout -match 'Traceback|unhandled exception' -or
+                $AbsoluteHelp.Stderr -match 'Traceback|unhandled exception'
+            ) {
+                Add-Failure "$Mode absolute CLI help failed"
+            }
+        }
+        Assert-WorkspaceAbsent "$Mode absolute CLI help" $WorkspaceRoot
+
+        $env:PATH = "$EnvironmentScripts;$PreviousPath"
+        Push-Location $WorkingDirectory
+        try {
+            $PathHelp = Invoke-Captured "$Mode PATH CLI help" `
+                'quillan' @('--help') $CaptureDirectory
+        }
+        finally {
+            Pop-Location
+            $env:PATH = $PreviousPath
+        }
+        if (
+            $PathHelp.ExitCode -ne 0 -or
+            [string]::IsNullOrWhiteSpace($PathHelp.Stdout) -or
+            $PathHelp.Stdout -match 'Traceback|unhandled exception' -or
+            $PathHelp.Stderr -match 'Traceback|unhandled exception'
+        ) {
+            Add-Failure "$Mode PATH CLI help failed"
+        }
+        Assert-WorkspaceAbsent "$Mode PATH CLI help" $WorkspaceRoot
+    }
+
+    if ($Failures.Count -gt 0) {
+        throw "Installation validation failed: $($Failures -join '; ')"
+    }
+    Write-Host "Editable and noneditable installation validation passed."
+}
+finally {
+    Set-Location $OriginalLocation
+    $env:PATH = $PreviousPath
+    if ($HadWorkspaceRoot) {
+        $env:PDS_WORKSPACE_ROOT = $PreviousWorkspaceRoot
+    }
+    else {
+        Remove-Item Env:PDS_WORKSPACE_ROOT -ErrorAction SilentlyContinue
+    }
+    Remove-ValidatedTemporaryRoot $TemporaryRoot $Repository `
+        $RepositoryParent $OriginalLocation
+}

--- a/tests/test_packaging_baseline.py
+++ b/tests/test_packaging_baseline.py
@@ -1,0 +1,85 @@
+"""Regression tests for Quillan's installed-package baseline."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+
+
+def _configuration() -> dict[str, object]:
+    with (REPOSITORY / "pyproject.toml").open("rb") as project_file:
+        return tomllib.load(project_file)
+
+
+def test_runtime_declares_one_ordinary_core_requirement() -> None:
+    project = _configuration()["project"]
+    assert isinstance(project, dict)
+    dependencies = project["dependencies"]
+    assert isinstance(dependencies, list)
+
+    core_values = [
+        value
+        for value in dependencies
+        if Requirement(value).name == "pds-core"
+    ]
+    assert core_values == ["pds-core>=0.5,<0.6"]
+
+    requirement = Requirement(core_values[0])
+    assert requirement.name.lower().replace("_", "-") == "pds-core"
+    assert requirement.url is None
+    assert {str(value) for value in requirement.specifier} == {">=0.5", "<0.6"}
+    assert "@" not in core_values[0]
+    assert not any(
+        marker in core_values[0].lower()
+        for marker in ("file:", "git+", "hg+", "svn+", "bzr+", "../", "..\\")
+    )
+
+
+def test_development_extras_declare_packaging_directly() -> None:
+    project = _configuration()["project"]
+    assert isinstance(project, dict)
+    optional_dependencies = project["optional-dependencies"]
+    assert isinstance(optional_dependencies, dict)
+    dev_dependencies = optional_dependencies["dev"]
+    assert isinstance(dev_dependencies, list)
+
+    names = {Requirement(value).name for value in dev_dependencies}
+    assert "packaging" in names
+
+
+def test_setuptools_build_and_complete_namespace_discovery_are_explicit() -> None:
+    configuration = _configuration()
+    assert configuration["build-system"] == {
+        "requires": ["setuptools>=61"],
+        "build-backend": "setuptools.build_meta",
+    }
+
+    tool = configuration["tool"]
+    assert isinstance(tool, dict)
+    discovery = tool["setuptools"]["packages"]["find"]
+    assert discovery == {
+        "where": ["."],
+        "include": ["quillan*"],
+        "namespaces": True,
+    }
+
+
+def test_mypy_does_not_use_core_source_paths_or_global_import_suppression() -> None:
+    tool = _configuration()["tool"]
+    assert isinstance(tool, dict)
+    mypy = tool["mypy"]
+    assert "mypy_path" not in mypy
+    assert mypy.get("ignore_missing_imports") is not True
+
+
+def test_requirements_dev_installs_only_local_quillan_extras() -> None:
+    content = (REPOSITORY / "requirements-dev.txt").read_text(encoding="utf-8")
+    assert content == (
+        "# Development dependencies are authoritative in pyproject.toml.\n"
+        "-e .[dev]\n"
+    )
+    assert "../pds-core" not in content

--- a/tests/test_pds_contract.py
+++ b/tests/test_pds_contract.py
@@ -1,0 +1,111 @@
+"""Tests for Quillan's stable PDS2 integration constants."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from pds_core.identifiers import validate_identifier
+from pds_core.module_profiles import CORE_ROUTING_CONTRACT_VERSION
+from pds_core.routing_models import (
+    PDS2_SCHEMA,
+    ROUTE_REGISTRATION_SCHEMA_VERSION,
+    ModuleRecordRef,
+)
+
+from quillan.pds_contract import (
+    DISPATCHABLE_ROUTE_STATUSES,
+    QUILLAN_DISPLAY_NAME,
+    QUILLAN_MODULE_ID,
+    RESPONSE_PAGE_CONTRACT_VERSION,
+    RESPONSE_PAGE_RECORD_KIND,
+    SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS,
+    SUPPORTED_QR_SCHEMAS,
+    SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS,
+)
+import quillan.pds_contract as pds_contract
+
+PUBLIC_CONTRACT_CONSTANTS = {
+    "DISPATCHABLE_ROUTE_STATUSES",
+    "QUILLAN_DISPLAY_NAME",
+    "QUILLAN_MODULE_ID",
+    "RESPONSE_PAGE_CONTRACT_VERSION",
+    "RESPONSE_PAGE_RECORD_KIND",
+    "SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS",
+    "SUPPORTED_QR_SCHEMAS",
+    "SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS",
+}
+
+
+def test_quillan_contract_has_approved_values() -> None:
+    assert QUILLAN_MODULE_ID == "quillan"
+    assert QUILLAN_DISPLAY_NAME == "Quillan"
+    assert RESPONSE_PAGE_RECORD_KIND == "response_page"
+    assert RESPONSE_PAGE_CONTRACT_VERSION == "1"
+    assert SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS == frozenset(
+        {CORE_ROUTING_CONTRACT_VERSION}
+    )
+    assert SUPPORTED_QR_SCHEMAS == frozenset({PDS2_SCHEMA})
+    assert SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS == frozenset(
+        {ROUTE_REGISTRATION_SCHEMA_VERSION}
+    )
+    assert DISPATCHABLE_ROUTE_STATUSES == frozenset({"active"})
+
+
+def test_contract_exports_exactly_the_public_constants() -> None:
+    assert len(pds_contract.__all__) == len(PUBLIC_CONTRACT_CONSTANTS)
+    assert set(pds_contract.__all__) == PUBLIC_CONTRACT_CONSTANTS
+
+
+@pytest.mark.parametrize(
+    "collection",
+    [
+        SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS,
+        SUPPORTED_QR_SCHEMAS,
+        SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS,
+        DISPATCHABLE_ROUTE_STATUSES,
+    ],
+)
+def test_compatibility_collections_are_immutable(collection: frozenset[str]) -> None:
+    assert isinstance(collection, frozenset)
+    assert not hasattr(collection, "add")
+    hash(collection)
+
+
+def test_response_page_target_is_valid_for_core_models() -> None:
+    assert validate_identifier(QUILLAN_MODULE_ID) == QUILLAN_MODULE_ID
+    assert validate_identifier(RESPONSE_PAGE_RECORD_KIND) == RESPONSE_PAGE_RECORD_KIND
+
+    target = ModuleRecordRef(
+        module_id=QUILLAN_MODULE_ID,
+        record_kind=RESPONSE_PAGE_RECORD_KIND,
+        record_id="synthetic_response_page_1",
+        contract_version=RESPONSE_PAGE_CONTRACT_VERSION,
+    )
+
+    assert target.module_id == QUILLAN_MODULE_ID
+    assert target.record_kind == RESPONSE_PAGE_RECORD_KIND
+    assert target.record_id == "synthetic_response_page_1"
+    assert target.contract_version == RESPONSE_PAGE_CONTRACT_VERSION
+
+
+def test_contract_import_has_no_output_or_workspace_side_effects(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace-must-not-exist"
+    environment = os.environ.copy()
+    environment["PDS_WORKSPACE_ROOT"] = str(workspace)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import quillan.pds_contract"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert not workspace.exists()


### PR DESCRIPTION
## Summary

Establishes Quillan’s PDS Core 0.5 package, typing, installation, and PDS2 contract baseline as the first implementation step under #329.

Closes #333.

## Changes

* Declares `pds-core>=0.5,<0.6` as an ordinary runtime dependency.
* Adds an explicit setuptools PEP 517 build backend and package discovery.
* Removes the development dependency on a sibling `../pds-core` checkout.
* Removes the sibling Core `mypy_path`.
* Adds a narrow mypy override for inspecting the installed Core 0.5 source package.
* Declares `packaging` as a direct development dependency.
* Adds `quillan.pds_contract` as the side-effect-free source of Quillan’s PDS2 integration constants.
* Adds focused contract and packaging regression tests.
* Updates `run_tests.ps1` to install Quillan, run `pip check`, verify imports, and preserve the full fail-fast validation sequence.
* Adds isolated editable and noneditable installation validation.
* Updates local-development documentation for wheel-based Core 0.5 installation.
* Adds no PDS1 compatibility shim, legacy-path fallback, or dual-format behavior.

## PDS2 Contract Baseline

The new Quillan-owned contract establishes:

```text
module ID:                 quillan
display name:              Quillan
response-page record kind: response_page
record contract version:   1
supported QR schema:       PDS2
dispatchable route status: active
```

Shared routing and registration versions are imported from PDS Core rather than duplicated as independent Quillan literals.

## Validation

### Passed

* Focused pytest: **13 passed**
* Editable package installation
* Noneditable package installation
* Distribution metadata validation
* Installed console-script entry-point validation
* `pip check`
* PDS Core import
* Quillan PDS2 contract import
* Import-origin validation
* Workspace side-effect checks
* Focused Ruff
* Full Ruff
* Focused mypy
* `git diff --check`

### Known intermediate migration failures

This change intentionally installs Quillan against the PDS2-only Core 0.5 contract before all existing Quillan runtime surfaces have been migrated.

The following repository-wide checks remain red:

* CLI import and `quillan --help`
* full pytest
* full mypy
* `run_tests.ps1`

The failures come from untouched Quillan code that still imports:

* removed unqualified assignment-path helpers;
* removed PDS1 payload APIs;
* and obsolete Core scan metadata fields and signatures.

The failures are inventoried and assigned to the sequenced migration work in #334–#342. No compatibility code, fallback path, import suppression, or PDS1 restoration was introduced to conceal them.

## Current Failure Baseline

```text
Full pytest:
562 passed
38 failed
62 collection errors

Full mypy:
56 errors in 13 files
```

The files introduced or modified by #333 pass their focused tests, Ruff checks, and mypy checks.

## Architectural Scope

This PR establishes the package and contract foundation only. It does not yet implement:

* module-qualified Quillan work paths;
* immutable response-page persistence;
* PDS2 packet generation;
* Core route registrations;
* the installed Quillan module profile;
* Core scan dispatch;
* routed-evidence migration;
* submission-assembly migration;
* or the removal of all remaining PDS1-era runtime surfaces.

Those changes are owned by the subsequent issues under #329.

## Compatibility Policy

Quillan is undergoing a PDS2-only hard cutover.

There is no support for:

* PDS1 generation;
* PDS1 semantic parsing or routing;
* legacy unqualified assignment paths;
* read-only legacy compatibility;
* workspace conversion or migration;
* dual-format records;
* or feature flags restoring legacy behavior.
