### PR TITLE
Define Quillan module-qualified work paths (#334)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,21 +54,31 @@ Canonical active records and exports live at:
 
 ```text
 classes/<class_id>/roster.csv
-classes/<class_id>/assignments/<assignment_id>/assignment.json
-classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
-classes/<class_id>/assignments/<assignment_id>/scans/
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
-classes/<class_id>/assignments/<assignment_id>/exports/student_performance_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/response_pages/
+classes/<class_id>/modules/quillan/work/<assignment_id>/templates/printable_response_pages.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/scans/
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/student_performance_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
 shared/focus_standard_comments/<comment_set_id>.json
 shared/standards/library.json
 scans/source/YYYY-MM-DD/
 scans/review/
 ```
+
+An assignment ID is Quillan's `work_id`; its complete identity is the module,
+class, and work ID. The class roster remains a shared Core-owned class record.
+Within Quillan work, `scans/` stores Quillan-routed evidence rather than Core's
+retained source scan, while `routes/` is reserved for Core-owned route
+registrations. Quillan supports only the module-qualified tree above: there is
+no unqualified assignment path, legacy migration, or fallback. This layout does
+not yet claim response-page persistence, PDS2 generation or routing, submission
+assembly, or completion of the CLI migration.
 
 ## Teacher-Facing Menu
 
@@ -104,7 +114,7 @@ Assignment Management supports:
 Assignment creation requires an existing roster and writes:
 
 ```text
-<workspace_root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+<workspace_root>/classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
 Printable response packets can also be generated non-interactively:
@@ -201,16 +211,16 @@ Student feedback export reads a valid matching `submission.json` and
 schema-version-2 `review.json` and can write:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
 The three assignment-local CSV reports are:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/student_performance_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/student_performance_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
 ```
 
 Student Performance Summary is the compact ordinary teacher-facing table.

--- a/examples/exports/assignment_results_manifest_v2_synthetic.json
+++ b/examples/exports/assignment_results_manifest_v2_synthetic.json
@@ -4,7 +4,7 @@
   "record_type": "assignment_results_manifest",
   "class_id": "english_10_simulation",
   "assignment_id": "coming-of-age_literary_analysis",
-  "assignment_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/assignment.json",
+  "assignment_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/assignment.json",
   "standards_profile_id": "english10_2023_njsls_ela",
   "focus_standard_ids": [
     "njsls-ela:RL.CR.9-10.1",
@@ -13,7 +13,7 @@
   ],
   "exports": {
     "class_summary_csv": {
-      "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/exports/class_summary.csv",
+      "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/exports/class_summary.csv",
       "format": "csv",
       "generated_at": "2026-07-02T00:00:00+00:00",
       "stale": false,
@@ -21,7 +21,7 @@
     },
     "class_summary_pdf": null,
     "standards_summary_csv": {
-      "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/exports/standards_summary.csv",
+      "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/exports/standards_summary.csv",
       "format": "csv",
       "generated_at": "2026-07-02T00:00:00+00:00",
       "stale": false,
@@ -41,10 +41,10 @@
       "student_id": "10001",
       "student_display_name": "Sample Student",
       "roster_status": "rostered",
-      "submission_manifest_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/submission.json",
+      "submission_manifest_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/submission.json",
       "submission_state": "reviewed",
       "submission_valid": true,
-      "review_record_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/review.json",
+      "review_record_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/review.json",
       "review_state": "ready_for_export",
       "review_valid": true,
       "minimum_requirement_status": "met",
@@ -71,12 +71,12 @@
       ],
       "feedback_exports": {
         "feedback_pdf": {
-          "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/exports/feedback.pdf",
+          "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/exports/feedback.pdf",
           "status": "present",
           "stale": false
         },
         "feedback_markdown": {
-          "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/exports/feedback.md",
+          "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/exports/feedback.md",
           "status": "present",
           "stale": false
         }
@@ -88,10 +88,10 @@
       "student_id": "10002",
       "student_display_name": "Jordan Example",
       "roster_status": "rostered",
-      "submission_manifest_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10002/submission.json",
+      "submission_manifest_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10002/submission.json",
       "submission_state": "reviewed",
       "submission_valid": true,
-      "review_record_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10002/review.json",
+      "review_record_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10002/review.json",
       "review_state": "returned_without_full_review",
       "review_valid": true,
       "minimum_requirement_status": "returned_without_full_review",
@@ -99,7 +99,7 @@
       "overall_standard_ratings": [],
       "feedback_exports": {
         "feedback_pdf": {
-          "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10002/exports/feedback.pdf",
+          "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10002/exports/feedback.pdf",
           "status": "present",
           "stale": false
         },
@@ -118,10 +118,10 @@
       "student_id": "10003",
       "student_display_name": "Casey Synthetic",
       "roster_status": "rostered",
-      "submission_manifest_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10003/submission.json",
+      "submission_manifest_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10003/submission.json",
       "submission_state": "in_progress",
       "submission_valid": true,
-      "review_record_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10003/review.json",
+      "review_record_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10003/review.json",
       "review_state": "observations_in_progress",
       "review_valid": true,
       "minimum_requirement_status": "met",
@@ -189,10 +189,10 @@
       "student_id": "19999",
       "student_display_name": "Unrostered Example",
       "roster_status": "unrostered_submission",
-      "submission_manifest_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/19999/submission.json",
+      "submission_manifest_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/19999/submission.json",
       "submission_state": "reviewed",
       "submission_valid": true,
-      "review_record_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/19999/review.json",
+      "review_record_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/19999/review.json",
       "review_state": "feedback_composed",
       "review_valid": true,
       "minimum_requirement_status": "met",

--- a/examples/exports/feedback_export_v2_synthetic.json
+++ b/examples/exports/feedback_export_v2_synthetic.json
@@ -6,13 +6,13 @@
 "primary_export_format": "pdf",
 "companion_export_format": "markdown",
 "source_records": {
-"assignment_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/assignment.json",
-"submission_manifest_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/submission.json",
-"review_record_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/review.json"
+"assignment_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/assignment.json",
+"submission_manifest_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/submission.json",
+"review_record_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/review.json"
 },
 "export_metadata": {
 "feedback_pdf": {
-"path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/exports/feedback.pdf",
+"path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/exports/feedback.pdf",
 "format": "pdf",
 "generated_at": "2026-07-02T00:00:00+00:00",
 "source_review_updated_at": "2026-07-02T00:00:00+00:00",
@@ -21,7 +21,7 @@
 "module_details": {}
 },
 "feedback_markdown": {
-"path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/exports/feedback.md",
+"path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/exports/feedback.md",
 "format": "markdown",
 "generated_at": "2026-07-02T00:00:00+00:00",
 "source_review_updated_at": "2026-07-02T00:00:00+00:00",

--- a/examples/submissions/review_record_synthetic.json
+++ b/examples/submissions/review_record_synthetic.json
@@ -5,7 +5,7 @@
   "class_id": "english12_p3_synthetic",
   "assignment_id": "essay_01_synthetic",
   "student_id": "00107",
-  "submission_manifest_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/submissions/00107/submission.json",
+  "submission_manifest_path": "classes/english12_p3_synthetic/modules/quillan/work/essay_01_synthetic/submissions/00107/submission.json",
   "review_state": "in_progress",
   "notes": [
     {

--- a/examples/submissions/review_record_v2_synthetic.json
+++ b/examples/submissions/review_record_v2_synthetic.json
@@ -5,8 +5,8 @@
   "class_id": "english_10_simulation",
   "assignment_id": "coming-of-age_literary_analysis",
   "student_id": "10001",
-  "submission_manifest_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/submission.json",
-  "assignment_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/assignment.json",
+  "submission_manifest_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/submission.json",
+  "assignment_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/assignment.json",
   "review_state": "feedback_composed",
   "minimum_requirement_checks": [
     {

--- a/examples/submissions/submission_manifest_synthetic.json
+++ b/examples/submissions/submission_manifest_synthetic.json
@@ -15,7 +15,7 @@
       "evidence": [
         {
           "evidence_id": "evidence_001",
-          "routed_evidence_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/scans/response_00107_pg_001.pdf",
+          "routed_evidence_path": "classes/english12_p3_synthetic/modules/quillan/work/essay_01_synthetic/scans/response_00107_pg_001.pdf",
           "evidence_role": "selected",
           "evidence_state": "active",
           "duplicate_number": null,
@@ -44,7 +44,7 @@
       "evidence": [
         {
           "evidence_id": "evidence_002",
-          "routed_evidence_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/scans/response_00107_pg_003.pdf",
+          "routed_evidence_path": "classes/english12_p3_synthetic/modules/quillan/work/essay_01_synthetic/scans/response_00107_pg_003.pdf",
           "evidence_role": "candidate",
           "evidence_state": "active",
           "duplicate_number": null,
@@ -60,7 +60,7 @@
         },
         {
           "evidence_id": "evidence_003",
-          "routed_evidence_path": "classes/english12_p3_synthetic/assignments/essay_01_synthetic/scans/response_00107_pg_003__dup_001.pdf",
+          "routed_evidence_path": "classes/english12_p3_synthetic/modules/quillan/work/essay_01_synthetic/scans/response_00107_pg_003__dup_001.pdf",
           "evidence_role": "candidate",
           "evidence_state": "active",
           "duplicate_number": 1,

--- a/quillan/assignment_discovery.py
+++ b/quillan/assignment_discovery.py
@@ -1,0 +1,79 @@
+"""Shared safe direct-child discovery for Quillan assignment work."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    _is_link_like,
+    preflight_quillan_work_collection,
+    quillan_work_paths,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveredAssignment:
+    """One ordinary direct work child and its validated assignment record."""
+
+    assignment_id: str
+    path: Path
+    assignment: dict[str, Any] | None
+    error: str | None
+
+
+def discover_quillan_assignments(
+    workspace_root: str | Path,
+    class_id: str,
+) -> tuple[DiscoveredAssignment, ...]:
+    """Inspect only safe direct children of one Quillan work collection."""
+    try:
+        collection = preflight_quillan_work_collection(workspace_root, class_id)
+    except QuillanWorkPathError:
+        return ()
+    try:
+        entries = sorted(collection.iterdir(), key=lambda entry: entry.name)
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        return ()
+
+    discovered: list[DiscoveredAssignment] = []
+    for entry in entries:
+        try:
+            validate_identifier(entry.name, "assignment_id")
+        except IdentifierValidationError:
+            continue
+        path = quillan_work_paths(
+            workspace_root, class_id, entry.name
+        ).assignment_path
+        try:
+            if _is_link_like(entry) or not entry.is_dir():
+                continue
+            if _is_link_like(path) or not path.is_file():
+                continue
+            assignment = load_assignment_config(path)
+        except (AssignmentConfigError, OSError) as error:
+            discovered.append(
+                DiscoveredAssignment(entry.name, path, None, str(error))
+            )
+            continue
+        if assignment["assignment_id"] != entry.name:
+            discovered.append(
+                DiscoveredAssignment(
+                    entry.name,
+                    path,
+                    None,
+                    "Path assignment_id does not match assignment config "
+                    "assignment_id.",
+                )
+            )
+            continue
+        discovered.append(DiscoveredAssignment(entry.name, path, assignment, None))
+    return tuple(discovered)
+
+
+__all__ = ["DiscoveredAssignment", "discover_quillan_assignments"]

--- a/quillan/assignment_picker.py
+++ b/quillan/assignment_picker.py
@@ -7,8 +7,7 @@ from pathlib import Path
 
 from pds_core.classes import list_class_folders
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
-from quillan.storage import assignment_config_path
+from quillan.assignment_discovery import discover_quillan_assignments
 from quillan.menu_navigation import (
     NavigationChoice,
     navigation_hint,
@@ -95,26 +94,18 @@ def available_assignments(
     workspace_root: Path, class_id: str
 ) -> tuple[AssignmentChoice, ...]:
     """Return valid canonical assignment configs for one class."""
-    assignments_dir = workspace_root / "classes" / class_id / "assignments"
-    if not assignments_dir.is_dir():
-        return ()
     choices: list[AssignmentChoice] = []
-    for assignment_dir in sorted(
-        (path for path in assignments_dir.iterdir() if path.is_dir()),
-        key=lambda path: path.name.casefold(),
-    ):
-        path = assignment_config_path(workspace_root, class_id, assignment_dir.name)
-        try:
-            assignment = load_assignment_config(path)
-        except (AssignmentConfigError, OSError):
+    for discovered in discover_quillan_assignments(workspace_root, class_id):
+        if discovered.assignment is None:
             continue
+        assignment = discovered.assignment
         title = assignment.get("title")
         choices.append(
             AssignmentChoice(
                 class_id=class_id,
-                assignment_id=assignment_dir.name,
+                assignment_id=discovered.assignment_id,
                 title=title if isinstance(title, str) and title.strip() else None,
-                path=path,
+                path=discovered.path,
             )
         )
     return tuple(choices)

--- a/quillan/assignment_summary_context.py
+++ b/quillan/assignment_summary_context.py
@@ -16,6 +16,7 @@ from quillan.submission_manifest import (
     SubmissionManifestError,
     load_submission_manifest,
 )
+from quillan.storage import assignment_config_path, assignment_submissions_dir
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,11 +44,11 @@ class LoadedStudentRecord:
 
 
 def assignment_path(workspace_root: Path, class_id: str, assignment_id: str) -> Path:
-    return workspace_root / "classes" / class_id / "assignments" / assignment_id / "assignment.json"
+    return assignment_config_path(workspace_root, class_id, assignment_id)
 
 
 def submissions_dir(workspace_root: Path, class_id: str, assignment_id: str) -> Path:
-    return workspace_root / "classes" / class_id / "assignments" / assignment_id / "submissions"
+    return assignment_submissions_dir(workspace_root, class_id, assignment_id)
 
 
 def load_assignment(workspace_root: Path, class_id: str, assignment_id: str) -> dict[str, Any]:

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import unicodedata
 from collections.abc import Mapping, Sequence
@@ -28,6 +29,13 @@ from quillan.assignments import (
 )
 from quillan.assignment_picker import prompt_assignment_choice
 from quillan.storage import assignment_config_path
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    initialize_managed_work_layout,
+    preflight_managed_work_layout,
+    preflight_work_file_destination,
+    quillan_work_paths,
+)
 
 _NUMERIC_REQUIREMENTS = (
     "paragraphs_min",
@@ -190,10 +198,20 @@ def write_assignment_config(
             "Assignment class_ids must include the selected class_id."
         )
     assignment_id = str(assignment_data["assignment_id"])
-    path = assignment_config_path(workspace_root, class_id, assignment_id)
-    if path.exists() and not overwrite:
+    paths = quillan_work_paths(workspace_root, class_id, assignment_id)
+    path = paths.assignment_path
+    if path.is_file() and not path.is_symlink() and not overwrite:
         raise FileExistsError(f"Assignment config already exists: {path}")
-    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        preflight_managed_work_layout(paths)
+        preflight_work_file_destination(
+            workspace_root, paths.work_ref, "assignment.json"
+        )
+    except QuillanWorkPathError as error:
+        raise AssignmentConfigError(str(error)) from error
+    if not overwrite and os.path.lexists(path):
+        raise FileExistsError(f"Assignment config already exists: {path}")
+    initialize_managed_work_layout(paths)
     path.write_text(
         json.dumps(assignment_data, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",

--- a/quillan/class_summary_export.py
+++ b/quillan/class_summary_export.py
@@ -22,6 +22,7 @@ from quillan.assignment_summary_context import (
     relative_path_for,
     standard_column_keys,
 )
+from quillan.work_paths import quillan_work_paths
 
 BASE_CSV_COLUMNS: Final[tuple[str, ...]] = (
     "class_id",
@@ -82,15 +83,9 @@ def class_summary_export_path(
     """Return the compatibility path for the comprehensive class summary."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
-    return (
-        Path(workspace_root)
-        / "classes"
-        / class_id
-        / "assignments"
-        / assignment_id
-        / "exports"
-        / "class_summary.csv"
-    )
+    return quillan_work_paths(
+        workspace_root, class_id, assignment_id
+    ).exports_dir / "class_summary.csv"
 
 
 def export_class_review_summary(

--- a/quillan/plain_paper_submission.py
+++ b/quillan/plain_paper_submission.py
@@ -22,6 +22,10 @@ from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
 )
+from quillan.work_paths import (
+    initialize_student_submission_dir,
+    quillan_work_ref,
+)
 
 PLAIN_PAPER_ENTRY_METHOD = "plain_paper_manual"
 PLAIN_PAPER_PHYSICAL_EVIDENCE_STATUS = "teacher_has_external_plain_paper"
@@ -162,6 +166,11 @@ def create_plain_paper_submission(
     validate_submission_manifest(manifest)
     validate_review_record(review)
 
+    initialize_student_submission_dir(
+        workspace_root,
+        quillan_work_ref(class_id, assignment_id),
+        student_id,
+    )
     write_submission_manifest(plan.submission_manifest_path, manifest)
     try:
         write_review_record(plan.review_record_path, review)

--- a/quillan/printable_response.py
+++ b/quillan/printable_response.py
@@ -19,8 +19,12 @@ from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.pdfgen.canvas import Canvas
 
 from quillan.assignments import load_assignment_config
-from quillan.payloads import build_response_payload
-from quillan.storage import assignment_templates_dir
+from quillan.work_paths import (
+    initialize_managed_work_layout,
+    preflight_managed_work_layout,
+    preflight_work_file_destination,
+    quillan_work_paths,
+)
 
 PRINTABLE_RESPONSE_FILENAME: Final = "printable_response_pages.pdf"
 StudentInput: TypeAlias = StudentRecord | Mapping[str, str]
@@ -51,6 +55,8 @@ def build_response_page_context(
     class_label: str | None = None,
 ) -> ResponsePageContext:
     """Build validated display and routing data for one response page."""
+    from quillan.payloads import build_response_payload
+
     display_name = _require_display_text(student_display_name, "student_display_name")
     resolved_assignment_title = _optional_display_text(
         assignment_title, assignment_id, "assignment_title"
@@ -104,9 +110,17 @@ def generate_printable_response_pdf(
         for page_number in range(1, pages_per_student + 1)
     ]
 
-    output_dir = assignment_templates_dir(workspace_root, class_id, assignment_id)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = output_dir / PRINTABLE_RESPONSE_FILENAME
+    paths = quillan_work_paths(workspace_root, class_id, assignment_id)
+    output_path = paths.templates_dir / PRINTABLE_RESPONSE_FILENAME
+    preflight_managed_work_layout(paths)
+    validated_output = preflight_work_file_destination(
+        workspace_root,
+        paths.work_ref,
+        Path("templates") / PRINTABLE_RESPONSE_FILENAME,
+    )
+    if validated_output != output_path:
+        raise ValueError("Printable response destination is not canonical.")
+    initialize_managed_work_layout(paths)
 
     pdf = Canvas(str(output_path), pagesize=letter)
     pdf.setTitle("Quillan Printable Writing Response Pages")

--- a/quillan/printable_response_workflows.py
+++ b/quillan/printable_response_workflows.py
@@ -8,21 +8,16 @@ from typing import cast
 
 from pds_core.classes import ClassFolder, list_class_folders
 from pds_core.rosters import RosterError
-from pds_core.routes import class_assignments_dir
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
-from quillan.cli_app.output import print_generated_printable_response_packet
+from quillan.assignment_discovery import discover_quillan_assignments
+from quillan.assignments import AssignmentConfigError
 from quillan.generated_output_opening import (
     GeneratedOutputOpeningError,
     open_generated_output_file,
     open_generated_output_folder,
 )
 from quillan.printable_response import PRINTABLE_RESPONSE_FILENAME
-from quillan.printable_response_packet import (
-    generate_printable_response_packet,
-    plan_printable_response_packet,
-)
 from quillan.storage import assignment_templates_dir
 
 
@@ -55,34 +50,24 @@ def discover_assignment_configs(
     class_id: str,
 ) -> tuple[AssignmentChoice, ...]:
     """Discover canonical assignment configs for one class folder."""
-    assignments_dir = class_assignments_dir(workspace_root, class_id)
-    try:
-        entries = sorted(assignments_dir.iterdir(), key=lambda entry: entry.name)
-    except (FileNotFoundError, NotADirectoryError):
-        return ()
-
     choices: list[AssignmentChoice] = []
-    for entry in entries:
-        path = entry / "assignment.json"
-        if not entry.is_dir() or not path.is_file():
-            continue
-        try:
-            assignment = load_assignment_config(path)
-        except (AssignmentConfigError, OSError) as error:
+    for discovered in discover_quillan_assignments(workspace_root, class_id):
+        if discovered.assignment is None:
             choices.append(
                 AssignmentChoice(
-                    assignment_id=entry.name,
-                    path=path,
+                    assignment_id=discovered.assignment_id,
+                    path=discovered.path,
                     title=None,
                     class_ids=(),
-                    error=str(error),
+                    error=discovered.error,
                 )
             )
             continue
+        assignment = discovered.assignment
         choices.append(
             AssignmentChoice(
-                assignment_id=cast(str, assignment["assignment_id"]),
-                path=path,
+                assignment_id=discovered.assignment_id,
+                path=discovered.path,
                 title=cast(str, assignment["title"]),
                 class_ids=tuple(cast(list[str], assignment["class_ids"])),
             )
@@ -247,7 +232,12 @@ def _prompt_assignment_selection(
 
 def prompt_generate_class_packet() -> int:
     """Prompt for roster and assignment selection, then generate one class PDF."""
+    from quillan.cli_app.output import print_generated_printable_response_packet
     from quillan.menu import print_menu_header
+    from quillan.printable_response_packet import (
+        generate_printable_response_packet,
+        plan_printable_response_packet,
+    )
 
     print_menu_header("Generate Printable Response Class Packet")
     workspace_root = _workspace_root()

--- a/quillan/review_dashboard.py
+++ b/quillan/review_dashboard.py
@@ -16,6 +16,7 @@ from quillan.assignment_submission_assembly import (
 )
 from quillan.assignment_summary_context import feedback_status, relative_path_for
 from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.storage import assignment_config_path
 from quillan.feedback_export import feedback_export_path, feedback_pdf_export_path
 from quillan.plain_paper_submission import is_plain_paper_submission
 from quillan.review_record import ReviewRecordError, load_review_record
@@ -147,9 +148,7 @@ def build_assignment_review_dashboard(
     except ValueError as error:
         raise ReviewDashboardError(str(error)) from error
     root = Path(workspace_root).resolve(strict=False)
-    assignment_path = (
-        root / "classes" / class_id / "assignments" / assignment_id / "assignment.json"
-    )
+    assignment_path = assignment_config_path(root, class_id, assignment_id)
     try:
         assignment = load_assignment_config(assignment_path)
     except (OSError, AssignmentConfigError) as error:
@@ -473,12 +472,9 @@ def _dashboard(**values: Any) -> AssignmentReviewDashboard:
         standards_profile_id=assignment["standards_profile_id"],
         focus_standard_count=len(assignment["focus_standard_ids"]),
         assignment_path=relative_path_for(
-            values["root"]
-            / "classes"
-            / values["class_id"]
-            / "assignments"
-            / values["assignment_id"]
-            / "assignment.json",
+            assignment_config_path(
+                values["root"], values["class_id"], values["assignment_id"]
+            ),
             values["root"],
         ),
         roster_available=roster_students is not None,

--- a/quillan/review_notes.py
+++ b/quillan/review_notes.py
@@ -29,6 +29,7 @@ from quillan.submission_manifest_paths import (
     submission_manifest_path,
 )
 from quillan.submission_guidance import missing_submission_guidance
+from quillan.work_paths import relative_assignment_path
 
 _SEQUENTIAL_NOTE_ID = re.compile(r"^note_(\d{4})$")
 
@@ -127,9 +128,7 @@ def add_review_note(
             assignment_id=assignment_id,
             student_id=student_id,
             submission_manifest_path=manifest_relative_path,
-            assignment_path=(
-                f"classes/{class_id}/assignments/{assignment_id}/assignment.json"
-            ),
+            assignment_path=relative_assignment_path(class_id, assignment_id),
             created_at=normalized_created_at,
         )
 

--- a/quillan/review_record.py
+++ b/quillan/review_record.py
@@ -11,6 +11,11 @@ from typing import Any, Final, cast
 
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
 
+from quillan.work_paths import (
+    relative_assignment_path,
+    relative_submission_manifest_path,
+)
+
 REVIEW_SCHEMA_VERSION: Final = "2"
 REVIEW_MODULE: Final = "quillan"
 REVIEW_RECORD_TYPE: Final = "submission_review"
@@ -320,14 +325,11 @@ def _validate_assignment_path(record: dict[str, Any]) -> None:
 def _canonical_submission_manifest_path(
     class_id: str, assignment_id: str, student_id: str
 ) -> str:
-    return (
-        f"classes/{class_id}/assignments/{assignment_id}/submissions/"
-        f"{student_id}/submission.json"
-    )
+    return relative_submission_manifest_path(class_id, assignment_id, student_id)
 
 
 def _canonical_assignment_path(class_id: str, assignment_id: str) -> str:
-    return f"classes/{class_id}/assignments/{assignment_id}/assignment.json"
+    return relative_assignment_path(class_id, assignment_id)
 
 
 def _validate_minimum_requirement_checks(value: Any) -> None:

--- a/quillan/review_record_paths.py
+++ b/quillan/review_record_paths.py
@@ -8,9 +8,14 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from pds_core.identifiers import IdentifierValidationError, validate_identifier
-
 from quillan.review_record import validate_review_record
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    _preflight_arbitrary_file_destination,
+    quillan_work_ref,
+    review_record_path as work_review_record_path,
+    student_submission_dir,
+)
 
 
 class ReviewRecordPathError(ValueError):
@@ -24,18 +29,11 @@ def review_record_dir(
     student_id: str,
 ) -> Path:
     """Return the canonical directory for one student's review record."""
-    _validate_identifier(class_id, "class_id")
-    _validate_identifier(assignment_id, "assignment_id")
-    _validate_identifier(student_id, "student_id")
-    return (
-        Path(workspace_root)
-        / "classes"
-        / class_id
-        / "assignments"
-        / assignment_id
-        / "submissions"
-        / student_id
-    )
+    try:
+        work_ref = quillan_work_ref(class_id, assignment_id)
+        return student_submission_dir(workspace_root, work_ref, student_id)
+    except ValueError as error:
+        raise ReviewRecordPathError(str(error)) from error
 
 
 def review_record_path(
@@ -45,10 +43,11 @@ def review_record_path(
     student_id: str,
 ) -> Path:
     """Return the canonical review.json path for one student."""
-    return (
-        review_record_dir(workspace_root, class_id, assignment_id, student_id)
-        / "review.json"
-    )
+    try:
+        work_ref = quillan_work_ref(class_id, assignment_id)
+        return work_review_record_path(workspace_root, work_ref, student_id)
+    except ValueError as error:
+        raise ReviewRecordPathError(str(error)) from error
 
 
 def write_review_record(
@@ -60,6 +59,11 @@ def write_review_record(
     """Validate and safely write a review record as UTF-8 JSON."""
     validate_review_record(record)
     review_path = Path(path)
+
+    try:
+        _preflight_arbitrary_file_destination(review_path)
+    except QuillanWorkPathError as error:
+        raise ReviewRecordPathError(str(error)) from error
 
     if not overwrite and review_path.exists():
         raise ReviewRecordPathError(f"Review record already exists: {review_path}")
@@ -115,10 +119,3 @@ def write_review_record(
                 pass
 
     return review_path
-
-
-def _validate_identifier(value: str, field: str) -> None:
-    try:
-        validate_identifier(value, field)
-    except IdentifierValidationError as error:
-        raise ReviewRecordPathError(str(error)) from error

--- a/quillan/review_requirements.py
+++ b/quillan/review_requirements.py
@@ -30,6 +30,7 @@ from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
     submission_manifest_path,
 )
+from quillan.work_paths import relative_assignment_path
 
 _SEQUENTIAL_REQUIREMENT_CHECK_ID = re.compile(r"^requirement_check_(\d{4})$")
 
@@ -159,9 +160,7 @@ def set_requirement_check(
             submission_manifest_path=_workspace_relative_path(
                 manifest_path, resolved_root, "submission manifest"
             ),
-            assignment_path=(
-                f"classes/{class_id}/assignments/{assignment_id}/assignment.json"
-            ),
+            assignment_path=relative_assignment_path(class_id, assignment_id),
             created_at=normalized_updated_at,
         )
         updated_review["review_state"] = "requirements_checked"
@@ -331,9 +330,7 @@ def set_minimum_requirement_outcome(
             submission_manifest_path=_workspace_relative_path(
                 manifest_path, resolved_root, "submission manifest"
             ),
-            assignment_path=(
-                f"classes/{class_id}/assignments/{assignment_id}/assignment.json"
-            ),
+            assignment_path=relative_assignment_path(class_id, assignment_id),
             created_at=normalized_updated_at,
         )
 

--- a/quillan/roster_management.py
+++ b/quillan/roster_management.py
@@ -243,11 +243,6 @@ def write_roster_creation(
 
 def _remove_new_empty_class_directories(plan: RosterCreationPlan) -> None:
     class_dir = plan.roster_path.parent
-    assignments_dir = class_dir / "assignments"
-    try:
-        assignments_dir.rmdir()
-    except OSError:
-        pass
     try:
         class_dir.rmdir()
     except OSError:

--- a/quillan/standards_summary_export.py
+++ b/quillan/standards_summary_export.py
@@ -28,6 +28,7 @@ from quillan.assignment_summary_context import (
     relative_path_for,
     standard_column_keys,
 )
+from quillan.work_paths import quillan_work_paths
 
 CSV_COLUMNS: Final[tuple[str, ...]] = (
     "class_id",
@@ -86,15 +87,9 @@ def standards_summary_export_path(
     """Return the canonical assignment-local standards summary CSV path."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
-    return (
-        Path(workspace_root)
-        / "classes"
-        / class_id
-        / "assignments"
-        / assignment_id
-        / "exports"
-        / "standards_summary.csv"
-    )
+    return quillan_work_paths(
+        workspace_root, class_id, assignment_id
+    ).exports_dir / "standards_summary.csv"
 
 
 def export_standards_summary(

--- a/quillan/storage.py
+++ b/quillan/storage.py
@@ -4,13 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pds_core.routes import (
-    assignment_config_path as pds_assignment_config_path,
-    assignment_dir as pds_assignment_dir,
-    assignment_scans_dir as pds_assignment_scans_dir,
-    assignment_submissions_dir as pds_assignment_submissions_dir,
-    assignment_templates_dir as pds_assignment_templates_dir,
-    student_submission_dir as pds_student_submission_dir,
+from quillan.work_paths import (
+    quillan_work_paths,
+    student_submission_dir as work_student_submission_dir,
 )
 
 
@@ -19,8 +15,8 @@ def assignment_dir(
     class_id: str,
     assignment_id: str,
 ) -> Path:
-    """Return the shared PDS directory for a Quillan assignment."""
-    return pds_assignment_dir(root, class_id, assignment_id)
+    """Return the module-qualified work root for a Quillan assignment."""
+    return quillan_work_paths(root, class_id, assignment_id).work_root
 
 
 def assignment_config_path(
@@ -28,8 +24,8 @@ def assignment_config_path(
     class_id: str,
     assignment_id: str,
 ) -> Path:
-    """Return the shared PDS assignment configuration path."""
-    return pds_assignment_config_path(root, class_id, assignment_id)
+    """Return the module-qualified Quillan assignment configuration path."""
+    return quillan_work_paths(root, class_id, assignment_id).assignment_path
 
 
 def assignment_submissions_dir(
@@ -37,8 +33,8 @@ def assignment_submissions_dir(
     class_id: str,
     assignment_id: str,
 ) -> Path:
-    """Return the shared PDS submissions directory for an assignment."""
-    return pds_assignment_submissions_dir(root, class_id, assignment_id)
+    """Return the module-qualified submissions directory for an assignment."""
+    return quillan_work_paths(root, class_id, assignment_id).submissions_dir
 
 
 def assignment_scans_dir(
@@ -46,8 +42,8 @@ def assignment_scans_dir(
     class_id: str,
     assignment_id: str,
 ) -> Path:
-    """Return the shared PDS routed-evidence directory for an assignment."""
-    return pds_assignment_scans_dir(root, class_id, assignment_id)
+    """Return the module-qualified routed-evidence directory for an assignment."""
+    return quillan_work_paths(root, class_id, assignment_id).scans_dir
 
 
 def assignment_templates_dir(
@@ -55,8 +51,8 @@ def assignment_templates_dir(
     class_id: str,
     assignment_id: str,
 ) -> Path:
-    """Return the shared PDS templates directory for an assignment."""
-    return pds_assignment_templates_dir(root, class_id, assignment_id)
+    """Return the module-qualified templates directory for an assignment."""
+    return quillan_work_paths(root, class_id, assignment_id).templates_dir
 
 
 def student_submission_dir(
@@ -65,5 +61,6 @@ def student_submission_dir(
     assignment_id: str,
     student_id: str,
 ) -> Path:
-    """Return the shared PDS directory for a student's submission."""
-    return pds_student_submission_dir(root, class_id, assignment_id, student_id)
+    """Return the module-qualified directory for a student's submission."""
+    paths = quillan_work_paths(root, class_id, assignment_id)
+    return work_student_submission_dir(root, paths.work_ref, student_id)

--- a/quillan/student_performance_summary_export.py
+++ b/quillan/student_performance_summary_export.py
@@ -21,6 +21,7 @@ from quillan.assignment_summary_context import (
     rating_labels,
     relative_path_for,
 )
+from quillan.work_paths import quillan_work_paths
 
 MISSING_RATING = ""
 BASE_CSV_COLUMNS = (
@@ -61,15 +62,9 @@ def student_performance_summary_export_path(
     """Return the assignment-local student performance summary CSV path."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
-    return (
-        Path(workspace_root)
-        / "classes"
-        / class_id
-        / "assignments"
-        / assignment_id
-        / "exports"
-        / "student_performance_summary.csv"
-    )
+    return quillan_work_paths(
+        workspace_root, class_id, assignment_id
+    ).exports_dir / "student_performance_summary.csv"
 
 
 def export_student_performance_summary(

--- a/quillan/student_review_status.py
+++ b/quillan/student_review_status.py
@@ -15,6 +15,7 @@ from pds_core.rosters import RosterError, student_display_name
 from quillan.assignment_submission_assembly import discover_assignment_routed_evidence_status
 from quillan.assignment_summary_context import feedback_status, relative_path_for
 from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.storage import assignment_config_path
 from quillan.feedback_export import feedback_export_path, feedback_pdf_export_path
 from quillan.minimum_requirement_review import configured_requirements
 from quillan.plain_paper_submission import is_plain_paper_submission
@@ -83,7 +84,7 @@ def build_student_review_status(
         raise StudentReviewStatusError(str(error)) from error
 
     root = Path(workspace_root).resolve(strict=False)
-    assignment_path = root / "classes" / class_id / "assignments" / assignment_id / "assignment.json"
+    assignment_path = assignment_config_path(root, class_id, assignment_id)
     try:
         assignment = load_assignment_config(assignment_path)
     except (OSError, AssignmentConfigError) as error:

--- a/quillan/submission_assembly.py
+++ b/quillan/submission_assembly.py
@@ -19,6 +19,10 @@ from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
 )
+from quillan.work_paths import (
+    initialize_student_submission_dir,
+    quillan_work_ref,
+)
 
 _RETAINED_SOURCE_FIELDS: Final[tuple[str, ...]] = (
     "source_scan_id",
@@ -154,6 +158,11 @@ def assemble_submission_manifest(
     )
     path = submission_manifest_path(
         workspace_root, class_id, assignment_id, student_id
+    )
+    initialize_student_submission_dir(
+        workspace_root,
+        quillan_work_ref(class_id, assignment_id),
+        student_id,
     )
     return write_submission_manifest(path, manifest, overwrite=overwrite)
 

--- a/quillan/submission_manifest_paths.py
+++ b/quillan/submission_manifest_paths.py
@@ -8,9 +8,14 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from pds_core.identifiers import IdentifierValidationError, validate_identifier
-
 from quillan.submission_manifest import validate_submission_manifest
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    _preflight_arbitrary_file_destination,
+    quillan_work_ref,
+    student_submission_dir,
+    submission_manifest_path as work_submission_manifest_path,
+)
 
 
 class SubmissionManifestPathError(ValueError):
@@ -24,18 +29,11 @@ def submission_dir(
     student_id: str,
 ) -> Path:
     """Return the canonical directory for one student's Quillan submission."""
-    _validate_identifier(class_id, "class_id")
-    _validate_identifier(assignment_id, "assignment_id")
-    _validate_identifier(student_id, "student_id")
-    return (
-        Path(workspace_root)
-        / "classes"
-        / class_id
-        / "assignments"
-        / assignment_id
-        / "submissions"
-        / student_id
-    )
+    try:
+        work_ref = quillan_work_ref(class_id, assignment_id)
+        return student_submission_dir(workspace_root, work_ref, student_id)
+    except ValueError as error:
+        raise SubmissionManifestPathError(str(error)) from error
 
 
 def submission_manifest_path(
@@ -45,10 +43,11 @@ def submission_manifest_path(
     student_id: str,
 ) -> Path:
     """Return the canonical submission.json path for one student."""
-    return (
-        submission_dir(workspace_root, class_id, assignment_id, student_id)
-        / "submission.json"
-    )
+    try:
+        work_ref = quillan_work_ref(class_id, assignment_id)
+        return work_submission_manifest_path(workspace_root, work_ref, student_id)
+    except ValueError as error:
+        raise SubmissionManifestPathError(str(error)) from error
 
 
 def write_submission_manifest(
@@ -60,6 +59,11 @@ def write_submission_manifest(
     """Validate and safely write a submission manifest as UTF-8 JSON."""
     validate_submission_manifest(manifest)
     manifest_path = Path(path)
+
+    try:
+        _preflight_arbitrary_file_destination(manifest_path)
+    except QuillanWorkPathError as error:
+        raise SubmissionManifestPathError(str(error)) from error
 
     if not overwrite and manifest_path.exists():
         raise SubmissionManifestPathError(
@@ -117,10 +121,3 @@ def write_submission_manifest(
                 pass
 
     return manifest_path
-
-
-def _validate_identifier(value: str, field: str) -> None:
-    try:
-        validate_identifier(value, field)
-    except IdentifierValidationError as error:
-        raise SubmissionManifestPathError(str(error)) from error

--- a/quillan/work_paths.py
+++ b/quillan/work_paths.py
@@ -1,0 +1,349 @@
+"""Pure canonical paths and safe layout initialization for Quillan work."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+from pds_core.identifiers import validate_identifier
+from pds_core.routes import (
+    class_roster_path,
+    module_work_collection_dir,
+    module_work_dir,
+    safe_module_work_descendant,
+)
+from pds_core.routing_models import ModuleWorkRef
+
+from quillan.pds_contract import QUILLAN_MODULE_ID
+
+
+class QuillanWorkPathError(ValueError):
+    """Raised when a Quillan work path cannot be used safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanWorkPaths:
+    """Canonical paths for one module-qualified Quillan assignment."""
+
+    work_ref: ModuleWorkRef
+    roster_path: Path
+    work_collection_dir: Path
+    work_root: Path
+    assignment_path: Path
+    response_pages_dir: Path
+    templates_dir: Path
+    scans_dir: Path
+    submissions_dir: Path
+    exports_dir: Path
+
+
+def quillan_work_ref(class_id: str, assignment_id: str) -> ModuleWorkRef:
+    """Return the complete Core work identity for a Quillan assignment."""
+    return ModuleWorkRef(
+        module_id=QUILLAN_MODULE_ID,
+        class_id=class_id,
+        work_id=assignment_id,
+    )
+
+
+def quillan_work_collection_dir(
+    workspace_root: str | Path,
+    class_id: str,
+) -> Path:
+    """Return Quillan's work collection for one class without creating it."""
+    return module_work_collection_dir(
+        workspace_root,
+        class_id,
+        QUILLAN_MODULE_ID,
+    )
+
+
+def quillan_work_paths(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> QuillanWorkPaths:
+    """Return every standard path for one Quillan assignment without I/O."""
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    return QuillanWorkPaths(
+        work_ref=work_ref,
+        roster_path=class_roster_path(workspace_root, class_id),
+        work_collection_dir=module_work_collection_dir(
+            workspace_root,
+            class_id,
+            QUILLAN_MODULE_ID,
+        ),
+        work_root=module_work_dir(workspace_root, work_ref),
+        assignment_path=safe_module_work_descendant(
+            workspace_root, work_ref, "assignment.json"
+        ),
+        response_pages_dir=safe_module_work_descendant(
+            workspace_root, work_ref, "response_pages"
+        ),
+        templates_dir=safe_module_work_descendant(
+            workspace_root, work_ref, "templates"
+        ),
+        scans_dir=safe_module_work_descendant(workspace_root, work_ref, "scans"),
+        submissions_dir=safe_module_work_descendant(
+            workspace_root, work_ref, "submissions"
+        ),
+        exports_dir=safe_module_work_descendant(
+            workspace_root, work_ref, "exports"
+        ),
+    )
+
+
+def student_submission_dir(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+) -> Path:
+    """Return one validated student's Quillan submission directory."""
+    validated_work = _require_quillan_work_ref(work_ref)
+    validated_student_id = validate_identifier(student_id, "student_id")
+    return safe_module_work_descendant(
+        workspace_root,
+        validated_work,
+        Path("submissions") / validated_student_id,
+    )
+
+
+def submission_manifest_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+) -> Path:
+    """Return one validated student's canonical submission manifest path."""
+    validated_work = _require_quillan_work_ref(work_ref)
+    validated_student_id = validate_identifier(student_id, "student_id")
+    return safe_module_work_descendant(
+        workspace_root,
+        validated_work,
+        Path("submissions") / validated_student_id / "submission.json",
+    )
+
+
+def review_record_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+) -> Path:
+    """Return one validated student's canonical review record path."""
+    validated_work = _require_quillan_work_ref(work_ref)
+    validated_student_id = validate_identifier(student_id, "student_id")
+    return safe_module_work_descendant(
+        workspace_root,
+        validated_work,
+        Path("submissions") / validated_student_id / "review.json",
+    )
+
+
+def relative_assignment_path(class_id: str, assignment_id: str) -> str:
+    """Return the canonical workspace-relative assignment record path."""
+    return quillan_work_paths(Path(), class_id, assignment_id).assignment_path.as_posix()
+
+
+def relative_submission_manifest_path(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> str:
+    """Return the canonical workspace-relative submission manifest path."""
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    return submission_manifest_path(Path(), work_ref, student_id).as_posix()
+
+
+def preflight_managed_work_layout(paths: QuillanWorkPaths) -> QuillanWorkPaths:
+    """Validate the complete static work layout without filesystem mutation."""
+    workspace_root = _workspace_root_for(paths)
+    _preflight_directories(workspace_root, _managed_directories(paths))
+    return paths
+
+
+def preflight_quillan_work_collection(
+    workspace_root: str | Path,
+    class_id: str,
+) -> Path:
+    """Validate Quillan's work collection chain without filesystem mutation."""
+    root = Path(workspace_root)
+    collection = quillan_work_collection_dir(root, class_id)
+    _preflight_path_chain(root, collection, expect_file=False)
+    return collection
+
+
+def preflight_work_file_destination(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    relative_path: str | Path,
+) -> Path:
+    """Validate a contained Quillan work file destination without mutation."""
+    validated_work = _require_quillan_work_ref(work_ref)
+    target = safe_module_work_descendant(
+        workspace_root, validated_work, relative_path
+    )
+    _preflight_file_destination(Path(workspace_root), target)
+    return target
+
+
+def initialize_managed_work_layout(paths: QuillanWorkPaths) -> QuillanWorkPaths:
+    """Preflight and create only Quillan's static managed work directories."""
+    preflight_managed_work_layout(paths)
+    for directory in _managed_directories(paths):
+        directory.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+def initialize_student_submission_dir(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+) -> Path:
+    """Safely create only the requested student's submission directory."""
+    validated_work = _require_quillan_work_ref(work_ref)
+    target = student_submission_dir(workspace_root, validated_work, student_id)
+    submissions = safe_module_work_descendant(
+        workspace_root, validated_work, "submissions"
+    )
+    root = Path(workspace_root)
+    _preflight_directories(root, (submissions, target))
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _preflight_arbitrary_file_destination(path: str | Path) -> Path:
+    """Validate a low-level path writer destination without creating anything."""
+    target = _absolute(Path(path))
+    _preflight_file_destination(Path(target.anchor), target)
+    return Path(path)
+
+
+def _require_quillan_work_ref(work_ref: ModuleWorkRef) -> ModuleWorkRef:
+    if not isinstance(work_ref, ModuleWorkRef):
+        raise QuillanWorkPathError("work_ref must be a ModuleWorkRef.")
+    # Core revalidates all fields when constructing a canonical work path.
+    module_work_dir(Path(), work_ref)
+    if work_ref.module_id != QUILLAN_MODULE_ID:
+        raise QuillanWorkPathError(
+            f"work_ref.module_id must be {QUILLAN_MODULE_ID!r}."
+        )
+    return work_ref
+
+
+def _workspace_root_for(paths: QuillanWorkPaths) -> Path:
+    if not isinstance(paths, QuillanWorkPaths):
+        raise QuillanWorkPathError("paths must be a QuillanWorkPaths instance.")
+    try:
+        workspace_root = paths.roster_path.parents[2]
+    except IndexError as error:
+        raise QuillanWorkPathError("Path bundle does not contain a workspace root.") from error
+    expected = quillan_work_paths(
+        workspace_root,
+        paths.work_ref.class_id,
+        paths.work_ref.work_id,
+    )
+    if paths != expected:
+        raise QuillanWorkPathError("Path bundle is not internally canonical.")
+    return workspace_root
+
+
+def _managed_directories(paths: QuillanWorkPaths) -> tuple[Path, ...]:
+    return (
+        paths.work_root,
+        paths.response_pages_dir,
+        paths.templates_dir,
+        paths.scans_dir,
+        paths.submissions_dir,
+        paths.exports_dir,
+    )
+
+
+def _preflight_directories(
+    workspace_root: Path,
+    directories: tuple[Path, ...],
+) -> None:
+    absolute_root = _absolute(workspace_root)
+    _preflight_path_chain(absolute_root, absolute_root, expect_file=False)
+    for directory in directories:
+        absolute_directory = _absolute(directory)
+        try:
+            absolute_directory.relative_to(absolute_root)
+        except ValueError as error:
+            raise QuillanWorkPathError(
+                f"Managed directory escapes workspace root: {directory}"
+            ) from error
+        _preflight_path_chain(absolute_root, absolute_directory, expect_file=False)
+
+
+def _preflight_file_destination(root: Path, target: Path) -> None:
+    _preflight_path_chain(root, target, expect_file=True)
+
+
+def _preflight_path_chain(
+    root: Path,
+    target: Path,
+    *,
+    expect_file: bool,
+) -> None:
+    absolute_root = _absolute(root)
+    absolute_target = _absolute(target)
+    try:
+        relative = absolute_target.relative_to(absolute_root)
+    except ValueError as error:
+        raise QuillanWorkPathError(
+            f"Managed path escapes preflight root: {target}"
+        ) from error
+    candidates = [absolute_root]
+    current = absolute_root
+    for component in relative.parts:
+        current /= component
+        candidates.append(current)
+    for index, candidate in enumerate(candidates):
+        if not _lexists(candidate):
+            continue
+        if _is_link_like(candidate):
+            raise QuillanWorkPathError(
+                f"Managed path must not be a symlink or junction: {candidate}"
+            )
+        is_target = index == len(candidates) - 1
+        if is_target and expect_file:
+            if not candidate.is_file():
+                raise QuillanWorkPathError(
+                    f"Managed file path is not a regular file: {candidate}"
+                )
+        elif not candidate.is_dir():
+            raise QuillanWorkPathError(
+                f"Managed directory path is not a directory: {candidate}"
+            )
+
+
+def _is_link_like(path: Path) -> bool:
+    is_junction = getattr(path, "is_junction", None)
+    return path.is_symlink() or bool(is_junction is not None and is_junction())
+
+
+def _absolute(path: Path) -> Path:
+    return Path(os.path.abspath(path))
+
+
+def _lexists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+__all__ = [
+    "QuillanWorkPathError",
+    "QuillanWorkPaths",
+    "initialize_managed_work_layout",
+    "initialize_student_submission_dir",
+    "preflight_managed_work_layout",
+    "preflight_quillan_work_collection",
+    "preflight_work_file_destination",
+    "quillan_work_collection_dir",
+    "quillan_work_paths",
+    "quillan_work_ref",
+    "relative_assignment_path",
+    "relative_submission_manifest_path",
+    "review_record_path",
+    "student_submission_dir",
+    "submission_manifest_path",
+]

--- a/tests/test_assignment_picker.py
+++ b/tests/test_assignment_picker.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 from typing import Any
 
 import pytest
@@ -12,6 +15,7 @@ from quillan.assignment_picker import (
     available_assignments,
     prompt_assignment_choice,
 )
+from quillan.work_paths import QuillanWorkPathError, _is_link_like
 
 
 CLASS_ID = "english_12_p3"
@@ -67,7 +71,9 @@ def _write_assignment(
         workspace_root
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / assignment_id
         / "assignment.json"
     )
@@ -83,6 +89,20 @@ def _write_roster(workspace_root: Path) -> None:
         f"{CLASS_ID},student_001,Student,Synthetic,3\n",
         encoding="utf-8",
     )
+
+
+def _create_windows_junction(link: Path, target: Path) -> None:
+    result = subprocess.run(
+        ["cmd.exe", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "Windows junction creation unavailable: "
+            f"exit {result.returncode}: {result.stderr.strip()}"
+        )
 
 
 def test_available_assignments_lists_valid_v2_assignments(tmp_path: Path) -> None:
@@ -122,6 +142,165 @@ def test_available_assignments_skips_invalid_and_legacy_configs(
     choices = available_assignments(tmp_path, CLASS_ID)
 
     assert [choice.assignment_id for choice in choices] == ["valid_assignment"]
+
+
+def test_available_assignments_skips_unsafe_non_direct_and_mismatched_entries(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path, "valid_assignment", _assignment("valid_assignment"))
+    _write_assignment(tmp_path, "bad assignment", _assignment("valid_assignment"))
+    _write_assignment(
+        tmp_path, "mismatched_assignment", _assignment("different_assignment")
+    )
+    work = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "quillan"
+        / "work"
+    )
+    directory_record = work / "directory_record" / "assignment.json"
+    directory_record.mkdir(parents=True)
+    nested_record = work / "nested_only" / "nested" / "assignment.json"
+    nested_record.parent.mkdir(parents=True)
+    nested_record.write_text(
+        json.dumps(_assignment("nested_only")), encoding="utf-8"
+    )
+
+    choices = available_assignments(tmp_path, CLASS_ID)
+
+    assert [choice.assignment_id for choice in choices] == ["valid_assignment"]
+
+
+def test_available_assignments_rejects_symlinked_assignment_file(
+    tmp_path: Path,
+) -> None:
+    work = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "quillan"
+        / "work"
+        / "linked_assignment"
+    )
+    work.mkdir(parents=True)
+    outside = tmp_path / "outside-assignment.json"
+    outside.write_text(
+        json.dumps(_assignment("linked_assignment")), encoding="utf-8"
+    )
+    try:
+        os.symlink(outside, work / "assignment.json")
+    except OSError as error:
+        pytest.skip(f"symlink creation is unavailable: {error}")
+
+    assert available_assignments(tmp_path, CLASS_ID) == ()
+    assert outside.read_text(encoding="utf-8") == json.dumps(
+        _assignment("linked_assignment")
+    )
+
+
+def test_available_assignments_has_deterministic_link_detection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_assignment(tmp_path, "linked_assignment", _assignment("linked_assignment"))
+    monkeypatch.setattr(
+        "quillan.assignment_discovery._is_link_like",
+        lambda path: path.name == "assignment.json" or _is_link_like(path),
+    )
+
+    assert available_assignments(tmp_path, CLASS_ID) == ()
+
+
+def test_available_assignments_handles_collection_preflight_rejection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_assignment(tmp_path, "external_assignment", _assignment("external_assignment"))
+
+    def reject_collection(_workspace_root: Path, _class_id: str) -> Path:
+        raise QuillanWorkPathError("synthetic link-like ancestor")
+
+    monkeypatch.setattr(
+        "quillan.assignment_discovery.preflight_quillan_work_collection",
+        reject_collection,
+    )
+
+    assert available_assignments(tmp_path, CLASS_ID) == ()
+
+
+def test_available_assignments_wrong_type_modules_ancestor_is_safe(
+    tmp_path: Path,
+) -> None:
+    modules = tmp_path / "classes" / CLASS_ID / "modules"
+    modules.parent.mkdir(parents=True)
+    modules.write_bytes(b"wrong-type-unchanged")
+
+    assert available_assignments(tmp_path, CLASS_ID) == ()
+    assert modules.read_bytes() == b"wrong-type-unchanged"
+    assert list(modules.parent.iterdir()) == [modules]
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows junction test")
+def test_available_assignments_rejects_intermediate_modules_junction(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside-modules"
+    assignment_path = (
+        outside
+        / "quillan"
+        / "work"
+        / "external_assignment"
+        / "assignment.json"
+    )
+    assignment_path.parent.mkdir(parents=True)
+    assignment_path.write_text(
+        json.dumps(_assignment("external_assignment")), encoding="utf-8"
+    )
+    original_bytes = assignment_path.read_bytes()
+    modules = workspace / "classes" / CLASS_ID / "modules"
+    modules.parent.mkdir(parents=True)
+    _create_windows_junction(modules, outside)
+
+    try:
+        assert available_assignments(workspace, CLASS_ID) == ()
+        assert assignment_path.read_bytes() == original_bytes
+        assert list(modules.parent.iterdir()) == [modules]
+    finally:
+        os.rmdir(modules)
+
+    assert outside.is_dir()
+    assert assignment_path.read_bytes() == original_bytes
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows junction test")
+def test_available_assignments_rejects_direct_collection_junction(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside-work"
+    assignment_path = outside / "external_assignment" / "assignment.json"
+    assignment_path.parent.mkdir(parents=True)
+    assignment_path.write_text(
+        json.dumps(_assignment("external_assignment")), encoding="utf-8"
+    )
+    original_bytes = assignment_path.read_bytes()
+    work = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work"
+    work.parent.mkdir(parents=True)
+    _create_windows_junction(work, outside)
+
+    try:
+        assert available_assignments(workspace, CLASS_ID) == ()
+        assert assignment_path.read_bytes() == original_bytes
+        assert list(work.parent.iterdir()) == [work]
+    finally:
+        os.rmdir(work)
+
+    assert outside.is_dir()
+    assert assignment_path.read_bytes() == original_bytes
 
 
 def test_prompt_assignment_choice_clears_and_reframes_after_class_selection(

--- a/tests/test_assignment_submission_assembly.py
+++ b/tests/test_assignment_submission_assembly.py
@@ -24,7 +24,9 @@ def _scans_dir(workspace: Path) -> Path:
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
     )

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from datetime import datetime, timezone
+import os
 from pathlib import Path
 
 from pds_core.classes import write_class_roster
@@ -23,6 +24,7 @@ from quillan.assignments import (
     validate_assignment_config,
 )
 from quillan.menu_navigation import QuitQuillan, ReturnToMainMenu
+from quillan.work_paths import quillan_work_paths
 
 STANDARD_ID = "njsls-ela:W.AW.11-12.1"
 SECOND_STANDARD_ID = "njsls-ela:L.KL.11-12.2"
@@ -221,7 +223,9 @@ def test_write_assignment_config_uses_canonical_path(tmp_path: Path) -> None:
         tmp_path
         / "classes"
         / "english_12_p3"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "literary_analysis_essay"
         / "assignment.json"
     )
@@ -244,7 +248,9 @@ def test_write_assignment_config_allows_included_multi_class_path(
         tmp_path
         / "classes"
         / "english_12_p4"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "literary_analysis_essay"
         / "assignment.json"
     )
@@ -264,6 +270,79 @@ def test_write_assignment_config_rejects_class_path_mismatch(
         )
 
     assert not list(tmp_path.rglob("assignment.json"))
+
+
+def test_write_assignment_config_rejects_assignment_directory_without_partial_layout(
+    tmp_path: Path,
+) -> None:
+    paths = quillan_work_paths(
+        tmp_path, "english_12_p3", "literary_analysis_essay"
+    )
+    paths.assignment_path.mkdir(parents=True)
+    marker = paths.assignment_path / "marker.bin"
+    marker.write_bytes(b"unchanged")
+
+    with pytest.raises(AssignmentConfigError, match="regular file"):
+        workflows.write_assignment_config(
+            tmp_path, "english_12_p3", _assignment()
+        )
+
+    assert marker.read_bytes() == b"unchanged"
+    assert not paths.response_pages_dir.exists()
+    assert not paths.templates_dir.exists()
+    assert not paths.scans_dir.exists()
+    assert not paths.submissions_dir.exists()
+    assert not paths.exports_dir.exists()
+
+
+def test_write_assignment_config_late_collision_is_all_or_nothing(
+    tmp_path: Path,
+) -> None:
+    paths = quillan_work_paths(
+        tmp_path, "english_12_p3", "literary_analysis_essay"
+    )
+    paths.exports_dir.parent.mkdir(parents=True)
+    paths.exports_dir.write_bytes(b"collision-bytes")
+
+    with pytest.raises(AssignmentConfigError, match="not a directory"):
+        workflows.write_assignment_config(
+            tmp_path, "english_12_p3", _assignment()
+        )
+
+    assert paths.exports_dir.read_bytes() == b"collision-bytes"
+    assert not paths.assignment_path.exists()
+    assert not paths.response_pages_dir.exists()
+    assert not paths.templates_dir.exists()
+    assert not paths.scans_dir.exists()
+    assert not paths.submissions_dir.exists()
+
+
+def test_write_assignment_config_rejects_symlink_destination_without_external_write(
+    tmp_path: Path,
+) -> None:
+    paths = quillan_work_paths(
+        tmp_path, "english_12_p3", "literary_analysis_essay"
+    )
+    paths.assignment_path.parent.mkdir(parents=True)
+    outside = tmp_path / "outside-assignment.json"
+    outside.write_bytes(b"outside-unchanged")
+    try:
+        os.symlink(outside, paths.assignment_path)
+    except OSError as error:
+        pytest.skip(f"symlink creation is unavailable: {error}")
+
+    with pytest.raises(AssignmentConfigError, match="symlink or junction"):
+        workflows.write_assignment_config(
+            tmp_path, "english_12_p3", _assignment(), overwrite=True
+        )
+
+    assert outside.read_bytes() == b"outside-unchanged"
+    assert paths.assignment_path.is_symlink()
+    assert not paths.response_pages_dir.exists()
+    assert not paths.templates_dir.exists()
+    assert not paths.scans_dir.exists()
+    assert not paths.submissions_dir.exists()
+    assert not paths.exports_dir.exists()
 
 
 def test_parse_class_folder_selection_accepts_numbers_and_class_ids(
@@ -384,7 +463,9 @@ def test_prompt_create_assignment_writes_valid_v2_config(
         tmp_path
         / "classes"
         / "english_12_p3"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "literary_analysis_essay"
         / "assignment.json"
     )
@@ -476,7 +557,9 @@ def test_prompt_create_assignment_writes_same_config_for_multiple_classes(
         tmp_path
         / "classes"
         / "english_12_p3"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "argument_essay"
         / "assignment.json"
     )
@@ -484,7 +567,9 @@ def test_prompt_create_assignment_writes_same_config_for_multiple_classes(
         tmp_path
         / "classes"
         / "english_12_p4"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "argument_essay"
         / "assignment.json"
     )
@@ -624,7 +709,9 @@ def test_prompt_create_assignment_default_rating_scale_has_four_unique_levels(
         tmp_path
         / "classes"
         / "english_12_p3"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "argument_essay"
         / "assignment.json"
     )
@@ -673,7 +760,9 @@ def test_prompt_create_assignment_writes_declined_minimum_requirement_policy(
         tmp_path
         / "classes"
         / "english_12_p3"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "argument_essay"
         / "assignment.json"
     )
@@ -780,7 +869,9 @@ def test_prompt_create_assignment_preflights_all_overwrite_conflicts(
         tmp_path
         / "classes"
         / "english_12_p4"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "argument_essay"
         / "assignment.json"
     )
@@ -859,7 +950,9 @@ def test_prompt_create_assignment_overwrites_with_explicit_confirmation(
         tmp_path
         / "classes"
         / "english_12_p3"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "argument_essay"
         / "assignment.json"
     )
@@ -933,7 +1026,9 @@ def test_view_validate_assignment_reports_error_without_traceback(
         tmp_path
         / "classes"
         / "english_12_p3"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "invalid"
         / "assignment.json"
     )

--- a/tests/test_class_summary_export.py
+++ b/tests/test_class_summary_export.py
@@ -37,7 +37,9 @@ def _student_dir(workspace: Path, student_id: str) -> Path:
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / student_id
@@ -55,7 +57,9 @@ def _write_assignment(workspace: Path) -> Path:
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json",
         {
@@ -112,7 +116,7 @@ def _records(student_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
     review = copy.deepcopy(_review("ready_for_export"))
     review["student_id"] = student_id
     review["submission_manifest_path"] = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
         f"{student_id}/submission.json"
     )
     return manifest, review
@@ -208,7 +212,7 @@ def test_exports_assignment_local_rows_with_focus_standard_ratings(
     md_path.write_text("feedback markdown", encoding="utf-8")
     first_review["exports"]["feedback_pdf"] = {
         "path": (
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             "00100/exports/feedback.pdf"
         ),
         "generated_at": TIMESTAMP,
@@ -217,7 +221,7 @@ def test_exports_assignment_local_rows_with_focus_standard_ratings(
     }
     first_review["exports"]["feedback_markdown"] = {
         "path": (
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             "00100/exports/feedback.md"
         ),
         "generated_at": TIMESTAMP,
@@ -261,7 +265,7 @@ def test_exports_assignment_local_rows_with_focus_standard_ratings(
         assignment_id=ASSIGNMENT_ID,
         summary_path=expected_path,
         summary_relative_path=(
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/exports/"
             "class_summary.csv"
         ),
         row_count=4,

--- a/tests/test_cli_assignments.py
+++ b/tests/test_cli_assignments.py
@@ -104,7 +104,7 @@ def test_create_show_validate_and_overwrite_safety(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     assert main(_args("--yes", "--paragraphs-min", "4")) == 0
-    path = workspace / "classes/english10_p2/assignments/literary_analysis/assignment.json"
+    path = workspace / "classes/english10_p2/modules/quillan/work/literary_analysis/assignment.json"
     assignment = json.loads(path.read_text(encoding="utf-8"))
     assert assignment["schema_version"] == "2"
     assert assignment["module"] == "quillan"
@@ -131,7 +131,7 @@ def test_dry_run_and_prompt_file_preserve_content(
     workspace: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     assert main(_args("--dry-run")) == 0
-    target = workspace / "classes/english10_p2/assignments/literary_analysis"
+    target = workspace / "classes/english10_p2/modules/quillan/work/literary_analysis"
     assert not target.exists()
     prompt_file = tmp_path / "prompt.txt"
     prompt_file.write_text("Line one.\nLine two.\n", encoding="utf-8")
@@ -152,7 +152,7 @@ def test_invalid_standards_and_path_identity_fail_cleanly(
     assert main(bad) == 1
     assert "assignment was not created" in capsys.readouterr().out
     assert main(_args("--yes")) == 0
-    path = workspace / "classes/english10_p2/assignments/literary_analysis/assignment.json"
+    path = workspace / "classes/english10_p2/modules/quillan/work/literary_analysis/assignment.json"
     data = json.loads(path.read_text(encoding="utf-8"))
     data["assignment_id"] = "different_id"
     path.write_text(json.dumps(data), encoding="utf-8")
@@ -164,7 +164,7 @@ def test_canonical_validate_rejects_assignment_missing_contract_metadata(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     assert main(_args("--yes")) == 0
-    path = workspace / "classes/english10_p2/assignments/literary_analysis/assignment.json"
+    path = workspace / "classes/english10_p2/modules/quillan/work/literary_analysis/assignment.json"
     assignment = json.loads(path.read_text(encoding="utf-8"))
     for field in ("created_at", "updated_at", "module_details"):
         assignment.pop(field)

--- a/tests/test_cli_class_summary_export.py
+++ b/tests/test_cli_class_summary_export.py
@@ -46,7 +46,7 @@ def test_cli_exports_ready_and_non_ready_rows_and_prints_summary(
     assert "Feedback PDF stale: 0" in output
     assert "Overwrote existing: no" in output
     relative = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/exports/"
         "class_summary.csv"
     )
     assert f"Summary file: {relative}" in output

--- a/tests/test_cli_feedback.py
+++ b/tests/test_cli_feedback.py
@@ -67,7 +67,7 @@ def test_bare_feedback_prints_help_without_resolving_workspace(
 def test_show_without_review_is_ordered_read_only(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    assignment = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     submission = assignment.parent / "submissions" / STUDENT_ID / "submission.json"
     before = assignment.read_bytes(), submission.read_bytes()
     assert main(["feedback", "show", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0

--- a/tests/test_cli_feedback_export.py
+++ b/tests/test_cli_feedback_export.py
@@ -78,7 +78,7 @@ def test_cli_exports_feedback_and_prints_summary(
     assert "Scores: 1" in output
     assert "Overwrote existing: no" in output
     relative = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
         f"{STUDENT_ID}/exports/feedback.md"
     )
     assert f"Feedback file: {relative}" in output

--- a/tests/test_cli_observations.py
+++ b/tests/test_cli_observations.py
@@ -82,7 +82,9 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -167,7 +169,7 @@ def test_list_without_review_is_read_only_and_reports_setup_guidance(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     assignment_path = (
-        workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+        workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     )
     manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     before = assignment_path.read_bytes(), manifest_path.read_bytes()

--- a/tests/test_cli_pages.py
+++ b/tests/test_cli_pages.py
@@ -25,7 +25,7 @@ def _evidence(evidence_id: str, page_number: int, role: str) -> dict[str, Any]:
     return {
         "evidence_id": evidence_id,
         "routed_evidence_path": (
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
             f"response_{STUDENT_ID}_pg_{page_number:03d}.pdf"
         ),
         "evidence_role": role,

--- a/tests/test_cli_printable_responses.py
+++ b/tests/test_cli_printable_responses.py
@@ -87,7 +87,7 @@ def test_dry_run_is_full_preflight_with_no_writes(
     assert "No files were written." in output
     assert str(tmp_path) not in output
     assert not (
-        tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "templates"
+        tmp_path / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "templates"
     ).exists()
 
 
@@ -101,7 +101,9 @@ def test_dry_run_reports_existing_target_without_touching_it(
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "templates"
         / "printable_response_pages.pdf"
@@ -143,7 +145,7 @@ def test_generation_is_noninteractive_and_uses_default_page_count(
     assert "Pages per student: 1" in output
     assert "Total packet pages: 2" in output
     assert "Action: created" in output
-    assert f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/templates/" in output
+    assert f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/templates/" in output
     assert str(tmp_path) not in output
 
 

--- a/tests/test_cli_ratings.py
+++ b/tests/test_cli_ratings.py
@@ -80,7 +80,9 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -156,7 +158,7 @@ def test_bare_namespace_prints_help_without_resolving_workspace(
 def test_list_without_review_is_ordered_and_strictly_read_only(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment_path = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     before = assignment_path.read_bytes(), manifest_path.read_bytes()
 
@@ -182,7 +184,7 @@ def test_set_creates_then_replaces_without_inference_or_duplicate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = _write_review(workspace)
-    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment_path = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     immutable = assignment_path.read_bytes(), manifest_path.read_bytes()
     monkeypatch.setattr("builtins.input", lambda *_args: pytest.fail("CLI prompted"))

--- a/tests/test_cli_requirements.py
+++ b/tests/test_cli_requirements.py
@@ -83,7 +83,9 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -134,7 +136,7 @@ def test_list_is_read_only_and_preserves_requirement_order(
     monkeypatch.setattr(
         "builtins.input", lambda *_args: pytest.fail("direct command prompted")
     )
-    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment_path = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     before = (assignment_path.read_bytes(), manifest_path.read_bytes())
 
@@ -245,7 +247,7 @@ def test_met_succeeds_only_after_every_configured_check_is_met(workspace: Path) 
 
 
 def test_assignment_policy_cannot_be_overridden(workspace: Path) -> None:
-    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment_path = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     assignment = _assignment()
     assignment["minimum_requirement_policy"]["allow_return_without_full_review"] = False
     assignment_path.write_text(json.dumps(assignment), encoding="utf-8")
@@ -297,7 +299,7 @@ def test_stale_unmet_check_does_not_enable_outcome(workspace: Path) -> None:
 def test_no_configured_requirements_list_succeeds_but_set_fails(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    path = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     assignment = _assignment()
     assignment["basic_requirements"] = {}
     path.write_text(json.dumps(assignment), encoding="utf-8")

--- a/tests/test_cli_review_units.py
+++ b/tests/test_cli_review_units.py
@@ -71,7 +71,7 @@ def _manifest() -> dict[str, Any]:
 @pytest.fixture
 def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     assignment_path = (
-        tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+        tmp_path / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     )
     assignment_path.parent.mkdir(parents=True)
     assignment_path.write_text(json.dumps(_assignment()), encoding="utf-8")
@@ -113,7 +113,7 @@ def test_bare_namespace_prints_help_without_resolving_workspace(
 def test_show_without_review_is_read_only(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment_path = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     before = assignment_path.read_bytes(), manifest_path.read_bytes()
 
@@ -134,7 +134,7 @@ def test_count_creates_menu_equivalent_canonical_units(
     workspace: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("builtins.input", lambda *_args: pytest.fail("CLI prompted"))
-    assignment_path = workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment_path = workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     manifest_path = submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     before = assignment_path.read_bytes(), manifest_path.read_bytes()
     args = ["review-units", "set", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]

--- a/tests/test_cli_rosters.py
+++ b/tests/test_cli_rosters.py
@@ -382,7 +382,7 @@ def test_remove_changes_only_roster_and_preserves_evidence_and_metadata(
         "english_10_p2", "2026-2027", created_at=datetime.now(timezone.utc)
     )
     metadata_path = write_class_metadata_for_class(workspace, metadata)
-    evidence = roster_path.parent / "assignments" / "essay" / "submissions" / "0007" / "feedback.md"
+    evidence = roster_path.parent / "modules" / "quillan" / "work" / "essay" / "submissions" / "0007" / "feedback.md"
     evidence.parent.mkdir(parents=True, exist_ok=True)
     evidence.write_text("retain", encoding="utf-8")
     metadata_before = metadata_path.read_bytes()

--- a/tests/test_cli_route_scan.py
+++ b/tests/test_cli_route_scan.py
@@ -26,7 +26,7 @@ VALID_PAYLOAD = (
 @pytest.fixture
 def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     class_dir = tmp_path / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
@@ -130,7 +130,9 @@ def test_route_scan_successfully_files_retained_and_routed_evidence(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
         / "response_00107_pg_002.pdf"
@@ -164,7 +166,9 @@ def test_route_scan_preserves_duplicate_routed_evidence(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
         / "response_00107_pg_002__dup_001.pdf"

--- a/tests/test_cli_route_scan_folder.py
+++ b/tests/test_cli_route_scan_folder.py
@@ -39,7 +39,7 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def _write_workspace(root: Path) -> None:
     class_dir = root / "classes" / CLASS_ID
-    assignments_dir = class_dir / "assignments"
+    assignments_dir = class_dir / "modules" / "quillan" / "work"
     assignments_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
@@ -185,7 +185,9 @@ def _routed_pngs(workspace: Path) -> list[Path]:
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "scans"
         ).glob("response_*.png")

--- a/tests/test_cli_route_scan_pdf.py
+++ b/tests/test_cli_route_scan_pdf.py
@@ -41,7 +41,7 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def _write_workspace(root: Path) -> None:
     class_dir = root / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
@@ -185,7 +185,9 @@ def _routed_pngs(workspace: Path) -> list[Path]:
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "scans"
         ).glob("response_*.png")

--- a/tests/test_cli_route_scan_qr.py
+++ b/tests/test_cli_route_scan_qr.py
@@ -40,7 +40,7 @@ def _write_workspace(
     assignment_id: str = ASSIGNMENT_ID,
 ) -> None:
     class_dir = root / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / assignment_id
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / assignment_id
     assignment_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
@@ -179,7 +179,9 @@ def test_route_scan_decode_qr_successfully_routes_single_image(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
         / "response_stu_0001_pg_002.png"
@@ -227,7 +229,9 @@ def test_route_scan_payload_mode_still_works_without_qr_decoding(
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "scans"
         ).glob("response_*.png")

--- a/tests/test_cli_standards_summary_export.py
+++ b/tests/test_cli_standards_summary_export.py
@@ -51,7 +51,7 @@ def test_cli_exports_standards_rows_and_prints_summary(
     assert "Identity mismatch: 0" in output
     assert "Overwrote existing: no" in output
     relative = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/exports/"
         "standards_summary.csv"
     )
     assert f"Summary file: {relative}" in output

--- a/tests/test_evidence_filing.py
+++ b/tests/test_evidence_filing.py
@@ -28,7 +28,7 @@ SOURCE_BYTES = b"%PDF-1.4\nsynthetic scan evidence\n%%EOF\n"
 @pytest.fixture
 def workspace(tmp_path: Path) -> Path:
     assignment_dir = (
-        tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+        tmp_path / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     )
     assignment_dir.mkdir(parents=True)
     (assignment_dir / "assignment.json").write_text(
@@ -43,7 +43,7 @@ def workspace(tmp_path: Path) -> Path:
 @pytest.fixture
 def route_plan(workspace: Path) -> RoutePlan:
     assignment_dir = (
-        workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+        workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     )
     return RoutePlan(
         class_id=CLASS_ID,
@@ -101,7 +101,7 @@ def test_files_retained_source_and_routed_evidence_with_provenance(
     )
     assert result.routed_evidence_path == expected_routed_path
     assert result.routed_evidence_relative_path == (
-        "classes/english12_p3_synthetic/assignments/"
+        "classes/english12_p3_synthetic/modules/quillan/work/"
         "essay_01_synthetic/scans/response_00107_pg_002.pdf"
     )
     assert result.class_id == CLASS_ID
@@ -436,7 +436,9 @@ def test_mismatched_routed_evidence_dir_is_rejected_before_writes(
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / "different_assignment"
             / "scans"
         ),

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -41,7 +41,7 @@ STANDARD_DESCRIPTION = (
 
 
 def _write_assignment(root: Path) -> None:
-    assignment_dir = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    assignment_dir = root / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True, exist_ok=True)
     assignment = {
         "schema_version": "2",
@@ -186,7 +186,9 @@ def test_exports_ordered_student_content_without_mutating_sources(
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
         / "response_00107_pg_001.pdf"
@@ -222,12 +224,12 @@ def test_exports_ordered_student_content_without_mutating_sources(
         student_id=STUDENT_ID,
         review_record_path=review_path,
         review_record_relative_path=(
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             f"{STUDENT_ID}/review.json"
         ),
         feedback_path=expected_path,
         feedback_relative_path=(
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             f"{STUDENT_ID}/exports/feedback.md"
         ),
         included_comment_count=2,
@@ -479,12 +481,12 @@ def test_identity_mismatch_is_rejected(
     else:
         review[field] = value
         review["submission_manifest_path"] = (
-            f"classes/{review['class_id']}/assignments/"
+            f"classes/{review['class_id']}/modules/quillan/work/"
             f"{review['assignment_id']}/submissions/{review['student_id']}/"
             "submission.json"
         )
         review["assignment_path"] = (
-            f"classes/{review['class_id']}/assignments/{review['assignment_id']}/"
+            f"classes/{review['class_id']}/modules/quillan/work/{review['assignment_id']}/"
             "assignment.json"
         )
     write_submission_manifest(

--- a/tests/test_feedback_pdf_export.py
+++ b/tests/test_feedback_pdf_export.py
@@ -47,7 +47,7 @@ def _write_roster(root: Path) -> None:
 
 def _write_assignment_with_rating_labels(root: Path) -> None:
     _write_assignment(root)
-    path = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    path = root / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     assignment = json.loads(path.read_text(encoding="utf-8"))
     assignment["rating_scale"]["levels"].append(
         {"value": 3, "label": "Meeting", "description": "Meets expectations."}
@@ -157,12 +157,12 @@ def test_normal_pdf_export_creates_student_facing_pdf_and_metadata(
         assignment_title="Synthetic Essay",
         review_record_path=review_path,
         review_record_relative_path=(
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             f"{STUDENT_ID}/review.json"
         ),
         feedback_pdf_path=expected_path,
         feedback_pdf_relative_path=(
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             f"{STUDENT_ID}/exports/feedback.pdf"
         ),
         feedback_markdown_path=None,
@@ -213,7 +213,7 @@ def test_normal_pdf_export_creates_student_facing_pdf_and_metadata(
     assert review_after["review_state"] == "exported"
     assert metadata == {
         "path": (
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             f"{STUDENT_ID}/exports/feedback.pdf"
         ),
         "generated_at": TIMESTAMP,

--- a/tests/test_focus_standard_comments.py
+++ b/tests/test_focus_standard_comments.py
@@ -173,7 +173,7 @@ def test_saving_reusable_comment_creates_default_set_with_teacher_text(
             "assignment_id": "essay_01_synthetic",
             "student_id": "00107",
             "review_path": (
-                "classes/english12_p3_synthetic/assignments/essay_01_synthetic/"
+                "classes/english12_p3_synthetic/modules/quillan/work/essay_01_synthetic/"
                 "submissions/00107/review.json"
             ),
             "feedback_comment_id": "feedback_comment_0001",

--- a/tests/test_generated_output_opening.py
+++ b/tests/test_generated_output_opening.py
@@ -18,7 +18,9 @@ def _generated_pdf(workspace_root: Path) -> Path:
         workspace_root
         / "classes"
         / "english10_p2"
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "essay_01"
         / "templates"
         / "printable_response_pages.pdf"
@@ -47,7 +49,7 @@ def test_open_generated_output_file_opens_valid_file_inside_workspace(
     assert opened == OpenedGeneratedOutput(
         path=output_path,
         relative_path=(
-            "classes/english10_p2/assignments/essay_01/templates/"
+            "classes/english10_p2/modules/quillan/work/essay_01/templates/"
             "printable_response_pages.pdf"
         ),
     )
@@ -71,7 +73,7 @@ def test_open_generated_output_folder_opens_valid_containing_folder(
     assert calls == [output_path.parent]
     assert opened == OpenedGeneratedOutput(
         path=output_path.parent,
-        relative_path="classes/english10_p2/assignments/essay_01/templates",
+        relative_path="classes/english10_p2/modules/quillan/work/essay_01/templates",
     )
 
 

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -66,7 +66,7 @@ def _exit_after_selected_student_action_to_main() -> list[str]:
 
 def _write_workspace(root: Path) -> None:
     class_dir = root / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
@@ -146,7 +146,9 @@ def _write_workspace(root: Path) -> None:
         root
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
         / "response_stu_0001_pg_001.pdf"
@@ -176,7 +178,7 @@ def _write_manifest(root: Path) -> Path:
                     {
                         "evidence_id": "evidence_001",
                         "routed_evidence_path": (
-                            f"classes/{CLASS_ID}/assignments/"
+                            f"classes/{CLASS_ID}/modules/quillan/work/"
                             f"{ASSIGNMENT_ID}/scans/"
                             "response_stu_0001_pg_001.pdf"
                         ),
@@ -317,7 +319,9 @@ def test_assignment_review_dashboard_hides_unused_duplicate_files(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
         / "response_stu_0001_pg_001__dup_001.pdf"
@@ -382,7 +386,9 @@ def test_menu_export_student_feedback_creates_feedback_file(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -439,7 +445,9 @@ def test_menu_export_student_feedback_pdf_creates_pdf_and_updates_metadata(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -480,7 +488,9 @@ def test_menu_export_class_summary_creates_summary_file(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
         / "class_summary.csv"
@@ -511,7 +521,9 @@ def test_menu_export_standards_summary_creates_summary_file(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
         / "standards_summary.csv"
@@ -542,7 +554,9 @@ def test_menu_export_feedback_invalid_overwrite_cancels_without_writing(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -573,7 +587,9 @@ def test_menu_export_feedback_reports_missing_review_record(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -606,7 +622,9 @@ def test_menu_export_feedback_requires_overwrite_when_existing(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -642,7 +660,9 @@ def test_menu_export_feedback_overwrites_existing_export(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -676,7 +696,9 @@ def test_menu_export_class_summary_requires_overwrite_when_existing(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
     )
@@ -708,7 +730,9 @@ def test_menu_export_class_summary_overwrites_existing_export(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
     )
@@ -739,7 +763,9 @@ def test_menu_export_class_summary_invalid_overwrite_cancels_without_writing(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
         / "class_summary.csv"
@@ -768,7 +794,9 @@ def test_menu_export_standards_summary_overwrites_existing_export(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
     )
@@ -800,7 +828,9 @@ def test_menu_export_standards_summary_requires_overwrite_when_existing(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
     )
@@ -831,7 +861,9 @@ def test_menu_export_standards_summary_invalid_overwrite_cancels_without_writing
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
         / "standards_summary.csv"

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -39,7 +39,7 @@ def _menu_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> None:
 
 def _write_workspace(root: Path) -> None:
     class_dir = root / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open("w", encoding="utf-8", newline="") as file:
@@ -108,7 +108,9 @@ def _write_workspace(root: Path) -> None:
         root
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
         / "response_stu_0001_pg_001.pdf"
@@ -137,7 +139,7 @@ def _write_manifest(root: Path) -> Path:
                     {
                         "evidence_id": "evidence_001",
                         "routed_evidence_path": (
-                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+                            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
                             "response_stu_0001_pg_001.pdf"
                         ),
                         "evidence_role": "selected",

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -30,7 +30,7 @@ STUDENT_ID = "stu_0001"
 SECOND_STUDENT_ID = "stu_0002"
 TIMESTAMP = "2026-06-22T12:00:00+00:00"
 EVIDENCE_RELATIVE_PATH = (
-    f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+    f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
     "response_stu_0001_pg_001.pdf"
 )
 
@@ -61,7 +61,7 @@ def _menu_input(
 
 def _write_workspace(root: Path) -> None:
     class_dir = root / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
@@ -194,7 +194,7 @@ def _write_two_page_manifest(root: Path) -> Path:
     )
     manifest = json.loads(path.read_text(encoding="utf-8"))
     second_evidence_path = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
         "response_stu_0001_pg_002.pdf"
     )
     (root / second_evidence_path).write_bytes(b"synthetic evidence page 2")
@@ -370,7 +370,9 @@ def test_review_summary_includes_existing_review_record_counts(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -732,7 +734,9 @@ def test_overall_rating_entry_loops_and_updates_without_duplicates(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -821,7 +825,9 @@ def test_overall_rating_entry_cancellations_do_not_write(
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "assignment.json"
         ).read_text(encoding="utf-8")
@@ -953,7 +959,9 @@ def test_review_menu_views_current_review_details_read_only(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -1193,7 +1201,9 @@ def test_review_menu_creates_plain_paper_submission_and_shows_review_actions(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / SECOND_STUDENT_ID
@@ -1236,7 +1246,9 @@ def test_review_menu_adds_teacher_note_to_review_record(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -1558,7 +1570,9 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -56,7 +56,7 @@ def _menu_input(
 
 def _write_workspace(root: Path) -> None:
     class_dir = root / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
@@ -186,7 +186,9 @@ def _routed_pngs(workspace: Path) -> list[Path]:
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "scans"
         ).glob("response_*.png")

--- a/tests/test_plain_paper_submission.py
+++ b/tests/test_plain_paper_submission.py
@@ -27,7 +27,7 @@ TIMESTAMP = "2026-07-12T12:30:00-04:00"
 @pytest.fixture
 def workspace(tmp_path: Path) -> Path:
     class_dir = tmp_path / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
     with (class_dir / "roster.csv").open("w", encoding="utf-8", newline="") as file:
         writer = csv.DictWriter(
@@ -146,7 +146,9 @@ def test_rejects_orphan_review_without_writing_manifest(workspace: Path) -> None
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -226,7 +228,9 @@ def test_cli_creates_plain_paper_submission(
         cli_workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -267,7 +271,7 @@ def test_cli_dry_run_validates_without_writing(
     )
 
     assert result == 0
-    assert not (cli_workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "submissions").exists()
+    assert not (cli_workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "submissions").exists()
     output = capsys.readouterr().out
     assert "Plain-paper submission dry run:" in output
     assert "Would create submission manifest: classes/" in output
@@ -284,7 +288,7 @@ def test_cli_requires_confirmation_without_writing(
 
     assert result == 1
     assert "requires --yes or --dry-run" in capsys.readouterr().out
-    assert not (cli_workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "submissions").exists()
+    assert not (cli_workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "submissions").exists()
 
 
 def test_cli_flags_are_mutually_exclusive() -> None:
@@ -321,7 +325,7 @@ def test_cli_rejects_invalid_student(
 
     assert result == 1
     assert "not in the roster" in capsys.readouterr().out
-    assert not (cli_workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "submissions").exists()
+    assert not (cli_workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "submissions").exists()
 
 
 def test_cli_refuses_existing_manifest_without_changing_it(
@@ -348,7 +352,7 @@ def test_cli_refuses_existing_manifest_without_changing_it(
 def test_cli_refuses_orphan_review_without_changing_it(
     cli_workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    student_dir = cli_workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "submissions" / STUDENT_ID
+    student_dir = cli_workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "submissions" / STUDENT_ID
     student_dir.mkdir(parents=True)
     review_path = student_dir / "review.json"
     review_path.write_bytes(b"existing review")
@@ -397,7 +401,9 @@ def test_cli_rejects_class_not_in_assignment(
         cli_workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -421,7 +427,9 @@ def test_cli_rejects_class_not_in_assignment(
         cli_workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
     ).exists()

--- a/tests/test_printable_response_packet.py
+++ b/tests/test_printable_response_packet.py
@@ -41,7 +41,7 @@ def write_packet_workspace(root: Path) -> tuple[Path, Path]:
         ),
     )
     assignment_path = (
-        root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+        root / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     )
     assignment_path.parent.mkdir(parents=True, exist_ok=True)
     assignment_path.write_text(json.dumps(valid_assignment()), encoding="utf-8")
@@ -96,7 +96,7 @@ def test_plan_validates_without_writing_and_reports_canonical_paths(
     assert plan.assignment_relative_path.endswith("/assignment.json")
     assert plan.roster_relative_path.endswith("/roster.csv")
     assert plan.output_relative_path == (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/templates/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/templates/"
         "printable_response_pages.pdf"
     )
     assert not plan.target_exists
@@ -122,7 +122,7 @@ def test_generation_counts_pages_and_preserves_inputs(tmp_path: Path) -> None:
     assignment_path, roster_path = write_packet_workspace(tmp_path)
     untouched_paths = [
         tmp_path / "classes" / CLASS_ID / "class.json",
-        tmp_path / "classes" / CLASS_ID / "assignments" / "sibling" / "assignment.json",
+        tmp_path / "classes" / CLASS_ID / "modules" / "quillan" / "work" / "sibling" / "assignment.json",
         assignment_path.parent / "submissions" / "synthetic_student" / "submission.json",
         assignment_path.parent / "submissions" / "synthetic_student" / "review.json",
         assignment_path.parent / "scans" / "synthetic_evidence.txt",
@@ -191,7 +191,7 @@ def test_empty_roster_fails_before_templates_directory(tmp_path: Path) -> None:
         plan_printable_response_packet(tmp_path, CLASS_ID, ASSIGNMENT_ID)
 
     assert not (
-        tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "templates"
+        tmp_path / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "templates"
     ).exists()
 
 

--- a/tests/test_printable_response_pdf.py
+++ b/tests/test_printable_response_pdf.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
-from pds_core.routes import assignment_templates_dir
+import quillan.printable_response as printable_response
+from quillan.storage import assignment_templates_dir
 from pypdf import PdfReader
 
 from quillan.printable_response import (
@@ -16,6 +17,7 @@ from quillan.printable_response import (
     generate_printable_response_pdf,
     generate_printable_responses_for_roster,
 )
+from quillan.work_paths import QuillanWorkPathError, quillan_work_paths
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "paper_workflow"
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
@@ -204,3 +206,40 @@ def test_generate_printable_response_pdf_rejects_empty_students(
             assignment_id="literary_argument_synthetic",
             students=[],
         )
+
+
+def test_printable_preflight_late_collision_creates_no_partial_layout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class_id = "english12_p4_synthetic"
+    assignment_id = "literary_argument_synthetic"
+    paths = quillan_work_paths(tmp_path, class_id, assignment_id)
+    paths.exports_dir.parent.mkdir(parents=True)
+    paths.exports_dir.write_bytes(b"collision-bytes")
+    monkeypatch.setattr(
+        printable_response,
+        "build_response_page_context",
+        lambda **_kwargs: object(),
+    )
+
+    with pytest.raises(QuillanWorkPathError, match="not a directory"):
+        generate_printable_response_pdf(
+            tmp_path,
+            class_id=class_id,
+            assignment_id=assignment_id,
+            students=[
+                {
+                    "student_id": "stu_0001",
+                    "student_display_name": "Synthetic Student",
+                    "class_id": class_id,
+                }
+            ],
+        )
+
+    assert paths.exports_dir.read_bytes() == b"collision-bytes"
+    assert not paths.assignment_path.exists()
+    assert not paths.response_pages_dir.exists()
+    assert not paths.templates_dir.exists()
+    assert not paths.scans_dir.exists()
+    assert not paths.submissions_dir.exists()

--- a/tests/test_printable_response_workflows.py
+++ b/tests/test_printable_response_workflows.py
@@ -111,7 +111,9 @@ def _write_assignment(
         workspace_root
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -121,6 +123,104 @@ def _write_assignment(
         encoding="utf-8",
     )
     return path
+
+
+def _write_discovered_assignment(
+    workspace_root: Path,
+    assignment_id: str,
+    assignment: dict[str, object] | None = None,
+) -> Path:
+    value = dict(assignment or _assignment())
+    if assignment is None:
+        value["assignment_id"] = assignment_id
+    path = (
+        workspace_root
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "quillan"
+        / "work"
+        / assignment_id
+        / "assignment.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def test_discovery_is_direct_deterministic_and_module_isolated(
+    tmp_path: Path,
+) -> None:
+    _write_discovered_assignment(tmp_path, "z_assignment")
+    _write_discovered_assignment(tmp_path, "A_assignment")
+    nested = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "quillan"
+        / "work"
+        / "nested"
+        / "extra"
+        / "assignment.json"
+    )
+    nested.parent.mkdir(parents=True)
+    nested.write_text(json.dumps(_assignment()), encoding="utf-8")
+    sibling = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "scoreform"
+        / "work"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    sibling.parent.mkdir(parents=True)
+    sibling.write_text(json.dumps(_assignment()), encoding="utf-8")
+    legacy = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(json.dumps(_assignment()), encoding="utf-8")
+
+    choices = workflows.discover_assignment_configs(tmp_path, CLASS_ID)
+
+    assert [choice.assignment_id for choice in choices] == [
+        "A_assignment",
+        "z_assignment",
+    ]
+    assert legacy.is_file()
+
+
+def test_discovery_reports_malformed_and_identity_mismatch(tmp_path: Path) -> None:
+    malformed = _write_discovered_assignment(tmp_path, "bad_json")
+    malformed.write_text("{", encoding="utf-8")
+    _write_discovered_assignment(
+        tmp_path,
+        "folder_id",
+        {**_assignment(), "assignment_id": "record_id"},
+    )
+
+    choices = workflows.discover_assignment_configs(tmp_path, CLASS_ID)
+
+    assert [choice.assignment_id for choice in choices] == ["bad_json", "folder_id"]
+    assert choices[0].error is not None
+    assert "not valid JSON" in choices[0].error
+    assert choices[1].error is not None
+    assert "does not match" in choices[1].error
+    assert malformed.read_text(encoding="utf-8") == "{"
+
+
+def test_discovery_absent_collection_is_pure(tmp_path: Path) -> None:
+    workspace = tmp_path / "absent"
+    assert workflows.discover_assignment_configs(workspace, CLASS_ID) == ()
+    assert not workspace.exists()
 
 
 @pytest.mark.parametrize("value", ["0", "-1", "abc", "1.5"])
@@ -152,7 +252,9 @@ def test_generate_class_packet_happy_path(
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "templates"
         / "printable_response_pages.pdf"

--- a/tests/test_review_dashboard.py
+++ b/tests/test_review_dashboard.py
@@ -38,7 +38,7 @@ def test_dashboard_unions_students_isolates_invalid_records_and_is_read_only(
     review = copy.deepcopy(_review("feedback_composed"))
     review["student_id"] = "00100"
     review["submission_manifest_path"] = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
         "00100/submission.json"
     )
     _write_json(_student_dir(tmp_path, "00100") / "submission.json", manifest)
@@ -50,7 +50,9 @@ def test_dashboard_unions_students_isolates_invalid_records_and_is_read_only(
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
         / "response_00400_pg_001.pdf"

--- a/tests/test_review_notes.py
+++ b/tests/test_review_notes.py
@@ -44,7 +44,7 @@ def _manifest() -> dict[str, Any]:
                     {
                         "evidence_id": "evidence_001",
                         "routed_evidence_path": (
-                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
                             "scans/response_00107_pg_001.pdf"
                         ),
                         "evidence_role": "selected",
@@ -112,7 +112,7 @@ def test_creates_v2_review_record_with_private_note(tmp_path: Path) -> None:
     )
 
     expected_relative_path = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
         f"{STUDENT_ID}/review.json"
     )
     assert result == AddedReviewNote(
@@ -255,11 +255,11 @@ def test_identity_mismatch_is_rejected_without_writing(
     else:
         review[field] = value
         review["submission_manifest_path"] = (
-            f"classes/{review['class_id']}/assignments/{review['assignment_id']}"
+            f"classes/{review['class_id']}/modules/quillan/work/{review['assignment_id']}"
             f"/submissions/{review['student_id']}/submission.json"
         )
         review["assignment_path"] = (
-            f"classes/{review['class_id']}/assignments/{review['assignment_id']}/assignment.json"
+            f"classes/{review['class_id']}/modules/quillan/work/{review['assignment_id']}/assignment.json"
         )
     _write_manifest(tmp_path, manifest)
     review_path = _write_review(tmp_path, review) if record_kind == "review" else None

--- a/tests/test_review_observations.py
+++ b/tests/test_review_observations.py
@@ -83,7 +83,7 @@ def _manifest() -> dict[str, Any]:
                     {
                         "evidence_id": "evidence_001",
                         "routed_evidence_path": (
-                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
                             "scans/response_00107_pg_001.pdf"
                         ),
                         "evidence_role": "selected",
@@ -103,7 +103,7 @@ def _manifest() -> dict[str, Any]:
 
 
 def _write_workspace(root: Path) -> None:
-    assignment_dir = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    assignment_dir = root / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
     (assignment_dir / "assignment.json").write_text(
         json.dumps(_assignment()),

--- a/tests/test_review_ratings.py
+++ b/tests/test_review_ratings.py
@@ -84,7 +84,7 @@ def _manifest() -> dict[str, Any]:
                     {
                         "evidence_id": "evidence_001",
                         "routed_evidence_path": (
-                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
                             "scans/response_00107_pg_001.pdf"
                         ),
                         "evidence_role": "selected",
@@ -104,7 +104,7 @@ def _manifest() -> dict[str, Any]:
 
 
 def _write_workspace(root: Path, review: dict[str, Any] | None = None) -> None:
-    assignment_dir = root / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+    assignment_dir = root / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
     (assignment_dir / "assignment.json").write_text(
         json.dumps(_assignment()),

--- a/tests/test_review_record.py
+++ b/tests/test_review_record.py
@@ -143,7 +143,7 @@ def _populated_record() -> dict[str, Any]:
     record["exports"] = {
         "feedback_pdf": {
             "path": (
-                f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+                f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
                 f"{STUDENT_ID}/feedback.pdf"
             ),
             "generated_at": LATER_TIMESTAMP,
@@ -185,7 +185,7 @@ def test_build_empty_review_record_returns_valid_v2_record() -> None:
     assert record["schema_version"] == "2"
     assert record["review_state"] == "not_started"
     assert record["assignment_path"] == (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/assignment.json"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/assignment.json"
     )
     assert record["minimum_requirement_outcome"] == {
         "status": "not_checked",
@@ -340,7 +340,7 @@ def test_invalid_identifier_is_rejected(field: str, value: str) -> None:
         ("submission_manifest_path", "submission.json"),
         ("submission_manifest_path", r"C:\workspace\submission.json"),
         ("assignment_path", "assignment.json"),
-        ("assignment_path", f"classes/{CLASS_ID}/assignments/../{ASSIGNMENT_ID}/assignment.json"),
+        ("assignment_path", f"classes/{CLASS_ID}/modules/quillan/work/../{ASSIGNMENT_ID}/assignment.json"),
     ],
 )
 def test_invalid_canonical_paths_are_rejected(field: str, value: str) -> None:

--- a/tests/test_review_record_paths.py
+++ b/tests/test_review_record_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -41,7 +42,9 @@ def test_review_record_paths_use_canonical_quillan_layout(tmp_path: Path) -> Non
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -74,7 +77,8 @@ def test_review_record_paths_reject_invalid_identifiers(
     }
     identifiers[field] = value
 
-    with pytest.raises(ReviewRecordPathError, match=field):
+    expected_field = "work_id" if field == "assignment_id" else field
+    with pytest.raises(ReviewRecordPathError, match=expected_field):
         review_record_dir(tmp_path, **identifiers)
 
 
@@ -136,8 +140,23 @@ def test_parent_path_that_is_a_file_raises(tmp_path: Path) -> None:
 
     with pytest.raises(
         ReviewRecordPathError,
-        match="Could not create review record directory",
+        match="not a directory",
     ):
         write_review_record(path, _record())
 
     assert parent.read_text(encoding="utf-8") == "not a directory"
+
+
+def test_review_symlink_is_rejected_without_modifying_target(tmp_path: Path) -> None:
+    target = tmp_path / "outside.json"
+    target.write_text("original", encoding="utf-8")
+    path = tmp_path / "review.json"
+    try:
+        os.symlink(target, path)
+    except OSError as error:
+        pytest.skip(f"symlink creation is unavailable: {error}")
+
+    with pytest.raises(ReviewRecordPathError, match="symlink"):
+        write_review_record(path, _record(), overwrite=True)
+
+    assert target.read_text(encoding="utf-8") == "original"

--- a/tests/test_review_requirements.py
+++ b/tests/test_review_requirements.py
@@ -47,7 +47,7 @@ def _manifest() -> dict[str, Any]:
                     {
                         "evidence_id": "evidence_001",
                         "routed_evidence_path": (
-                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
                             "scans/response_00107_pg_001.pdf"
                         ),
                         "evidence_role": "selected",

--- a/tests/test_review_workflow_state.py
+++ b/tests/test_review_workflow_state.py
@@ -53,7 +53,7 @@ def _manifest() -> dict[str, Any]:
 
 @pytest.fixture
 def workspace(tmp_path: Path) -> Path:
-    assignment_path = tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID / "assignment.json"
+    assignment_path = tmp_path / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "assignment.json"
     assignment_path.parent.mkdir(parents=True)
     assignment_path.write_text(json.dumps(_assignment()), encoding="utf-8")
     write_submission_manifest(

--- a/tests/test_roster_to_printable_response_smoke.py
+++ b/tests/test_roster_to_printable_response_smoke.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
-from pds_core.routes import assignment_templates_dir
+from quillan.storage import assignment_templates_dir
 from pypdf import PdfReader
 
 import quillan.printable_response as printable_response

--- a/tests/test_roster_workflows.py
+++ b/tests/test_roster_workflows.py
@@ -436,7 +436,9 @@ def test_remove_is_in_memory_only_and_does_not_touch_evidence(
         tmp_path
         / "classes"
         / roster.class_id
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / "essay"
         / "submissions"
         / "0012"

--- a/tests/test_route_planning.py
+++ b/tests/test_route_planning.py
@@ -25,7 +25,7 @@ STUDENT_ID = "00107"
 @pytest.fixture
 def workspace(tmp_path: Path) -> Path:
     class_dir = tmp_path / "classes" / CLASS_ID
-    assignment_dir = class_dir / "assignments" / ASSIGNMENT_ID
+    assignment_dir = class_dir / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True)
 
     with (class_dir / "roster.csv").open(
@@ -131,7 +131,9 @@ def test_valid_decoded_page_returns_expected_route_plan(
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "assignment.json"
         ),
@@ -140,7 +142,9 @@ def test_valid_decoded_page_returns_expected_route_plan(
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "scans"
         ),
@@ -148,7 +152,9 @@ def test_valid_decoded_page_returns_expected_route_plan(
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "submissions"
             / STUDENT_ID
@@ -243,7 +249,9 @@ def test_invalid_assignment_config_returns_processing_error(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -264,7 +272,9 @@ def test_assignment_class_mismatch_returns_route_mismatch(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -285,7 +295,9 @@ def test_assignment_id_mismatch_returns_route_mismatch(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )

--- a/tests/test_routing_review.py
+++ b/tests/test_routing_review.py
@@ -77,7 +77,7 @@ def _route_failure(workspace: Path) -> RouteFailure:
 
 def _route_plan(workspace: Path) -> RoutePlan:
     assignment_dir = (
-        workspace / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+        workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     )
     return RoutePlan(
         class_id=CLASS_ID,

--- a/tests/test_standards_summary_export.py
+++ b/tests/test_standards_summary_export.py
@@ -124,7 +124,7 @@ def test_focus_standard_rows_follow_assignment_order_and_count_ratings(
     stale_pdf_path.write_bytes(b"%PDF")
     first_review["exports"]["feedback_pdf"] = {
         "path": (
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             "00100/exports/feedback.pdf"
         ),
         "generated_at": TIMESTAMP,
@@ -135,7 +135,7 @@ def test_focus_standard_rows_follow_assignment_order_and_count_ratings(
     stale_review = json.loads(second_review_path.read_text(encoding="utf-8"))
     stale_review["exports"]["feedback_pdf"] = {
         "path": (
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             "00200/exports/feedback.pdf"
         ),
         "generated_at": TIMESTAMP,
@@ -170,7 +170,7 @@ def test_focus_standard_rows_follow_assignment_order_and_count_ratings(
         assignment_id=ASSIGNMENT_ID,
         summary_path=expected_path,
         summary_relative_path=(
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/exports/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/exports/"
             "standards_summary.csv"
         ),
         row_count=2,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,18 +1,12 @@
-"""Tests for shared PDS assignment storage paths."""
+"""Tests for module-qualified Quillan assignment storage paths."""
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 
-from pds_core.routes import (
-    assignment_config_path as pds_assignment_config_path,
-    assignment_dir as pds_assignment_dir,
-    assignment_scans_dir as pds_assignment_scans_dir,
-    assignment_submissions_dir as pds_assignment_submissions_dir,
-    assignment_templates_dir as pds_assignment_templates_dir,
-    student_submission_dir as pds_student_submission_dir,
-)
-
+import quillan.printable_response_workflows as printable_workflows
+import quillan.storage as storage
 from quillan.storage import (
     assignment_config_path,
     assignment_dir,
@@ -27,36 +21,52 @@ ASSIGNMENT_ID = "villainy_final_essay_synthetic"
 STUDENT_ID = "stu_0001"
 
 
-def test_assignment_paths_use_shared_pds_routes(tmp_path: Path) -> None:
-    expected_dir = tmp_path / "classes" / CLASS_ID / "assignments" / ASSIGNMENT_ID
+def test_path_modules_do_not_import_removed_assignment_helpers() -> None:
+    storage_source = inspect.getsource(storage)
+    discovery_source = inspect.getsource(printable_workflows)
 
-    assert assignment_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID) == expected_dir
-    assert assignment_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID) == pds_assignment_dir(
-        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    assert "from pds_core.routes import" not in storage_source
+    assert "class_assignments_dir" not in discovery_source
+    assert ' / "assignments"' not in storage_source
+    assert ' / "assignments"' not in discovery_source
+
+
+def test_assignment_paths_use_module_qualified_work(tmp_path: Path) -> None:
+    workspace = tmp_path / "absent"
+    expected_dir = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "quillan"
+        / "work"
+        / ASSIGNMENT_ID
     )
-    assert assignment_config_path(
-        tmp_path, CLASS_ID, ASSIGNMENT_ID
-    ) == pds_assignment_config_path(tmp_path, CLASS_ID, ASSIGNMENT_ID)
-    assert assignment_submissions_dir(
-        tmp_path, CLASS_ID, ASSIGNMENT_ID
-    ) == pds_assignment_submissions_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
-    assert assignment_scans_dir(
-        tmp_path, CLASS_ID, ASSIGNMENT_ID
-    ) == pds_assignment_scans_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
-    assert assignment_templates_dir(
-        tmp_path, CLASS_ID, ASSIGNMENT_ID
-    ) == pds_assignment_templates_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+    assert assignment_dir(workspace, CLASS_ID, ASSIGNMENT_ID) == expected_dir
+    assert assignment_config_path(workspace, CLASS_ID, ASSIGNMENT_ID) == (
+        expected_dir / "assignment.json"
+    )
+    assert assignment_submissions_dir(workspace, CLASS_ID, ASSIGNMENT_ID) == (
+        expected_dir / "submissions"
+    )
+    assert assignment_scans_dir(workspace, CLASS_ID, ASSIGNMENT_ID) == (
+        expected_dir / "scans"
+    )
+    assert assignment_templates_dir(workspace, CLASS_ID, ASSIGNMENT_ID) == (
+        expected_dir / "templates"
+    )
+    assert not workspace.exists()
 
 
-def test_student_submission_dir_uses_shared_pds_route(tmp_path: Path) -> None:
-    expected_dir = pds_student_submission_dir(
-        tmp_path,
-        CLASS_ID,
-        ASSIGNMENT_ID,
-        STUDENT_ID,
+def test_student_submission_dir_uses_module_qualified_work(tmp_path: Path) -> None:
+    workspace = tmp_path / "absent"
+    expected_dir = (
+        assignment_submissions_dir(workspace, CLASS_ID, ASSIGNMENT_ID) / STUDENT_ID
     )
 
     assert (
-        student_submission_dir(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
+        student_submission_dir(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
         == expected_dir
     )
+    assert not workspace.exists()

--- a/tests/test_submission_assembly.py
+++ b/tests/test_submission_assembly.py
@@ -421,7 +421,9 @@ def test_assemble_writes_canonical_reloadable_manifest_and_overwrite(
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID

--- a/tests/test_submission_manifest_paths.py
+++ b/tests/test_submission_manifest_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -46,7 +47,9 @@ def test_submission_paths_use_canonical_quillan_layout(tmp_path: Path) -> None:
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -86,7 +89,8 @@ def test_submission_paths_reject_invalid_identifiers(
     }
     identifiers[field] = value
 
-    with pytest.raises(SubmissionManifestPathError, match=field):
+    expected_field = "work_id" if field == "assignment_id" else field
+    with pytest.raises(SubmissionManifestPathError, match=expected_field):
         submission_dir(tmp_path, **identifiers)
 
 
@@ -147,8 +151,23 @@ def test_parent_path_that_is_a_file_raises(tmp_path: Path) -> None:
 
     with pytest.raises(
         SubmissionManifestPathError,
-        match="Could not create submission manifest directory",
+        match="not a directory",
     ):
         write_submission_manifest(path, _manifest())
 
     assert parent.read_text(encoding="utf-8") == "not a directory"
+
+
+def test_manifest_symlink_is_rejected_without_modifying_target(tmp_path: Path) -> None:
+    target = tmp_path / "outside.json"
+    target.write_text("original", encoding="utf-8")
+    path = tmp_path / "submission.json"
+    try:
+        os.symlink(target, path)
+    except OSError as error:
+        pytest.skip(f"symlink creation is unavailable: {error}")
+
+    with pytest.raises(SubmissionManifestPathError, match="symlink"):
+        write_submission_manifest(path, _manifest(), overwrite=True)
+
+    assert target.read_text(encoding="utf-8") == "original"

--- a/tests/test_submission_page_management.py
+++ b/tests/test_submission_page_management.py
@@ -30,7 +30,7 @@ def _evidence(evidence_id: str, page_number: int, *, role: str = "selected") -> 
     return {
         "evidence_id": evidence_id,
         "routed_evidence_path": (
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
             f"response_{STUDENT_ID}_pg_{page_number:03d}_{evidence_id}.pdf"
         ),
         "evidence_role": role,

--- a/tests/test_submission_review_opening.py
+++ b/tests/test_submission_review_opening.py
@@ -27,7 +27,7 @@ CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
 STUDENT_ID = "00107"
 EVIDENCE_PATH = (
-    f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+    f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
     "response_00107_pg_001.pdf"
 )
 
@@ -127,7 +127,7 @@ def test_success_opens_selected_evidence_and_returns_context(
         student_id=STUDENT_ID,
         manifest_path=manifest_path,
         manifest_relative_path=(
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
             f"{STUDENT_ID}/submission.json"
         ),
         submission_state="unreviewed",
@@ -199,11 +199,11 @@ def test_multiple_selected_evidence_files_open_in_page_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     page_1_path = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
         "response_00107_pg_001.pdf"
     )
     page_2_path = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
         "response_00107_pg_002.pdf"
     )
     _write_manifest(
@@ -246,7 +246,7 @@ def test_page_number_opens_only_requested_page(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     page_2_path = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
         "response_00107_pg_002.pdf"
     )
     _write_manifest(

--- a/tests/test_submission_review_state.py
+++ b/tests/test_submission_review_state.py
@@ -54,7 +54,7 @@ def _manifest() -> dict[str, Any]:
                     {
                         "evidence_id": "evidence_001",
                         "routed_evidence_path": (
-                            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/"
+                            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
                             "scans/response_00107_pg_001.pdf"
                         ),
                         "evidence_role": "selected",
@@ -111,7 +111,7 @@ def test_success_updates_state_and_timestamp_only(tmp_path: Path) -> None:
     )
 
     expected_relative_path = (
-        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/"
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
         f"{STUDENT_ID}/submission.json"
     )
     assert result == UpdatedSubmissionReviewState(
@@ -358,7 +358,7 @@ def test_cli_success_prints_teacher_context(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     relative_path = (
-        "classes/class/assignments/assignment/submissions/00107/submission.json"
+        "classes/class/modules/quillan/work/assignment/submissions/00107/submission.json"
     )
     updated = UpdatedSubmissionReviewState(
         class_id=CLASS_ID,

--- a/tests/test_submission_status.py
+++ b/tests/test_submission_status.py
@@ -30,7 +30,9 @@ def _assignment_dir(workspace: Path) -> Path:
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
     )
 
@@ -50,7 +52,7 @@ def _evidence(
     return RoutedSubmissionEvidence(
         page_number=page_number,
         routed_evidence_path=(
-            f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/scans/{filename}"
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/{filename}"
         ),
         **kwargs,
     )

--- a/tests/test_v06_reviewable_evidence_smoke.py
+++ b/tests/test_v06_reviewable_evidence_smoke.py
@@ -36,7 +36,9 @@ def test_v06_synthetic_reviewable_evidence_workflow_is_non_destructive(
         tmp_path
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "scans"
     )
@@ -66,7 +68,9 @@ def test_v06_synthetic_reviewable_evidence_workflow_is_non_destructive(
         (
             Path("classes")
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "submissions"
             / student_id

--- a/tests/test_v080_end_to_end_smoke.py
+++ b/tests/test_v080_end_to_end_smoke.py
@@ -184,7 +184,9 @@ def test_v080_scan_review_export_end_to_end_smoke(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "assignment.json"
     )
@@ -208,7 +210,9 @@ def test_v080_scan_review_export_end_to_end_smoke(
             workspace
             / "classes"
             / CLASS_ID
-            / "assignments"
+            / "modules"
+            / "quillan"
+            / "work"
             / ASSIGNMENT_ID
             / "scans"
         ).glob("response_*.pdf")
@@ -314,7 +318,9 @@ def test_v080_scan_review_export_end_to_end_smoke(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "submissions"
         / STUDENT_ID
@@ -325,7 +331,9 @@ def test_v080_scan_review_export_end_to_end_smoke(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
         / "class_summary.csv"
@@ -334,7 +342,9 @@ def test_v080_scan_review_export_end_to_end_smoke(
         workspace
         / "classes"
         / CLASS_ID
-        / "assignments"
+        / "modules"
+        / "quillan"
+        / "work"
         / ASSIGNMENT_ID
         / "exports"
         / "standards_summary.csv"

--- a/tests/test_work_paths.py
+++ b/tests/test_work_paths.py
@@ -1,0 +1,381 @@
+"""Tests for Quillan's module-qualified work path contract."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from pds_core.routes import module_work_dir
+from pds_core.routing_models import ModuleWorkRef
+import pytest
+
+from quillan.pds_contract import QUILLAN_MODULE_ID
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    _is_link_like,
+    initialize_managed_work_layout,
+    initialize_student_submission_dir,
+    preflight_managed_work_layout,
+    preflight_quillan_work_collection,
+    preflight_work_file_destination,
+    quillan_work_collection_dir,
+    quillan_work_paths,
+    quillan_work_ref,
+    relative_assignment_path,
+    relative_submission_manifest_path,
+    review_record_path,
+    student_submission_dir,
+    submission_manifest_path,
+)
+
+CLASS_ID = "English12_P03"
+ASSIGNMENT_ID = "Essay_007"
+STUDENT_ID = "00107"
+
+
+def test_work_reference_and_exact_layout_are_module_qualified(tmp_path: Path) -> None:
+    work_ref = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    paths = quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    root = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / QUILLAN_MODULE_ID
+        / "work"
+        / ASSIGNMENT_ID
+    )
+
+    assert work_ref == ModuleWorkRef(QUILLAN_MODULE_ID, CLASS_ID, ASSIGNMENT_ID)
+    assert paths.work_ref is not None
+    assert paths.roster_path == tmp_path / "classes" / CLASS_ID / "roster.csv"
+    assert paths.work_collection_dir == root.parent
+    assert quillan_work_collection_dir(tmp_path, CLASS_ID) == root.parent
+    assert paths.work_root == root
+    assert paths.assignment_path == root / "assignment.json"
+    assert paths.response_pages_dir == root / "response_pages"
+    assert paths.templates_dir == root / "templates"
+    assert paths.scans_dir == root / "scans"
+    assert paths.submissions_dir == root / "submissions"
+    assert paths.exports_dir == root / "exports"
+    assert student_submission_dir(tmp_path, work_ref, STUDENT_ID) == (
+        root / "submissions" / STUDENT_ID
+    )
+    assert submission_manifest_path(tmp_path, work_ref, STUDENT_ID) == (
+        root / "submissions" / STUDENT_ID / "submission.json"
+    )
+    assert review_record_path(tmp_path, work_ref, STUDENT_ID) == (
+        root / "submissions" / STUDENT_ID / "review.json"
+    )
+    assert all(
+        path.is_relative_to(root)
+        for path in (
+            paths.assignment_path,
+            paths.response_pages_dir,
+            paths.templates_dir,
+            paths.scans_dir,
+            paths.submissions_dir,
+            paths.exports_dir,
+        )
+    )
+    assert all(
+        "assignments" not in path.parts
+        for path in (
+            paths.roster_path,
+            paths.work_collection_dir,
+            paths.work_root,
+            paths.assignment_path,
+            paths.response_pages_dir,
+            paths.templates_dir,
+            paths.scans_dir,
+            paths.submissions_dir,
+            paths.exports_dir,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("class_id", "assignment_id"),
+    [("../class", ASSIGNMENT_ID), (CLASS_ID, "bad/work"), ("", ASSIGNMENT_ID)],
+)
+def test_invalid_work_identifiers_are_rejected(
+    tmp_path: Path, class_id: str, assignment_id: str
+) -> None:
+    workspace = tmp_path / "absent"
+    with pytest.raises(ValueError):
+        quillan_work_paths(workspace, class_id, assignment_id)
+    assert not workspace.exists()
+
+
+def test_all_path_construction_is_side_effect_free(tmp_path: Path) -> None:
+    workspace = tmp_path / "absent"
+    work_ref = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+    quillan_work_collection_dir(workspace, CLASS_ID)
+    quillan_work_paths(workspace, CLASS_ID, ASSIGNMENT_ID)
+    student_submission_dir(workspace, work_ref, STUDENT_ID)
+    submission_manifest_path(workspace, work_ref, STUDENT_ID)
+    review_record_path(workspace, work_ref, STUDENT_ID)
+
+    assert not workspace.exists()
+
+
+def test_relative_paths_are_central_exact_pure_and_preserve_leading_zeroes(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "absent"
+    assert relative_assignment_path(CLASS_ID, ASSIGNMENT_ID) == (
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/assignment.json"
+    )
+    assert relative_submission_manifest_path(
+        CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ) == (
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
+        f"{STUDENT_ID}/submission.json"
+    )
+    with pytest.raises(ValueError):
+        relative_assignment_path(CLASS_ID, "../unsafe")
+    with pytest.raises(ValueError):
+        relative_submission_manifest_path(CLASS_ID, ASSIGNMENT_ID, "bad/student")
+    assert not workspace.exists()
+
+
+def test_work_file_preflight_is_contained_and_nonmutating(tmp_path: Path) -> None:
+    workspace = tmp_path / "absent"
+    paths = quillan_work_paths(workspace, CLASS_ID, ASSIGNMENT_ID)
+
+    assert preflight_managed_work_layout(paths) == paths
+    assert preflight_work_file_destination(
+        workspace, paths.work_ref, "assignment.json"
+    ) == paths.assignment_path
+    with pytest.raises(ValueError):
+        preflight_work_file_destination(
+            workspace, paths.work_ref, "../outside.json"
+        )
+    with pytest.raises(QuillanWorkPathError, match="module_id"):
+        preflight_work_file_destination(
+            workspace,
+            ModuleWorkRef("scoreform", CLASS_ID, ASSIGNMENT_ID),
+            "assignment.json",
+        )
+    assert not workspace.exists()
+
+
+def test_work_collection_preflight_is_bounded_pure_and_allows_absence(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "absent"
+    expected = quillan_work_collection_dir(workspace, CLASS_ID)
+
+    assert preflight_quillan_work_collection(workspace, CLASS_ID) == expected
+    assert not workspace.exists()
+
+
+def test_work_collection_preflight_rejects_wrong_type_ancestor_without_mutation(
+    tmp_path: Path,
+) -> None:
+    modules = tmp_path / "classes" / CLASS_ID / "modules"
+    modules.parent.mkdir(parents=True)
+    modules.write_bytes(b"unchanged")
+
+    with pytest.raises(QuillanWorkPathError, match="not a directory"):
+        preflight_quillan_work_collection(tmp_path, CLASS_ID)
+
+    assert modules.read_bytes() == b"unchanged"
+    assert list(modules.parent.iterdir()) == [modules]
+
+
+def test_student_helpers_reject_other_modules_and_invalid_students(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "absent"
+    other = ModuleWorkRef("scoreform", CLASS_ID, ASSIGNMENT_ID)
+    with pytest.raises(QuillanWorkPathError, match="module_id"):
+        student_submission_dir(workspace, other, STUDENT_ID)
+    with pytest.raises(ValueError, match="student_id"):
+        student_submission_dir(
+            workspace, quillan_work_ref(CLASS_ID, ASSIGNMENT_ID), "../student"
+        )
+
+    assert module_work_dir(workspace, other) != quillan_work_paths(
+        workspace, CLASS_ID, ASSIGNMENT_ID
+    ).work_root
+    assert not workspace.exists()
+
+
+def test_initializer_creates_only_static_layout_and_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    paths = quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    initialize_managed_work_layout(paths)
+    marker = paths.work_root / "teacher-marker.txt"
+    marker.write_text("preserve", encoding="utf-8")
+
+    assert initialize_managed_work_layout(paths) == paths
+    assert marker.read_text(encoding="utf-8") == "preserve"
+    assert {child.name for child in paths.work_root.iterdir()} == {
+        "response_pages",
+        "templates",
+        "scans",
+        "submissions",
+        "exports",
+        "teacher-marker.txt",
+    }
+    assert not paths.assignment_path.exists()
+    assert not (paths.work_root / "routes").exists()
+    assert not list(paths.work_root.rglob("*.json"))
+    assert not list(paths.work_root.rglob("*.pdf"))
+
+
+@pytest.mark.parametrize(
+    "collision_name",
+    ["work_root", "response_pages_dir", "templates_dir", "scans_dir", "submissions_dir", "exports_dir"],
+)
+def test_initializer_preflights_all_wrong_type_collisions(
+    tmp_path: Path, collision_name: str
+) -> None:
+    paths = quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    collision = getattr(paths, collision_name)
+    collision.parent.mkdir(parents=True, exist_ok=True)
+    collision.write_bytes(b"unchanged")
+
+    with pytest.raises(QuillanWorkPathError, match="not a directory"):
+        initialize_managed_work_layout(paths)
+
+    assert collision.read_bytes() == b"unchanged"
+    for required in (
+        paths.response_pages_dir,
+        paths.templates_dir,
+        paths.scans_dir,
+        paths.submissions_dir,
+        paths.exports_dir,
+    ):
+        if required != collision and not required.is_relative_to(collision):
+            assert not required.exists()
+
+
+def test_initializer_preserves_sibling_module_work(tmp_path: Path) -> None:
+    sibling = module_work_dir(
+        tmp_path, ModuleWorkRef("scoreform", CLASS_ID, ASSIGNMENT_ID)
+    )
+    sibling.mkdir(parents=True)
+    marker = sibling / "marker.txt"
+    marker.write_text("sibling", encoding="utf-8")
+
+    initialize_managed_work_layout(
+        quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    )
+
+    assert marker.read_text(encoding="utf-8") == "sibling"
+
+
+def test_student_directory_initialization_is_narrow_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    paths = quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+    student_dir = initialize_student_submission_dir(
+        tmp_path, paths.work_ref, STUDENT_ID
+    )
+    assert student_dir.is_dir()
+    assert list(student_dir.iterdir()) == []
+    assert initialize_student_submission_dir(
+        tmp_path, paths.work_ref, STUDENT_ID
+    ) == student_dir
+    assert not paths.response_pages_dir.exists()
+    assert not paths.templates_dir.exists()
+    assert not paths.scans_dir.exists()
+    assert not paths.exports_dir.exists()
+
+
+def test_student_directory_initialization_rejects_link_like_target(
+    tmp_path: Path,
+) -> None:
+    paths = quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    initialize_managed_work_layout(paths)
+    outside = tmp_path / "outside-student"
+    outside.mkdir()
+    marker = outside / "marker.bin"
+    marker.write_bytes(b"unchanged")
+    student = student_submission_dir(tmp_path, paths.work_ref, STUDENT_ID)
+    try:
+        os.symlink(outside, student, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"symlink creation is unavailable: {error}")
+
+    with pytest.raises(QuillanWorkPathError, match="symlink or junction"):
+        initialize_student_submission_dir(tmp_path, paths.work_ref, STUDENT_ID)
+
+    assert marker.read_bytes() == b"unchanged"
+    assert student.is_symlink()
+
+
+def test_initializer_rejects_symlink_ancestor_before_mutation(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    modules = workspace / "classes" / CLASS_ID / "modules"
+    modules.parent.mkdir(parents=True)
+    try:
+        os.symlink(outside, modules, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"symlink creation is unavailable: {error}")
+
+    with pytest.raises(QuillanWorkPathError, match="symlink"):
+        initialize_managed_work_layout(
+            quillan_work_paths(workspace, CLASS_ID, ASSIGNMENT_ID)
+        )
+
+    assert list(outside.iterdir()) == []
+
+
+def test_link_like_predicate_has_deterministic_symlink_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "is_symlink", lambda _path: True)
+    assert _is_link_like(tmp_path / "synthetic")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows junction test")
+def test_initializer_rejects_real_windows_junction_escape(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "marker.txt"
+    marker.write_text("unchanged", encoding="utf-8")
+    modules = workspace / "classes" / CLASS_ID / "modules"
+    modules.parent.mkdir(parents=True)
+    result = subprocess.run(
+        ["cmd.exe", "/c", "mklink", "/J", str(modules), str(outside)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            "Windows junction creation unavailable: "
+            f"exit {result.returncode}: {result.stderr.strip()}"
+        )
+    try:
+        with pytest.raises(QuillanWorkPathError, match="junction"):
+            initialize_managed_work_layout(
+                quillan_work_paths(workspace, CLASS_ID, ASSIGNMENT_ID)
+            )
+        assert marker.read_text(encoding="utf-8") == "unchanged"
+        assert list(outside.iterdir()) == [marker]
+    finally:
+        os.rmdir(modules)
+
+
+def test_production_modules_do_not_reconstruct_canonical_work_literal() -> None:
+    production_root = Path(__file__).parents[1] / "quillan"
+    offenders = [
+        path
+        for path in production_root.rglob("*.py")
+        if path.name != "work_paths.py"
+        and "modules/quillan/work" in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == []


### PR DESCRIPTION
## Summary

Defines and activates Quillan’s canonical PDS2-era, module-qualified work-path contract.

Quillan assignments now use the complete Core work identity:

```python
ModuleWorkRef(
    module_id="quillan",
    class_id=<class_id>,
    work_id=<assignment_id>,
)
```

and are stored beneath:

```text
classes/<class_id>/modules/quillan/work/<assignment_id>/
```

Closes #334.

Part of #329.

## Canonical Layout

```text
classes/
  <class_id>/
    roster.csv
    modules/
      quillan/
        work/
          <assignment_id>/
            assignment.json
            response_pages/
            templates/
            scans/
            submissions/
              <student_id>/
                submission.json
                review.json
            exports/
```

For Quillan, `assignment_id` is the module-owned `work_id`. Complete assignment identity consists of the module, class, and work IDs.

The shared class roster remains outside Quillan work at:

```text
classes/<class_id>/roster.csv
```

Core-owned route registrations remain reserved for the work root’s future `routes/` directory.

## Changes

### Centralized path contract

Adds `quillan.work_paths` as the authoritative path API for:

* Quillan work references;
* class work collections;
* assignment work roots;
* assignment configuration;
* response-page collections;
* templates;
* scans and routed evidence;
* assignment submissions;
* student submission directories;
* submission manifests;
* review records;
* assignment exports;
* and canonical workspace-relative record paths.

All module-owned descendants are derived through PDS Core’s module-work helpers rather than independently reconstructing the workspace tree.

### Safe managed-layout initialization

Adds explicit preflight and initialization operations that:

* separate pure path construction from filesystem mutation;
* preflight the complete required directory set before mutation;
* reject wrong filesystem types;
* reject symbolic links and Windows directory junctions;
* enforce workspace containment;
* preserve existing compatible directories;
* remain idempotent;
* preserve sibling-module work;
* and avoid partial layout creation after a failed preflight.

The initializer creates only the static directory structure. It does not create:

* assignment records;
* response-page records;
* submission or review records;
* PDFs;
* scans;
* exports;
* route registrations;
* or placeholder files.

### Safe file destinations

Assignment, printable-response, submission-manifest, and review-record writers now validate their destination chains before creating directories or writing records.

Canonical student submission directories are initialized only when an actual submission or review workflow requires them.

Plain-paper submissions continue to use the current Quillan workflow without fabricating QR, page, route, scan, or digital-evidence records.

### Assignment discovery

Adds one shared assignment-discovery implementation that:

* inspects only direct children of:

  ```text
  classes/<class_id>/modules/quillan/work/
  ```
* validates work IDs;
* requires a direct ordinary `assignment.json`;
* rejects symbolic links and junctions;
* validates intermediate collection ancestors before reading;
* rejects wrong-type collection ancestors;
* validates assignment records;
* requires the stored `assignment_id` to match the work directory;
* sorts results deterministically;
* does not recurse;
* does not inspect sibling modules;
* and does not inspect the former unqualified assignment tree.

Real Windows tests verify that discovery refuses to traverse:

* an intermediate `modules/` junction; and
* a direct `work/` collection junction.

External target files and directories remain unchanged.

### Existing path consumers

Migrates active Quillan path consumers, fixtures, and examples, including:

* assignment creation and selection;
* printable-response paths and discovery;
* submission assembly;
* plain-paper submission;
* submission and review records;
* review dashboards and status;
* assignment summaries;
* class, standards, and student-performance exports;
* roster cleanup;
* and persisted record path fields.

The existing `quillan.storage` API remains available as a Quillan-facing abstraction but now returns module-qualified paths exclusively.

### Persisted path values

Canonical workspace-relative values stored in records now derive from the central path contract rather than repeated string interpolation.

Examples include:

```text
classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
```

## Hard-Cutover Policy

This change provides no support for:

* unqualified assignment-path discovery;
* fallback reads;
* fallback writes;
* dual writes;
* legacy-path aliases;
* workspace migration;
* automatic or manual conversion;
* read-only legacy compatibility;
* or feature flags restoring the former layout.

Existing development records beneath:

```text
classes/<class_id>/assignments/<assignment_id>/
```

are neither discovered nor modified.

Synthetic legacy directories appear in tests only to prove that they are ignored and preserved unchanged.

## Safety Validation

The path contract verifies:

* side-effect-free path construction;
* identifier validation without sanitization;
* exact module ownership;
* workspace containment;
* all-or-nothing directory preflight;
* wrong-type collision handling;
* symlink rejection;
* Windows junction rejection;
* student-directory safety;
* sibling-module isolation;
* direct-only discovery;
* absent-collection behavior;
* invalid-child handling;
* assignment-record identity matching;
* and preservation of external and collision content.

Executed containment coverage includes:

* intermediate Windows `modules/` junction rejection;
* direct Windows `work/` junction rejection;
* deterministic link-like detection;
* wrong-type intermediate ancestor rejection;
* and no traversal of external discovery targets.

OS-level symbolic-link tests that require unavailable Windows privileges are skipped with explicit reasons; equivalent deterministic link-rejection branches and executable junction cases pass.

## Validation

### Passed

* Exact assignment-discovery tests: **11 passed, 1 skipped**
* Focused path and containment tests: **30 passed, 3 skipped**
* Full Ruff
* Focused mypy for #334 files
* `git diff --check`
* Repository scan for independent active `modules/quillan/work` construction
* Repository scan for removed Core unqualified assignment-helper imports

### Full diagnostic baseline

```text
Full pytest:
763 passed
86 failed
6 skipped
43 collection errors

Full mypy:
35 errors in 8 files
```

No remaining failure is attributed to #334 path construction, containment, discovery, mutation ordering, or typing.

## Known Intermediate Migration Failures

The repository remains intentionally red while later hard-cutover tickets replace untouched legacy contracts.

Remaining failure families are:

* removed PDS1 and QR-payload APIs;
* obsolete scan failure and resolution metadata fields;
* obsolete routing failure categories;
* and downstream CLI imports that still reach those surfaces.

These are assigned to the subsequent migration work under #329, principally #336, #338, #339, #341, and #342.

No compatibility shim, legacy fallback, broad suppression, or PDS1 restoration was introduced.

## Scope Boundaries

This PR does not implement:

* immutable response-page records;
* response generation or issuance identity;
* PDS2 QR generation;
* Core route registration;
* the installed Quillan module profile;
* a Quillan response-page handler;
* Core source retention;
* PDS2 scan dispatch;
* routed-evidence metadata migration;
* immutable submission-assembly identity;
* scan-review schema migration;
* or package-version and release changes.

The `response_pages/` directory is reserved by the path contract only. Its record model and persistence behavior remain assigned to #335.
