### PR TITLE
Define immutable printable-response records (#335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Canonical active records and exports live at:
 ```text
 classes/<class_id>/roster.csv
 classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
-classes/<class_id>/modules/quillan/work/<assignment_id>/response_pages/
+classes/<class_id>/modules/quillan/work/<assignment_id>/response_pages/issuances/<issuance_id>.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/response_pages/pages/<page_id>.json
 classes/<class_id>/modules/quillan/work/<assignment_id>/templates/printable_response_pages.pdf
 classes/<class_id>/modules/quillan/work/<assignment_id>/scans/
 classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
@@ -76,9 +77,10 @@ class, and work ID. The class roster remains a shared Core-owned class record.
 Within Quillan work, `scans/` stores Quillan-routed evidence rather than Core's
 retained source scan, while `routes/` is reserved for Core-owned route
 registrations. Quillan supports only the module-qualified tree above: there is
-no unqualified assignment path, legacy migration, or fallback. This layout does
-not yet claim response-page persistence, PDS2 generation or routing, submission
-assembly, or completion of the CLI migration.
+no unqualified assignment path, legacy migration, or fallback. Immutable v1
+issuance and physical-page records are now defined and safely persisted. This
+does not yet claim PDS2 PDF generation, route registration, QR rendering,
+submission assembly, or completion of the CLI migration.
 
 ## Teacher-Facing Menu
 
@@ -409,6 +411,6 @@ Review Student Work and choose **Create plain-paper submission for this
 student**. Quillan creates a review-ready `submission.json` and `review.json`
 without routing a scan, running OCR, or fabricating digital evidence. The
 physical paper remains under the teacher's control, and the normal
-standards-based review and export actions apply after setup. This does not
-change printable QR/PDS1 response pages. Never commit real student data or
-workspace artifacts.
+standards-based review and export actions apply after setup. This plain-paper
+workflow does not create QR, route, page, scan, or digital-evidence records.
+Never commit real student data or workspace artifacts.

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -33,7 +33,7 @@ schemas.
 Active assignments use schema version `2` and live at:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/assignment.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
 The v0.8.6 assignment contract is defined in
@@ -56,7 +56,7 @@ not active schema version `2` fields.
 Submission manifests live at:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
 ```
 
 They describe routed evidence, retained-source provenance, page state, selected
@@ -81,7 +81,7 @@ separate from the standards-based review workflow state in
 The active teacher-review artifact is schema version `2` `review.json`:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json
 ```
 
 The contract is defined in
@@ -123,8 +123,8 @@ comment lookup.
 Student feedback exports are derived artifacts:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
 The export contract is defined in
@@ -143,9 +143,9 @@ and unselected comments.
 Assignment-level reports are derived artifacts:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/student_performance_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/student_performance_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
 ```
 
 The reporting contract is defined in
@@ -164,23 +164,165 @@ coverage.
 Reports do not calculate grades, percentages, mastery, or cross-assignment
 results.
 
-### Printable Response Payloads
+### Immutable Printable-response Records
 
-Printable response pages use pds-core PDS1 payloads:
+Quillan owns a PDS2-only v1 identity contract for intended printable response
+pages. The identities are deliberately distinct:
+
+* a **generation** is one user-invoked generation operation and has a fresh
+  `gen_<32 lowercase hex>` identity;
+* an **artifact** is one intended PDF file and has a fresh
+  `art_<32 lowercase hex>` identity;
+* an **issuance** is one intended copy for one class, assignment, and student
+  and has a fresh `iss_<32 lowercase hex>` identity; and
+* a **page** is one intended physical page in an issuance and has a fresh
+  `pg_<32 lowercase hex>` identity.
+
+A future Core route is separate from all four. Issue #336 will register exactly
+one immutable Core route per page, targeted at:
 
 ```text
-PDS1|module=quillan|class=<class_id>|aid=<assignment_id>|sid=<student_id>|page=<page_number>|doc=response
+module_id:        quillan
+record_kind:      response_page
+record_id:        <page_id>
+contract_version: "1"
 ```
 
-Printable response generation embeds the payload as a QR code on each response
-page and writes:
+This contract creates no route ID, route registration, locator, QR payload, or
+PDF. It contains no PDS1 compatibility, legacy import, fallback loader, or
+unqualified-path lookup.
+
+#### Storage
+
+Only issuance and page records are persisted. There are no generation or
+artifact aggregate files, indexes, or latest/current pointers.
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/templates/printable_response_pages.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/
+  response_pages/
+    issuances/
+      <issuance_id>.json
+    pages/
+      <page_id>.json
 ```
 
-The printable response contract is documented in
-[`printable_response_template.md`](printable_response_template.md).
+Core alone owns `routes/`; Quillan response records never live there.
+
+#### Issuance schema version 1
+
+```json
+{
+  "schema_version": "1",
+  "issuance_id": "iss_0123456789abcdef0123456789abcdef",
+  "generation_id": "gen_0123456789abcdef0123456789abcdef",
+  "artifact_id": "art_0123456789abcdef0123456789abcdef",
+  "class_id": "english10_p2",
+  "assignment_id": "literary_analysis",
+  "student_id": "00107",
+  "generation_context": {
+    "output_kind": "class_packet_pdf",
+    "reason": "initial",
+    "predecessor_issuance_id": null
+  },
+  "class_label": "English 10 Period 2",
+  "assignment_snapshot": {
+    "schema_version": "2",
+    "title": "Coming-of-Age Literary Analysis",
+    "updated_at": "2026-07-19T18:00:00+00:00"
+  },
+  "student_snapshot": {
+    "display_name": "Sample Student",
+    "last_name": "Student",
+    "first_name": "Sample",
+    "period": "2"
+  },
+  "page_count": 2,
+  "page_ids": [
+    "pg_0123456789abcdef0123456789abcdef",
+    "pg_1123456789abcdef0123456789abcdef"
+  ],
+  "lifecycle": {
+    "status": "prepared",
+    "revision": 1,
+    "created_at": "2026-07-19T18:30:00+00:00",
+    "updated_at": "2026-07-19T18:30:00+00:00",
+    "issued_at": null,
+    "ended_at": null,
+    "reason": null,
+    "replacement_issuance_id": null
+  }
+}
+```
+
+The assignment snapshot is bounded to schema version, title, and update time.
+The student snapshot is bounded to the printed display name, first/last names,
+and period. Creation verifies both snapshots against the current canonical
+assignment and roster. Later loading does not consult those mutable sources;
+the immutable records remain the historical authority.
+
+#### Page schema and contract version 1
+
+```json
+{
+  "schema_version": "1",
+  "page_id": "pg_0123456789abcdef0123456789abcdef",
+  "issuance_id": "iss_0123456789abcdef0123456789abcdef",
+  "generation_id": "gen_0123456789abcdef0123456789abcdef",
+  "artifact_id": "art_0123456789abcdef0123456789abcdef",
+  "class_id": "english10_p2",
+  "assignment_id": "literary_analysis",
+  "student_id": "00107",
+  "logical_page": 1,
+  "total_pages": 2,
+  "page_role": "response_start",
+  "created_at": "2026-07-19T18:30:00+00:00"
+}
+```
+
+Page one is always `response_start`; every later logical page is
+`continuation`. The immutable page record—not QR text, a filename, scan order,
+source-page number, current packet settings, or a submission manifest—is the
+authority for student identity, issuance membership, logical page, total pages,
+and continuation meaning. `source_page_number` will identify a page in a
+retained scan file; `logical_page` identifies a page in the original student
+issuance. They are independent values.
+
+Page records are created exclusively, cannot be overwritten or updated, and
+cannot move between issuances. An issuance is written only after all member
+pages and acts as their aggregate commit marker. Its controlled lifecycle is:
+
+```text
+prepared -> issued
+prepared -> cancelled
+prepared -> invalidated
+issued   -> superseded
+issued   -> invalidated
+```
+
+Lifecycle writes require the expected revision and atomically replace only the
+issuance JSON. Page bytes never change. `cancelled`, `superseded`, and
+`invalidated` are terminal and require a reason; supersession also names a
+different, already-issued replacement for the same class, assignment, and
+student.
+
+Every additional physical copy receives fresh generation, artifact, issuance,
+and page IDs. An `additional_copy` has no predecessor. A `regeneration` names a
+persisted predecessor with the same class, assignment, and student, but does
+not mutate it. The predecessor may be explicitly superseded only after the
+replacement is issued.
+
+Because v1 deliberately has no generation or artifact index, issue #336 must
+generate fresh cryptographically random generation and artifact IDs for every
+additional copy; it must not infer reuse from equivalent content or paths.
+
+These generated-page records are not student submissions and do not prove that
+work was returned. Submission-manifest pages remain mutable, teacher-reviewed
+evidence state until issue #339 migrates that contract. Plain-paper submissions
+remain valid without a generation, issuance, page, route, scan, or evidence
+record.
+
+Issue #335 does not complete PDS2 PDF generation, route registration, QR
+rendering, scan intake, evidence filing, submission assembly, or CLI migration.
 
 ## Standards References
 

--- a/quillan/printable_response_persistence.py
+++ b/quillan/printable_response_persistence.py
@@ -1,0 +1,711 @@
+"""Safe persistence for immutable Quillan printable-response records."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, cast
+
+from pds_core.classes import load_class_roster
+from pds_core.rosters import RosterError, student_display_name
+from pds_core.routing_models import (
+    ModuleWorkRef,
+    RoutingModelError,
+    validate_module_work_ref,
+)
+
+from quillan.assignments import AssignmentConfigError, load_assignment_config
+from quillan.pds_contract import QUILLAN_MODULE_ID
+from quillan.printable_response_records import (
+    PrintableResponseIssuance,
+    PrintableResponsePage,
+    PrintableResponsePageContext,
+    PrintableResponseRecordSet,
+    PrintableResponseRecordValidationError,
+    printable_response_issuance_from_mapping,
+    printable_response_page_from_mapping,
+    transition_printable_response_lifecycle,
+    validate_issuance_id,
+    validate_page_id,
+    validate_printable_response_record_set,
+)
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    _is_link_like,
+    _preflight_directories,
+    preflight_work_file_destination,
+    quillan_work_paths,
+    response_page_issuance_path,
+    response_page_record_path,
+)
+
+
+class PrintableResponsePersistenceError(Exception):
+    """Base error for printable-response persistence operations."""
+
+
+class PrintableResponsePersistenceValidationError(PrintableResponsePersistenceError):
+    """Raised when a supplied record set or work identity is invalid."""
+
+
+class PrintableResponseRecordCollisionError(PrintableResponsePersistenceError):
+    """Raised when any immutable record destination already exists."""
+
+
+class PrintableResponseReadError(PrintableResponsePersistenceError):
+    """Raised when an exact record cannot be decoded or read safely."""
+
+
+class PrintableResponseNotFoundError(PrintableResponseReadError):
+    """Raised when an exact requested record is absent."""
+
+
+class PrintableResponseIntegrityError(PrintableResponsePersistenceError):
+    """Raised when persisted identities or record membership disagree."""
+
+
+class PrintableResponseRecordSetWriteError(PrintableResponsePersistenceError):
+    """Raised when exclusive record-set creation does not complete."""
+
+
+class PrintableResponseRollbackError(
+    PrintableResponseIntegrityError, PrintableResponseRecordSetWriteError
+):
+    """Raised when current-operation files cannot be completely rolled back."""
+
+
+class PrintableResponseLifecycleError(PrintableResponsePersistenceError):
+    """Raised when a persisted lifecycle cannot be transitioned safely."""
+
+
+class PrintableResponseLifecycleCleanupError(PrintableResponseLifecycleError):
+    """Raised when an abandoned lifecycle temporary file cannot be removed."""
+
+
+class PrintableResponseRevisionConflictError(PrintableResponseLifecycleError):
+    """Raised when the caller's expected issuance revision is stale."""
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedPrintableResponseRecordSet:
+    record_set: PrintableResponseRecordSet
+    issuance_path: Path
+    page_paths: tuple[Path, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _CreatedRecord:
+    path: Path
+    expected_bytes: bytes
+
+
+def _validated_quillan_work_ref(value: object) -> ModuleWorkRef:
+    if not isinstance(value, ModuleWorkRef):
+        raise PrintableResponsePersistenceValidationError(
+            "work_ref must be a ModuleWorkRef."
+        )
+    try:
+        validated = validate_module_work_ref(value)
+    except (RoutingModelError, TypeError, AttributeError) as error:
+        raise PrintableResponsePersistenceValidationError(
+            f"Invalid work_ref: {error}"
+        ) from error
+    if validated.module_id != QUILLAN_MODULE_ID:
+        raise PrintableResponsePersistenceValidationError(
+            f"work_ref.module_id must be {QUILLAN_MODULE_ID!r}."
+        )
+    return validated
+
+
+def canonical_printable_response_json(value: Mapping[str, Any]) -> bytes:
+    """Encode a record as deterministic strict UTF-8 JSON with one newline."""
+    try:
+        text = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as error:
+        raise PrintableResponsePersistenceValidationError(
+            f"Record is not strict JSON: {error}"
+        ) from error
+    return f"{text}\n".encode("utf-8")
+
+
+def _duplicate_rejecting_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise PrintableResponseReadError(f"Duplicate JSON object key: {key!r}.")
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> None:
+    raise PrintableResponseReadError(f"Non-standard JSON constant is forbidden: {value}.")
+
+
+def _strict_json_bytes(data: bytes, path: Path) -> Mapping[str, Any]:
+    try:
+        text = data.decode("utf-8", errors="strict")
+        value = json.loads(
+            text,
+            object_pairs_hook=_duplicate_rejecting_object,
+            parse_constant=_reject_json_constant,
+        )
+    except PrintableResponseReadError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise PrintableResponseReadError(f"Invalid UTF-8 JSON record {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise PrintableResponseReadError(f"Record must be a JSON object: {path}")
+    return cast(Mapping[str, Any], value)
+
+
+def _record_relative_path(path: Path, work_root: Path) -> Path:
+    try:
+        return path.relative_to(work_root)
+    except ValueError as error:
+        raise PrintableResponseIntegrityError(
+            f"Record path escapes exact Quillan work root: {path}"
+        ) from error
+
+
+def _preflight_exact_file(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    path: Path,
+) -> None:
+    try:
+        work_root = quillan_work_paths(
+            workspace_root, work_ref.class_id, work_ref.work_id
+        ).work_root
+        preflight_work_file_destination(
+            workspace_root, work_ref, _record_relative_path(path, work_root)
+        )
+    except QuillanWorkPathError as error:
+        raise PrintableResponseIntegrityError(str(error)) from error
+
+
+def _read_exact_record(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    path: Path,
+) -> Mapping[str, Any]:
+    value, _ = _read_exact_record_with_bytes(workspace_root, work_ref, path)
+    return value
+
+
+def _read_exact_record_with_bytes(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    path: Path,
+) -> tuple[Mapping[str, Any], bytes]:
+    _preflight_exact_file(workspace_root, work_ref, path)
+    if not path.exists():
+        raise PrintableResponseNotFoundError(f"Printable-response record not found: {path}")
+    if _is_link_like(path) or not path.is_file():
+        raise PrintableResponseReadError(f"Record is not an ordinary non-link file: {path}")
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        raise PrintableResponseReadError(f"Could not read record {path}: {error}") from error
+    return _strict_json_bytes(data, path), data
+
+
+def _load_printable_response_issuance_with_bytes(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    issuance_id: str,
+) -> tuple[PrintableResponseIssuance, bytes]:
+    issuance_id = validate_issuance_id(issuance_id)
+    try:
+        path = response_page_issuance_path(workspace_root, work_ref, issuance_id)
+    except QuillanWorkPathError as error:
+        raise PrintableResponseIntegrityError(str(error)) from error
+    try:
+        mapping, data = _read_exact_record_with_bytes(workspace_root, work_ref, path)
+        issuance = printable_response_issuance_from_mapping(mapping)
+    except (PrintableResponseRecordValidationError, TypeError, AttributeError) as error:
+        raise PrintableResponseReadError(f"Invalid issuance record {path}: {error}") from error
+    if issuance.issuance_id != issuance_id:
+        raise PrintableResponseIntegrityError("Stored issuance_id does not match its filename.")
+    if (issuance.class_id, issuance.assignment_id) != (
+        work_ref.class_id,
+        work_ref.work_id,
+    ):
+        raise PrintableResponseIntegrityError("Issuance identity does not match work_ref.")
+    return issuance, data
+
+
+def load_printable_response_issuance(
+    workspace_root: str | Path,
+    work_ref: object,
+    issuance_id: str,
+) -> PrintableResponseIssuance:
+    """Load only one exact validated issuance record."""
+    validated_work_ref = _validated_quillan_work_ref(work_ref)
+    issuance, _ = _load_printable_response_issuance_with_bytes(
+        workspace_root, validated_work_ref, issuance_id
+    )
+    return issuance
+
+
+def load_printable_response_page(
+    workspace_root: str | Path,
+    work_ref: object,
+    page_id: str,
+) -> PrintableResponsePage:
+    """Load only one exact validated immutable page record."""
+    validated_work_ref = _validated_quillan_work_ref(work_ref)
+    page_id = validate_page_id(page_id)
+    try:
+        path = response_page_record_path(workspace_root, validated_work_ref, page_id)
+    except QuillanWorkPathError as error:
+        raise PrintableResponseIntegrityError(str(error)) from error
+    try:
+        page = printable_response_page_from_mapping(
+            _read_exact_record(workspace_root, validated_work_ref, path)
+        )
+    except (PrintableResponseRecordValidationError, TypeError, AttributeError) as error:
+        raise PrintableResponseReadError(f"Invalid page record {path}: {error}") from error
+    if page.page_id != page_id:
+        raise PrintableResponseIntegrityError("Stored page_id does not match its filename.")
+    if (page.class_id, page.assignment_id) != (
+        validated_work_ref.class_id,
+        validated_work_ref.work_id,
+    ):
+        raise PrintableResponseIntegrityError("Page identity does not match work_ref.")
+    return page
+
+
+def load_printable_response_record_set(
+    workspace_root: str | Path,
+    work_ref: object,
+    issuance_id: str,
+) -> PrintableResponseRecordSet:
+    """Load an issuance and all exact members in authoritative stored order."""
+    validated_work_ref = _validated_quillan_work_ref(work_ref)
+    issuance = load_printable_response_issuance(
+        workspace_root, validated_work_ref, issuance_id
+    )
+    pages = tuple(
+        load_printable_response_page(workspace_root, validated_work_ref, page_id)
+        for page_id in issuance.page_ids
+    )
+    try:
+        return PrintableResponseRecordSet(issuance, pages)
+    except PrintableResponseRecordValidationError as error:
+        raise PrintableResponseIntegrityError(f"Invalid record-set membership: {error}") from error
+
+
+def load_printable_response_page_context(
+    workspace_root: str | Path,
+    work_ref: object,
+    page_id: str,
+) -> PrintableResponsePageContext:
+    """Resolve page meaning solely from its complete immutable record set."""
+    validated_work_ref = _validated_quillan_work_ref(work_ref)
+    page = load_printable_response_page(workspace_root, validated_work_ref, page_id)
+    record_set = load_printable_response_record_set(
+        workspace_root, validated_work_ref, page.issuance_id
+    )
+    members = tuple(member for member in record_set.pages if member.page_id == page.page_id)
+    if len(members) != 1 or members[0] != page:
+        raise PrintableResponseIntegrityError(
+            "Requested page does not occur exactly once in its named issuance."
+        )
+    return PrintableResponsePageContext(page, record_set.issuance, record_set.pages)
+
+
+def _verify_source_file(path: Path, description: str) -> None:
+    if not path.exists():
+        raise PrintableResponsePersistenceValidationError(f"{description} not found: {path}")
+    if _is_link_like(path) or not path.is_file():
+        raise PrintableResponsePersistenceValidationError(
+            f"{description} must be an ordinary non-link file: {path}"
+        )
+
+
+def _verify_creation_sources(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    issuance: PrintableResponseIssuance,
+) -> None:
+    paths = quillan_work_paths(workspace_root, work_ref.class_id, work_ref.work_id)
+    _verify_source_file(paths.assignment_path, "Canonical assignment")
+    try:
+        assignment = load_assignment_config(paths.assignment_path)
+    except (AssignmentConfigError, OSError) as error:
+        raise PrintableResponsePersistenceValidationError(
+            f"Canonical assignment is invalid: {error}"
+        ) from error
+    expected_assignment = (
+        issuance.assignment_id,
+        issuance.assignment_snapshot.schema_version,
+        issuance.assignment_snapshot.title,
+        issuance.assignment_snapshot.updated_at,
+    )
+    actual_assignment = (
+        assignment["assignment_id"],
+        assignment["schema_version"],
+        assignment["title"],
+        assignment["updated_at"],
+    )
+    if actual_assignment != expected_assignment or issuance.class_id not in assignment["class_ids"]:
+        raise PrintableResponsePersistenceValidationError(
+            "Assignment snapshot does not match the current canonical assignment."
+        )
+    _verify_source_file(paths.roster_path, "Canonical class roster")
+    try:
+        roster = load_class_roster(workspace_root, work_ref.class_id)
+    except (RosterError, OSError, ValueError) as error:
+        raise PrintableResponsePersistenceValidationError(
+            f"Canonical class roster is invalid: {error}"
+        ) from error
+    if roster.class_id != issuance.class_id:
+        raise PrintableResponsePersistenceValidationError("Roster class does not match issuance.")
+    matches = tuple(
+        student for student in roster.students if student.student_id == issuance.student_id
+    )
+    if len(matches) != 1:
+        raise PrintableResponsePersistenceValidationError(
+            "Issuance student_id must occur exactly once in the current roster."
+        )
+    student = matches[0]
+    snapshot = issuance.student_snapshot
+    if (
+        student_display_name(student), student.last_name, student.first_name, student.period
+    ) != (snapshot.display_name, snapshot.last_name, snapshot.first_name, snapshot.period):
+        raise PrintableResponsePersistenceValidationError(
+            "Student snapshot does not match the current canonical roster."
+        )
+
+
+def _verify_predecessor(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    issuance: PrintableResponseIssuance,
+) -> None:
+    predecessor_id = issuance.generation_context.predecessor_issuance_id
+    if predecessor_id is None:
+        return
+    predecessor = load_printable_response_issuance(
+        workspace_root, work_ref, predecessor_id
+    )
+    if (
+        predecessor.class_id,
+        predecessor.assignment_id,
+        predecessor.student_id,
+    ) != (issuance.class_id, issuance.assignment_id, issuance.student_id):
+        raise PrintableResponsePersistenceValidationError(
+            "Regeneration predecessor does not share class, assignment, and student identity."
+        )
+    reused: list[str] = []
+    if issuance.issuance_id == predecessor.issuance_id:
+        reused.append("issuance_id")
+    if issuance.generation_id == predecessor.generation_id:
+        reused.append("generation_id")
+    if issuance.artifact_id == predecessor.artifact_id:
+        reused.append("artifact_id")
+    if not set(issuance.page_ids).isdisjoint(predecessor.page_ids):
+        reused.append("page_ids")
+    if reused:
+        raise PrintableResponsePersistenceValidationError(
+            "Regeneration must use fresh identities; reused: " + ", ".join(reused) + "."
+        )
+
+
+def _write_json_exclusive(
+    path: Path, value: Mapping[str, Any]
+) -> _CreatedRecord:
+    data = canonical_printable_response_json(value)
+    created = False
+    try:
+        with path.open("xb") as file:
+            created = True
+            file.write(data)
+            file.flush()
+            os.fsync(file.fileno())
+    except FileExistsError as error:
+        raise PrintableResponseRecordCollisionError(
+            f"Immutable record destination already exists: {path}"
+        ) from error
+    except OSError as error:
+        if created:
+            rollback_failures = _rollback_created_records(
+                [_CreatedRecord(path, data)]
+            )
+            if rollback_failures:
+                raise PrintableResponseRollbackError(
+                    f"Failed write left an incompletely rolled-back record: {path}"
+                ) from error
+        raise
+    return _CreatedRecord(path, data)
+
+
+def _rollback_created_records(
+    created: list[_CreatedRecord],
+) -> tuple[Path, ...]:
+    failures: list[Path] = []
+    for record in reversed(created):
+        path = record.path
+        try:
+            if not path.exists() and not _is_link_like(path):
+                continue
+            if _is_link_like(path) or (path.exists() and not path.is_file()):
+                failures.append(path)
+                continue
+            if path.read_bytes() != record.expected_bytes:
+                failures.append(path)
+                continue
+            path.unlink(missing_ok=True)
+        except OSError:
+            failures.append(path)
+    return tuple(failures)
+
+
+def write_printable_response_record_set(
+    workspace_root: str | Path,
+    work_ref: object,
+    record_set: object,
+) -> PersistedPrintableResponseRecordSet:
+    """Exclusively commit pages first and the issuance aggregate marker last."""
+    validated_work_ref = _validated_quillan_work_ref(work_ref)
+    try:
+        validate_printable_response_record_set(record_set)
+        validated_record_set = cast(PrintableResponseRecordSet, record_set)
+        paths = quillan_work_paths(
+            workspace_root,
+            validated_work_ref.class_id,
+            validated_work_ref.work_id,
+        )
+    except (PrintableResponseRecordValidationError, ValueError, TypeError) as error:
+        raise PrintableResponsePersistenceValidationError(str(error)) from error
+    if validated_work_ref != paths.work_ref:
+        raise PrintableResponsePersistenceValidationError(
+            "work_ref must be a canonical Quillan-owned ModuleWorkRef."
+        )
+    issuance = validated_record_set.issuance
+    if (issuance.class_id, issuance.assignment_id) != (
+        validated_work_ref.class_id,
+        validated_work_ref.work_id,
+    ):
+        raise PrintableResponsePersistenceValidationError(
+            "Record-set identity does not match work_ref."
+        )
+    lifecycle = issuance.lifecycle
+    if lifecycle.status != "prepared" or lifecycle.revision != 1:
+        raise PrintableResponsePersistenceValidationError(
+            "New record sets require a prepared revision-1 lifecycle."
+        )
+    try:
+        page_paths = tuple(
+            response_page_record_path(
+                workspace_root, validated_work_ref, page.page_id
+            )
+            for page in validated_record_set.pages
+        )
+        issuance_path = response_page_issuance_path(
+            workspace_root, validated_work_ref, issuance.issuance_id
+        )
+        _preflight_directories(
+            Path(workspace_root),
+            (
+                paths.response_pages_dir,
+                paths.response_page_issuances_dir,
+                paths.response_page_records_dir,
+            ),
+        )
+        for target in (*page_paths, issuance_path):
+            _preflight_exact_file(workspace_root, validated_work_ref, target)
+    except (QuillanWorkPathError, PrintableResponseIntegrityError) as error:
+        raise PrintableResponseIntegrityError(str(error)) from error
+    _verify_predecessor(workspace_root, validated_work_ref, issuance)
+    collisions = tuple(path for path in (*page_paths, issuance_path) if path.exists())
+    if collisions:
+        raise PrintableResponseRecordCollisionError(
+            f"Immutable record destination already exists: {collisions[0]}"
+        )
+    _verify_creation_sources(workspace_root, validated_work_ref, issuance)
+    try:
+        paths.response_page_records_dir.mkdir(parents=True, exist_ok=True)
+        paths.response_page_issuances_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise PrintableResponseRecordSetWriteError(
+            f"Could not create response-page collection directories: {error}"
+        ) from error
+    created: list[_CreatedRecord] = []
+    try:
+        for page, path in zip(validated_record_set.pages, page_paths, strict=True):
+            _preflight_exact_file(workspace_root, validated_work_ref, path)
+            created.append(_write_json_exclusive(path, page.to_mapping()))
+        _preflight_exact_file(workspace_root, validated_work_ref, issuance_path)
+        created.append(_write_json_exclusive(issuance_path, issuance.to_mapping()))
+    except Exception as error:
+        rollback_failures = _rollback_created_records(created)
+        if rollback_failures:
+            raise PrintableResponseRollbackError(
+                "Record-set write failed and rollback was incomplete: "
+                + ", ".join(str(path) for path in rollback_failures)
+            ) from error
+        if isinstance(error, PrintableResponsePersistenceError):
+            raise
+        raise PrintableResponseRecordSetWriteError(
+            f"Record-set write failed and current-operation files were rolled back: {error}"
+        ) from error
+    return PersistedPrintableResponseRecordSet(
+        validated_record_set, issuance_path, page_paths
+    )
+
+
+def _atomic_replace_issuance(
+    path: Path,
+    issuance: PrintableResponseIssuance,
+    *,
+    expected_bytes: bytes,
+) -> None:
+    data = canonical_printable_response_json(issuance.to_mapping())
+    temporary: Path | None = None
+    failure: PrintableResponseLifecycleError | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{issuance.issuance_id}.", suffix=".tmp", dir=path.parent
+        )
+        temporary = Path(temporary_name)
+        with os.fdopen(descriptor, "wb") as file:
+            file.write(data)
+            file.flush()
+            os.fsync(file.fileno())
+        if _is_link_like(path) or not path.is_file():
+            raise PrintableResponseLifecycleError(
+                "Issuance destination changed filesystem type before replacement."
+            )
+        if path.read_bytes() != expected_bytes:
+            raise PrintableResponseRevisionConflictError(
+                "Issuance changed after its revision was checked."
+            )
+        os.replace(temporary, path)
+        temporary = None
+    except PrintableResponseLifecycleError as error:
+        failure = error
+    except OSError as error:
+        failure = PrintableResponseLifecycleError(
+            f"Could not atomically replace issuance lifecycle: {error}"
+        )
+    if temporary is not None:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            primary = (
+                f" Primary failure: {failure}"
+                if failure is not None
+                else ""
+            )
+            combined = PrintableResponseLifecycleCleanupError(
+                f"Could not remove abandoned lifecycle temporary file {temporary}: "
+                f"{cleanup_error}.{primary}"
+            )
+            if failure is not None:
+                raise combined from failure
+            raise combined from cleanup_error
+    if failure is not None:
+        raise failure
+
+
+def transition_printable_response_issuance(
+    workspace_root: str | Path,
+    work_ref: object,
+    issuance_id: str,
+    *,
+    expected_revision: int,
+    new_status: str,
+    timestamp: datetime | str,
+    reason: str | None = None,
+    replacement_issuance_id: str | None = None,
+) -> PrintableResponseIssuance:
+    """Revision-guard and atomically persist one allowed issuance transition."""
+    validated_work_ref = _validated_quillan_work_ref(work_ref)
+    if isinstance(expected_revision, bool) or not isinstance(expected_revision, int):
+        raise PrintableResponseRevisionConflictError("expected_revision must be an integer.")
+    issuance, original_bytes = _load_printable_response_issuance_with_bytes(
+        workspace_root, validated_work_ref, issuance_id
+    )
+    if issuance.lifecycle.revision != expected_revision:
+        raise PrintableResponseRevisionConflictError(
+            f"Expected revision {expected_revision}, found {issuance.lifecycle.revision}."
+        )
+    if new_status == "superseded":
+        if replacement_issuance_id is None:
+            raise PrintableResponseLifecycleError(
+                "Supersession requires replacement_issuance_id."
+            )
+        replacement = load_printable_response_issuance(
+            workspace_root, validated_work_ref, replacement_issuance_id
+        )
+        if replacement.issuance_id == issuance.issuance_id:
+            raise PrintableResponseLifecycleError("An issuance cannot replace itself.")
+        if replacement.lifecycle.status != "issued":
+            raise PrintableResponseLifecycleError(
+                "A supersession replacement must already be issued."
+            )
+        if (
+            replacement.class_id,
+            replacement.assignment_id,
+            replacement.student_id,
+        ) != (issuance.class_id, issuance.assignment_id, issuance.student_id):
+            raise PrintableResponseLifecycleError(
+                "Replacement must share class, assignment, and student identity."
+            )
+    try:
+        lifecycle = transition_printable_response_lifecycle(
+            issuance.lifecycle,
+            new_status=new_status,
+            timestamp=timestamp,
+            reason=reason,
+            replacement_issuance_id=replacement_issuance_id,
+        )
+        updated = replace(issuance, lifecycle=lifecycle)
+    except PrintableResponseRecordValidationError as error:
+        raise PrintableResponseLifecycleError(str(error)) from error
+    try:
+        path = response_page_issuance_path(
+            workspace_root, validated_work_ref, issuance.issuance_id
+        )
+    except QuillanWorkPathError as error:
+        raise PrintableResponseIntegrityError(str(error)) from error
+    _preflight_exact_file(workspace_root, validated_work_ref, path)
+    _atomic_replace_issuance(path, updated, expected_bytes=original_bytes)
+    return updated
+
+
+__all__ = [
+    "PersistedPrintableResponseRecordSet",
+    "PrintableResponseIntegrityError",
+    "PrintableResponseLifecycleCleanupError",
+    "PrintableResponseLifecycleError",
+    "PrintableResponseNotFoundError",
+    "PrintableResponsePersistenceError",
+    "PrintableResponsePersistenceValidationError",
+    "PrintableResponseReadError",
+    "PrintableResponseRecordCollisionError",
+    "PrintableResponseRecordSetWriteError",
+    "PrintableResponseRevisionConflictError",
+    "PrintableResponseRollbackError",
+    "canonical_printable_response_json",
+    "load_printable_response_issuance",
+    "load_printable_response_page",
+    "load_printable_response_page_context",
+    "load_printable_response_record_set",
+    "response_page_issuance_path",
+    "response_page_record_path",
+    "transition_printable_response_issuance",
+    "write_printable_response_record_set",
+]

--- a/quillan/printable_response_records.py
+++ b/quillan/printable_response_records.py
@@ -1,0 +1,948 @@
+"""Immutable Quillan v1 printable-response identity and record models."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import re
+import secrets
+from typing import Any, Final, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.rosters import (
+    ROSTER_REQUIRED_COLUMNS,
+    RosterValidationError,
+    StudentRecord,
+    student_display_name,
+    validate_roster_rows,
+)
+from pds_core.routing_models import ModuleRecordRef
+
+from quillan.assignments import ASSIGNMENT_SCHEMA_VERSION, validate_assignment_config
+from quillan.pds_contract import (
+    QUILLAN_MODULE_ID,
+    RESPONSE_PAGE_CONTRACT_VERSION,
+    RESPONSE_PAGE_RECORD_KIND,
+)
+
+PRINTABLE_RESPONSE_ISSUANCE_SCHEMA_VERSION: Final[str] = "1"
+PRINTABLE_RESPONSE_OUTPUT_KINDS: Final[frozenset[str]] = frozenset(
+    {"class_packet_pdf", "individual_pdf"}
+)
+PRINTABLE_RESPONSE_GENERATION_REASONS: Final[frozenset[str]] = frozenset(
+    {"initial", "additional_copy", "regeneration"}
+)
+PRINTABLE_RESPONSE_PAGE_ROLES: Final[frozenset[str]] = frozenset(
+    {"response_start", "continuation"}
+)
+PRINTABLE_RESPONSE_LIFECYCLE_STATUSES: Final[frozenset[str]] = frozenset(
+    {"prepared", "issued", "cancelled", "superseded", "invalidated"}
+)
+_TERMINAL_STATUSES = frozenset({"cancelled", "superseded", "invalidated"})
+_ALLOWED_TRANSITIONS = frozenset(
+    {
+        ("prepared", "issued"),
+        ("prepared", "cancelled"),
+        ("prepared", "invalidated"),
+        ("issued", "superseded"),
+        ("issued", "invalidated"),
+    }
+)
+_ID_PATTERN = re.compile(r"^(?P<prefix>gen|art|iss|pg)_[0-9a-f]{32}$")
+
+
+class PrintableResponseRecordValidationError(ValueError):
+    """Raised when an immutable printable-response record is invalid."""
+
+
+def _validate_typed_id(value: object, prefix: str, field: str) -> str:
+    if not isinstance(value, str):
+        raise PrintableResponseRecordValidationError(f"{field} must be a string.")
+    if _ID_PATTERN.fullmatch(value) is None or not value.startswith(f"{prefix}_"):
+        raise PrintableResponseRecordValidationError(
+            f"{field} must be {prefix}_ followed by 32 lowercase hexadecimal characters."
+        )
+    try:
+        validate_identifier(value, field)
+    except IdentifierValidationError as error:
+        raise PrintableResponseRecordValidationError(str(error)) from error
+    return value
+
+
+def validate_generation_id(value: object) -> str:
+    return _validate_typed_id(value, "gen", "generation_id")
+
+
+def validate_artifact_id(value: object) -> str:
+    return _validate_typed_id(value, "art", "artifact_id")
+
+
+def validate_issuance_id(value: object) -> str:
+    return _validate_typed_id(value, "iss", "issuance_id")
+
+
+def validate_page_id(value: object) -> str:
+    return _validate_typed_id(value, "pg", "page_id")
+
+
+def _generate_id(prefix: str, token_hex: Callable[[int], str]) -> str:
+    value = f"{prefix}_{token_hex(16)}"
+    return _validate_typed_id(value, prefix, f"{prefix}_id")
+
+
+def generate_generation_id(
+    token_hex: Callable[[int], str] = secrets.token_hex,
+) -> str:
+    return _generate_id("gen", token_hex)
+
+
+def generate_artifact_id(token_hex: Callable[[int], str] = secrets.token_hex) -> str:
+    return _generate_id("art", token_hex)
+
+
+def generate_issuance_id(token_hex: Callable[[int], str] = secrets.token_hex) -> str:
+    return _generate_id("iss", token_hex)
+
+
+def generate_page_id(token_hex: Callable[[int], str] = secrets.token_hex) -> str:
+    return _generate_id("pg", token_hex)
+
+
+def _exact_mapping(value: object, keys: frozenset[str], name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise PrintableResponseRecordValidationError(f"{name} must be an object.")
+    actual_keys = tuple(value)
+    non_string_keys = tuple(key for key in actual_keys if not isinstance(key, str))
+    if non_string_keys:
+        raise PrintableResponseRecordValidationError(
+            f"Invalid {name}: object keys must be strings."
+        )
+    actual = set(cast(tuple[str, ...], actual_keys))
+    missing = sorted(keys - actual)
+    unknown = sorted(actual - keys)
+    if missing or unknown:
+        details = []
+        if missing:
+            details.append(f"missing fields: {', '.join(missing)}")
+        if unknown:
+            details.append(f"unknown fields: {', '.join(unknown)}")
+        raise PrintableResponseRecordValidationError(f"Invalid {name}: {'; '.join(details)}.")
+    return cast(Mapping[str, Any], value)
+
+
+def _nonempty_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise PrintableResponseRecordValidationError(
+            f"{field} must be a nonempty string."
+        )
+    return value
+
+
+def _string(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise PrintableResponseRecordValidationError(f"{field} must be a string.")
+    return value
+
+
+def _identifier(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise PrintableResponseRecordValidationError(f"{field} must be a string.")
+    try:
+        return validate_identifier(value, field)
+    except (IdentifierValidationError, TypeError) as error:
+        raise PrintableResponseRecordValidationError(str(error)) from error
+
+
+def _positive_integer(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise PrintableResponseRecordValidationError(
+            f"{field} must be a positive integer."
+        )
+    return value
+
+
+def _timestamp(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise PrintableResponseRecordValidationError(
+            f"{field} must be a timezone-aware ISO 8601 string."
+        )
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise PrintableResponseRecordValidationError(
+            f"{field} must be a timezone-aware ISO 8601 string."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise PrintableResponseRecordValidationError(
+            f"{field} must be a timezone-aware ISO 8601 string."
+        )
+    return value
+
+
+def _timestamp_value(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponseGenerationContext:
+    output_kind: str
+    reason: str
+    predecessor_issuance_id: str | None
+
+    def __post_init__(self) -> None:
+        _string(self.output_kind, "generation_context.output_kind")
+        _string(self.reason, "generation_context.reason")
+        if self.output_kind not in PRINTABLE_RESPONSE_OUTPUT_KINDS:
+            raise PrintableResponseRecordValidationError("Unsupported output_kind.")
+        if self.reason not in PRINTABLE_RESPONSE_GENERATION_REASONS:
+            raise PrintableResponseRecordValidationError("Unsupported generation reason.")
+        if self.reason == "regeneration":
+            validate_issuance_id(self.predecessor_issuance_id)
+        elif self.predecessor_issuance_id is not None:
+            raise PrintableResponseRecordValidationError(
+                f"{self.reason} requires predecessor_issuance_id to be null."
+            )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "output_kind": self.output_kind,
+            "reason": self.reason,
+            "predecessor_issuance_id": self.predecessor_issuance_id,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: object) -> PrintableResponseGenerationContext:
+        data = _exact_mapping(
+            value,
+            frozenset({"output_kind", "reason", "predecessor_issuance_id"}),
+            "generation_context",
+        )
+        return cls(data["output_kind"], data["reason"], data["predecessor_issuance_id"])
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponseAssignmentSnapshot:
+    schema_version: str
+    title: str
+    updated_at: str
+
+    def __post_init__(self) -> None:
+        _string(self.schema_version, "assignment_snapshot.schema_version")
+        if self.schema_version != ASSIGNMENT_SCHEMA_VERSION:
+            raise PrintableResponseRecordValidationError(
+                f"assignment_snapshot.schema_version must be {ASSIGNMENT_SCHEMA_VERSION!r}."
+            )
+        _nonempty_string(self.title, "assignment_snapshot.title")
+        _timestamp(self.updated_at, "assignment_snapshot.updated_at")
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "title": self.title,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: object) -> PrintableResponseAssignmentSnapshot:
+        data = _exact_mapping(
+            value,
+            frozenset({"schema_version", "title", "updated_at"}),
+            "assignment_snapshot",
+        )
+        return cls(data["schema_version"], data["title"], data["updated_at"])
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponseStudentSnapshot:
+    display_name: str
+    last_name: str
+    first_name: str
+    period: str
+
+    def __post_init__(self) -> None:
+        _normalized_roster_string(
+            self.display_name, "student_snapshot.display_name"
+        )
+        _normalized_roster_string(self.last_name, "student_snapshot.last_name")
+        _normalized_roster_string(self.first_name, "student_snapshot.first_name")
+        _normalized_roster_string(self.period, "student_snapshot.period")
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "display_name": self.display_name,
+            "last_name": self.last_name,
+            "first_name": self.first_name,
+            "period": self.period,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: object) -> PrintableResponseStudentSnapshot:
+        data = _exact_mapping(
+            value,
+            frozenset({"display_name", "last_name", "first_name", "period"}),
+            "student_snapshot",
+        )
+        return cls(
+            data["display_name"], data["last_name"], data["first_name"], data["period"]
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponseLifecycle:
+    status: str
+    revision: int
+    created_at: str
+    updated_at: str
+    issued_at: str | None
+    ended_at: str | None
+    reason: str | None
+    replacement_issuance_id: str | None
+
+    def __post_init__(self) -> None:
+        _string(self.status, "lifecycle.status")
+        if self.status not in PRINTABLE_RESPONSE_LIFECYCLE_STATUSES:
+            raise PrintableResponseRecordValidationError("Unsupported lifecycle status.")
+        _positive_integer(self.revision, "lifecycle.revision")
+        _timestamp(self.created_at, "lifecycle.created_at")
+        _timestamp(self.updated_at, "lifecycle.updated_at")
+        if _timestamp_value(self.updated_at) < _timestamp_value(self.created_at):
+            raise PrintableResponseRecordValidationError(
+                "lifecycle.updated_at must not precede created_at."
+            )
+        if self.issued_at is not None:
+            _timestamp(self.issued_at, "lifecycle.issued_at")
+            if _timestamp_value(self.issued_at) < _timestamp_value(self.created_at):
+                raise PrintableResponseRecordValidationError(
+                    "lifecycle.issued_at must not precede created_at."
+                )
+            if _timestamp_value(self.issued_at) > _timestamp_value(self.updated_at):
+                raise PrintableResponseRecordValidationError(
+                    "lifecycle.issued_at must not follow updated_at."
+                )
+        if self.status == "prepared" and self.revision != 1:
+            raise PrintableResponseRecordValidationError(
+                "A prepared lifecycle must have revision 1."
+            )
+        if self.status == "prepared":
+            if self.created_at != self.updated_at or self.issued_at is not None:
+                raise PrintableResponseRecordValidationError(
+                    "A prepared lifecycle requires equal creation/update times and no issued_at."
+                )
+        if self.status == "issued" and self.revision != 2:
+            raise PrintableResponseRecordValidationError(
+                "An issued lifecycle must have revision 2."
+            )
+        if self.status == "issued" and self.issued_at is None:
+            raise PrintableResponseRecordValidationError("issued_at is required for issued.")
+        if self.status in {"prepared", "issued"}:
+            if self.ended_at is not None or self.reason is not None:
+                raise PrintableResponseRecordValidationError(
+                    "Active lifecycle statuses cannot have ended_at or reason."
+                )
+        else:
+            if self.ended_at is None:
+                raise PrintableResponseRecordValidationError(
+                    "ended_at is required for terminal lifecycle statuses."
+                )
+            _timestamp(self.ended_at, "lifecycle.ended_at")
+            if _timestamp_value(self.ended_at) < _timestamp_value(self.updated_at):
+                raise PrintableResponseRecordValidationError(
+                    "lifecycle.ended_at must not precede updated_at."
+                )
+            _nonempty_string(self.reason, "lifecycle.reason")
+            if self.ended_at != self.updated_at:
+                raise PrintableResponseRecordValidationError(
+                    "Terminal lifecycle ended_at must equal updated_at."
+                )
+        if self.status == "cancelled" and self.issued_at is not None:
+            raise PrintableResponseRecordValidationError(
+                "A cancelled issuance cannot have issued_at."
+            )
+        if self.status == "cancelled" and self.revision != 2:
+            raise PrintableResponseRecordValidationError(
+                "A cancelled lifecycle must have revision 2."
+            )
+        if self.status == "superseded":
+            if self.revision != 3:
+                raise PrintableResponseRecordValidationError(
+                    "A superseded lifecycle must have revision 3."
+                )
+            validate_issuance_id(self.replacement_issuance_id)
+            if self.issued_at is None:
+                raise PrintableResponseRecordValidationError(
+                    "A superseded issuance must retain issued_at."
+                )
+        elif self.replacement_issuance_id is not None:
+            raise PrintableResponseRecordValidationError(
+                "replacement_issuance_id is allowed only for superseded."
+            )
+        if self.status == "invalidated":
+            expected_revision = 3 if self.issued_at is not None else 2
+            if self.revision != expected_revision:
+                raise PrintableResponseRecordValidationError(
+                    "An invalidated lifecycle revision must reflect whether it was issued."
+                )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "revision": self.revision,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "issued_at": self.issued_at,
+            "ended_at": self.ended_at,
+            "reason": self.reason,
+            "replacement_issuance_id": self.replacement_issuance_id,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: object) -> PrintableResponseLifecycle:
+        data = _exact_mapping(
+            value,
+            frozenset(
+                {
+                    "status", "revision", "created_at", "updated_at", "issued_at",
+                    "ended_at", "reason", "replacement_issuance_id",
+                }
+            ),
+            "lifecycle",
+        )
+        return cls(**data)
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponseIssuance:
+    schema_version: str
+    issuance_id: str
+    generation_id: str
+    artifact_id: str
+    class_id: str
+    assignment_id: str
+    student_id: str
+    generation_context: PrintableResponseGenerationContext
+    class_label: str
+    assignment_snapshot: PrintableResponseAssignmentSnapshot
+    student_snapshot: PrintableResponseStudentSnapshot
+    page_count: int
+    page_ids: tuple[str, ...]
+    lifecycle: PrintableResponseLifecycle
+
+    def __post_init__(self) -> None:
+        _string(self.schema_version, "schema_version")
+        if self.schema_version != PRINTABLE_RESPONSE_ISSUANCE_SCHEMA_VERSION:
+            raise PrintableResponseRecordValidationError("Unsupported issuance schema_version.")
+        validate_issuance_id(self.issuance_id)
+        validate_generation_id(self.generation_id)
+        validate_artifact_id(self.artifact_id)
+        _identifier(self.class_id, "class_id")
+        _identifier(self.assignment_id, "assignment_id")
+        _identifier(self.student_id, "student_id")
+        if not isinstance(self.generation_context, PrintableResponseGenerationContext):
+            raise PrintableResponseRecordValidationError("Invalid generation_context.")
+        _nonempty_string(self.class_label, "class_label")
+        if not isinstance(self.assignment_snapshot, PrintableResponseAssignmentSnapshot):
+            raise PrintableResponseRecordValidationError("Invalid assignment_snapshot.")
+        if not isinstance(self.student_snapshot, PrintableResponseStudentSnapshot):
+            raise PrintableResponseRecordValidationError("Invalid student_snapshot.")
+        if not isinstance(self.lifecycle, PrintableResponseLifecycle):
+            raise PrintableResponseRecordValidationError("Invalid lifecycle.")
+        _positive_integer(self.page_count, "page_count")
+        if not isinstance(self.page_ids, tuple):
+            raise PrintableResponseRecordValidationError("page_ids must be a tuple.")
+        for page_id in self.page_ids:
+            validate_page_id(page_id)
+        if len(self.page_ids) != self.page_count or len(set(self.page_ids)) != len(self.page_ids):
+            raise PrintableResponseRecordValidationError(
+                "page_ids must be unique and have exactly page_count members."
+            )
+        if self.generation_context.predecessor_issuance_id == self.issuance_id:
+            raise PrintableResponseRecordValidationError("An issuance cannot name itself as predecessor.")
+        if self.lifecycle.replacement_issuance_id == self.issuance_id:
+            raise PrintableResponseRecordValidationError("An issuance cannot replace itself.")
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "issuance_id": self.issuance_id,
+            "generation_id": self.generation_id,
+            "artifact_id": self.artifact_id,
+            "class_id": self.class_id,
+            "assignment_id": self.assignment_id,
+            "student_id": self.student_id,
+            "generation_context": self.generation_context.to_mapping(),
+            "class_label": self.class_label,
+            "assignment_snapshot": self.assignment_snapshot.to_mapping(),
+            "student_snapshot": self.student_snapshot.to_mapping(),
+            "page_count": self.page_count,
+            "page_ids": list(self.page_ids),
+            "lifecycle": self.lifecycle.to_mapping(),
+        }
+
+    @classmethod
+    def from_mapping(cls, value: object) -> PrintableResponseIssuance:
+        keys = frozenset(
+            {
+                "schema_version", "issuance_id", "generation_id", "artifact_id",
+                "class_id", "assignment_id", "student_id", "generation_context",
+                "class_label", "assignment_snapshot", "student_snapshot", "page_count",
+                "page_ids", "lifecycle",
+            }
+        )
+        data = _exact_mapping(value, keys, "printable response issuance")
+        page_ids = data["page_ids"]
+        if not isinstance(page_ids, list):
+            raise PrintableResponseRecordValidationError("page_ids must be an array.")
+        return cls(
+            schema_version=data["schema_version"],
+            issuance_id=data["issuance_id"],
+            generation_id=data["generation_id"],
+            artifact_id=data["artifact_id"],
+            class_id=data["class_id"],
+            assignment_id=data["assignment_id"],
+            student_id=data["student_id"],
+            generation_context=PrintableResponseGenerationContext.from_mapping(data["generation_context"]),
+            class_label=data["class_label"],
+            assignment_snapshot=PrintableResponseAssignmentSnapshot.from_mapping(data["assignment_snapshot"]),
+            student_snapshot=PrintableResponseStudentSnapshot.from_mapping(data["student_snapshot"]),
+            page_count=data["page_count"],
+            page_ids=tuple(page_ids),
+            lifecycle=PrintableResponseLifecycle.from_mapping(data["lifecycle"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponsePage:
+    schema_version: str
+    page_id: str
+    issuance_id: str
+    generation_id: str
+    artifact_id: str
+    class_id: str
+    assignment_id: str
+    student_id: str
+    logical_page: int
+    total_pages: int
+    page_role: str
+    created_at: str
+
+    def __post_init__(self) -> None:
+        _string(self.schema_version, "schema_version")
+        if self.schema_version != RESPONSE_PAGE_CONTRACT_VERSION:
+            raise PrintableResponseRecordValidationError("Unsupported page schema_version.")
+        validate_page_id(self.page_id)
+        validate_issuance_id(self.issuance_id)
+        validate_generation_id(self.generation_id)
+        validate_artifact_id(self.artifact_id)
+        _identifier(self.class_id, "class_id")
+        _identifier(self.assignment_id, "assignment_id")
+        _identifier(self.student_id, "student_id")
+        _positive_integer(self.logical_page, "logical_page")
+        _positive_integer(self.total_pages, "total_pages")
+        if self.logical_page > self.total_pages:
+            raise PrintableResponseRecordValidationError("logical_page exceeds total_pages.")
+        _string(self.page_role, "page_role")
+        expected_role = page_role_for_logical_page(self.logical_page)
+        if self.page_role != expected_role:
+            raise PrintableResponseRecordValidationError(
+                f"logical_page {self.logical_page} requires page_role {expected_role!r}."
+            )
+        _timestamp(self.created_at, "created_at")
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "page_id": self.page_id,
+            "issuance_id": self.issuance_id,
+            "generation_id": self.generation_id,
+            "artifact_id": self.artifact_id,
+            "class_id": self.class_id,
+            "assignment_id": self.assignment_id,
+            "student_id": self.student_id,
+            "logical_page": self.logical_page,
+            "total_pages": self.total_pages,
+            "page_role": self.page_role,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: object) -> PrintableResponsePage:
+        keys = frozenset(
+            {
+                "schema_version", "page_id", "issuance_id", "generation_id",
+                "artifact_id", "class_id", "assignment_id", "student_id",
+                "logical_page", "total_pages", "page_role", "created_at",
+            }
+        )
+        return cls(**_exact_mapping(value, keys, "printable response page"))
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponseRecordSet:
+    issuance: PrintableResponseIssuance
+    pages: tuple[PrintableResponsePage, ...]
+
+    def __post_init__(self) -> None:
+        validate_printable_response_record_set(self)
+
+
+@dataclass(frozen=True, slots=True)
+class PrintableResponsePageContext:
+    page: PrintableResponsePage
+    issuance: PrintableResponseIssuance
+    member_pages: tuple[PrintableResponsePage, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.page, PrintableResponsePage):
+            raise PrintableResponseRecordValidationError("Context page is invalid.")
+        if not isinstance(self.issuance, PrintableResponseIssuance):
+            raise PrintableResponseRecordValidationError("Context issuance is invalid.")
+        if not isinstance(self.member_pages, tuple):
+            raise PrintableResponseRecordValidationError(
+                "Context member_pages must be a tuple."
+            )
+        record_set = PrintableResponseRecordSet(self.issuance, self.member_pages)
+        matches = tuple(
+            member for member in record_set.pages if member.page_id == self.page.page_id
+        )
+        if len(matches) != 1 or matches[0] != self.page:
+            raise PrintableResponseRecordValidationError(
+                "Context page must occur exactly once in its complete record set."
+            )
+
+    @property
+    def student_id(self) -> str:
+        return self.page.student_id
+
+    @property
+    def logical_page(self) -> int:
+        return self.page.logical_page
+
+    @property
+    def total_pages(self) -> int:
+        return self.page.total_pages
+
+    @property
+    def page_role(self) -> str:
+        return self.page.page_role
+
+    @property
+    def is_continuation(self) -> bool:
+        return self.page.page_role == "continuation"
+
+
+def page_role_for_logical_page(logical_page: int) -> str:
+    _positive_integer(logical_page, "logical_page")
+    return "response_start" if logical_page == 1 else "continuation"
+
+
+def validate_printable_response_record_set(
+    record_set: object,
+) -> None:
+    if not isinstance(record_set, PrintableResponseRecordSet):
+        raise PrintableResponseRecordValidationError(
+            "record_set must be a PrintableResponseRecordSet."
+        )
+    if not isinstance(record_set.issuance, PrintableResponseIssuance):
+        raise PrintableResponseRecordValidationError("record_set.issuance is invalid.")
+    if not isinstance(record_set.pages, tuple):
+        raise PrintableResponseRecordValidationError("record_set.pages must be a tuple.")
+    issuance = record_set.issuance
+    if len(record_set.pages) != issuance.page_count:
+        raise PrintableResponseRecordValidationError("Record-set page count is incomplete.")
+    for expected_number, (expected_id, page) in enumerate(
+        zip(issuance.page_ids, record_set.pages, strict=True), start=1
+    ):
+        if not isinstance(page, PrintableResponsePage):
+            raise PrintableResponseRecordValidationError("record_set contains an invalid page.")
+        if page.page_id != expected_id or page.logical_page != expected_number:
+            raise PrintableResponseRecordValidationError("Page membership is reordered or incomplete.")
+        if page.total_pages != issuance.page_count:
+            raise PrintableResponseRecordValidationError("Page total does not match issuance page_count.")
+        page_context = (
+            page.issuance_id, page.generation_id, page.artifact_id, page.class_id,
+            page.assignment_id, page.student_id,
+        )
+        issuance_context = (
+            issuance.issuance_id, issuance.generation_id, issuance.artifact_id,
+            issuance.class_id, issuance.assignment_id, issuance.student_id,
+        )
+        if page_context != issuance_context:
+            raise PrintableResponseRecordValidationError("Page provenance contradicts its issuance.")
+        if page.created_at != issuance.lifecycle.created_at:
+            raise PrintableResponseRecordValidationError("All member pages must share issuance created_at.")
+
+
+def _clock_iso(clock: Callable[[], datetime | str] | None) -> str:
+    value: datetime | str = (
+        datetime.now(timezone.utc) if clock is None else clock()
+    )
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise PrintableResponseRecordValidationError("clock must return an aware datetime.")
+        value = value.isoformat()
+    return _timestamp(value, "clock")
+
+
+def _normalized_roster_string(value: object, field: str) -> str:
+    text = _nonempty_string(value, field)
+    if text != text.strip():
+        raise PrintableResponseRecordValidationError(
+            f"{field} must not have surrounding whitespace."
+        )
+    return text
+
+
+def _validate_student(student: object, class_id: str) -> StudentRecord:
+    if not isinstance(student, StudentRecord):
+        raise PrintableResponseRecordValidationError("student must be a StudentRecord.")
+    row = {
+        "class_id": student.class_id,
+        "student_id": student.student_id,
+        "last_name": student.last_name,
+        "first_name": student.first_name,
+        "period": student.period,
+    }
+    try:
+        validated = validate_roster_rows(ROSTER_REQUIRED_COLUMNS, (row,)).students[0]
+    except RosterValidationError as error:
+        raise PrintableResponseRecordValidationError(
+            f"student does not satisfy the roster contract: {error}"
+        ) from error
+    validated_required = (
+        validated.class_id,
+        validated.student_id,
+        validated.last_name,
+        validated.first_name,
+        validated.period,
+    )
+    supplied_required = (
+        student.class_id,
+        student.student_id,
+        student.last_name,
+        student.first_name,
+        student.period,
+    )
+    if validated_required != supplied_required:
+        raise PrintableResponseRecordValidationError(
+            "student fields must already be normalized by the roster contract."
+        )
+    if validated.class_id != class_id:
+        raise PrintableResponseRecordValidationError(
+            "Student class_id does not match class_id."
+        )
+    return student
+
+
+def build_printable_response_record_set(
+    class_id: str,
+    assignment: Mapping[str, Any],
+    student: StudentRecord,
+    *,
+    generation_id: str,
+    artifact_id: str,
+    output_kind: str,
+    reason: str,
+    pages_per_student: int,
+    class_label: str | None = None,
+    predecessor_issuance_id: str | None = None,
+    issuance_id: str | None = None,
+    page_ids: Sequence[str] | None = None,
+    issuance_id_generator: Callable[[], str] = generate_issuance_id,
+    page_id_generator: Callable[[], str] = generate_page_id,
+    clock: Callable[[], datetime | str] | None = None,
+) -> PrintableResponseRecordSet:
+    """Purely plan one student-specific issuance and all physical pages."""
+    class_id = _identifier(class_id, "class_id")
+    if not isinstance(assignment, dict):
+        assignment = dict(assignment)
+    try:
+        validate_assignment_config(assignment)
+    except ValueError as error:
+        raise PrintableResponseRecordValidationError(str(error)) from error
+    if class_id not in assignment["class_ids"]:
+        raise PrintableResponseRecordValidationError("Assignment does not belong to class_id.")
+    student = _validate_student(student, class_id)
+    pages_per_student = _positive_integer(pages_per_student, "pages_per_student")
+    issuance_id = validate_issuance_id(
+        issuance_id_generator() if issuance_id is None else issuance_id
+    )
+    generated_page_ids = (
+        tuple(page_id_generator() for _ in range(pages_per_student))
+        if page_ids is None
+        else tuple(page_ids)
+    )
+    if len(generated_page_ids) != pages_per_student:
+        raise PrintableResponseRecordValidationError("page_ids length must equal pages_per_student.")
+    for page_id in generated_page_ids:
+        validate_page_id(page_id)
+    if len(set(generated_page_ids)) != len(generated_page_ids):
+        raise PrintableResponseRecordValidationError("page_ids must be unique.")
+    generation_id = validate_generation_id(generation_id)
+    artifact_id = validate_artifact_id(artifact_id)
+    timestamp = _clock_iso(clock)
+    context = PrintableResponseGenerationContext(output_kind, reason, predecessor_issuance_id)
+    lifecycle = PrintableResponseLifecycle(
+        "prepared", 1, timestamp, timestamp, None, None, None, None
+    )
+    assignment_snapshot = PrintableResponseAssignmentSnapshot(
+        cast(str, assignment["schema_version"]),
+        cast(str, assignment["title"]),
+        cast(str, assignment["updated_at"]),
+    )
+    snapshot = PrintableResponseStudentSnapshot(
+        student_display_name(student), student.last_name, student.first_name, student.period
+    )
+    issuance = PrintableResponseIssuance(
+        PRINTABLE_RESPONSE_ISSUANCE_SCHEMA_VERSION,
+        issuance_id,
+        generation_id,
+        artifact_id,
+        class_id,
+        cast(str, assignment["assignment_id"]),
+        student.student_id,
+        context,
+        class_id if class_label is None else class_label,
+        assignment_snapshot,
+        snapshot,
+        pages_per_student,
+        generated_page_ids,
+        lifecycle,
+    )
+    pages = tuple(
+        PrintableResponsePage(
+            RESPONSE_PAGE_CONTRACT_VERSION,
+            page_id,
+            issuance_id,
+            generation_id,
+            artifact_id,
+            class_id,
+            issuance.assignment_id,
+            student.student_id,
+            logical_page,
+            pages_per_student,
+            page_role_for_logical_page(logical_page),
+            timestamp,
+        )
+        for logical_page, page_id in enumerate(generated_page_ids, start=1)
+    )
+    return PrintableResponseRecordSet(issuance, pages)
+
+
+def transition_printable_response_lifecycle(
+    lifecycle: PrintableResponseLifecycle,
+    *,
+    new_status: str,
+    timestamp: datetime | str,
+    reason: str | None = None,
+    replacement_issuance_id: str | None = None,
+) -> PrintableResponseLifecycle:
+    """Construct one allowed immutable lifecycle transition."""
+    if not isinstance(lifecycle, PrintableResponseLifecycle):
+        raise PrintableResponseRecordValidationError("lifecycle is invalid.")
+    _string(new_status, "new_status")
+    if (lifecycle.status, new_status) not in _ALLOWED_TRANSITIONS:
+        raise PrintableResponseRecordValidationError(
+            f"Lifecycle transition {lifecycle.status!r} -> {new_status!r} is not allowed."
+        )
+    if new_status not in _TERMINAL_STATUSES and reason is not None:
+        raise PrintableResponseRecordValidationError(
+            "A reason is allowed only for a terminal lifecycle status."
+        )
+    if new_status != "superseded" and replacement_issuance_id is not None:
+        raise PrintableResponseRecordValidationError(
+            "replacement_issuance_id is allowed only for superseded."
+        )
+    timestamp_text = timestamp.isoformat() if isinstance(timestamp, datetime) else timestamp
+    _timestamp(timestamp_text, "timestamp")
+    if _timestamp_value(timestamp_text) < _timestamp_value(lifecycle.updated_at):
+        raise PrintableResponseRecordValidationError("Transition timestamp precedes updated_at.")
+    terminal = new_status in _TERMINAL_STATUSES
+    return PrintableResponseLifecycle(
+        status=new_status,
+        revision=lifecycle.revision + 1,
+        created_at=lifecycle.created_at,
+        updated_at=timestamp_text,
+        issued_at=timestamp_text if new_status == "issued" else lifecycle.issued_at,
+        ended_at=timestamp_text if terminal else None,
+        reason=reason if terminal else None,
+        replacement_issuance_id=(
+            replacement_issuance_id if new_status == "superseded" else None
+        ),
+    )
+
+
+def response_page_target(page_or_page_id: PrintableResponsePage | str) -> ModuleRecordRef:
+    """Return the pure future Core route target for one immutable page."""
+    page_id = (
+        page_or_page_id.page_id
+        if isinstance(page_or_page_id, PrintableResponsePage)
+        else page_or_page_id
+    )
+    return ModuleRecordRef(
+        module_id=QUILLAN_MODULE_ID,
+        record_kind=RESPONSE_PAGE_RECORD_KIND,
+        record_id=validate_page_id(page_id),
+        contract_version=RESPONSE_PAGE_CONTRACT_VERSION,
+    )
+
+
+def printable_response_issuance_to_mapping(
+    issuance: object,
+) -> dict[str, Any]:
+    if not isinstance(issuance, PrintableResponseIssuance):
+        raise PrintableResponseRecordValidationError(
+            "issuance must be a PrintableResponseIssuance."
+        )
+    return issuance.to_mapping()
+
+
+def printable_response_issuance_from_mapping(value: object) -> PrintableResponseIssuance:
+    return PrintableResponseIssuance.from_mapping(value)
+
+
+def printable_response_page_to_mapping(page: object) -> dict[str, Any]:
+    if not isinstance(page, PrintableResponsePage):
+        raise PrintableResponseRecordValidationError(
+            "page must be a PrintableResponsePage."
+        )
+    return page.to_mapping()
+
+
+def printable_response_page_from_mapping(value: object) -> PrintableResponsePage:
+    return PrintableResponsePage.from_mapping(value)
+
+
+__all__ = [
+    "PRINTABLE_RESPONSE_GENERATION_REASONS",
+    "PRINTABLE_RESPONSE_ISSUANCE_SCHEMA_VERSION",
+    "PRINTABLE_RESPONSE_LIFECYCLE_STATUSES",
+    "PRINTABLE_RESPONSE_OUTPUT_KINDS",
+    "PRINTABLE_RESPONSE_PAGE_ROLES",
+    "PrintableResponseAssignmentSnapshot",
+    "PrintableResponseGenerationContext",
+    "PrintableResponseIssuance",
+    "PrintableResponseLifecycle",
+    "PrintableResponsePage",
+    "PrintableResponsePageContext",
+    "PrintableResponseRecordSet",
+    "PrintableResponseRecordValidationError",
+    "PrintableResponseStudentSnapshot",
+    "build_printable_response_record_set",
+    "generate_artifact_id",
+    "generate_generation_id",
+    "generate_issuance_id",
+    "generate_page_id",
+    "page_role_for_logical_page",
+    "printable_response_issuance_from_mapping",
+    "printable_response_issuance_to_mapping",
+    "printable_response_page_from_mapping",
+    "printable_response_page_to_mapping",
+    "response_page_target",
+    "transition_printable_response_lifecycle",
+    "validate_artifact_id",
+    "validate_generation_id",
+    "validate_issuance_id",
+    "validate_page_id",
+    "validate_printable_response_record_set",
+]

--- a/quillan/work_paths.py
+++ b/quillan/work_paths.py
@@ -32,6 +32,8 @@ class QuillanWorkPaths:
     work_root: Path
     assignment_path: Path
     response_pages_dir: Path
+    response_page_issuances_dir: Path
+    response_page_records_dir: Path
     templates_dir: Path
     scans_dir: Path
     submissions_dir: Path
@@ -81,6 +83,12 @@ def quillan_work_paths(
         response_pages_dir=safe_module_work_descendant(
             workspace_root, work_ref, "response_pages"
         ),
+        response_page_issuances_dir=safe_module_work_descendant(
+            workspace_root, work_ref, Path("response_pages") / "issuances"
+        ),
+        response_page_records_dir=safe_module_work_descendant(
+            workspace_root, work_ref, Path("response_pages") / "pages"
+        ),
         templates_dir=safe_module_work_descendant(
             workspace_root, work_ref, "templates"
         ),
@@ -106,6 +114,40 @@ def student_submission_dir(
         workspace_root,
         validated_work,
         Path("submissions") / validated_student_id,
+    )
+
+
+def response_page_issuance_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    issuance_id: str,
+) -> Path:
+    """Return one exact immutable issuance path without filesystem access."""
+    from quillan.printable_response_records import validate_issuance_id
+
+    validated_work = _require_quillan_work_ref(work_ref)
+    validated_id = validate_issuance_id(issuance_id)
+    return safe_module_work_descendant(
+        workspace_root,
+        validated_work,
+        Path("response_pages") / "issuances" / f"{validated_id}.json",
+    )
+
+
+def response_page_record_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    page_id: str,
+) -> Path:
+    """Return one exact immutable response-page path without filesystem access."""
+    from quillan.printable_response_records import validate_page_id
+
+    validated_work = _require_quillan_work_ref(work_ref)
+    validated_id = validate_page_id(page_id)
+    return safe_module_work_descendant(
+        workspace_root,
+        validated_work,
+        Path("response_pages") / "pages" / f"{validated_id}.json",
     )
 
 
@@ -251,6 +293,8 @@ def _managed_directories(paths: QuillanWorkPaths) -> tuple[Path, ...]:
     return (
         paths.work_root,
         paths.response_pages_dir,
+        paths.response_page_issuances_dir,
+        paths.response_page_records_dir,
         paths.templates_dir,
         paths.scans_dir,
         paths.submissions_dir,
@@ -343,6 +387,8 @@ __all__ = [
     "quillan_work_ref",
     "relative_assignment_path",
     "relative_submission_manifest_path",
+    "response_page_issuance_path",
+    "response_page_record_path",
     "review_record_path",
     "student_submission_dir",
     "submission_manifest_path",

--- a/tests/test_printable_response_persistence.py
+++ b/tests/test_printable_response_persistence.py
@@ -1,0 +1,871 @@
+"""Persistence tests for immutable printable-response record sets."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+
+from pds_core.classes import load_class_roster, write_class_roster
+from pds_core.rosters import StudentRecord, create_roster
+from pds_core.routing_models import ModuleWorkRef
+import pytest
+
+import quillan.printable_response_persistence as persistence
+
+from quillan.printable_response_persistence import (
+    PrintableResponseIntegrityError,
+    PrintableResponseLifecycleCleanupError,
+    PrintableResponseLifecycleError,
+    PrintableResponseNotFoundError,
+    PrintableResponsePersistenceError,
+    PrintableResponsePersistenceValidationError,
+    PrintableResponseReadError,
+    PrintableResponseRecordCollisionError,
+    PrintableResponseRecordSetWriteError,
+    PrintableResponseRevisionConflictError,
+    canonical_printable_response_json,
+    load_printable_response_issuance,
+    load_printable_response_page,
+    load_printable_response_page_context,
+    transition_printable_response_issuance,
+    write_printable_response_record_set,
+)
+from quillan.printable_response_records import (
+    PrintableResponseRecordSet,
+    build_printable_response_record_set,
+)
+from quillan.work_paths import (
+    QuillanWorkPaths,
+    _is_link_like,
+    quillan_work_paths,
+    quillan_work_ref,
+)
+
+CLASS_ID = "english10_p2"
+ASSIGNMENT_ID = "literary_analysis"
+STUDENT_ID = "00107"
+GENERATION_ID = "gen_0123456789abcdef0123456789abcdef"
+ARTIFACT_ID = "art_0123456789abcdef0123456789abcdef"
+ISSUANCE_ID = "iss_0123456789abcdef0123456789abcdef"
+FRESH_GENERATION_ID = "gen_f123456789abcdef0123456789abcdef"
+FRESH_ARTIFACT_ID = "art_f123456789abcdef0123456789abcdef"
+FRESH_ISSUANCE_ID = "iss_f123456789abcdef0123456789abcdef"
+PAGE_IDS = (
+    "pg_0123456789abcdef0123456789abcdef",
+    "pg_1123456789abcdef0123456789abcdef",
+)
+FRESH_PAGE_IDS = (
+    "pg_f123456789abcdef0123456789abcdef",
+    "pg_e123456789abcdef0123456789abcdef",
+)
+NOW = datetime(2026, 7, 19, 18, 30, tzinfo=timezone.utc)
+
+
+def assignment() -> dict[str, object]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": ASSIGNMENT_ID,
+        "title": "Coming-of-Age Literary Analysis",
+        "class_ids": [CLASS_ID],
+        "writing_type": "literary_analysis",
+        "student_prompt": "Synthetic prompt.",
+        "standards_profile_id": "synthetic_profile",
+        "focus_standard_ids": ["W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "synthetic_scale",
+            "levels": [{"value": 1, "label": "Meets", "description": "Meets."}],
+        },
+        "basic_requirements": {},
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+        "created_at": "2026-07-19T18:00:00+00:00",
+        "updated_at": "2026-07-19T18:00:00+00:00",
+        "module_details": {},
+    }
+
+
+def student() -> StudentRecord:
+    return StudentRecord(CLASS_ID, STUDENT_ID, "Student", "Sample", "2", {})
+
+
+def prepare_workspace(
+    tmp_path: Path,
+) -> tuple[QuillanWorkPaths, PrintableResponseRecordSet]:
+    write_class_roster(
+        tmp_path,
+        create_roster(
+            CLASS_ID,
+            [
+                {
+                    "student_id": STUDENT_ID,
+                    "last_name": "Student",
+                    "first_name": "Sample",
+                    "period": "2",
+                }
+            ],
+        ),
+    )
+    paths = quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    paths.work_root.mkdir(parents=True, exist_ok=True)
+    paths.assignment_path.write_text(
+        json.dumps(assignment(), indent=2) + "\n", encoding="utf-8"
+    )
+    records = build_printable_response_record_set(
+        CLASS_ID,
+        assignment(),
+        student(),
+        generation_id=GENERATION_ID,
+        artifact_id=ARTIFACT_ID,
+        output_kind="class_packet_pdf",
+        reason="initial",
+        pages_per_student=2,
+        issuance_id=ISSUANCE_ID,
+        page_ids=PAGE_IDS,
+        class_label="English 10 Period 2",
+        clock=lambda: NOW,
+    )
+    return paths, records
+
+
+def regeneration_record_set(
+    *,
+    generation_id: str = FRESH_GENERATION_ID,
+    artifact_id: str = FRESH_ARTIFACT_ID,
+    issuance_id: str = FRESH_ISSUANCE_ID,
+    page_ids: tuple[str, ...] = FRESH_PAGE_IDS,
+) -> PrintableResponseRecordSet:
+    return build_printable_response_record_set(
+        CLASS_ID,
+        assignment(),
+        student(),
+        generation_id=generation_id,
+        artifact_id=artifact_id,
+        output_kind="class_packet_pdf",
+        reason="regeneration",
+        predecessor_issuance_id=ISSUANCE_ID,
+        pages_per_student=2,
+        issuance_id=issuance_id,
+        page_ids=page_ids,
+        class_label="English 10 Period 2",
+        clock=lambda: datetime(2026, 7, 19, 19, 30, tzinfo=timezone.utc),
+    )
+
+
+def additional_copy_record_set() -> PrintableResponseRecordSet:
+    return build_printable_response_record_set(
+        CLASS_ID,
+        assignment(),
+        student(),
+        generation_id=FRESH_GENERATION_ID,
+        artifact_id=FRESH_ARTIFACT_ID,
+        output_kind="class_packet_pdf",
+        reason="additional_copy",
+        pages_per_student=2,
+        issuance_id=FRESH_ISSUANCE_ID,
+        page_ids=FRESH_PAGE_IDS,
+        class_label="English 10 Period 2",
+        clock=lambda: datetime(2026, 7, 19, 19, 30, tzinfo=timezone.utc),
+    )
+
+
+def test_exclusive_write_commits_pages_then_issuance_and_loads_context(
+    tmp_path: Path,
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    persisted = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+
+    assert persisted.issuance_path.is_file()
+    assert all(path.is_file() for path in persisted.page_paths)
+    assert persisted.issuance_path.read_bytes().endswith(b"\n")
+    assert load_printable_response_issuance(
+        tmp_path, paths.work_ref, ISSUANCE_ID
+    ) == records.issuance
+    context = load_printable_response_page_context(
+        tmp_path, paths.work_ref, PAGE_IDS[1]
+    )
+    assert context.student_id == STUDENT_ID
+    assert context.logical_page == 2
+    assert context.total_pages == 2
+    assert context.is_continuation
+    assert context.member_pages == records.pages
+    assert not (paths.work_root / "routes").exists()
+    assert not list(paths.work_root.rglob("*.pdf"))
+
+
+def test_persistence_accepts_optional_roster_columns_without_serializing_them(
+    tmp_path: Path,
+) -> None:
+    roster = create_roster(
+        CLASS_ID,
+        [
+            {
+                "student_id": STUDENT_ID,
+                "last_name": "Student",
+                "first_name": "Sample",
+                "period": "2",
+                "email": "sample@example.test",
+                "grade_level": "10",
+            }
+        ],
+    )
+    write_class_roster(tmp_path, roster)
+    loaded_student = load_class_roster(tmp_path, CLASS_ID).students[0]
+    paths = quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    paths.work_root.mkdir(parents=True, exist_ok=True)
+    paths.assignment_path.write_text(
+        json.dumps(assignment(), indent=2) + "\n", encoding="utf-8"
+    )
+    records = build_printable_response_record_set(
+        CLASS_ID,
+        assignment(),
+        loaded_student,
+        generation_id=GENERATION_ID,
+        artifact_id=ARTIFACT_ID,
+        output_kind="class_packet_pdf",
+        reason="initial",
+        pages_per_student=2,
+        issuance_id=ISSUANCE_ID,
+        page_ids=PAGE_IDS,
+        clock=lambda: NOW,
+    )
+
+    persisted = write_printable_response_record_set(
+        tmp_path, paths.work_ref, records
+    )
+
+    assert dict(loaded_student.extra_fields) == {
+        "email": "sample@example.test",
+        "grade_level": "10",
+    }
+    for path in (persisted.issuance_path, *persisted.page_paths):
+        text = path.read_text(encoding="utf-8")
+        assert "email" not in text
+        assert "grade_level" not in text
+        assert "extra_fields" not in text
+        assert "sample@example.test" not in text
+
+
+def test_collision_preserves_all_existing_bytes_and_writes_nothing_new(
+    tmp_path: Path,
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    paths.response_page_records_dir.mkdir(parents=True)
+    collision = paths.response_page_records_dir / f"{PAGE_IDS[1]}.json"
+    collision.write_bytes(b"existing")
+
+    with pytest.raises(PrintableResponseRecordCollisionError):
+        write_printable_response_record_set(tmp_path, paths.work_ref, records)
+
+    assert collision.read_bytes() == b"existing"
+    assert not (paths.response_page_records_dir / f"{PAGE_IDS[0]}.json").exists()
+    assert not (paths.response_page_issuances_dir / f"{ISSUANCE_ID}.json").exists()
+
+
+def _malformed_quillan_work_ref() -> ModuleWorkRef:
+    malformed = object.__new__(ModuleWorkRef)
+    object.__setattr__(malformed, "module_id", "quillan")
+    object.__setattr__(malformed, "class_id", [])
+    object.__setattr__(malformed, "work_id", ASSIGNMENT_ID)
+    return malformed
+
+
+@pytest.mark.parametrize(
+    "invalid_work_ref",
+    [
+        None,
+        object(),
+        ModuleWorkRef("scoreform", CLASS_ID, ASSIGNMENT_ID),
+        _malformed_quillan_work_ref(),
+    ],
+)
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "load_issuance",
+        "load_page",
+        "load_record_set",
+        "load_page_context",
+        "write_record_set",
+        "transition_issuance",
+    ],
+)
+def test_every_persistence_entry_rejects_invalid_work_refs_without_side_effects(
+    tmp_path: Path,
+    invalid_work_ref: object,
+    operation: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    with pytest.raises(PrintableResponsePersistenceError):
+        if operation == "load_issuance":
+            load_printable_response_issuance(
+                workspace, invalid_work_ref, ISSUANCE_ID
+            )
+        elif operation == "load_page":
+            load_printable_response_page(workspace, invalid_work_ref, PAGE_IDS[0])
+        elif operation == "load_record_set":
+            persistence.load_printable_response_record_set(
+                workspace, invalid_work_ref, ISSUANCE_ID
+            )
+        elif operation == "load_page_context":
+            load_printable_response_page_context(
+                workspace, invalid_work_ref, PAGE_IDS[0]
+            )
+        elif operation == "write_record_set":
+            write_printable_response_record_set(
+                workspace, invalid_work_ref, object()
+            )
+        else:
+            transition_printable_response_issuance(
+                workspace,
+                invalid_work_ref,
+                ISSUANCE_ID,
+                expected_revision=1,
+                new_status="issued",
+                timestamp="2026-07-20T00:00:00+00:00",
+            )
+    assert not workspace.exists()
+
+
+@pytest.mark.parametrize("invalid_record_set", [None, {}, object()])
+def test_write_rejects_invalid_record_sets_without_side_effects(
+    tmp_path: Path, invalid_record_set: object
+) -> None:
+    workspace = tmp_path / "workspace"
+    with pytest.raises(
+        PrintableResponsePersistenceValidationError,
+        match="PrintableResponseRecordSet",
+    ):
+        write_printable_response_record_set(
+            workspace,
+            quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+            invalid_record_set,
+        )
+    assert not workspace.exists()
+
+
+def test_injected_later_write_failure_rolls_back_only_current_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    original = persistence._write_json_exclusive
+    calls = 0
+
+    def fail_second(path: Path, value: dict[str, object]) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("synthetic write failure")
+        return original(path, value)
+
+    monkeypatch.setattr(persistence, "_write_json_exclusive", fail_second)
+    with pytest.raises(PrintableResponseRecordSetWriteError, match="rolled back"):
+        write_printable_response_record_set(tmp_path, paths.work_ref, records)
+
+    assert not list(paths.response_page_records_dir.glob("*.json"))
+    assert not list(paths.response_page_issuances_dir.glob("*.json"))
+
+
+def test_rollback_preserves_page_replaced_by_competing_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    unrelated = paths.work_root / "unrelated.json"
+    unrelated.write_bytes(b"existing unrelated bytes")
+    original = persistence._write_json_exclusive
+    competing_bytes = b"competing writer bytes\n"
+    calls = 0
+
+    def compete_then_fail(path: Path, value: dict[str, object]) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            paths.response_page_records_dir.joinpath(
+                f"{PAGE_IDS[0]}.json"
+            ).write_bytes(competing_bytes)
+            raise OSError("synthetic second-page failure")
+        return original(path, value)
+
+    monkeypatch.setattr(persistence, "_write_json_exclusive", compete_then_fail)
+    with pytest.raises(persistence.PrintableResponseRollbackError, match=PAGE_IDS[0]):
+        write_printable_response_record_set(tmp_path, paths.work_ref, records)
+
+    assert (paths.response_page_records_dir / f"{PAGE_IDS[0]}.json").read_bytes() == competing_bytes
+    assert unrelated.read_bytes() == b"existing unrelated bytes"
+
+
+def test_rollback_preserves_entry_that_becomes_link_like(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    original_write = persistence._write_json_exclusive
+    original_is_link_like = _is_link_like
+    first_path = paths.response_page_records_dir / f"{PAGE_IDS[0]}.json"
+    competed = False
+    calls = 0
+
+    def mark_then_fail(path: Path, value: dict[str, object]) -> object:
+        nonlocal calls, competed
+        calls += 1
+        if calls == 2:
+            competed = True
+            raise OSError("synthetic second-page failure")
+        return original_write(path, value)
+
+    def simulate_link_like(path: Path) -> bool:
+        return (competed and path == first_path) or original_is_link_like(path)
+
+    monkeypatch.setattr(persistence, "_write_json_exclusive", mark_then_fail)
+    monkeypatch.setattr(
+        "quillan.printable_response_persistence._is_link_like", simulate_link_like
+    )
+    with pytest.raises(persistence.PrintableResponseRollbackError, match=PAGE_IDS[0]):
+        write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    assert first_path.is_file()
+
+
+def test_snapshot_mismatch_fails_before_record_directories_are_created(
+    tmp_path: Path,
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    changed = assignment()
+    changed["title"] = "Changed title"
+    paths.assignment_path.write_text(json.dumps(changed), encoding="utf-8")
+
+    with pytest.raises(PrintableResponsePersistenceValidationError, match="snapshot"):
+        write_printable_response_record_set(tmp_path, paths.work_ref, records)
+
+    assert not paths.response_pages_dir.exists()
+
+
+def test_strict_loader_rejects_duplicate_keys_nan_and_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    persisted = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    persisted.page_paths[0].write_text(
+        '{"page_id":"x","page_id":"y"}\n', encoding="utf-8"
+    )
+    with pytest.raises(PrintableResponseReadError, match="Duplicate"):
+        load_printable_response_page(tmp_path, paths.work_ref, PAGE_IDS[0])
+
+    persisted.page_paths[0].write_text('{"value": NaN}\n', encoding="utf-8")
+    with pytest.raises(PrintableResponseReadError, match="constant"):
+        load_printable_response_page(tmp_path, paths.work_ref, PAGE_IDS[0])
+
+    persisted.page_paths[0].write_bytes(
+        canonical_printable_response_json(records.pages[1].to_mapping())
+    )
+    with pytest.raises(PrintableResponseIntegrityError, match="filename"):
+        load_printable_response_page(tmp_path, paths.work_ref, PAGE_IDS[0])
+
+
+@pytest.mark.parametrize(
+    ("record_kind", "field", "malformed"),
+    [
+        ("issuance", "output_kind", []),
+        ("issuance", "reason", {}),
+        ("issuance", "status", []),
+        ("issuance", "class_label", 12),
+        ("issuance", "schema_version", None),
+        ("page", "page_role", {}),
+        ("page", "page_role", True),
+        ("page", "schema_version", None),
+    ],
+)
+def test_malformed_nested_record_types_raise_typed_read_errors(
+    tmp_path: Path, record_kind: str, field: str, malformed: object
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    persisted = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    if record_kind == "issuance":
+        mapping = records.issuance.to_mapping()
+        if field in {"output_kind", "reason"}:
+            mapping["generation_context"][field] = malformed
+        elif field == "status":
+            mapping["lifecycle"][field] = malformed
+        else:
+            mapping[field] = malformed
+        persisted.issuance_path.write_bytes(canonical_printable_response_json(mapping))
+    else:
+        mapping = records.pages[0].to_mapping()
+        mapping[field] = malformed
+        persisted.page_paths[0].write_bytes(canonical_printable_response_json(mapping))
+    with pytest.raises(PrintableResponseReadError):
+        if record_kind == "issuance":
+            load_printable_response_issuance(tmp_path, paths.work_ref, ISSUANCE_ID)
+        else:
+            load_printable_response_page(tmp_path, paths.work_ref, PAGE_IDS[0])
+
+
+@pytest.mark.parametrize(
+    ("generation_id", "artifact_id", "page_ids", "expected"),
+    [
+        (GENERATION_ID, FRESH_ARTIFACT_ID, FRESH_PAGE_IDS, "generation_id"),
+        (FRESH_GENERATION_ID, ARTIFACT_ID, FRESH_PAGE_IDS, "artifact_id"),
+        (FRESH_GENERATION_ID, FRESH_ARTIFACT_ID, (PAGE_IDS[0], FRESH_PAGE_IDS[1]), "page_ids"),
+    ],
+)
+def test_regeneration_rejects_reused_identities_without_mutating_predecessor(
+    tmp_path: Path,
+    generation_id: str,
+    artifact_id: str,
+    page_ids: tuple[str, ...],
+    expected: str,
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    predecessor = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    before = {
+        path: path.read_bytes()
+        for path in (predecessor.issuance_path, *predecessor.page_paths)
+    }
+    replacement = regeneration_record_set(
+        generation_id=generation_id,
+        artifact_id=artifact_id,
+        page_ids=page_ids,
+    )
+
+    with pytest.raises(PrintableResponsePersistenceValidationError, match=expected):
+        write_printable_response_record_set(tmp_path, paths.work_ref, replacement)
+
+    assert {path: path.read_bytes() for path in before} == before
+
+
+def test_regeneration_with_all_fresh_identities_preserves_predecessor_bytes(
+    tmp_path: Path,
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    predecessor = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    before = {
+        path: path.read_bytes()
+        for path in (predecessor.issuance_path, *predecessor.page_paths)
+    }
+
+    replacement = write_printable_response_record_set(
+        tmp_path, paths.work_ref, regeneration_record_set()
+    )
+
+    assert replacement.record_set.issuance.generation_id == FRESH_GENERATION_ID
+    assert replacement.record_set.issuance.artifact_id == FRESH_ARTIFACT_ID
+    assert replacement.record_set.issuance.issuance_id == FRESH_ISSUANCE_ID
+    assert replacement.record_set.issuance.page_ids == FRESH_PAGE_IDS
+    assert {path: path.read_bytes() for path in before} == before
+
+def test_loading_remains_authoritative_after_roster_and_assignment_change(
+    tmp_path: Path,
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    changed = assignment()
+    changed["title"] = "Later title"
+    changed["updated_at"] = "2026-07-20T18:00:00+00:00"
+    paths.assignment_path.write_text(json.dumps(changed), encoding="utf-8")
+    write_class_roster(
+        tmp_path,
+        create_roster(
+            CLASS_ID,
+            [
+                {
+                    "student_id": "00999",
+                    "last_name": "Other",
+                    "first_name": "Learner",
+                    "period": "2",
+                }
+            ],
+        ),
+        overwrite=True,
+    )
+
+    context = load_printable_response_page_context(
+        tmp_path, paths.work_ref, PAGE_IDS[0]
+    )
+    assert context.student_id == STUDENT_ID
+    assert context.issuance.assignment_snapshot.title == assignment()["title"]
+
+
+def test_revision_guarded_lifecycle_changes_only_issuance_bytes(tmp_path: Path) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    persisted = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    page_bytes = tuple(path.read_bytes() for path in persisted.page_paths)
+
+    issued = transition_printable_response_issuance(
+        tmp_path,
+        paths.work_ref,
+        ISSUANCE_ID,
+        expected_revision=1,
+        new_status="issued",
+        timestamp="2026-07-19T18:31:00+00:00",
+    )
+    assert issued.lifecycle.status == "issued"
+    assert issued.lifecycle.revision == 2
+    with pytest.raises(PrintableResponseRevisionConflictError):
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=1,
+            new_status="invalidated",
+            timestamp="2026-07-19T18:32:00+00:00",
+            reason="Synthetic administrative decision",
+        )
+    invalidated = transition_printable_response_issuance(
+        tmp_path,
+        paths.work_ref,
+        ISSUANCE_ID,
+        expected_revision=2,
+        new_status="invalidated",
+        timestamp="2026-07-19T18:32:00+00:00",
+        reason="Synthetic administrative decision",
+    )
+    assert invalidated.lifecycle.revision == 3
+    assert tuple(path.read_bytes() for path in persisted.page_paths) == page_bytes
+
+
+def test_lifecycle_rejects_bytes_changed_after_revision_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    persisted = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    original_replace = persistence._atomic_replace_issuance
+    competing_bytes = b"synthetic competing lifecycle write\n"
+
+    def compete_then_replace(
+        path: Path,
+        issuance: object,
+        *,
+        expected_bytes: bytes,
+    ) -> None:
+        path.write_bytes(competing_bytes)
+        original_replace(path, issuance, expected_bytes=expected_bytes)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(persistence, "_atomic_replace_issuance", compete_then_replace)
+    with pytest.raises(PrintableResponseRevisionConflictError, match="changed"):
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=1,
+            new_status="issued",
+            timestamp="2026-07-19T18:31:00+00:00",
+        )
+
+    assert persisted.issuance_path.read_bytes() == competing_bytes
+    assert not list(persisted.issuance_path.parent.glob("*.tmp"))
+
+
+def test_lifecycle_temporary_cleanup_failure_is_surfaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    persisted = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    original_bytes = persisted.issuance_path.read_bytes()
+    original_unlink = Path.unlink
+
+    def fail_replace(source: object, destination: object) -> None:
+        raise OSError("synthetic replacement failure")
+
+    def fail_temporary_unlink(
+        path: Path, missing_ok: bool = False
+    ) -> None:
+        if path.suffix == ".tmp":
+            raise OSError("synthetic cleanup failure")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    monkeypatch.setattr(Path, "unlink", fail_temporary_unlink)
+    with pytest.raises(PrintableResponseLifecycleCleanupError) as caught:
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=1,
+            new_status="issued",
+            timestamp="2026-07-19T18:31:00+00:00",
+        )
+
+    assert ".tmp" in str(caught.value)
+    assert "synthetic replacement failure" in str(caught.value)
+    assert "synthetic cleanup failure" in str(caught.value)
+    assert persisted.issuance_path.read_bytes() == original_bytes
+
+
+@pytest.mark.parametrize(
+    "transition_case",
+    [
+        "prepared_to_issued",
+        "prepared_to_cancelled",
+        "prepared_to_invalidated",
+        "issued_to_superseded",
+        "issued_to_invalidated",
+    ],
+)
+def test_every_allowed_persisted_transition_preserves_all_page_bytes(
+    tmp_path: Path, transition_case: str
+) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    persisted = write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    tracked_pages = list(persisted.page_paths)
+    before = {path: path.read_bytes() for path in tracked_pages}
+
+    if transition_case.startswith("issued_to_"):
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=1,
+            new_status="issued",
+            timestamp="2026-07-19T18:31:00+00:00",
+        )
+        if transition_case == "issued_to_superseded":
+            replacement = write_printable_response_record_set(
+                tmp_path, paths.work_ref, additional_copy_record_set()
+            )
+            tracked_pages.extend(replacement.page_paths)
+            before.update({path: path.read_bytes() for path in replacement.page_paths})
+            transition_printable_response_issuance(
+                tmp_path,
+                paths.work_ref,
+                FRESH_ISSUANCE_ID,
+                expected_revision=1,
+                new_status="issued",
+                timestamp="2026-07-19T19:31:00+00:00",
+            )
+            result = transition_printable_response_issuance(
+                tmp_path,
+                paths.work_ref,
+                ISSUANCE_ID,
+                expected_revision=2,
+                new_status="superseded",
+                timestamp="2026-07-19T19:32:00+00:00",
+                reason="Fresh issued replacement",
+                replacement_issuance_id=FRESH_ISSUANCE_ID,
+            )
+        else:
+            result = transition_printable_response_issuance(
+                tmp_path,
+                paths.work_ref,
+                ISSUANCE_ID,
+                expected_revision=2,
+                new_status="invalidated",
+                timestamp="2026-07-19T18:32:00+00:00",
+                reason="Synthetic integrity decision",
+            )
+    else:
+        new_status = transition_case.removeprefix("prepared_to_")
+        result = transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=1,
+            new_status=new_status,
+            timestamp="2026-07-19T18:31:00+00:00",
+            reason=(
+                "Synthetic terminal decision"
+                if new_status in {"cancelled", "invalidated"}
+                else None
+            ),
+        )
+
+    assert result.lifecycle.status == transition_case.rsplit("_to_", 1)[1]
+    assert {path: path.read_bytes() for path in tracked_pages} == before
+
+
+def test_supersession_replacement_rules_are_enforced(tmp_path: Path) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    transition_printable_response_issuance(
+        tmp_path,
+        paths.work_ref,
+        ISSUANCE_ID,
+        expected_revision=1,
+        new_status="issued",
+        timestamp="2026-07-19T18:31:00+00:00",
+    )
+
+    with pytest.raises(PrintableResponseNotFoundError):
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=2,
+            new_status="superseded",
+            timestamp="2026-07-19T19:32:00+00:00",
+            reason="Missing replacement",
+            replacement_issuance_id=FRESH_ISSUANCE_ID,
+        )
+
+    replacement = write_printable_response_record_set(
+        tmp_path, paths.work_ref, additional_copy_record_set()
+    )
+    with pytest.raises(PrintableResponseLifecycleError, match="already be issued"):
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=2,
+            new_status="superseded",
+            timestamp="2026-07-19T19:32:00+00:00",
+            reason="Prepared replacement",
+            replacement_issuance_id=FRESH_ISSUANCE_ID,
+        )
+
+    transition_printable_response_issuance(
+        tmp_path,
+        paths.work_ref,
+        FRESH_ISSUANCE_ID,
+        expected_revision=1,
+        new_status="issued",
+        timestamp="2026-07-19T19:31:00+00:00",
+    )
+    with pytest.raises(PrintableResponseLifecycleError, match="itself"):
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=2,
+            new_status="superseded",
+            timestamp="2026-07-19T19:32:00+00:00",
+            reason="Self replacement",
+            replacement_issuance_id=ISSUANCE_ID,
+        )
+
+    replacement_issuance = load_printable_response_issuance(
+        tmp_path, paths.work_ref, FRESH_ISSUANCE_ID
+    )
+    mismatched = replace(replacement_issuance, student_id="00999")
+    replacement.issuance_path.write_bytes(
+        canonical_printable_response_json(mismatched.to_mapping())
+    )
+    with pytest.raises(PrintableResponseLifecycleError, match="share class"):
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=2,
+            new_status="superseded",
+            timestamp="2026-07-19T19:32:00+00:00",
+            reason="Wrong student replacement",
+            replacement_issuance_id=FRESH_ISSUANCE_ID,
+        )
+
+
+def test_lifecycle_rejects_timestamp_before_stored_timestamp(tmp_path: Path) -> None:
+    paths, records = prepare_workspace(tmp_path)
+    write_printable_response_record_set(tmp_path, paths.work_ref, records)
+    with pytest.raises(PrintableResponseLifecycleError, match="precedes"):
+        transition_printable_response_issuance(
+            tmp_path,
+            paths.work_ref,
+            ISSUANCE_ID,
+            expected_revision=1,
+            new_status="issued",
+            timestamp="2026-07-19T18:29:00+00:00",
+        )

--- a/tests/test_printable_response_records.py
+++ b/tests/test_printable_response_records.py
@@ -1,0 +1,527 @@
+"""Contract tests for immutable printable-response records."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+from pathlib import Path
+from collections.abc import Callable
+
+from pds_core.rosters import StudentRecord
+from pds_core.routing_models import ModuleRecordRef
+import pytest
+
+import quillan.printable_response_persistence as response_persistence
+import quillan.printable_response_records as response_records
+from quillan.pds_contract import RESPONSE_PAGE_CONTRACT_VERSION
+from quillan.printable_response_records import (
+    PrintableResponseIssuance,
+    PrintableResponseLifecycle,
+    PrintableResponseRecordSet,
+    PrintableResponseRecordValidationError,
+    build_printable_response_record_set,
+    generate_generation_id,
+    printable_response_issuance_from_mapping,
+    printable_response_page_from_mapping,
+    response_page_target,
+    transition_printable_response_lifecycle,
+    validate_artifact_id,
+    validate_generation_id,
+    validate_issuance_id,
+    validate_page_id,
+)
+
+GENERATION_ID = "gen_0123456789abcdef0123456789abcdef"
+ARTIFACT_ID = "art_0123456789abcdef0123456789abcdef"
+ISSUANCE_ID = "iss_0123456789abcdef0123456789abcdef"
+PAGE_IDS = (
+    "pg_0123456789abcdef0123456789abcdef",
+    "pg_1123456789abcdef0123456789abcdef",
+    "pg_2123456789abcdef0123456789abcdef",
+)
+NOW = datetime(2026, 7, 19, 18, 30, tzinfo=timezone.utc)
+
+
+def assignment() -> dict[str, object]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": "literary_analysis",
+        "title": "Coming-of-Age Literary Analysis",
+        "class_ids": ["english10_p2"],
+        "writing_type": "literary_analysis",
+        "student_prompt": "Synthetic prompt.",
+        "standards_profile_id": "synthetic_profile",
+        "focus_standard_ids": ["W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "synthetic_scale",
+            "levels": [{"value": 1, "label": "Meets", "description": "Meets."}],
+        },
+        "basic_requirements": {},
+        "minimum_requirement_policy": {"allow_return_without_full_review": True},
+        "created_at": "2026-07-19T18:00:00+00:00",
+        "updated_at": "2026-07-19T18:00:00+00:00",
+        "module_details": {},
+    }
+
+
+def student(student_id: str = "00107") -> StudentRecord:
+    return StudentRecord(
+        "english10_p2", student_id, "Student", "Sample", "2", {}
+    )
+
+
+def record_set(*, pages: int = 3, reason: str = "initial") -> PrintableResponseRecordSet:
+    return build_printable_response_record_set(
+        "english10_p2",
+        assignment(),
+        student(),
+        generation_id=GENERATION_ID,
+        artifact_id=ARTIFACT_ID,
+        output_kind="class_packet_pdf",
+        reason=reason,
+        predecessor_issuance_id=(ISSUANCE_ID[:-1] + "e" if reason == "regeneration" else None),
+        pages_per_student=pages,
+        issuance_id=ISSUANCE_ID,
+        page_ids=PAGE_IDS[:pages],
+        class_label="English 10 Period 2",
+        clock=lambda: NOW,
+    )
+
+
+@pytest.mark.parametrize(
+    ("validator", "valid"),
+    [
+        (validate_generation_id, GENERATION_ID),
+        (validate_artifact_id, ARTIFACT_ID),
+        (validate_issuance_id, ISSUANCE_ID),
+        (validate_page_id, PAGE_IDS[0]),
+    ],
+)
+def test_exact_identifier_contract(
+    validator: Callable[[object], str], valid: str
+) -> None:
+    assert validator(valid) == valid
+    for invalid in (valid.upper(), valid[:-1], valid + "0", "../unsafe", True, 1, None):
+        with pytest.raises(PrintableResponseRecordValidationError):
+            validator(invalid)
+
+
+def test_generator_uses_exactly_128_bits_and_is_injectable() -> None:
+    calls: list[int] = []
+
+    def token_hex(size: int) -> str:
+        calls.append(size)
+        return "a" * 32
+
+    assert generate_generation_id(token_hex) == "gen_" + "a" * 32
+    assert calls == [16]
+
+
+def test_builder_is_pure_complete_frozen_and_preserves_zero_id(
+    tmp_path: Path,
+) -> None:
+    records = record_set()
+    assert records.issuance.student_id == "00107"
+    assert records.issuance.page_ids == PAGE_IDS
+    assert [page.logical_page for page in records.pages] == [1, 2, 3]
+    assert [page.page_role for page in records.pages] == [
+        "response_start",
+        "continuation",
+        "continuation",
+    ]
+    assert {page.created_at for page in records.pages} == {
+        records.issuance.lifecycle.created_at
+    }
+    assert records.issuance.student_snapshot.display_name == "Sample Student"
+    with pytest.raises(FrozenInstanceError):
+        records.pages[0].page_id = PAGE_IDS[1]  # type: ignore[misc]
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_exact_mapping_round_trip_and_unknown_missing_rejection() -> None:
+    records = record_set()
+    issuance_mapping = records.issuance.to_mapping()
+    page_mapping = records.pages[0].to_mapping()
+    assert PrintableResponseIssuance.from_mapping(issuance_mapping) == records.issuance
+    assert printable_response_page_from_mapping(page_mapping) == records.pages[0]
+    assert isinstance(issuance_mapping["page_ids"], list)
+    for mapping, loader in (
+        ({**issuance_mapping, "unknown": 1}, printable_response_issuance_from_mapping),
+        ({key: value for key, value in page_mapping.items() if key != "page_id"}, printable_response_page_from_mapping),
+    ):
+        with pytest.raises(PrintableResponseRecordValidationError):
+            loader(mapping)
+
+
+def test_mapping_rejects_boolean_integer_and_nonstandard_role() -> None:
+    page = record_set().pages[0].to_mapping()
+    page["logical_page"] = True
+    with pytest.raises(PrintableResponseRecordValidationError):
+        printable_response_page_from_mapping(page)
+    page = record_set().pages[0].to_mapping()
+    page["page_role"] = "continuation"
+    with pytest.raises(PrintableResponseRecordValidationError):
+        printable_response_page_from_mapping(page)
+
+
+def test_generation_context_rules_and_self_predecessor() -> None:
+    with pytest.raises(PrintableResponseRecordValidationError):
+        build_printable_response_record_set(
+            "english10_p2",
+            assignment(),
+            student(),
+            generation_id=GENERATION_ID,
+            artifact_id=ARTIFACT_ID,
+            output_kind="class_packet_pdf",
+            reason="initial",
+            predecessor_issuance_id=ISSUANCE_ID,
+            pages_per_student=1,
+            issuance_id=ISSUANCE_ID,
+            page_ids=PAGE_IDS[:1],
+        )
+    with pytest.raises(PrintableResponseRecordValidationError, match="itself"):
+        build_printable_response_record_set(
+            "english10_p2",
+            assignment(),
+            student(),
+            generation_id=GENERATION_ID,
+            artifact_id=ARTIFACT_ID,
+            output_kind="class_packet_pdf",
+            reason="regeneration",
+            predecessor_issuance_id=ISSUANCE_ID,
+            pages_per_student=1,
+            issuance_id=ISSUANCE_ID,
+            page_ids=PAGE_IDS[:1],
+        )
+
+
+def test_lifecycle_allows_only_governed_transitions() -> None:
+    lifecycle = record_set(pages=1).issuance.lifecycle
+    issued = transition_printable_response_lifecycle(
+        lifecycle, new_status="issued", timestamp="2026-07-19T18:31:00+00:00"
+    )
+    assert issued.status == "issued"
+    assert issued.revision == 2
+    assert issued.issued_at == issued.updated_at
+    with pytest.raises(PrintableResponseRecordValidationError):
+        transition_printable_response_lifecycle(
+            issued, new_status="cancelled", timestamp="2026-07-19T18:32:00+00:00"
+        )
+
+
+def _allowed_lifecycle_examples() -> dict[str, PrintableResponseLifecycle]:
+    prepared = record_set(pages=1).issuance.lifecycle
+    issued = transition_printable_response_lifecycle(
+        prepared,
+        new_status="issued",
+        timestamp="2026-07-19T18:31:00+00:00",
+    )
+    return {
+        "prepared": prepared,
+        "issued": issued,
+        "cancelled": transition_printable_response_lifecycle(
+            prepared,
+            new_status="cancelled",
+            timestamp="2026-07-19T18:31:00+00:00",
+            reason="Preparation abandoned",
+        ),
+        "superseded": transition_printable_response_lifecycle(
+            issued,
+            new_status="superseded",
+            timestamp="2026-07-19T18:32:00+00:00",
+            reason="Fresh issued copy",
+            replacement_issuance_id=ISSUANCE_ID[:-1] + "e",
+        ),
+        "invalidated": transition_printable_response_lifecycle(
+            issued,
+            new_status="invalidated",
+            timestamp="2026-07-19T18:32:00+00:00",
+            reason="Synthetic integrity decision",
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    ("start", "allowed"),
+    [
+        ("prepared", {"issued", "cancelled", "invalidated"}),
+        ("issued", {"superseded", "invalidated"}),
+        ("cancelled", set()),
+        ("superseded", set()),
+        ("invalidated", set()),
+    ],
+)
+def test_every_forbidden_lifecycle_transition_is_rejected(
+    start: str, allowed: set[str]
+) -> None:
+    lifecycle = _allowed_lifecycle_examples()[start]
+    for new_status in {"prepared", "issued", "cancelled", "superseded", "invalidated"} - allowed:
+        with pytest.raises(PrintableResponseRecordValidationError, match="not allowed"):
+            transition_printable_response_lifecycle(
+                lifecycle,
+                new_status=new_status,
+                timestamp="2026-07-19T18:33:00+00:00",
+                reason=("Terminal reason" if new_status in {"cancelled", "superseded", "invalidated"} else None),
+                replacement_issuance_id=(
+                    ISSUANCE_ID[:-1] + "e" if new_status == "superseded" else None
+                ),
+            )
+
+
+@pytest.mark.parametrize("terminal_status", ["cancelled", "invalidated"])
+def test_terminal_transition_requires_nonempty_reason(terminal_status: str) -> None:
+    prepared = record_set(pages=1).issuance.lifecycle
+    with pytest.raises(PrintableResponseRecordValidationError, match="reason"):
+        transition_printable_response_lifecycle(
+            prepared,
+            new_status=terminal_status,
+            timestamp="2026-07-19T18:31:00+00:00",
+            reason="",
+        )
+
+
+def test_issued_prohibits_reason_and_superseded_requires_replacement() -> None:
+    prepared = record_set(pages=1).issuance.lifecycle
+    with pytest.raises(PrintableResponseRecordValidationError, match="reason"):
+        transition_printable_response_lifecycle(
+            prepared,
+            new_status="issued",
+            timestamp="2026-07-19T18:31:00+00:00",
+            reason="not allowed",
+        )
+    issued = transition_printable_response_lifecycle(
+        prepared,
+        new_status="issued",
+        timestamp="2026-07-19T18:31:00+00:00",
+    )
+    with pytest.raises(PrintableResponseRecordValidationError):
+        transition_printable_response_lifecycle(
+            issued,
+            new_status="superseded",
+            timestamp="2026-07-19T18:32:00+00:00",
+            reason="Replacement missing",
+        )
+    with pytest.raises(PrintableResponseRecordValidationError, match="reason"):
+        transition_printable_response_lifecycle(
+            issued,
+            new_status="superseded",
+            timestamp="2026-07-19T18:32:00+00:00",
+            reason="",
+            replacement_issuance_id=ISSUANCE_ID[:-1] + "e",
+        )
+
+
+@pytest.mark.parametrize(
+    ("status", "revision", "issued_at"),
+    [
+        ("issued", 3, "2026-07-19T18:31:00+00:00"),
+        ("cancelled", 3, None),
+        ("superseded", 2, "2026-07-19T18:31:00+00:00"),
+        ("invalidated", 3, None),
+        ("invalidated", 2, "2026-07-19T18:31:00+00:00"),
+    ],
+)
+def test_persisted_lifecycle_revision_must_match_transition_history(
+    status: str, revision: int, issued_at: str | None
+) -> None:
+    terminal = status != "issued"
+    with pytest.raises(PrintableResponseRecordValidationError, match="revision"):
+        PrintableResponseLifecycle(
+            status=status,
+            revision=revision,
+            created_at=NOW.isoformat(),
+            updated_at="2026-07-19T18:32:00+00:00",
+            issued_at=issued_at,
+            ended_at="2026-07-19T18:32:00+00:00" if terminal else None,
+            reason="Synthetic terminal reason" if terminal else None,
+            replacement_issuance_id=(
+                ISSUANCE_ID[:-1] + "e" if status == "superseded" else None
+            ),
+        )
+
+
+def test_builder_rejects_student_not_normalized_by_roster_contract() -> None:
+    with pytest.raises(PrintableResponseRecordValidationError, match="normalized"):
+        build_printable_response_record_set(
+            "english10_p2",
+            assignment(),
+            StudentRecord(
+                "english10_p2",
+                "00107",
+                " Student ",
+                "Sample",
+                "2",
+                {"email": "sample@example.test"},
+            ),
+            generation_id=GENERATION_ID,
+            artifact_id=ARTIFACT_ID,
+            output_kind="class_packet_pdf",
+            reason="initial",
+            pages_per_student=1,
+            issuance_id=ISSUANCE_ID,
+            page_ids=PAGE_IDS[:1],
+        )
+
+
+def test_builder_accepts_optional_roster_fields_without_serializing_them() -> None:
+    optional_fields = {
+        "email": "sample@example.test",
+        "grade_level": "10",
+    }
+    roster_student = StudentRecord(
+        class_id="english10_p2",
+        student_id="00107",
+        last_name="Student",
+        first_name="Sample",
+        period="2",
+        extra_fields=optional_fields,
+    )
+
+    records = build_printable_response_record_set(
+        "english10_p2",
+        assignment(),
+        roster_student,
+        generation_id=GENERATION_ID,
+        artifact_id=ARTIFACT_ID,
+        output_kind="class_packet_pdf",
+        reason="initial",
+        pages_per_student=1,
+        issuance_id=ISSUANCE_ID,
+        page_ids=PAGE_IDS[:1],
+        clock=lambda: NOW,
+    )
+
+    assert records.issuance.student_id == "00107"
+    assert records.issuance.student_snapshot.to_mapping() == {
+        "display_name": "Sample Student",
+        "last_name": "Student",
+        "first_name": "Sample",
+        "period": "2",
+    }
+    serialized = (records.issuance.to_mapping(), records.pages[0].to_mapping())
+    for mapping in serialized:
+        assert "email" not in mapping
+        assert "grade_level" not in mapping
+        assert "extra_fields" not in mapping
+        assert "sample@example.test" not in repr(mapping)
+    assert dict(roster_student.extra_fields) == optional_fields
+
+
+@pytest.mark.parametrize("invalid", [None, {}, [], object()])
+def test_public_record_set_validator_rejects_wrong_model_types(
+    invalid: object,
+) -> None:
+    with pytest.raises(
+        PrintableResponseRecordValidationError,
+        match="record_set must be a PrintableResponseRecordSet",
+    ):
+        response_records.validate_printable_response_record_set(invalid)
+
+
+@pytest.mark.parametrize("invalid", [None, {}, object()])
+def test_public_mapping_converters_reject_wrong_model_types(
+    invalid: object,
+) -> None:
+    with pytest.raises(PrintableResponseRecordValidationError, match="issuance"):
+        response_records.printable_response_issuance_to_mapping(invalid)
+    with pytest.raises(PrintableResponseRecordValidationError, match="page"):
+        response_records.printable_response_page_to_mapping(invalid)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("output_kind", []),
+        ("reason", {}),
+    ],
+)
+def test_generation_context_malformed_enum_types_are_typed(
+    field: str, value: object
+) -> None:
+    mapping = record_set(pages=1).issuance.generation_context.to_mapping()
+    mapping[field] = value
+    with pytest.raises(PrintableResponseRecordValidationError):
+        response_records.PrintableResponseGenerationContext.from_mapping(mapping)
+
+
+def test_exact_mapping_rejects_non_string_keys_without_builtin_type_error() -> None:
+    mapping: dict[object, object] = {
+        "output_kind": "class_packet_pdf",
+        "reason": "initial",
+        "predecessor_issuance_id": None,
+        1: "unexpected",
+    }
+    with pytest.raises(PrintableResponseRecordValidationError, match="keys"):
+        response_records.PrintableResponseGenerationContext.from_mapping(mapping)
+
+
+def test_transition_rejects_unhashable_new_status_through_typed_error() -> None:
+    with pytest.raises(PrintableResponseRecordValidationError, match="new_status"):
+        transition_printable_response_lifecycle(
+            record_set(pages=1).issuance.lifecycle,
+            new_status=[],  # type: ignore[arg-type]
+            timestamp="2026-07-19T18:31:00+00:00",
+        )
+
+
+def test_new_modules_keep_pds2_only_schema_and_narrow_public_api() -> None:
+    root = Path(response_records.__file__).parent
+    sources = {
+        name: (root / name).read_text(encoding="utf-8")
+        for name in (
+            "printable_response_records.py",
+            "printable_response_persistence.py",
+        )
+    }
+    forbidden_imports = (
+        "pds_core.pds1",
+        "pds_core.qr_payload",
+        "quillan.payloads",
+    )
+    assert all(
+        forbidden not in source
+        for source in sources.values()
+        for forbidden in forbidden_imports
+    )
+    page_mapping = record_set(pages=1).pages[0].to_mapping()
+    assert set(page_mapping).isdisjoint(
+        {
+            "route_id",
+            "qr_payload",
+            "scan_id",
+            "evidence",
+            "evidence_state",
+            "submission",
+            "submission_state",
+        }
+    )
+    assert "with_printable_response_lifecycle" not in response_records.__all__
+    assert not hasattr(response_records, "with_printable_response_lifecycle")
+    assert all(
+        "page" not in name or all(word not in name for word in ("update", "overwrite"))
+        for name in response_persistence.__all__
+    )
+    assert record_set(pages=1).pages[0].schema_version == RESPONSE_PAGE_CONTRACT_VERSION
+    assert response_page_target(PAGE_IDS[0]).contract_version == RESPONSE_PAGE_CONTRACT_VERSION
+    target_constructors = [
+        name
+        for name in response_records.__all__
+        if name == "response_page_target"
+    ]
+    assert target_constructors == ["response_page_target"]
+    assert sum(source.count("def response_page_target(") for source in sources.values()) == 1
+
+
+def test_page_target_is_exact_and_side_effect_free(tmp_path: Path) -> None:
+    target = response_page_target(record_set(pages=1).pages[0])
+    assert target == ModuleRecordRef(
+        "quillan", "response_page", PAGE_IDS[0], RESPONSE_PAGE_CONTRACT_VERSION
+    )
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_work_paths.py
+++ b/tests/test_work_paths.py
@@ -25,6 +25,8 @@ from quillan.work_paths import (
     quillan_work_ref,
     relative_assignment_path,
     relative_submission_manifest_path,
+    response_page_issuance_path,
+    response_page_record_path,
     review_record_path,
     student_submission_dir,
     submission_manifest_path,
@@ -56,6 +58,8 @@ def test_work_reference_and_exact_layout_are_module_qualified(tmp_path: Path) ->
     assert paths.work_root == root
     assert paths.assignment_path == root / "assignment.json"
     assert paths.response_pages_dir == root / "response_pages"
+    assert paths.response_page_issuances_dir == root / "response_pages" / "issuances"
+    assert paths.response_page_records_dir == root / "response_pages" / "pages"
     assert paths.templates_dir == root / "templates"
     assert paths.scans_dir == root / "scans"
     assert paths.submissions_dir == root / "submissions"
@@ -69,11 +73,23 @@ def test_work_reference_and_exact_layout_are_module_qualified(tmp_path: Path) ->
     assert review_record_path(tmp_path, work_ref, STUDENT_ID) == (
         root / "submissions" / STUDENT_ID / "review.json"
     )
+    assert response_page_issuance_path(
+        tmp_path, work_ref, "iss_0123456789abcdef0123456789abcdef"
+    ) == root / "response_pages" / "issuances" / (
+        "iss_0123456789abcdef0123456789abcdef.json"
+    )
+    assert response_page_record_path(
+        tmp_path, work_ref, "pg_0123456789abcdef0123456789abcdef"
+    ) == root / "response_pages" / "pages" / (
+        "pg_0123456789abcdef0123456789abcdef.json"
+    )
     assert all(
         path.is_relative_to(root)
         for path in (
             paths.assignment_path,
             paths.response_pages_dir,
+            paths.response_page_issuances_dir,
+            paths.response_page_records_dir,
             paths.templates_dir,
             paths.scans_dir,
             paths.submissions_dir,
@@ -88,6 +104,8 @@ def test_work_reference_and_exact_layout_are_module_qualified(tmp_path: Path) ->
             paths.work_root,
             paths.assignment_path,
             paths.response_pages_dir,
+            paths.response_page_issuances_dir,
+            paths.response_page_records_dir,
             paths.templates_dir,
             paths.scans_dir,
             paths.submissions_dir,
@@ -118,6 +136,12 @@ def test_all_path_construction_is_side_effect_free(tmp_path: Path) -> None:
     student_submission_dir(workspace, work_ref, STUDENT_ID)
     submission_manifest_path(workspace, work_ref, STUDENT_ID)
     review_record_path(workspace, work_ref, STUDENT_ID)
+    response_page_issuance_path(
+        workspace, work_ref, "iss_0123456789abcdef0123456789abcdef"
+    )
+    response_page_record_path(
+        workspace, work_ref, "pg_0123456789abcdef0123456789abcdef"
+    )
 
     assert not workspace.exists()
 
@@ -198,6 +222,16 @@ def test_student_helpers_reject_other_modules_and_invalid_students(
         student_submission_dir(
             workspace, quillan_work_ref(CLASS_ID, ASSIGNMENT_ID), "../student"
         )
+    with pytest.raises(QuillanWorkPathError, match="module_id"):
+        response_page_issuance_path(
+            workspace,
+            other,
+            "iss_0123456789abcdef0123456789abcdef",
+        )
+    with pytest.raises(ValueError, match="page_id"):
+        response_page_record_path(
+            workspace, quillan_work_ref(CLASS_ID, ASSIGNMENT_ID), "../unsafe"
+        )
 
     assert module_work_dir(workspace, other) != quillan_work_paths(
         workspace, CLASS_ID, ASSIGNMENT_ID
@@ -223,6 +257,8 @@ def test_initializer_creates_only_static_layout_and_is_idempotent(
         "exports",
         "teacher-marker.txt",
     }
+    assert paths.response_page_issuances_dir.is_dir()
+    assert paths.response_page_records_dir.is_dir()
     assert not paths.assignment_path.exists()
     assert not (paths.work_root / "routes").exists()
     assert not list(paths.work_root.rglob("*.json"))
@@ -231,7 +267,16 @@ def test_initializer_creates_only_static_layout_and_is_idempotent(
 
 @pytest.mark.parametrize(
     "collision_name",
-    ["work_root", "response_pages_dir", "templates_dir", "scans_dir", "submissions_dir", "exports_dir"],
+    [
+        "work_root",
+        "response_pages_dir",
+        "response_page_issuances_dir",
+        "response_page_records_dir",
+        "templates_dir",
+        "scans_dir",
+        "submissions_dir",
+        "exports_dir",
+    ],
 )
 def test_initializer_preflights_all_wrong_type_collisions(
     tmp_path: Path, collision_name: str
@@ -252,7 +297,11 @@ def test_initializer_preflights_all_wrong_type_collisions(
         paths.submissions_dir,
         paths.exports_dir,
     ):
-        if required != collision and not required.is_relative_to(collision):
+        if (
+            required != collision
+            and not required.is_relative_to(collision)
+            and not collision.is_relative_to(required)
+        ):
             assert not required.exists()
 
 


### PR DESCRIPTION
## Summary

Defines Quillan’s immutable PDS2-era identity and persistence contract for student-specific printable-response issuances and physical response pages.

This establishes the authoritative records that subsequent migration work will use for PDS2 packet generation, per-page Core route registration, scan dispatch, and submission assembly.

Closes #335.

Part of #329.

## Identity Model

The implementation distinguishes four identities:

* **Generation** — one user-invoked printable-response generation operation:

  ```text
  gen_<32 lowercase hexadecimal characters>
  ```

* **Artifact** — one intended generated PDF:

  ```text
  art_<32 lowercase hexadecimal characters>
  ```

* **Issuance** — one intended physical response copy for one class, assignment, and student:

  ```text
  iss_<32 lowercase hexadecimal characters>
  ```

* **Page** — one intended physical page within an issuance:

  ```text
  pg_<32 lowercase hexadecimal characters>
  ```

Each identifier uses 128 bits of cryptographically secure randomness and contains no class, assignment, student, page-number, timestamp, filename, or path semantics.

Generation and artifact identity are persisted within issuance and page records. This version deliberately creates no generation or artifact aggregate files, indexes, or current/latest pointers.

## Canonical Storage

Immutable records are stored beneath the module-qualified Quillan work root:

```text
classes/<class_id>/modules/quillan/work/<assignment_id>/
  response_pages/
    issuances/
      <issuance_id>.json
    pages/
      <page_id>.json
```

The Quillan path contract now provides canonical, side-effect-free constructors for exact issuance and page-record paths.

The managed-layout initializer creates the two record collection directories but does not create records, routes, QR payloads, PDFs, scans, submissions, or placeholder files.

Core-owned route registrations remain separate beneath the work root’s reserved `routes/` directory.

## Immutable Issuance Records

An issuance record contains:

* schema version;
* issuance, generation, and artifact IDs;
* class, assignment, and student identity;
* generation reason and predecessor relationship;
* a bounded assignment snapshot;
* a bounded student snapshot;
* ordered page membership;
* total page count;
* and controlled lifecycle state.

The assignment snapshot contains only:

```text
schema_version
title
updated_at
```

The student snapshot contains only:

```text
display_name
last_name
first_name
period
```

Optional roster columns are accepted and preserved in the source `StudentRecord`, but they are not copied into immutable Quillan records.

Leading-zero student IDs remain unchanged.

## Immutable Page Records

Each physical response page has one immutable page record containing:

* page, issuance, generation, and artifact identity;
* class, assignment, and student identity;
* logical page;
* total expected pages;
* page role;
* and creation time.

Supported page roles are:

```text
logical page 1     -> response_start
logical page 2..N  -> continuation
```

The page record—not QR text, a routed filename, scan order, source-page position, mutable roster data, current assignment configuration, or a submission manifest—is the authority for:

* student identity;
* issuance membership;
* logical-page identity;
* total-page meaning;
* and continuation-page meaning.

A retained scan’s future `source_page_number` remains distinct from the response record’s `logical_page`.

## Future Core Route Target

The implementation provides one pure target constructor for the future Core registration:

```text
module_id:        quillan
record_kind:      response_page
record_id:        <page_id>
contract_version: "1"
```

This PR does not create route IDs, route registrations, PDS2 locators, QR codes, or PDF artifacts.

Those operations remain assigned to #336.

## Record-Set Integrity

A valid student issuance must contain exactly the logical pages:

```text
1 through page_count
```

The implementation validates that:

* page IDs are unique;
* membership is complete and ordered;
* each page ID matches its issuance position;
* all pages share issuance, generation, artifact, class, assignment, and student identity;
* each page’s total matches the issuance page count;
* every page uses the issuance creation timestamp;
* and each page role agrees with its logical-page position.

The complete record-set validator rejects wrong model types through a typed Quillan validation error rather than leaking built-in attribute or type errors.

## Persistence

Record-set persistence:

1. validates the Quillan-owned `ModuleWorkRef`;
2. validates the complete record set;
3. requires an initial `prepared`, revision-1 issuance;
4. verifies work, class, assignment, and student identity;
5. preflights every collection and record destination;
6. rejects symlinks, Windows junctions, wrong filesystem types, path escapes, and existing destinations;
7. verifies assignment and roster snapshots;
8. verifies regeneration predecessor identity and fresh IDs;
9. writes page records exclusively;
10. writes the issuance record last as the aggregate commit marker.

No immutable record is overwritten or reused.

Exact loaders do not search or glob record collections. They load only the requested canonical path and verify that the stored identity matches both the filename and containing work reference.

## Ownership-Aware Rollback

If a later record write fails, rollback removes only files that:

* were created by the current operation;
* remain ordinary non-link files;
* and still contain the exact bytes written by the current operation.

If another writer replaces a file or changes its filesystem type, Quillan preserves that entry and raises a distinct rollback-integrity error rather than deleting data it can no longer prove it owns.

Existing records and unrelated files remain unchanged.

## Strict Serialization

Persisted JSON uses:

* strict UTF-8;
* sorted keys;
* two-space indentation;
* standard JSON numbers only;
* and exactly one trailing newline.

Loading rejects:

* missing fields;
* unknown fields;
* duplicate JSON keys;
* invalid UTF-8;
* NaN and Infinity;
* unsupported schema versions;
* invalid IDs;
* malformed timestamps;
* Boolean integer values;
* and arrays, objects, numbers, nulls, or other incorrect types in string and enum fields.

Public serializers accept only the exact issuance or page model and return typed record-validation errors for incorrect inputs.

## Regeneration and Additional Copies

Regeneration requires a persisted predecessor with the same:

```text
class_id
assignment_id
student_id
```

A regeneration must use fresh and disjoint:

```text
issuance_id
generation_id
artifact_id
page_ids
```

Creating a replacement does not mutate the predecessor.

Every predecessor file remains byte-for-byte unchanged.

An additional copy has no predecessor. Because v1 intentionally has no generation or artifact index, #336 must generate fresh cryptographically random generation and artifact IDs for every additional copy.

## Issuance Lifecycle

Every issuance begins as:

```text
prepared
revision 1
```

Allowed transitions are:

```text
prepared -> issued
prepared -> cancelled
prepared -> invalidated
issued   -> superseded
issued   -> invalidated
```

Lifecycle changes:

* require an expected revision;
* increment the revision exactly once;
* preserve the creation timestamp;
* enforce timestamp ordering;
* require reasons for terminal states;
* require a different, already-issued replacement for supersession;
* atomically replace only the issuance JSON;
* and never modify page records.

Temporary lifecycle-file cleanup failures are surfaced through a dedicated typed error that includes the abandoned temporary path and primary failure context.

No arbitrary public lifecycle-replacement API is exposed.

## Historical Authority

Assignment and roster values are verified when a new issuance is prepared.

After successful persistence, ordinary record loading does not require:

* the student to remain in the roster;
* roster values to remain unchanged;
* the assignment title to remain unchanged;
* or the assignment update timestamp to remain unchanged.

The immutable records preserve generation-time identity and snapshots.

## Plain-Paper Separation

Generated response-page records are not student submissions and do not prove that work was returned.

Plain-paper submissions remain valid without:

* generation identity;
* artifact identity;
* issuance identity;
* page identity;
* route registration;
* scan records;
* or digital evidence.

The plain-paper workflow does not fabricate any of those records.

## Hard-Cutover Policy

This change introduces no:

* PDS1 parsing or generation;
* PDS1 record fields;
* QR payload storage;
* route ID storage;
* legacy path lookup;
* fallback loader;
* dual schema;
* data conversion;
* workspace migration;
* or compatibility flag.

All active documentation paths now use:

```text
classes/<class_id>/modules/quillan/work/<assignment_id>/
```

## Validation

### Passed

* Expanded focused pytest: **120 passed, 2 skipped**
* ID and model validation
* Exact serialization and malformed-input handling
* Pure record-set building
* Optional roster-column behavior
* Record-set membership validation
* Exclusive persistence
* Snapshot verification
* Collision handling
* Ownership-aware rollback
* Regeneration identity freshness
* Exact record loading
* Authoritative page-context resolution
* Every allowed and forbidden lifecycle transition
* Revision and concurrent-write protection
* Lifecycle temporary cleanup reporting
* Path containment and filesystem-type checks
* Real Windows junction rejection
* Import side-effect checks
* Focused Ruff
* Focused mypy
* Full Ruff
* `git diff --check`
* Active documentation-path regression checks
* PDS2-only schema and public-API regression checks

### Known Intermediate Migration Baseline

```text
Full pytest:
861 passed
86 failed
6 skipped
43 collection errors

Full mypy:
35 errors in 8 files
```

The remaining failures are confined to the existing migration boundaries:

* removed PDS1 and QR-payload APIs;
* obsolete scan failure and resolution metadata;
* obsolete routing taxonomy;
* and downstream CLI imports that still reach those legacy surfaces.

No remaining failure originates from #335’s models, serializers, persistence, paths, rollback, regeneration, lifecycle, page context, roster handling, or public runtime boundaries.

## Scope Boundaries

This PR does not implement:

* PDF generation migration;
* PDS2 locator generation;
* QR rendering;
* route ID generation;
* Core route registration;
* route-registration rollback;
* installed Quillan module profiles;
* response-page dispatch handling;
* retained-source intake;
* scan decoding;
* routed-evidence persistence;
* submission-manifest schema migration;
* submission assembly;
* review-service migration;
* or release preparation.

Those changes remain assigned to the subsequent issues under #329.
