### PR TITLE
Add installed Quillan module profile (#337)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Quillan
 
+## Installed PDS2 module boundary
+
+Quillan registers the `quillan` entry point in `paper_data_suite.modules` through
+`quillan.pds_module:get_module_profile`. The profile supports Core routing contract
+`1`, QR schema `PDS2`, route-registration schema `1`, and only Core route status
+`active`.
+
+An active route is only structurally dispatchable. The response-page handler also
+requires the immutable issuance lifecycle to be exactly `issued`. Student and page
+meaning come from immutable page context, never QR text, fallback text, filenames,
+current roster data, or current assignment data. This boundary validates one
+retained source page and returns a typed runtime result; it does not extract evidence,
+persist observations, or assemble submissions.
+
 For a compact, read-only diagnostic of one student's submission and review
 workflow, use `quillan review-status <class_id> <assignment_id> <student_id>`;
 add `--format json` for the stable versioned structured contract.

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -1,5 +1,14 @@
 # Quillan CLI Contract
 
+## Installed module availability
+
+The profile is discoverable as
+`paper_data_suite.modules: quillan = quillan.pds_module:get_module_profile` and is
+safe to load before a workspace or scan is selected. This does not migrate the
+teacher CLI or menu to PDS2 intake. QR extraction, mixed-module batch dispatch,
+retained-source orchestration, routed evidence, scan review, and submission assembly
+remain #338–#339 work.
+
 ## Direct Student Review Status
 
 `quillan review-status <class_id> <assignment_id> <student_id> [--format text|json]`

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -1,5 +1,26 @@
 # Quillan Data Contracts
 
+## Quillan response-page dispatch result
+
+`QuillanResponsePageDispatchResult` is a frozen, slotted runtime model. Its route ID
+comes from the resolved Core locator. Page, issuance, generation, artifact, class,
+assignment, student, logical-page, total-page, and page-role fields come from the
+immutable page and issuance context. Source scan ID, original filename, requested
+source page, retained path and relative path, SHA-256, intake timestamp, and intake
+date come from validated Core retained-source provenance.
+
+That provenance is one indivisible Core retention event. The aware intake timestamp,
+original filename, and SHA-256 generate the retained filename. The independently
+authoritative `intake_date` selects the `scans/source/YYYY-MM-DD/` bucket, including
+when Core receives an explicit date override. Quillan requires both values, the
+retained path, POSIX relative path, extension, and `scan_<retained stem>` identity to
+agree exactly. Original source filenames may contain no control or Unicode line- or
+paragraph-separator characters.
+
+The result is not persisted and contains no submission ID, routed-evidence path,
+display name, assignment title, or writable continuation flag. Continuation is
+derived from page role. Observation and submission persistence remain #339.
+
 The versioned, read-only selected-student diagnostic is defined separately in
 [`review_status_contract.md`](review_status_contract.md). It composes canonical
 assignment, submission-manifest, and review-record data without changing any of

--- a/docs/module_profile_and_dispatch.md
+++ b/docs/module_profile_and_dispatch.md
@@ -1,0 +1,31 @@
+# Quillan Installed Module Profile and Dispatch
+
+Quillan's zero-argument provider is
+`quillan.pds_module:get_module_profile` in `paper_data_suite.modules`. It returns
+module ID `quillan`, display name `Quillan`, Core routing contract `1`, QR schema
+`PDS2`, route-registration schema `1`, active-only dispatch, the response-page
+handler, and the strict registration validator.
+
+The provider creates no registry, resolves no workspace, reads no records, and
+imports no CLI or legacy scan path. Calls return equivalent immutable profiles.
+
+The validator is structural. The handler defends direct calls, checks canonical
+roots, loads the exact immutable page context, requires lifecycle `issued`, validates
+retained provenance, and returns `QuillanResponsePageDispatchResult`. Current roster
+and assignment files are deliberately irrelevant.
+
+Retained provenance is accepted only when Core's public filename and path helpers can
+reconstruct the exact recorded event. The aware timestamp generates the filename;
+the independently supplied `intake_date` selects the path bucket and may explicitly
+override the timestamp's date. Source filenames must be free of control and Unicode
+line-separator characters. The public result validator repeats the same pure check
+without filesystem access. The handler authorizes the immutable route and `issued`
+issuance first, then adds nonfollowing ordinary-file and link-chain checks. Structural
+registration validation requires the canonical `rt_<32 lowercase hex>` route ID.
+
+An `active` Core registration is structurally resolvable; it does not authorize a
+prepared, cancelled, superseded, or invalidated physical issuance. QR text, fallback,
+route IDs, filenames, module details, scan order, and caller values never supply
+student identity, logical-page identity, continuation meaning, or submission
+membership. #337 neither decodes pages nor writes evidence. #338 owns intake and
+source-page enumeration; #339 owns observations and submission assembly.

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -1,5 +1,38 @@
 # Quillan Scan Routing Design
 
+## Installed PDS2 response-page handler
+
+Core invokes Quillan with a `RouteResolution`, `RetainedSourceScan`, and one positive
+source-page number. Quillan revalidates the registration, derives the workspace only
+from `class_root.parent.parent`, and requires canonical class, module, and work roots
+without link-like components. It loads only the registered immutable page context and
+cross-checks target, work identity, creation time, diagnostic details, exact fallback,
+ordered issuance membership, and page-to-issuance provenance.
+
+The filesystem-free registration validator requires target
+`quillan/response_page/<page_id>` contract `1`, exactly `issuance_id`, `logical_page`,
+and `total_pages` details, and the exact one-line Quillan fallback grammar. These
+diagnostics never become routing authority.
+
+Retained provenance must use `scans/source/YYYY-MM-DD/<retained filename>`, match
+Core's canonical path, and identify a readable ordinary non-link file. Images allow
+only source page 1; PDFs allow a positive requested page without decoding. Actual
+enumeration belongs to #338. Core preserves typed Quillan causes when wrapping
+validator or handler failures. The handler writes no evidence or submission data.
+
+Both retained-source validation and public dispatch-result validation use the same
+pure provenance-consistency service. The aware timestamp generates Core's retained
+filename while `intake_date` independently selects the retained date bucket; Core may
+supply an explicit override, so the dates need not match. The service reconstructs
+the source-scan ID and requires control-free source filename text, source extension,
+retained extension, hash prefix, normalized stem, absolute path, and POSIX relative
+path to describe the same retention event.
+
+The handler validates canonical route context and immutable page records and requires
+an `issued` issuance before inspecting retained-source provenance or filesystem paths.
+Quillan's registration validator also requires the canonical route form
+`rt_<32 lowercase hexadecimal characters>` before the handler can run.
+
 ## Overview
 
 This design describes how Quillan accepts a selected writing-response scan with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = [
 [project.scripts]
 quillan = "quillan.cli:main"
 
+[project.entry-points."paper_data_suite.modules"]
+quillan = "quillan.pds_module:get_module_profile"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/quillan/module_errors.py
+++ b/quillan/module_errors.py
@@ -1,0 +1,40 @@
+"""Typed failures exposed by Quillan's installed-module boundary."""
+
+
+class QuillanModuleError(Exception):
+    """Base failure raised through Quillan's installed module boundary."""
+
+
+class QuillanRegistrationValidationError(QuillanModuleError, ValueError):
+    """A Core registration violates Quillan's structural route contract."""
+
+
+class QuillanRouteContextError(QuillanModuleError):
+    """A direct handler call or resolved Core path context is invalid."""
+
+
+class QuillanTargetIntegrityError(QuillanModuleError):
+    """The route registration and immutable Quillan records disagree."""
+
+
+class QuillanIssuanceAuthorizationError(QuillanModuleError):
+    """The immutable issuance is not currently authorized for handling."""
+
+
+class QuillanRetainedSourceError(QuillanModuleError):
+    """Retained-source provenance or source-page meaning is invalid."""
+
+
+class QuillanDispatchResultError(QuillanModuleError, ValueError):
+    """A response-page dispatch result violates its runtime contract."""
+
+
+__all__ = [
+    "QuillanDispatchResultError",
+    "QuillanIssuanceAuthorizationError",
+    "QuillanModuleError",
+    "QuillanRegistrationValidationError",
+    "QuillanRetainedSourceError",
+    "QuillanRouteContextError",
+    "QuillanTargetIntegrityError",
+]

--- a/quillan/pds_module.py
+++ b/quillan/pds_module.py
@@ -1,0 +1,136 @@
+"""Side-effect-free installed Quillan module profile."""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+from pds_core.identifiers import validate_identifier
+from pds_core.module_profiles import ModuleProfile, validate_module_profile
+from pds_core.routing_models import (
+    PDS2_SCHEMA,
+    ROUTE_REGISTRATION_SCHEMA_VERSION,
+    RouteRegistration,
+    validate_route_registration,
+)
+
+from quillan.module_errors import QuillanRegistrationValidationError
+from quillan.pds_contract import (
+    DISPATCHABLE_ROUTE_STATUSES,
+    QUILLAN_DISPLAY_NAME,
+    QUILLAN_MODULE_ID,
+    RESPONSE_PAGE_CONTRACT_VERSION,
+    RESPONSE_PAGE_RECORD_KIND,
+    SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS,
+    SUPPORTED_QR_SCHEMAS,
+    SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS,
+)
+from quillan.printable_response_records import validate_issuance_id, validate_page_id
+
+_DETAIL_KEYS: Final[frozenset[str]] = frozenset(
+    {"issuance_id", "logical_page", "total_pages"}
+)
+_FALLBACK: Final[re.Pattern[str]] = re.compile(
+    r"Quillan \| class=([^ |]+) \| assignment=([^ |]+) "
+    r"\| student=([^ |]+) \| page=([0-9]+)/([0-9]+) "
+    r"\| page_id=([^ |]+)"
+)
+
+
+def validate_quillan_registration(registration: RouteRegistration, /) -> None:
+    """Validate Quillan's exact, nonwriting response-page route structure."""
+    try:
+        if not isinstance(registration, RouteRegistration):
+            raise ValueError("registration must be a RouteRegistration.")
+        validate_route_registration(registration)
+        if registration.schema_version != ROUTE_REGISTRATION_SCHEMA_VERSION:
+            raise ValueError("registration schema_version must be '1'.")
+        locator = registration.locator
+        if locator.schema != PDS2_SCHEMA:
+            raise ValueError("locator schema must be 'PDS2'.")
+        if locator.module_id != QUILLAN_MODULE_ID:
+            raise ValueError("locator module_id must be 'quillan'.")
+        from quillan.printable_response_routes import validate_route_id
+
+        validate_route_id(locator.route_id)
+        if registration.status != "active":
+            raise ValueError("registration status must be 'active'.")
+
+        target = registration.target
+        if target.module_id != QUILLAN_MODULE_ID:
+            raise ValueError("target module_id must be 'quillan'.")
+        if target.record_kind != RESPONSE_PAGE_RECORD_KIND:
+            raise ValueError("target record_kind must be 'response_page'.")
+        if target.contract_version != RESPONSE_PAGE_CONTRACT_VERSION:
+            raise ValueError("target contract_version must be '1'.")
+        validate_page_id(target.record_id)
+
+        details = registration.module_details
+        if frozenset(details) != _DETAIL_KEYS or len(details) != len(_DETAIL_KEYS):
+            raise ValueError(
+                "module_details must contain exactly issuance_id, logical_page, "
+                "and total_pages."
+            )
+        issuance_id = validate_issuance_id(details["issuance_id"])
+        logical_page = _positive_integer(details["logical_page"], "logical_page")
+        total_pages = _positive_integer(details["total_pages"], "total_pages")
+        if logical_page > total_pages:
+            raise ValueError("logical_page must not exceed total_pages.")
+
+        match = _FALLBACK.fullmatch(registration.human_fallback)
+        if match is None:
+            raise ValueError("human_fallback does not use Quillan's exact grammar.")
+        class_id, assignment_id, student_id, logical, total, page_id = match.groups()
+        validate_identifier(class_id, "fallback class_id")
+        validate_identifier(assignment_id, "fallback assignment_id")
+        validate_identifier(student_id, "fallback student_id")
+        validate_page_id(page_id)
+        if class_id != locator.class_id:
+            raise ValueError("fallback class does not match the locator.")
+        if assignment_id != locator.work_id:
+            raise ValueError("fallback assignment does not match the locator.")
+        if page_id != target.record_id:
+            raise ValueError("fallback page_id does not match the target.")
+        if logical != str(logical_page) or total != str(total_pages):
+            raise ValueError("fallback page meaning does not match module_details.")
+        # Keep the validated value live so static analysis catches contract drift.
+        if not issuance_id:
+            raise ValueError("issuance_id must not be empty.")
+    except QuillanRegistrationValidationError:
+        raise
+    except (ValueError, TypeError, AttributeError, KeyError) as error:
+        raise QuillanRegistrationValidationError(
+            f"Invalid Quillan route registration: {error}"
+        ) from error
+    return None
+
+
+def _positive_integer(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field_name} must be a positive non-Boolean integer.")
+    return value
+
+
+def get_module_profile() -> ModuleProfile:
+    """Return a newly constructed, validated, immutable Quillan profile."""
+    from quillan.route_handler import handle_quillan_response_page_route
+
+    return validate_module_profile(
+        ModuleProfile(
+            module_id=QUILLAN_MODULE_ID,
+            display_name=QUILLAN_DISPLAY_NAME,
+            supported_core_routing_contract_versions=(
+                SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS
+            ),
+            supported_qr_schemas=SUPPORTED_QR_SCHEMAS,
+            supported_route_registration_schema_versions=(
+                SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS
+            ),
+            dispatchable_route_statuses=DISPATCHABLE_ROUTE_STATUSES,
+            route_handler=handle_quillan_response_page_route,
+            registration_validator=validate_quillan_registration,
+        )
+    )
+
+
+__all__ = ["get_module_profile", "validate_quillan_registration"]

--- a/quillan/response_page_dispatch.py
+++ b/quillan/response_page_dispatch.py
@@ -1,0 +1,103 @@
+"""Typed runtime result for one dispatched Quillan response page."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+from pds_core.identifiers import validate_identifier
+
+from quillan.module_errors import QuillanDispatchResultError
+from quillan.printable_response_records import (
+    page_role_for_logical_page,
+    validate_artifact_id,
+    validate_generation_id,
+    validate_issuance_id,
+    validate_page_id,
+)
+from quillan.printable_response_routes import validate_route_id
+from quillan.retained_source_provenance import (
+    validate_core_retention_event_consistency,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanResponsePageDispatchResult:
+    route_id: str
+    page_id: str
+    issuance_id: str
+    generation_id: str
+    artifact_id: str
+    class_id: str
+    assignment_id: str
+    student_id: str
+    logical_page: int
+    total_pages: int
+    page_role: str
+    source_scan_id: str
+    source_filename: str
+    source_page_number: int
+    retained_source_path: Path
+    retained_source_relative_path: str
+    source_sha256: str
+    intake_timestamp: datetime
+    intake_date: date
+
+    @property
+    def is_continuation(self) -> bool:
+        return self.page_role == "continuation"
+
+
+def validate_quillan_response_page_dispatch_result(
+    result: object,
+) -> QuillanResponsePageDispatchResult:
+    """Revalidate and return one exact Quillan dispatch result."""
+    try:
+        if not isinstance(result, QuillanResponsePageDispatchResult):
+            raise ValueError(
+                "result must be a QuillanResponsePageDispatchResult."
+            )
+        validate_route_id(result.route_id)
+        validate_page_id(result.page_id)
+        validate_issuance_id(result.issuance_id)
+        validate_generation_id(result.generation_id)
+        validate_artifact_id(result.artifact_id)
+        validate_identifier(result.class_id, "class_id")
+        validate_identifier(result.assignment_id, "assignment_id")
+        validate_identifier(result.student_id, "student_id")
+        logical_page = _positive_integer(result.logical_page, "logical_page")
+        total_pages = _positive_integer(result.total_pages, "total_pages")
+        if logical_page > total_pages:
+            raise ValueError("logical_page must not exceed total_pages.")
+        if result.page_role != page_role_for_logical_page(logical_page):
+            raise ValueError("page_role contradicts logical_page.")
+        _positive_integer(result.source_page_number, "source_page_number")
+        validate_core_retention_event_consistency(
+            source_scan_id=result.source_scan_id,
+            source_filename=result.source_filename,
+            source_sha256=result.source_sha256,
+            retained_source_path=result.retained_source_path,
+            retained_source_relative_path=result.retained_source_relative_path,
+            intake_timestamp=result.intake_timestamp,
+            intake_date=result.intake_date,
+        )
+        return result
+    except QuillanDispatchResultError:
+        raise
+    except (ValueError, TypeError, AttributeError, IndexError) as error:
+        raise QuillanDispatchResultError(
+            f"Invalid Quillan response-page dispatch result: {error}"
+        ) from error
+
+
+def _positive_integer(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field_name} must be a positive non-Boolean integer.")
+    return value
+
+
+__all__ = [
+    "QuillanResponsePageDispatchResult",
+    "validate_quillan_response_page_dispatch_result",
+]

--- a/quillan/retained_source.py
+++ b/quillan/retained_source.py
@@ -1,0 +1,104 @@
+"""Nonwriting validation for one retained Quillan source page."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+from pds_core.scan_retention import RetainedSourceScan
+
+from quillan.module_errors import QuillanRetainedSourceError
+from quillan.retained_source_provenance import (
+    validate_core_retention_event_consistency,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedQuillanRetainedPageProvenance:
+    retained_source: RetainedSourceScan
+    source_page_number: int
+
+
+def validate_quillan_retained_source(
+    retained_source: object,
+    *,
+    workspace_root: Path,
+    source_page_number: object,
+) -> ValidatedQuillanRetainedPageProvenance:
+    """Validate exact retained provenance and one source-page meaning."""
+    try:
+        if not isinstance(retained_source, RetainedSourceScan):
+            raise ValueError("retained_source must be a RetainedSourceScan.")
+        if not isinstance(workspace_root, Path):
+            raise ValueError("workspace_root must be a Path.")
+        page_number = _positive_integer(source_page_number, "source_page_number")
+        validate_core_retention_event_consistency(
+            source_scan_id=retained_source.source_scan_id,
+            source_filename=retained_source.source_filename,
+            source_sha256=retained_source.source_sha256,
+            retained_source_path=retained_source.retained_source_path,
+            retained_source_relative_path=(
+                retained_source.retained_source_relative_path
+            ),
+            intake_timestamp=retained_source.intake_timestamp,
+            intake_date=retained_source.intake_date,
+            workspace_root=workspace_root,
+        )
+        _validate_file_chain(workspace_root, retained_source.retained_source_path)
+        if retained_source.retained_source_path.suffix.lower() != ".pdf" and page_number != 1:
+            raise ValueError("image retained sources contain only source page 1.")
+        return ValidatedQuillanRetainedPageProvenance(
+            retained_source=retained_source,
+            source_page_number=page_number,
+        )
+    except QuillanRetainedSourceError:
+        raise
+    except (ValueError, TypeError, AttributeError, OSError) as error:
+        raise QuillanRetainedSourceError(
+            f"Invalid Quillan retained-source provenance: {error}"
+        ) from error
+
+
+def _positive_integer(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field_name} must be a positive non-Boolean integer.")
+    return value
+
+
+def _validate_file_chain(workspace_root: Path, retained_path: Path) -> None:
+    absolute_root = Path(os.path.abspath(workspace_root))
+    absolute_path = Path(os.path.abspath(retained_path))
+    if workspace_root != absolute_root or retained_path != absolute_path:
+        raise ValueError("workspace and retained paths must be absolute and canonical.")
+    try:
+        relative = absolute_path.relative_to(absolute_root)
+    except ValueError as error:
+        raise ValueError("retained source escapes the workspace.") from error
+    current = absolute_root
+    candidates = [current]
+    for component in relative.parts:
+        current /= component
+        candidates.append(current)
+    for candidate in candidates:
+        if not os.path.lexists(candidate):
+            raise ValueError("retained source path has a missing component.")
+        if _is_link_like(candidate):
+            raise ValueError("retained source path contains a symlink or junction.")
+    if not absolute_root.is_dir():
+        raise ValueError("workspace_root must be an existing directory.")
+    if not absolute_path.is_file():
+        raise ValueError("retained source must be an ordinary file.")
+    if not os.access(absolute_path, os.R_OK):
+        raise ValueError("retained source must be readable.")
+
+
+def _is_link_like(path: Path) -> bool:
+    is_junction = getattr(path, "is_junction", None)
+    return path.is_symlink() or bool(is_junction is not None and is_junction())
+
+
+__all__ = [
+    "ValidatedQuillanRetainedPageProvenance",
+    "validate_quillan_retained_source",
+]

--- a/quillan/retained_source_provenance.py
+++ b/quillan/retained_source_provenance.py
@@ -1,0 +1,121 @@
+"""Pure consistency validation for one exact Core source-retention event."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path, PurePosixPath
+import re
+from typing import Final
+import unicodedata
+
+from pds_core.identifiers import validate_identifier
+from pds_core.scan_routes import (
+    build_retained_source_filename,
+    retained_source_scan_path,
+)
+
+_SHA256: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class CoreRetentionEventIdentity:
+    retained_filename: str
+    retained_relative_path: PurePosixPath
+    source_scan_id: str
+
+
+def validate_core_retention_event_consistency(
+    *,
+    source_scan_id: object,
+    source_filename: object,
+    source_sha256: object,
+    retained_source_path: object,
+    retained_source_relative_path: object,
+    intake_timestamp: object,
+    intake_date: object,
+    workspace_root: Path | None = None,
+) -> CoreRetentionEventIdentity:
+    """Require all provenance fields to describe one exact Core retention event."""
+    if not isinstance(source_scan_id, str):
+        raise ValueError("source_scan_id must be a string.")
+    validate_identifier(source_scan_id, "source_scan_id")
+    if not isinstance(source_filename, str):
+        raise ValueError("source_filename must be a string.")
+    if any(
+        unicodedata.category(character) in {"Cc", "Zl", "Zp"}
+        for character in source_filename
+    ):
+        raise ValueError(
+            "source_filename must not contain control or line-separator characters."
+        )
+    if not isinstance(source_sha256, str) or _SHA256.fullmatch(source_sha256) is None:
+        raise ValueError("source_sha256 must be 64 lowercase hexadecimal characters.")
+    if not isinstance(intake_timestamp, datetime):
+        raise ValueError("intake_timestamp must be a datetime.")
+    if intake_timestamp.tzinfo is None or intake_timestamp.utcoffset() is None:
+        raise ValueError("intake_timestamp must be timezone-aware.")
+    if isinstance(intake_date, datetime) or not isinstance(intake_date, date):
+        raise ValueError("intake_date must be a date, not a datetime.")
+    if not isinstance(retained_source_path, Path):
+        raise ValueError("retained_source_path must be a Path.")
+    if not retained_source_path.is_absolute():
+        raise ValueError("retained_source_path must be absolute.")
+    relative = _canonical_relative_path(retained_source_relative_path)
+
+    expected_filename = build_retained_source_filename(
+        intake_timestamp=intake_timestamp,
+        original_filename=source_filename,
+        sha256_hex=source_sha256,
+    )
+    expected_scan_id = f"scan_{Path(expected_filename).stem}"
+    if retained_source_path.name != expected_filename:
+        raise ValueError("retained filename contradicts the Core retention event.")
+    if relative.name != expected_filename:
+        raise ValueError("retained relative filename contradicts the Core event.")
+    if source_scan_id != expected_scan_id:
+        raise ValueError("source_scan_id contradicts the retained filename.")
+    if Path(source_filename).suffix.lower() != Path(expected_filename).suffix.lower():
+        raise ValueError("source and retained extensions disagree.")
+    if relative.parts[2] != intake_date.isoformat():
+        raise ValueError("retained date bucket contradicts intake_date.")
+    if tuple(retained_source_path.parts[-len(relative.parts) :]) != relative.parts:
+        raise ValueError("retained absolute and relative paths disagree.")
+    if workspace_root is not None:
+        if not isinstance(workspace_root, Path):
+            raise ValueError("workspace_root must be a Path.")
+        expected_path = retained_source_scan_path(
+            workspace_root,
+            intake_date=intake_date,
+            retained_filename=expected_filename,
+        )
+        if retained_source_path != expected_path:
+            raise ValueError("retained_source_path is not the canonical Core path.")
+        if relative.as_posix() != expected_path.relative_to(workspace_root).as_posix():
+            raise ValueError("retained_source_relative_path is not canonical.")
+    return CoreRetentionEventIdentity(expected_filename, relative, expected_scan_id)
+
+
+def _canonical_relative_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError("retained relative path must be nonempty POSIX text.")
+    path = PurePosixPath(value)
+    if path.is_absolute() or len(path.parts) != 4:
+        raise ValueError("retained relative path has the wrong shape.")
+    if path.parts[:2] != ("scans", "source") or any(
+        part in {"", ".", ".."} for part in path.parts
+    ):
+        raise ValueError("retained relative path is not canonical.")
+    if path.as_posix() != value:
+        raise ValueError("retained relative path is not canonical POSIX text.")
+    try:
+        date.fromisoformat(path.parts[2])
+    except ValueError as error:
+        raise ValueError("retained relative path date bucket is invalid.") from error
+    return path
+
+
+__all__ = [
+    "CoreRetentionEventIdentity",
+    "validate_core_retention_event_consistency",
+]

--- a/quillan/route_handler.py
+++ b/quillan/route_handler.py
@@ -1,0 +1,315 @@
+"""Defensive one-page handler for resolved Quillan response-page routes."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pds_core.routes import class_dir, class_module_dir, module_work_dir
+from pds_core.routing_models import (
+    RouteResolution,
+    validate_route_locator,
+    validate_route_registration,
+)
+from pds_core.scan_retention import RetainedSourceScan
+
+from quillan.module_errors import (
+    QuillanDispatchResultError,
+    QuillanIssuanceAuthorizationError,
+    QuillanRegistrationValidationError,
+    QuillanRetainedSourceError,
+    QuillanRouteContextError,
+    QuillanTargetIntegrityError,
+)
+from quillan.pds_contract import QUILLAN_MODULE_ID
+from quillan.pds_module import validate_quillan_registration
+from quillan.printable_response_persistence import (
+    PrintableResponsePersistenceError,
+    load_printable_response_page_context,
+)
+from quillan.printable_response_records import (
+    PrintableResponsePageContext,
+    PrintableResponseRecordSet,
+    PrintableResponseRecordValidationError,
+    response_page_target,
+    validate_printable_response_record_set,
+)
+from quillan.printable_response_routes import (
+    printable_response_human_fallback,
+    printable_response_module_details,
+)
+from quillan.response_page_dispatch import (
+    QuillanResponsePageDispatchResult,
+    validate_quillan_response_page_dispatch_result,
+)
+from quillan.retained_source import (
+    ValidatedQuillanRetainedPageProvenance,
+    validate_quillan_retained_source,
+)
+
+
+def handle_quillan_response_page_route(
+    resolution: RouteResolution,
+    retained_source: RetainedSourceScan,
+    source_page_number: int,
+    /,
+) -> QuillanResponsePageDispatchResult:
+    """Validate and resolve one retained page without writing workspace state."""
+    _validate_handler_arguments(resolution, retained_source, source_page_number)
+    workspace_root = _validate_resolution_context(resolution)
+    registration = resolution.registration
+    try:
+        context = load_printable_response_page_context(
+            workspace_root,
+            resolution.locator.work,
+            registration.target.record_id,
+        )
+    except (
+        PrintableResponsePersistenceError,
+        PrintableResponseRecordValidationError,
+    ) as error:
+        raise QuillanTargetIntegrityError(
+            "Could not load the registered immutable response-page context."
+        ) from error
+    _cross_validate_context(resolution, context)
+    if context.issuance.lifecycle.status != "issued":
+        raise QuillanIssuanceAuthorizationError(
+            "The registered response-page issuance is not issued."
+        )
+    provenance = validate_quillan_retained_source(
+        retained_source,
+        workspace_root=workspace_root,
+        source_page_number=source_page_number,
+    )
+    page = context.page
+    retained = provenance.retained_source
+    result = QuillanResponsePageDispatchResult(
+        route_id=resolution.locator.route_id,
+        page_id=page.page_id,
+        issuance_id=page.issuance_id,
+        generation_id=page.generation_id,
+        artifact_id=page.artifact_id,
+        class_id=page.class_id,
+        assignment_id=page.assignment_id,
+        student_id=page.student_id,
+        logical_page=page.logical_page,
+        total_pages=page.total_pages,
+        page_role=page.page_role,
+        source_scan_id=retained.source_scan_id,
+        source_filename=retained.source_filename,
+        source_page_number=provenance.source_page_number,
+        retained_source_path=retained.retained_source_path,
+        retained_source_relative_path=retained.retained_source_relative_path,
+        source_sha256=retained.source_sha256,
+        intake_timestamp=retained.intake_timestamp,
+        intake_date=retained.intake_date,
+    )
+    try:
+        validated = validate_quillan_response_page_dispatch_result(result)
+    except QuillanDispatchResultError:
+        raise
+    _cross_validate_result(validated, resolution, context, provenance)
+    return validated
+
+
+def _validate_handler_arguments(
+    resolution: object,
+    retained_source: object,
+    source_page_number: object,
+) -> None:
+    if not isinstance(resolution, RouteResolution):
+        raise QuillanRouteContextError("resolution must be a RouteResolution.")
+    if not isinstance(retained_source, RetainedSourceScan):
+        raise QuillanRetainedSourceError(
+            "retained_source must be a RetainedSourceScan."
+        )
+    if (
+        isinstance(source_page_number, bool)
+        or not isinstance(source_page_number, int)
+        or source_page_number < 1
+    ):
+        raise QuillanRetainedSourceError(
+            "source_page_number must be a positive non-Boolean integer."
+        )
+
+
+def _validate_resolution_context(resolution: object) -> Path:
+    try:
+        if not isinstance(resolution, RouteResolution):
+            raise ValueError("resolution must be a RouteResolution.")
+        validate_route_locator(resolution.locator)
+        validate_route_registration(resolution.registration)
+        if resolution.locator != resolution.registration.locator:
+            raise ValueError("resolution locator does not match its registration.")
+        if resolution.locator.module_id != QUILLAN_MODULE_ID:
+            raise ValueError("resolution is not owned by Quillan.")
+        validate_quillan_registration(resolution.registration)
+        workspace_root = resolution.class_root.parent.parent
+        expected_class = class_dir(workspace_root, resolution.locator.class_id)
+        expected_module = class_module_dir(
+            workspace_root, resolution.locator.class_id, QUILLAN_MODULE_ID
+        )
+        expected_work = module_work_dir(workspace_root, resolution.locator.work)
+        if (
+            resolution.class_root != expected_class
+            or resolution.module_root != expected_module
+            or resolution.work_root != expected_work
+        ):
+            raise ValueError("resolution roots are not canonical Core roots.")
+        _validate_root_chain(workspace_root, resolution.work_root)
+        return workspace_root
+    except QuillanRouteContextError:
+        raise
+    except QuillanRegistrationValidationError as error:
+        raise QuillanRouteContextError(
+            "The resolved Quillan registration is invalid."
+        ) from error
+    except (ValueError, TypeError, AttributeError, OSError) as error:
+        raise QuillanRouteContextError(
+            f"Invalid Quillan route resolution context: {error}"
+        ) from error
+
+
+def _validate_root_chain(workspace_root: Path, work_root: Path) -> None:
+    absolute_workspace = Path(os.path.abspath(workspace_root))
+    absolute_work = Path(os.path.abspath(work_root))
+    if workspace_root != absolute_workspace or work_root != absolute_work:
+        raise ValueError("resolution roots must be absolute and canonical.")
+    try:
+        relative = absolute_work.relative_to(absolute_workspace)
+    except ValueError as error:
+        raise ValueError("work_root escapes the derived workspace.") from error
+    current = absolute_workspace
+    candidates = [current]
+    for component in relative.parts:
+        current /= component
+        candidates.append(current)
+    for candidate in candidates:
+        if not os.path.lexists(candidate):
+            raise ValueError("resolution root chain contains a missing path.")
+        if _is_link_like(candidate):
+            raise ValueError("resolution root chain contains a symlink or junction.")
+        if not candidate.is_dir():
+            raise ValueError("resolution root chain contains a non-directory.")
+
+
+def _is_link_like(path: Path) -> bool:
+    is_junction = getattr(path, "is_junction", None)
+    return path.is_symlink() or bool(is_junction is not None and is_junction())
+
+
+def _cross_validate_context(
+    resolution: RouteResolution,
+    context: PrintableResponsePageContext,
+) -> None:
+    try:
+        page = context.page
+        issuance = context.issuance
+        members = context.member_pages
+        registration = resolution.registration
+        locator = resolution.locator
+        validate_printable_response_record_set(
+            PrintableResponseRecordSet(issuance, members)
+        )
+        if registration.target != response_page_target(page):
+            raise ValueError("registration target contradicts the page.")
+        if (
+            locator.class_id != page.class_id
+            or locator.work_id != page.assignment_id
+            or issuance.class_id != page.class_id
+            or issuance.assignment_id != page.assignment_id
+        ):
+            raise ValueError("route work identity contradicts immutable records.")
+        if registration.created_at != page.created_at:
+            raise ValueError("route creation identity contradicts the page.")
+        if registration.module_details != printable_response_module_details(page):
+            raise ValueError("route module_details contradict the page.")
+        if registration.human_fallback != printable_response_human_fallback(page):
+            raise ValueError("route human fallback contradicts the page.")
+        page_identity = (
+            page.issuance_id,
+            page.generation_id,
+            page.artifact_id,
+            page.class_id,
+            page.assignment_id,
+            page.student_id,
+        )
+        issuance_identity = (
+            issuance.issuance_id,
+            issuance.generation_id,
+            issuance.artifact_id,
+            issuance.class_id,
+            issuance.assignment_id,
+            issuance.student_id,
+        )
+        if page_identity != issuance_identity:
+            raise ValueError("page provenance contradicts its issuance.")
+    except QuillanTargetIntegrityError:
+        raise
+    except (ValueError, TypeError, AttributeError, IndexError) as error:
+        raise QuillanTargetIntegrityError(
+            f"Resolved route contradicts immutable response-page context: {error}"
+        ) from error
+
+
+def _cross_validate_result(
+    result: QuillanResponsePageDispatchResult,
+    resolution: RouteResolution,
+    context: PrintableResponsePageContext,
+    provenance: ValidatedQuillanRetainedPageProvenance,
+) -> None:
+    page = context.page
+    retained = provenance.retained_source
+    expected_identity = (
+        resolution.locator.route_id,
+        page.page_id,
+        page.issuance_id,
+        page.generation_id,
+        page.artifact_id,
+        page.class_id,
+        page.assignment_id,
+        page.student_id,
+        page.logical_page,
+        page.total_pages,
+        page.page_role,
+    )
+    actual_identity = (
+        result.route_id,
+        result.page_id,
+        result.issuance_id,
+        result.generation_id,
+        result.artifact_id,
+        result.class_id,
+        result.assignment_id,
+        result.student_id,
+        result.logical_page,
+        result.total_pages,
+        result.page_role,
+    )
+    expected_provenance = (
+        retained.source_scan_id,
+        retained.source_filename,
+        provenance.source_page_number,
+        retained.retained_source_path,
+        retained.retained_source_relative_path,
+        retained.source_sha256,
+        retained.intake_timestamp,
+        retained.intake_date,
+    )
+    actual_provenance = (
+        result.source_scan_id,
+        result.source_filename,
+        result.source_page_number,
+        result.retained_source_path,
+        result.retained_source_relative_path,
+        result.source_sha256,
+        result.intake_timestamp,
+        result.intake_date,
+    )
+    if actual_identity != expected_identity or actual_provenance != expected_provenance:
+        raise QuillanDispatchResultError(
+            "Validated dispatch result contradicts its authoritative sources."
+        )
+
+
+__all__ = ["handle_quillan_response_page_route"]

--- a/tests/test_installed_module_profile.py
+++ b/tests/test_installed_module_profile.py
@@ -1,0 +1,314 @@
+"""Installed entry-point and Core one-page dispatch integration."""
+
+from importlib import metadata
+from dataclasses import replace
+from pathlib import Path
+import os
+import subprocess
+import sys
+
+import pds_core.module_dispatch as core_dispatch
+from pds_core.module_dispatch import (
+    ModuleContractCompatibilityError,
+    ModuleRegistrationValidationError,
+    ModuleRouteHandlingError,
+    RouteDispatchRequest,
+    RouteStatusNotDispatchableError,
+    dispatch_route,
+)
+from pds_core.module_profiles import (
+    ModuleRegistry,
+    ModuleRegistryError,
+    UnsupportedModuleError,
+    build_module_registry,
+)
+from pds_core.route_registrations import write_route_registration
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef, RouteLocator, RouteRegistration
+import pytest
+
+from quillan.module_errors import (
+    QuillanRegistrationValidationError,
+    QuillanTargetIntegrityError,
+)
+from quillan.pds_module import get_module_profile
+import quillan.route_handler as quillan_handler
+from quillan.route_handler import handle_quillan_response_page_route
+from quillan.response_page_dispatch import QuillanResponsePageDispatchResult
+from tests.test_route_handler import route_context
+
+
+def test_project_declares_exact_installed_entry_point() -> None:
+    text = Path("pyproject.toml").read_text(encoding="utf-8")
+    assert text.count('[project.entry-points."paper_data_suite.modules"]') == 1
+    assert text.count('quillan = "quillan.pds_module:get_module_profile"') == 1
+
+
+def test_installed_metadata_has_exact_quillan_entry_point() -> None:
+    entries = tuple(
+        entry
+        for entry in metadata.entry_points(group="paper_data_suite.modules")
+        if entry.name == "quillan"
+    )
+    assert len(entries) == 1
+    assert entries[0].value == "quillan.pds_module:get_module_profile"
+
+
+def test_core_dispatch_preserves_typed_result(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    write_route_registration(tmp_path, resolution.registration)
+    profile = get_module_profile()
+    success = dispatch_route(
+        tmp_path,
+        ModuleRegistry((profile,)),
+        RouteDispatchRequest(resolution.locator, source, 1),
+    )
+    assert success.profile == profile
+    assert isinstance(success.module_result, QuillanResponsePageDispatchResult)
+    assert success.module_result.page_id == resolution.registration.target.record_id
+
+
+def test_installed_discovery_dispatches_one_quillan_page(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    write_route_registration(tmp_path, resolution.registration)
+    success = dispatch_route(
+        tmp_path,
+        build_module_registry(discover_installed=True),
+        RouteDispatchRequest(resolution.locator, source, 1),
+    )
+    assert success.profile == get_module_profile()
+    assert isinstance(success.module_result, QuillanResponsePageDispatchResult)
+
+
+def rebuild_registration(
+    registration: RouteRegistration,
+    *,
+    target: ModuleRecordRef | None = None,
+    status: str | None = None,
+) -> RouteRegistration:
+    return RouteRegistration(
+        registration.schema_version,
+        registration.locator,
+        registration.target if target is None else target,
+        registration.created_at,
+        registration.status if status is None else status,
+        registration.human_fallback,
+        registration.module_details,
+    )
+
+
+def test_validator_failure_is_wrapped_with_quillan_cause(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    invalid = rebuild_registration(
+        resolution.registration,
+        target=replace(resolution.registration.target, record_kind="other"),
+    )
+    write_route_registration(tmp_path, invalid)
+    with pytest.raises(ModuleRegistrationValidationError) as captured:
+        dispatch_route(
+            tmp_path,
+            ModuleRegistry((get_module_profile(),)),
+            RouteDispatchRequest(resolution.locator, source, 1),
+        )
+    assert isinstance(captured.value.__cause__, QuillanRegistrationValidationError)
+
+
+def test_handler_failure_is_wrapped_with_typed_cause(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    write_route_registration(tmp_path, resolution.registration)
+    page_path = resolution.work_root / "response_pages" / "pages" / (
+        resolution.registration.target.record_id + ".json"
+    )
+    page_path.unlink()
+    with pytest.raises(ModuleRouteHandlingError) as captured:
+        dispatch_route(
+            tmp_path,
+            ModuleRegistry((get_module_profile(),)),
+            RouteDispatchRequest(resolution.locator, source, 1),
+        )
+    assert isinstance(captured.value.__cause__, QuillanTargetIntegrityError)
+
+
+def test_inactive_route_is_rejected_before_handler(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    write_route_registration(
+        tmp_path, rebuild_registration(resolution.registration, status="inactive")
+    )
+    calls = 0
+
+    def forbidden(*_args: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("handler must not run")
+
+    profile = replace(get_module_profile(), route_handler=forbidden)
+    with pytest.raises(RouteStatusNotDispatchableError):
+        dispatch_route(
+            tmp_path,
+            ModuleRegistry((profile,)),
+            RouteDispatchRequest(resolution.locator, source, 1),
+        )
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [
+        replace(
+            get_module_profile(),
+            supported_core_routing_contract_versions=frozenset({"999"}),
+        ),
+        replace(get_module_profile(), supported_qr_schemas=frozenset({"OTHER"})),
+    ],
+)
+def test_preload_contract_rejection_occurs_before_route_loading(
+    tmp_path: Path, profile: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resolution, source = route_context(tmp_path)
+
+    def forbidden(*_args: object) -> object:
+        raise AssertionError("route loading must not occur")
+
+    monkeypatch.setattr(core_dispatch, "resolve_route_registration", forbidden)
+    with pytest.raises(ModuleContractCompatibilityError):
+        dispatch_route(
+            tmp_path,
+            ModuleRegistry((profile,)),  # type: ignore[arg-type]
+            RouteDispatchRequest(resolution.locator, source, 1),
+        )
+
+
+def test_wrong_module_and_discovery_disabled_never_invoke_quillan(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    other_locator = RouteLocator(
+        "PDS2",
+        ModuleWorkRef("other", resolution.locator.class_id, resolution.locator.work_id),
+        resolution.locator.route_id,
+    )
+    registry = build_module_registry(discover_installed=False)
+    assert registry.module_ids() == ()
+    with pytest.raises(UnsupportedModuleError):
+        dispatch_route(
+            tmp_path,
+            registry,
+            RouteDispatchRequest(other_locator, source, 1),
+        )
+
+
+def test_explicit_plus_installed_profile_remains_duplicate_error() -> None:
+    with pytest.raises(ModuleRegistryError):
+        build_module_registry(
+            explicit_profiles=(get_module_profile(),), discover_installed=True
+        )
+
+
+def test_core_returns_handler_result_object_unchanged(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    write_route_registration(tmp_path, resolution.registration)
+    returned: list[QuillanResponsePageDispatchResult] = []
+
+    def recording_handler(*args: object) -> QuillanResponsePageDispatchResult:
+        result = handle_quillan_response_page_route(*args)  # type: ignore[arg-type]
+        returned.append(result)
+        return result
+
+    profile = replace(get_module_profile(), route_handler=recording_handler)
+    success = dispatch_route(
+        tmp_path,
+        ModuleRegistry((profile,)),
+        RouteDispatchRequest(resolution.locator, source, 1),
+    )
+    assert success.module_result is returned[0]
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "import quillan.pds_module",
+        (
+            "from quillan.pds_module import get_module_profile; "
+            "first=get_module_profile(); second=get_module_profile(); "
+            "assert first == second"
+        ),
+    ],
+)
+def test_provider_import_is_silent_and_safe_outside_workspace(
+    tmp_path: Path, statement: str
+) -> None:
+    forbidden = {
+        "quillan.cli",
+        "quillan.cli_app",
+        "quillan.payload_validation",
+        "quillan.routing_review",
+        "pds_core.pds1",
+        "pds_core.qr_payload",
+        "cv2",
+        "pdf2image",
+        "reportlab",
+        "qrcode",
+    }
+    code = (
+        "import os,sys; before=os.getcwd(); "
+        f"{statement}; "
+        f"forbidden={forbidden!r}; "
+        "assert forbidden.isdisjoint(sys.modules); "
+        "assert os.getcwd()==before"
+    )
+    before = tuple(tmp_path.iterdir())
+    environment = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
+    assert completed.stderr == ""
+    assert tuple(tmp_path.iterdir()) == before
+
+
+def test_noncanonical_safe_route_id_fails_in_quillan_validator_before_handler(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resolution, source = route_context(tmp_path)
+    locator = RouteLocator(
+        "PDS2", resolution.locator.work, "route_safe"
+    )
+    registration = RouteRegistration(
+        resolution.registration.schema_version,
+        locator,
+        resolution.registration.target,
+        resolution.registration.created_at,
+        resolution.registration.status,
+        resolution.registration.human_fallback,
+        resolution.registration.module_details,
+    )
+    write_route_registration(tmp_path, registration)
+    handler_calls = 0
+    retained_calls = 0
+
+    def forbidden_handler(*_args: object) -> object:
+        nonlocal handler_calls
+        handler_calls += 1
+        raise AssertionError("handler must not run")
+
+    def forbidden_retained(*_args: object, **_kwargs: object) -> object:
+        nonlocal retained_calls
+        retained_calls += 1
+        raise AssertionError("retained validation must not run")
+
+    monkeypatch.setattr(
+        quillan_handler, "validate_quillan_retained_source", forbidden_retained
+    )
+    profile = replace(get_module_profile(), route_handler=forbidden_handler)
+    with pytest.raises(ModuleRegistrationValidationError) as captured:
+        dispatch_route(
+            tmp_path,
+            ModuleRegistry((profile,)),
+            RouteDispatchRequest(locator, source, 1),
+        )
+    assert isinstance(captured.value.__cause__, QuillanRegistrationValidationError)
+    assert handler_calls == 0
+    assert retained_calls == 0

--- a/tests/test_pds_module.py
+++ b/tests/test_pds_module.py
@@ -1,0 +1,195 @@
+"""Focused installed-profile and structural registration tests."""
+
+import copy
+from dataclasses import FrozenInstanceError, replace
+import inspect
+from pathlib import Path
+
+from pds_core.module_profiles import ModuleProfile, validate_module_profile
+from pds_core.routing_models import (
+    ModuleWorkRef,
+    RouteLocator,
+    RouteRegistration,
+)
+import pytest
+
+from quillan.module_errors import QuillanRegistrationValidationError
+from quillan.pds_module import get_module_profile, validate_quillan_registration
+from quillan.printable_response_routes import build_printable_response_page_route
+from tests.test_printable_response_records import record_set
+
+
+def valid_registration() -> RouteRegistration:
+    return build_printable_response_page_route(
+        record_set(pages=1).pages[0],
+        "rt_0123456789abcdef0123456789abcdef",
+    ).registration
+
+
+def forged(value: object, **changes: object) -> object:
+    result = copy.copy(value)
+    for name, replacement in changes.items():
+        object.__setattr__(result, name, replacement)
+    return result
+
+
+def rebuilt(
+    *,
+    details: dict[str, object] | None = None,
+    fallback: str | None = None,
+    status: str | None = None,
+) -> RouteRegistration:
+    registration = valid_registration()
+    return RouteRegistration(
+        registration.schema_version,
+        registration.locator,
+        registration.target,
+        registration.created_at,
+        registration.status if status is None else status,
+        registration.human_fallback if fallback is None else fallback,
+        registration.module_details if details is None else details,  # type: ignore[arg-type]
+    )
+
+
+def test_provider_is_zero_argument_exact_and_immutable() -> None:
+    assert len(inspect.signature(get_module_profile).parameters) == 0
+    profile = get_module_profile()
+    assert isinstance(profile, ModuleProfile)
+    assert validate_module_profile(profile) is profile
+    assert profile.module_id == "quillan"
+    assert profile.display_name == "Quillan"
+    assert profile.supported_core_routing_contract_versions == frozenset({"1"})
+    assert profile.supported_qr_schemas == frozenset({"PDS2"})
+    assert profile.supported_route_registration_schema_versions == frozenset({"1"})
+    assert profile.dispatchable_route_statuses == frozenset({"active"})
+    assert get_module_profile() == profile
+    with pytest.raises(FrozenInstanceError):
+        profile.module_id = "other"  # type: ignore[misc]
+
+
+def test_registration_validator_accepts_exact_route_and_returns_none() -> None:
+    registration = valid_registration()
+    before = registration.module_details
+    result = validate_quillan_registration(registration)  # type: ignore[func-returns-value]
+    assert result is None
+    assert registration == valid_registration()
+    assert registration.module_details == before
+
+
+@pytest.mark.parametrize("invalid", [None, object(), True, "route"])
+def test_registration_validator_has_one_typed_failure(invalid: object) -> None:
+    with pytest.raises(QuillanRegistrationValidationError):
+        validate_quillan_registration(invalid)  # type: ignore[arg-type]
+
+
+def invalid_registrations() -> tuple[object, ...]:
+    registration = valid_registration()
+    locator = registration.locator
+    target = registration.target
+    fallback = registration.human_fallback
+    details = registration.module_details
+    wrong_qr_locator = forged(locator, schema="PDS1")
+    wrong_module_locator = RouteLocator(
+        schema="PDS2",
+        work=ModuleWorkRef("other", locator.class_id, locator.work_id),
+        route_id=locator.route_id,
+    )
+    return (
+        forged(registration, schema_version="2"),
+        forged(registration, locator=wrong_qr_locator),
+        forged(registration, locator=wrong_module_locator),
+        rebuilt(status="inactive"),
+        rebuilt(status="retired"),
+        forged(registration, target=forged(target, module_id="other")),
+        replace(registration, target=replace(target, record_kind="other")),
+        replace(registration, target=replace(target, contract_version="2")),
+        forged(registration, target=forged(target, record_id="bad")),
+        replace(
+            registration,
+            target=replace(target, record_id=str(details["issuance_id"])),
+        ),
+        replace(registration, target=replace(target, record_id=locator.route_id)),
+        rebuilt(details={key: value for key, value in details.items() if key != "issuance_id"}),
+        rebuilt(details={**details, "extra": 1}),
+        rebuilt(details={**details, "issuance_id": "bad"}),
+        rebuilt(details={**details, "logical_page": True}),
+        rebuilt(details={**details, "total_pages": True}),
+        rebuilt(details={**details, "logical_page": 0}),
+        rebuilt(details={**details, "total_pages": 0}),
+        rebuilt(details={**details, "logical_page": -1}),
+        rebuilt(details={**details, "total_pages": -1}),
+        rebuilt(details={**details, "logical_page": 2, "total_pages": 1}),
+        rebuilt(fallback="malformed"),
+        forged(registration, human_fallback=" " + fallback),
+        forged(registration, human_fallback=fallback + " "),
+        forged(registration, human_fallback=fallback + "\nextra"),
+        forged(registration, human_fallback=fallback + "\x00"),
+        rebuilt(fallback=fallback + " | extra=value"),
+        rebuilt(
+            fallback=fallback.replace(
+                "class=english10_p2 | assignment=literary_analysis",
+                "assignment=literary_analysis | class=english10_p2",
+            )
+        ),
+        rebuilt(fallback=fallback.replace("class=english10_p2", "class=other")),
+        rebuilt(
+            fallback=fallback.replace(
+                "assignment=literary_analysis", "assignment=other"
+            )
+        ),
+        rebuilt(fallback=fallback.replace("student=00107", "student=../bad")),
+        rebuilt(
+            fallback=fallback.replace(
+                str(target.record_id), "pg_ffffffffffffffffffffffffffffffff"
+            )
+        ),
+        rebuilt(fallback=fallback.replace("page=1/1", "page=2/2")),
+        rebuilt(fallback=fallback.replace("page=1/1", "page=1/2")),
+    )
+
+
+@pytest.mark.parametrize("registration", invalid_registrations())
+def test_every_registration_field_is_independently_rejected(
+    registration: object,
+) -> None:
+    with pytest.raises(QuillanRegistrationValidationError):
+        validate_quillan_registration(registration)  # type: ignore[arg-type]
+
+
+def test_registration_validator_never_touches_filesystem_or_record_loaders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("filesystem or record loading is forbidden")
+
+    monkeypatch.setattr(Path, "exists", forbidden)
+    monkeypatch.setattr(Path, "open", forbidden)
+    assert validate_quillan_registration(valid_registration()) is None  # type: ignore[func-returns-value]
+
+
+@pytest.mark.parametrize(
+    "route_id",
+    [
+        "route_safe",
+        "rt_short",
+        "rt_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456",
+        "rt_0123456789ABCDEF0123456789ABCDEF",
+        "pg_0123456789abcdef0123456789abcdef",
+    ],
+)
+def test_registration_requires_canonical_quillan_route_id(route_id: str) -> None:
+    registration = valid_registration()
+    locator = RouteLocator(
+        "PDS2", registration.locator.work, route_id
+    )
+    invalid = RouteRegistration(
+        registration.schema_version,
+        locator,
+        registration.target,
+        registration.created_at,
+        registration.status,
+        registration.human_fallback,
+        registration.module_details,
+    )
+    with pytest.raises(QuillanRegistrationValidationError):
+        validate_quillan_registration(invalid)

--- a/tests/test_quillan_retained_source.py
+++ b/tests/test_quillan_retained_source.py
@@ -1,0 +1,298 @@
+"""Focused nonwriting retained-source validation tests."""
+
+from dataclasses import replace
+from datetime import date, datetime, timezone
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+from pds_core.scan_retention import RetainedSourceScan
+from pds_core.scan_routes import build_retained_source_filename
+import pytest
+
+from quillan.module_errors import QuillanRetainedSourceError
+import quillan.retained_source as retained_service
+from quillan.retained_source import validate_quillan_retained_source
+
+
+def retained_source(root: Path, extension: str = ".pdf") -> RetainedSourceScan:
+    timestamp = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    source_filename = f"original{extension}"
+    retained_filename = build_retained_source_filename(
+        intake_timestamp=timestamp,
+        original_filename=source_filename,
+        sha256_hex="a" * 64,
+    )
+    retained = root / "scans" / "source" / "2026-07-20" / retained_filename
+    retained.parent.mkdir(parents=True)
+    retained.write_bytes(b"synthetic")
+    return RetainedSourceScan(
+        source_scan_id=f"scan_{retained.stem}",
+        source_filename=source_filename,
+        source_sha256="a" * 64,
+        retained_source_path=retained,
+        retained_source_relative_path=retained.relative_to(root).as_posix(),
+        intake_timestamp=timestamp,
+        intake_date=date(2026, 7, 20),
+    )
+
+
+def test_exact_pdf_provenance_is_validated_without_mutation(tmp_path: Path) -> None:
+    source = retained_source(tmp_path)
+    before = source.retained_source_path.read_bytes()
+    result = validate_quillan_retained_source(
+        source, workspace_root=tmp_path, source_page_number=3
+    )
+    assert result.retained_source is source
+    assert result.source_page_number == 3
+    assert source.retained_source_path.read_bytes() == before
+
+
+def test_image_has_only_one_source_page(tmp_path: Path) -> None:
+    source = retained_source(tmp_path, ".png")
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            source, workspace_root=tmp_path, source_page_number=2
+        )
+
+
+def test_path_and_provenance_contradictions_fail(tmp_path: Path) -> None:
+    source = retained_source(tmp_path)
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            replace(source, source_sha256="A" * 64),
+            workspace_root=tmp_path,
+            source_page_number=1,
+        )
+
+
+@pytest.mark.parametrize("extension", [".pdf", ".png", ".jpg", ".jpeg", ".tif", ".tiff"])
+def test_all_supported_extensions_describe_exact_core_events(
+    tmp_path: Path, extension: str
+) -> None:
+    source = retained_source(tmp_path, extension)
+    result = validate_quillan_retained_source(
+        source, workspace_root=tmp_path, source_page_number=1
+    )
+    assert result.retained_source is source
+
+
+@pytest.mark.parametrize("page", [True, 0, -1])
+def test_invalid_source_page_is_rejected_without_mutation(
+    tmp_path: Path, page: object
+) -> None:
+    source = retained_source(tmp_path)
+    before = source.retained_source_path.read_bytes()
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            source, workspace_root=tmp_path, source_page_number=page
+        )
+    assert source.retained_source_path.read_bytes() == before
+
+
+def test_every_core_retention_identity_contradiction_is_rejected(
+    tmp_path: Path,
+) -> None:
+    source = retained_source(tmp_path)
+    arbitrary = source.retained_source_path.with_name("arbitrary.pdf")
+    arbitrary.write_bytes(b"sentinel")
+    contradictions = (
+        replace(source, source_scan_id="arbitrary_safe_id"),
+        replace(source, source_filename="different.pdf"),
+        replace(source, source_filename="original.png"),
+        replace(source, source_sha256="b" * 64),
+        replace(
+            source,
+            intake_timestamp=source.intake_timestamp.replace(second=1),
+        ),
+        replace(source, intake_date=date(2026, 7, 21)),
+        replace(source, retained_source_path=arbitrary),
+        replace(
+            source,
+            retained_source_relative_path="scans/source/2026-07-20/arbitrary.pdf",
+        ),
+        replace(
+            source,
+            retained_source_relative_path="scans/source/2026-07-21/"
+            + source.retained_source_path.name,
+        ),
+        replace(source, retained_source_relative_path="/scans/source/file.pdf"),
+        replace(source, retained_source_relative_path=r"scans\source\file.pdf"),
+        replace(source, retained_source_relative_path="scans/source/../file.pdf"),
+    )
+    before = source.retained_source_path.read_bytes()
+    sentinel = arbitrary.read_bytes()
+    for invalid in contradictions:
+        with pytest.raises(QuillanRetainedSourceError):
+            validate_quillan_retained_source(
+                invalid, workspace_root=tmp_path, source_page_number=1
+            )
+        assert source.retained_source_path.read_bytes() == before
+        assert arbitrary.read_bytes() == sentinel
+
+
+def test_missing_directory_external_relative_and_wrong_workspace_fail(
+    tmp_path: Path,
+) -> None:
+    source = retained_source(tmp_path)
+    missing = source.retained_source_path.with_name("missing.pdf")
+    directory = source.retained_source_path.with_name("directory.pdf")
+    directory.mkdir()
+    outside = tmp_path.parent / source.retained_source_path.name
+    outside.write_bytes(b"external sentinel")
+    cases = (
+        (replace(source, retained_source_path=missing), tmp_path),
+        (replace(source, retained_source_path=directory), tmp_path),
+        (replace(source, retained_source_path=outside), tmp_path),
+        (replace(source, retained_source_path=Path(source.retained_source_path.name)), tmp_path),
+        (source, Path("relative-root")),
+    )
+    for invalid, root in cases:
+        with pytest.raises(QuillanRetainedSourceError):
+            validate_quillan_retained_source(
+                invalid, workspace_root=root, source_page_number=1
+            )
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            source, workspace_root="wrong", source_page_number=1  # type: ignore[arg-type]
+        )
+    assert outside.read_bytes() == b"external sentinel"
+
+
+def test_link_like_source_branch_is_rejected_without_reading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = retained_source(tmp_path)
+    monkeypatch.setattr(
+        retained_service,
+        "_is_link_like",
+        lambda path: path == source.retained_source_path,
+    )
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            source, workspace_root=tmp_path, source_page_number=1
+        )
+
+
+def test_real_symlinked_retained_source_is_rejected(tmp_path: Path) -> None:
+    source = retained_source(tmp_path)
+    target = source.retained_source_path.with_name("target.pdf")
+    target.write_bytes(b"target sentinel")
+    source.retained_source_path.unlink()
+    try:
+        os.symlink(target, source.retained_source_path)
+    except OSError as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            source, workspace_root=tmp_path, source_page_number=1
+        )
+    assert target.read_bytes() == b"target sentinel"
+
+
+def test_real_windows_junctioned_source_ancestor_is_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "junction-target"
+    target.mkdir()
+    junction = tmp_path / "junction"
+    completed = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.skip(f"junction creation unavailable: {completed.stderr}")
+    source = retained_source(target)
+    redirected_path = junction / source.retained_source_path.relative_to(target)
+    redirected = replace(
+        source,
+        retained_source_path=redirected_path,
+    )
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            redirected, workspace_root=junction, source_page_number=1
+        )
+
+
+@pytest.mark.parametrize("control", ["\n", "\r", "\t", "\x00", "\u2028", "\u2029"])
+def test_source_filename_rejects_control_and_line_separators(
+    tmp_path: Path, control: str
+) -> None:
+    source = retained_source(tmp_path)
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            replace(source, source_filename=f"original{control}.pdf"),
+            workspace_root=tmp_path,
+            source_page_number=1,
+        )
+
+
+def test_unexpected_retained_boundary_runtime_error_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = retained_source(tmp_path)
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("programming failure")
+
+    monkeypatch.setattr(retained_service, "_validate_file_chain", fail)
+    with pytest.raises(RuntimeError, match="programming failure"):
+        validate_quillan_retained_source(
+            source, workspace_root=tmp_path, source_page_number=1
+        )
+
+
+@pytest.mark.parametrize("component", ["scans", "source", "date"])
+def test_each_intermediate_retained_link_branch_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    component: str,
+) -> None:
+    source = retained_source(tmp_path)
+    components = {
+        "scans": tmp_path / "scans",
+        "source": tmp_path / "scans" / "source",
+        "date": tmp_path / "scans" / "source" / "2026-07-20",
+    }
+    rejected = components[component]
+    original = retained_service._is_link_like
+    monkeypatch.setattr(
+        retained_service,
+        "_is_link_like",
+        lambda path: path == rejected or original(path),
+    )
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            source, workspace_root=tmp_path, source_page_number=1
+        )
+
+
+@pytest.mark.parametrize("component", ["scans", "source", "date"])
+def test_real_junctioned_intermediate_retained_paths_are_rejected(
+    tmp_path: Path, component: str
+) -> None:
+    source = retained_source(tmp_path)
+    components = {
+        "scans": tmp_path / "scans",
+        "source": tmp_path / "scans" / "source",
+        "date": tmp_path / "scans" / "source" / "2026-07-20",
+    }
+    junction = components[component]
+    target = tmp_path / f"external-{component}"
+    shutil.move(str(junction), str(target))
+    sentinel = target / "sentinel.txt"
+    sentinel.write_text("external sentinel", encoding="utf-8")
+    completed = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.skip(f"junction creation unavailable: {completed.stderr}")
+    with pytest.raises(QuillanRetainedSourceError):
+        validate_quillan_retained_source(
+            source, workspace_root=tmp_path, source_page_number=1
+        )
+    assert sentinel.read_text(encoding="utf-8") == "external sentinel"

--- a/tests/test_response_page_dispatch.py
+++ b/tests/test_response_page_dispatch.py
@@ -1,0 +1,156 @@
+"""Focused tests for the frozen Quillan dispatch result."""
+
+from dataclasses import FrozenInstanceError, replace
+import copy
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from pds_core.scan_routes import build_retained_source_filename
+import pytest
+
+from quillan.module_errors import QuillanDispatchResultError
+from quillan.response_page_dispatch import (
+    QuillanResponsePageDispatchResult,
+    validate_quillan_response_page_dispatch_result,
+)
+
+
+def valid_result() -> QuillanResponsePageDispatchResult:
+    timestamp = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    retained_filename = build_retained_source_filename(
+        intake_timestamp=timestamp,
+        original_filename="original.pdf",
+        sha256_hex="a" * 64,
+    )
+    retained = Path("C:/workspace/scans/source/2026-07-20") / retained_filename
+    return QuillanResponsePageDispatchResult(
+        route_id="rt_0123456789abcdef0123456789abcdef",
+        page_id="pg_0123456789abcdef0123456789abcdef",
+        issuance_id="iss_0123456789abcdef0123456789abcdef",
+        generation_id="gen_0123456789abcdef0123456789abcdef",
+        artifact_id="art_0123456789abcdef0123456789abcdef",
+        class_id="english10_p2",
+        assignment_id="literary_analysis",
+        student_id="00107",
+        logical_page=1,
+        total_pages=2,
+        page_role="response_start",
+        source_scan_id=f"scan_{retained.stem}",
+        source_filename="original.pdf",
+        source_page_number=1,
+        retained_source_path=retained,
+        retained_source_relative_path=f"scans/source/2026-07-20/{retained_filename}",
+        source_sha256="a" * 64,
+        intake_timestamp=timestamp,
+        intake_date=date(2026, 7, 20),
+    )
+
+
+def test_valid_result_is_frozen_and_continuation_is_derived() -> None:
+    result = valid_result()
+    assert validate_quillan_response_page_dispatch_result(result) is result
+    assert not result.is_continuation
+    continuation = replace(result, logical_page=2, page_role="continuation")
+    assert validate_quillan_response_page_dispatch_result(continuation).is_continuation
+    with pytest.raises(FrozenInstanceError):
+        result.page_id = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        object(),
+        replace(valid_result(), logical_page=True),
+        replace(valid_result(), page_role="continuation"),
+        replace(valid_result(), source_sha256="A" * 64),
+        replace(valid_result(), intake_timestamp=datetime(2026, 7, 20)),
+        replace(valid_result(), intake_date=datetime(2026, 7, 20)),
+    ],
+)
+def test_invalid_result_uses_typed_failure(result: object) -> None:
+    with pytest.raises(QuillanDispatchResultError):
+        validate_quillan_response_page_dispatch_result(result)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("route_id", "bad"),
+        ("page_id", "bad"),
+        ("issuance_id", "bad"),
+        ("generation_id", "bad"),
+        ("artifact_id", "bad"),
+        ("class_id", "../bad"),
+        ("assignment_id", "../bad"),
+        ("student_id", "../bad"),
+        ("logical_page", False),
+        ("logical_page", 0),
+        ("logical_page", -1),
+        ("logical_page", 3),
+        ("total_pages", True),
+        ("total_pages", 0),
+        ("total_pages", -1),
+        ("page_role", "continuation"),
+        ("source_scan_id", "arbitrary_safe_id"),
+        ("source_filename", "../original.pdf"),
+        ("source_filename", "original.exe"),
+        ("source_page_number", True),
+        ("source_page_number", 0),
+        ("source_page_number", -1),
+        ("retained_source_relative_path", "/scans/source/2026-07-20/file.pdf"),
+        ("retained_source_relative_path", r"scans\source\2026-07-20\file.pdf"),
+        ("retained_source_relative_path", "scans/source/../file.pdf"),
+        ("retained_source_path", "not-a-path"),
+        ("retained_source_path", Path("relative.pdf")),
+        ("source_sha256", "A" * 64),
+        ("source_sha256", "a" * 63),
+        ("intake_timestamp", datetime(2026, 7, 20)),
+        ("intake_date", datetime(2026, 7, 20, tzinfo=timezone.utc)),
+        ("intake_date", date(2026, 7, 21)),
+    ],
+)
+def test_every_result_field_boundary(field: str, value: object) -> None:
+    result = copy.copy(valid_result())
+    object.__setattr__(result, field, value)
+    with pytest.raises(QuillanDispatchResultError):
+        validate_quillan_response_page_dispatch_result(result)
+
+
+def test_result_rejects_core_filename_and_extension_contradictions() -> None:
+    result = valid_result()
+    arbitrary = replace(
+        result,
+        retained_source_path=result.retained_source_path.with_name("arbitrary.pdf"),
+        retained_source_relative_path=(
+            "scans/source/2026-07-20/arbitrary.pdf"
+        ),
+        source_scan_id="scan_arbitrary",
+    )
+    mismatch = replace(
+        result,
+        source_filename="original.png",
+    )
+    scan_mismatch = replace(result, source_scan_id="scan_arbitrary")
+    bucket_mismatch = replace(
+        result,
+        retained_source_relative_path=result.retained_source_relative_path.replace(
+            "2026-07-20", "2026-07-21"
+        ),
+    )
+    for invalid in (arbitrary, mismatch, scan_mismatch, bucket_mismatch):
+        with pytest.raises(QuillanDispatchResultError):
+            validate_quillan_response_page_dispatch_result(invalid)
+
+
+def test_result_model_is_slotted() -> None:
+    assert "__dict__" not in dir(valid_result())
+
+
+@pytest.mark.parametrize("control", ["\n", "\r", "\t", "\x00", "\u2028", "\u2029"])
+def test_result_source_filename_rejects_control_and_line_separators(
+    control: str,
+) -> None:
+    with pytest.raises(QuillanDispatchResultError):
+        validate_quillan_response_page_dispatch_result(
+            replace(valid_result(), source_filename=f"original{control}.pdf")
+        )

--- a/tests/test_route_handler.py
+++ b/tests/test_route_handler.py
@@ -1,0 +1,646 @@
+"""Direct one-page Quillan route-handler tests."""
+
+from dataclasses import replace
+import copy
+from datetime import date, datetime, timezone
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+from pds_core.routing_models import (
+    ModuleWorkRef,
+    RouteLocator,
+    RouteRegistration,
+    RouteResolution,
+)
+from pds_core.scan_retention import RetainedSourceScan, retain_source_scan
+from pds_core.scan_routes import build_retained_source_filename
+from pds_core.route_registrations import write_route_registration
+import pytest
+
+from quillan.module_errors import (
+    QuillanDispatchResultError,
+    QuillanIssuanceAuthorizationError,
+    QuillanRouteContextError,
+    QuillanTargetIntegrityError,
+)
+import quillan.route_handler as route_handler
+from quillan.printable_response_persistence import canonical_printable_response_json
+from quillan.printable_response_records import (
+    PrintableResponseRecordSet,
+    transition_printable_response_lifecycle,
+)
+from quillan.printable_response_routes import build_printable_response_page_route
+from quillan.response_page_dispatch import (
+    QuillanResponsePageDispatchResult,
+    validate_quillan_response_page_dispatch_result,
+)
+from quillan.retained_source import validate_quillan_retained_source
+from quillan.route_handler import handle_quillan_response_page_route
+from quillan.work_paths import quillan_work_paths
+from tests.test_printable_response_records import record_set
+
+
+def route_context(
+    root: Path, *, status: str = "issued", pages: int = 1
+) -> tuple[RouteResolution, RetainedSourceScan]:
+    records = record_set(pages=pages)
+    if status != "prepared":
+        terminal_reason = "synthetic lifecycle test"
+        if status == "cancelled":
+            lifecycle = transition_printable_response_lifecycle(
+                records.issuance.lifecycle,
+                new_status="cancelled",
+                timestamp="2026-07-20T00:00:00+00:00",
+                reason=terminal_reason,
+            )
+        else:
+            lifecycle = transition_printable_response_lifecycle(
+                records.issuance.lifecycle,
+                new_status="issued",
+                timestamp="2026-07-20T00:00:00+00:00",
+            )
+            if status in {"superseded", "invalidated"}:
+                lifecycle = transition_printable_response_lifecycle(
+                    lifecycle,
+                    new_status=status,
+                    timestamp="2026-07-20T01:00:00+00:00",
+                    reason=terminal_reason,
+                    replacement_issuance_id=(
+                        "iss_ffffffffffffffffffffffffffffffff"
+                        if status == "superseded"
+                        else None
+                    ),
+                )
+        records = PrintableResponseRecordSet(
+            replace(records.issuance, lifecycle=lifecycle), records.pages
+        )
+    paths = quillan_work_paths(root, records.issuance.class_id, records.issuance.assignment_id)
+    paths.response_page_records_dir.mkdir(parents=True)
+    paths.response_page_issuances_dir.mkdir(parents=True)
+    for page in records.pages:
+        paths.response_page_records_dir.joinpath(f"{page.page_id}.json").write_bytes(
+            canonical_printable_response_json(page.to_mapping())
+        )
+    paths.response_page_issuances_dir.joinpath(
+        f"{records.issuance.issuance_id}.json"
+    ).write_bytes(canonical_printable_response_json(records.issuance.to_mapping()))
+    route = build_printable_response_page_route(
+        records.pages[0], "rt_0123456789abcdef0123456789abcdef"
+    )
+    resolution = RouteResolution(
+        locator=route.locator,
+        registration=route.registration,
+        class_root=paths.work_root.parents[3],
+        module_root=paths.work_root.parents[1],
+        work_root=paths.work_root,
+    )
+    timestamp = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    retained_filename = build_retained_source_filename(
+        intake_timestamp=timestamp,
+        original_filename="original.pdf",
+        sha256_hex="a" * 64,
+    )
+    retained = root / "scans" / "source" / "2026-07-20" / retained_filename
+    retained.parent.mkdir(parents=True)
+    retained.write_bytes(b"synthetic")
+    source = RetainedSourceScan(
+        source_scan_id=f"scan_{retained.stem}",
+        source_filename="original.pdf",
+        source_sha256="a" * 64,
+        retained_source_path=retained,
+        retained_source_relative_path=retained.relative_to(root).as_posix(),
+        intake_timestamp=timestamp,
+        intake_date=date(2026, 7, 20),
+    )
+    return resolution, source
+
+
+def test_direct_handler_returns_authoritative_identity_without_writes(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    before = {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
+    result = handle_quillan_response_page_route(resolution, source, 1)
+    assert result.route_id == resolution.locator.route_id
+    assert result.page_id == resolution.registration.target.record_id
+    assert result.student_id == "00107"
+    assert not result.is_continuation
+    assert {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()} == before
+
+
+def test_direct_handler_requires_issued_lifecycle(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path, status="prepared")
+    with pytest.raises(QuillanIssuanceAuthorizationError):
+        handle_quillan_response_page_route(resolution, source, 1)
+
+
+def test_direct_handler_rejects_wrong_call_types() -> None:
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(object(), object(), True)  # type: ignore[arg-type]
+
+
+def test_handler_rejects_validator_result_that_contradicts_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resolution, source = route_context(tmp_path)
+
+    def substitute(
+        result: QuillanResponsePageDispatchResult,
+    ) -> QuillanResponsePageDispatchResult:
+        return replace(result, student_id="other_student")
+
+    monkeypatch.setattr(
+        route_handler,
+        "validate_quillan_response_page_dispatch_result",
+        substitute,
+    )
+    with pytest.raises(QuillanDispatchResultError):
+        handle_quillan_response_page_route(resolution, source, 1)
+
+
+def test_unexpected_loader_runtime_error_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resolution, source = route_context(tmp_path)
+
+    def fail(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("programming failure")
+
+    monkeypatch.setattr(route_handler, "load_printable_response_page_context", fail)
+    with pytest.raises(RuntimeError, match="programming failure"):
+        handle_quillan_response_page_route(resolution, source, 1)
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["issued", "prepared", "cancelled", "superseded", "invalidated"],
+)
+def test_complete_lifecycle_matrix_is_nonmutating(
+    tmp_path: Path, status: str
+) -> None:
+    resolution, source = route_context(tmp_path, status=status)
+    route_path = write_route_registration(tmp_path, resolution.registration)
+    tracked = tuple(path for path in tmp_path.rglob("*") if path.is_file())
+    before = {path: path.read_bytes() for path in tracked}
+    if status == "issued":
+        result = handle_quillan_response_page_route(resolution, source, 1)
+        assert result.page_id == resolution.registration.target.record_id
+    else:
+        with pytest.raises(QuillanIssuanceAuthorizationError):
+            handle_quillan_response_page_route(resolution, source, 1)
+    assert route_path.read_bytes() == before[route_path]
+    assert {path: path.read_bytes() for path in tracked} == before
+
+
+def test_fabricated_and_noncanonical_resolution_roots_are_rejected(
+    tmp_path: Path,
+) -> None:
+    resolution, source = route_context(tmp_path)
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    fabricated = (
+        replace(resolution, class_root=tmp_path / "classes" / "other"),
+        replace(resolution, module_root=tmp_path / "classes" / "other" / "modules" / "quillan"),
+        replace(resolution, work_root=resolution.work_root.with_name("other")),
+        replace(resolution, work_root=outside),
+        replace(
+            resolution,
+            class_root=Path("classes") / resolution.locator.class_id,
+            module_root=Path("classes") / resolution.locator.class_id / "modules" / "quillan",
+            work_root=Path("classes") / resolution.locator.class_id / "modules" / "quillan" / "work" / resolution.locator.work_id,
+        ),
+    )
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("external", encoding="utf-8")
+    for invalid in fabricated:
+        with pytest.raises(QuillanRouteContextError):
+            handle_quillan_response_page_route(invalid, source, 1)
+    assert sentinel.read_text(encoding="utf-8") == "external"
+
+
+def test_missing_and_file_roots_are_rejected(tmp_path: Path) -> None:
+    resolution, source = route_context(tmp_path)
+    missing = resolution.work_root / "missing"
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(
+            replace(resolution, work_root=missing), source, 1
+        )
+    for root_field in ("class_root", "module_root", "work_root"):
+        invalid_root = tmp_path / f"{root_field}.file"
+        invalid_root.write_text("sentinel", encoding="utf-8")
+        invalid = copy.copy(resolution)
+        object.__setattr__(invalid, root_field, invalid_root)
+        with pytest.raises(QuillanRouteContextError):
+            handle_quillan_response_page_route(invalid, source, 1)
+
+
+def test_missing_and_malformed_target_records_have_preserved_causes(
+    tmp_path: Path,
+) -> None:
+    resolution, source = route_context(tmp_path)
+    paths = quillan_work_paths(
+        tmp_path, resolution.locator.class_id, resolution.locator.work_id
+    )
+    page_path = paths.response_page_records_dir / (
+        resolution.registration.target.record_id + ".json"
+    )
+    original = page_path.read_bytes()
+    page_path.unlink()
+    with pytest.raises(QuillanTargetIntegrityError) as missing:
+        handle_quillan_response_page_route(resolution, source, 1)
+    assert missing.value.__cause__ is not None
+    page_path.write_bytes(b"{malformed")
+    with pytest.raises(QuillanTargetIntegrityError) as malformed:
+        handle_quillan_response_page_route(resolution, source, 1)
+    assert malformed.value.__cause__ is not None
+    page_path.write_bytes(original)
+
+
+def test_current_assignment_and_roster_are_never_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resolution, source = route_context(tmp_path)
+    class_root = resolution.class_root
+    (class_root / "roster.csv").write_text(
+        "class_id,student_id,last_name,first_name,period\n"
+        "other,other,Wrong,Student,9\n",
+        encoding="utf-8",
+    )
+    assignment_path = resolution.work_root / "assignment.json"
+    assignment_path.write_text(json.dumps({"contradictory": True}), encoding="utf-8")
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("mutable current-data loader was called")
+
+    for module_name, names in (
+        ("quillan.assignments", ("load_assignment_config",)),
+        ("pds_core.rosters", ("load_class_roster",)),
+        ("quillan.assignment_discovery", ("discover_assignments",)),
+    ):
+        module = __import__(module_name, fromlist=["unused"])
+        for name in names:
+            if hasattr(module, name):
+                monkeypatch.setattr(module, name, forbidden)
+    result = handle_quillan_response_page_route(resolution, source, 1)
+    assert result.student_id == "00107"
+
+
+@pytest.mark.parametrize("root_field", ["class_root", "module_root", "work_root"])
+def test_each_link_like_resolution_root_branch_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    root_field: str,
+) -> None:
+    resolution, source = route_context(tmp_path)
+    rejected = getattr(resolution, root_field)
+    original = route_handler._is_link_like
+    monkeypatch.setattr(
+        route_handler,
+        "_is_link_like",
+        lambda path: path == rejected or original(path),
+    )
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(resolution, source, 1)
+
+
+@pytest.mark.parametrize("root_field", ["class_root", "module_root", "work_root"])
+def test_real_symlinked_resolution_roots_are_rejected(
+    tmp_path: Path, root_field: str
+) -> None:
+    resolution, source = route_context(tmp_path)
+    link = getattr(resolution, root_field)
+    target = tmp_path / f"symlink-target-{root_field}"
+    shutil.move(str(link), str(target))
+    try:
+        os.symlink(target, link, target_is_directory=True)
+    except OSError as error:
+        pytest.skip(f"directory symlink creation unavailable: {error}")
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(resolution, source, 1)
+
+
+@pytest.mark.parametrize("root_field", ["class_root", "module_root", "work_root"])
+def test_real_junctioned_resolution_roots_are_rejected(
+    tmp_path: Path, root_field: str
+) -> None:
+    resolution, source = route_context(tmp_path)
+    junction = getattr(resolution, root_field)
+    target = tmp_path / f"junction-target-{root_field}"
+    shutil.move(str(junction), str(target))
+    completed = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.skip(f"junction creation unavailable: {completed.stderr}")
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(resolution, source, 1)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("page_id", "pg_ffffffffffffffffffffffffffffffff"),
+        ("class_id", "other_class"),
+        ("assignment_id", "other_assignment"),
+        ("issuance_id", "iss_ffffffffffffffffffffffffffffffff"),
+        ("generation_id", "gen_ffffffffffffffffffffffffffffffff"),
+        ("artifact_id", "art_ffffffffffffffffffffffffffffffff"),
+        ("student_id", "other_student"),
+        ("created_at", "2026-07-19T18:31:00+00:00"),
+    ],
+)
+def test_page_record_identity_contradictions_are_target_failures(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    resolution, source = route_context(tmp_path)
+    page_path = resolution.work_root / "response_pages" / "pages" / (
+        resolution.registration.target.record_id + ".json"
+    )
+    mapping = json.loads(page_path.read_text(encoding="utf-8"))
+    mapping[field] = value
+    page_path.write_text(json.dumps(mapping), encoding="utf-8")
+    with pytest.raises(QuillanTargetIntegrityError) as captured:
+        handle_quillan_response_page_route(resolution, source, 1)
+    assert captured.value.__cause__ is not None
+
+
+@pytest.mark.parametrize("mode", ["missing", "malformed", "incomplete", "reordered", "duplicate"])
+def test_issuance_record_integrity_failures_are_typed(
+    tmp_path: Path, mode: str
+) -> None:
+    resolution, source = route_context(tmp_path, pages=2)
+    issuance_id = str(resolution.registration.module_details["issuance_id"])
+    issuance_path = (
+        resolution.work_root / "response_pages" / "issuances" / f"{issuance_id}.json"
+    )
+    if mode == "missing":
+        issuance_path.unlink()
+    elif mode == "malformed":
+        issuance_path.write_bytes(b"{malformed")
+    else:
+        mapping = json.loads(issuance_path.read_text(encoding="utf-8"))
+        page_ids = list(mapping["page_ids"])
+        if mode == "incomplete":
+            mapping["page_ids"] = page_ids[:1]
+        elif mode == "reordered":
+            mapping["page_ids"] = list(reversed(page_ids))
+        else:
+            mapping["page_ids"] = [page_ids[0], page_ids[0]]
+        issuance_path.write_text(json.dumps(mapping), encoding="utf-8")
+    with pytest.raises(QuillanTargetIntegrityError) as captured:
+        handle_quillan_response_page_route(resolution, source, 1)
+    assert captured.value.__cause__ is not None
+
+
+def registration_copy(
+    registration: RouteRegistration,
+    *,
+    target: object | None = None,
+    created_at: str | None = None,
+    details: dict[str, object] | None = None,
+    fallback: str | None = None,
+    locator: RouteLocator | None = None,
+) -> RouteRegistration:
+    return RouteRegistration(
+        registration.schema_version,
+        registration.locator if locator is None else locator,
+        registration.target if target is None else target,  # type: ignore[arg-type]
+        registration.created_at if created_at is None else created_at,
+        registration.status,
+        registration.human_fallback if fallback is None else fallback,
+        registration.module_details if details is None else details,  # type: ignore[arg-type]
+    )
+
+
+def test_route_diagnostics_cannot_override_authoritative_page(
+    tmp_path: Path,
+) -> None:
+    resolution, source = route_context(tmp_path)
+    registration = resolution.registration
+    details = registration.module_details
+    fallback = registration.human_fallback
+    other_page = "pg_ffffffffffffffffffffffffffffffff"
+    cases = (
+        registration_copy(
+            registration,
+            target=replace(registration.target, record_id=other_page),
+            fallback=fallback.replace(registration.target.record_id, other_page),
+        ),
+        registration_copy(
+            registration, created_at="2026-07-19T18:31:00+00:00"
+        ),
+        registration_copy(
+            registration,
+            details={
+                **details,
+                "issuance_id": "iss_ffffffffffffffffffffffffffffffff",
+            },
+        ),
+        registration_copy(
+            registration,
+            details={**details, "logical_page": 2, "total_pages": 2},
+            fallback=fallback.replace("page=1/1", "page=2/2"),
+        ),
+        registration_copy(
+            registration,
+            details={**details, "total_pages": 2},
+            fallback=fallback.replace("page=1/1", "page=1/2"),
+        ),
+        registration_copy(
+            registration,
+            fallback=fallback.replace("student=00107", "student=other_student"),
+        ),
+    )
+    for invalid_registration in cases:
+        invalid = replace(resolution, registration=invalid_registration)
+        with pytest.raises(QuillanTargetIntegrityError):
+            handle_quillan_response_page_route(invalid, source, 1)
+
+
+@pytest.mark.parametrize("identity", ["class", "work"])
+def test_locator_identity_tampering_is_rejected_before_target_loading(
+    tmp_path: Path, identity: str
+) -> None:
+    resolution, source = route_context(tmp_path)
+    work = ModuleWorkRef(
+        "quillan",
+        "other_class" if identity == "class" else resolution.locator.class_id,
+        "other_work" if identity == "work" else resolution.locator.work_id,
+    )
+    locator = RouteLocator("PDS2", work, resolution.locator.route_id)
+    registration = registration_copy(resolution.registration, locator=locator)
+    invalid = RouteResolution(
+        locator,
+        registration,
+        resolution.class_root,
+        resolution.module_root,
+        resolution.work_root,
+    )
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(invalid, source, 1)
+
+
+def test_core_explicit_intake_date_override_is_accepted_end_to_end(
+    tmp_path: Path,
+) -> None:
+    resolution, _ = route_context(tmp_path)
+    source_path = tmp_path / "override-source.pdf"
+    source_path.write_bytes(b"synthetic override source")
+    retained = retain_source_scan(
+        tmp_path,
+        source_path,
+        intake_timestamp=datetime(2026, 7, 20, 23, 30, tzinfo=timezone.utc),
+        intake_date=date(2026, 7, 21),
+    )
+    before = retained
+    retained_bytes = retained.retained_source_path.read_bytes()
+    assert retained.retained_source_relative_path.startswith(
+        "scans/source/2026-07-21/"
+    )
+    provenance = validate_quillan_retained_source(
+        retained, workspace_root=tmp_path, source_page_number=1
+    )
+    assert provenance.retained_source is retained
+    result = handle_quillan_response_page_route(resolution, retained, 1)
+    assert validate_quillan_response_page_dispatch_result(result) is result
+    assert result.intake_timestamp.date() == date(2026, 7, 20)
+    assert result.intake_date == date(2026, 7, 21)
+    assert retained == before
+    assert retained.retained_source_path.read_bytes() == retained_bytes
+
+
+@pytest.mark.parametrize(
+    "status", ["prepared", "cancelled", "superseded", "invalidated"]
+)
+def test_unauthorized_lifecycle_precedes_retained_source_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+) -> None:
+    resolution, source = route_context(tmp_path, status=status)
+    route_path = write_route_registration(tmp_path, resolution.registration)
+    tracked = tuple(path for path in tmp_path.rglob("*") if path.is_file())
+    before = {path: path.read_bytes() for path in tracked}
+    calls = 0
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("retained-source validation must not run")
+
+    monkeypatch.setattr(route_handler, "validate_quillan_retained_source", forbidden)
+    with pytest.raises(QuillanIssuanceAuthorizationError):
+        handle_quillan_response_page_route(resolution, source, 1)
+    assert calls == 0
+    assert route_path.read_bytes() == before[route_path]
+    assert {path: path.read_bytes() for path in tracked} == before
+
+
+def test_invalid_route_and_target_precede_retained_source_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resolution, source = route_context(tmp_path)
+    calls = 0
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("retained-source validation must not run")
+
+    monkeypatch.setattr(route_handler, "validate_quillan_retained_source", forbidden)
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(
+            replace(resolution, work_root=tmp_path / "fabricated"), source, 1
+        )
+    page_path = resolution.work_root / "response_pages" / "pages" / (
+        resolution.registration.target.record_id + ".json"
+    )
+    page_path.unlink()
+    with pytest.raises(QuillanTargetIntegrityError):
+        handle_quillan_response_page_route(resolution, source, 1)
+    assert calls == 0
+
+
+def test_issued_context_invokes_retained_validation_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resolution, source = route_context(tmp_path)
+    original = getattr(route_handler, "validate_quillan_retained_source")
+    calls = 0
+
+    def counting(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(route_handler, "validate_quillan_retained_source", counting)
+    handle_quillan_response_page_route(resolution, source, 1)
+    assert calls == 1
+
+
+def test_unexpected_resolution_runtime_error_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resolution, source = route_context(tmp_path)
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("programming failure")
+
+    monkeypatch.setattr(route_handler, "_validate_root_chain", fail)
+    with pytest.raises(RuntimeError, match="programming failure"):
+        handle_quillan_response_page_route(resolution, source, 1)
+
+
+@pytest.mark.parametrize("component", ["classes", "modules", "work"])
+def test_each_intermediate_route_link_branch_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    component: str,
+) -> None:
+    resolution, source = route_context(tmp_path)
+    paths = {
+        "classes": tmp_path / "classes",
+        "modules": resolution.class_root / "modules",
+        "work": resolution.module_root / "work",
+    }
+    rejected = paths[component]
+    original = route_handler._is_link_like
+    monkeypatch.setattr(
+        route_handler,
+        "_is_link_like",
+        lambda path: path == rejected or original(path),
+    )
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(resolution, source, 1)
+
+
+@pytest.mark.parametrize("component", ["classes", "modules", "work"])
+def test_real_junctioned_intermediate_route_paths_are_rejected(
+    tmp_path: Path, component: str
+) -> None:
+    resolution, source = route_context(tmp_path)
+    paths = {
+        "classes": tmp_path / "classes",
+        "modules": resolution.class_root / "modules",
+        "work": resolution.module_root / "work",
+    }
+    junction = paths[component]
+    target = tmp_path / f"external-{component}"
+    shutil.move(str(junction), str(target))
+    sentinel = target / "sentinel.txt"
+    sentinel.write_text("external sentinel", encoding="utf-8")
+    completed = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.skip(f"junction creation unavailable: {completed.stderr}")
+    with pytest.raises(QuillanRouteContextError):
+        handle_quillan_response_page_route(resolution, source, 1)
+    assert sentinel.read_text(encoding="utf-8") == "external sentinel"


### PR DESCRIPTION
## Summary

Registers Quillan as an installed PDS Core 0.5 module and adds the strict one-page response-handler boundary used by Core route dispatch.

The implementation adds:

* the `paper_data_suite.modules` entry point;
* a zero-argument, side-effect-safe module-profile provider;
* strict Quillan route-registration validation;
* typed module-boundary errors;
* retained-source provenance validation;
* a frozen response-page dispatch result;
* and a defensive response-page route handler.

Closes #337.

Part of #329.

## Installed Module Profile

Quillan now declares:

```toml
[project.entry-points."paper_data_suite.modules"]
quillan = "quillan.pds_module:get_module_profile"
```

The installed profile advertises:

```text
module_id:                         quillan
display_name:                      Quillan
Core routing contract versions:   {"1"}
QR schemas:                        {"PDS2"}
route-registration schemas:       {"1"}
dispatchable route statuses:      {"active"}
```

The profile supplies:

```text
handler:    handle_quillan_response_page_route
validator:  validate_quillan_registration
```

The provider:

* takes no arguments;
* returns an immutable validated `ModuleProfile`;
* performs no workspace discovery;
* reads no routes, records, assignments, rosters, or scans;
* creates no files or directories;
* imports no CLI or legacy PDS1 scan path;
* and returns equivalent profiles on repeated calls.

## Registration Validation

The Quillan registration validator is structural and nonwriting.

It requires:

```text
registration schema:     1
QR schema:               PDS2
locator module:          quillan
route status:            active
route ID:                rt_<32 lowercase hexadecimal characters>
target module:           quillan
target record kind:      response_page
target contract:         1
target record ID:        valid pg_<32 lowercase hex> page ID
```

Module details must contain exactly:

```json
{
  "issuance_id": "<issuance_id>",
  "logical_page": 1,
  "total_pages": 3
}
```

The human fallback must use the exact grammar:

```text
Quillan | class=<class_id> | assignment=<assignment_id> | student=<student_id> | page=<logical_page>/<total_pages> | page_id=<page_id>
```

The validator cross-checks the locator, target, details, and fallback but does not load the page or issuance. These diagnostic values never become student or page authority.

## Defensive Route Handler

Core invokes the handler with:

```python
handle_quillan_response_page_route(
    resolution,
    retained_source,
    source_page_number,
)
```

The handler performs these operations in order:

1. Validate direct-call argument types and the source-page number.
2. Revalidate the Core locator and registration.
3. Derive the workspace only from `class_root.parent.parent`.
4. Require exact canonical Core class, module, and work roots.
5. Reject missing, escaping, symlinked, junctioned, or wrong-type root components.
6. Load the exact immutable page context named by the registration target.
7. Cross-validate the route, target, page, issuance, diagnostics, and ordered membership.
8. Require the issuance lifecycle to be exactly `issued`.
9. Validate the retained-source provenance and filesystem path.
10. Construct and revalidate the typed Quillan result.

The handler does not parse QR text, resolve the route again, search records, inspect filenames for student meaning, or load mutable assignment or roster data.

## Immutable Page Authority

Student and response-page meaning come only from the immutable page and issuance records.

The handler verifies:

* target equality;
* class and assignment identity;
* page and issuance identity;
* generation and artifact identity;
* student identity;
* creation timestamp;
* logical-page and total-page meaning;
* page role;
* ordered page membership;
* exact module details;
* and exact human fallback reconstruction.

It does not trust:

* QR text beyond Core’s resolved locator;
* route-ID contents;
* filenames;
* scan order;
* human fallback fields;
* module details;
* current roster membership;
* current assignment state;
* or caller-supplied student or logical-page values.

## Issuance Authorization

An active Core registration is structurally resolvable but is not by itself sufficient authorization.

The handler accepts only:

```text
issued
```

It rejects:

```text
prepared
cancelled
superseded
invalidated
```

Lifecycle authorization occurs before retained-source filesystem inspection.

Rejected historical or incomplete issuances remain immutable. The handler does not transition them, reactivate them, or select a replacement issuance.

## Retained-Source Provenance

Quillan validates one exact Core source-retention event.

The aware intake timestamp, original source filename, and SHA-256 determine Core’s generated retained filename.

The independently authoritative `intake_date` selects:

```text
scans/source/YYYY-MM-DD/
```

This supports Core’s explicit date-bucket override; the timestamp date and `intake_date` do not need to match.

Quillan requires exact agreement among:

* source filename;
* retained filename;
* supported extension;
* SHA-256 and retained hash prefix;
* normalized source stem;
* timestamp component;
* `scan_<retained stem>` source-scan ID;
* retained absolute path;
* retained POSIX relative path;
* and the `intake_date` directory bucket.

Original source filenames may not contain Unicode categories:

```text
Cc
Zl
Zp
```

including control characters and line or paragraph separators.

The retained file must be an ordinary readable non-link file inside the canonical workspace path. All existing components are checked without following symlinks or Windows junctions.

Quillan does not recompute the retained file’s hash, rewrite provenance, decode the file, or extract pages under this issue.

## Source-Page Rules

For image retained sources:

```text
source_page_number == 1
```

For PDF retained sources:

```text
source_page_number >= 1
```

This issue validates the requested source-page meaning but does not enumerate or render PDF pages. Actual source-page enumeration remains #338.

## Typed Dispatch Result

The handler returns:

```python
QuillanResponsePageDispatchResult
```

with:

```text
route_id
page_id
issuance_id
generation_id
artifact_id
class_id
assignment_id
student_id
logical_page
total_pages
page_role
source_scan_id
source_filename
source_page_number
retained_source_path
retained_source_relative_path
source_sha256
intake_timestamp
intake_date
```

Identity fields come from the Core locator and immutable Quillan page context.

Source fields come from validated Core retained-source provenance.

`is_continuation` is derived from `page_role` and is not independently stored.

The runtime result contains no:

* submission ID;
* routed-evidence path;
* assignment title;
* student display name;
* review data;
* scoring data;
* image bytes;
* OCR text;
* or writable continuation flag.

The result is not persisted by #337.

## Mutable-Data Independence

The route handler does not load or trust:

```text
assignment.json
roster.csv
```

A valid issued page remains dispatchable if:

* the student later leaves the roster;
* the student’s display name changes;
* optional roster fields change;
* the assignment title changes;
* the assignment timestamp changes;
* or the current assignment becomes unavailable.

The immutable issued record remains authoritative for this boundary.

## Core Integration

Core can now discover Quillan through installed distribution metadata:

```python
registry = build_module_registry(discover_installed=True)
profile = registry.require("quillan")
```

Successful Core dispatch returns:

```python
RouteDispatchSuccess(
    request=<exact request>,
    profile=<Quillan profile>,
    resolution=<exact resolution>,
    module_result=<QuillanResponsePageDispatchResult>,
)
```

Core preserves the exact typed result.

Registration failures are wrapped as:

```text
ModuleRegistrationValidationError
```

with `QuillanRegistrationValidationError` as the cause.

Handler failures are wrapped as:

```text
ModuleRouteHandlingError
```

with the appropriate typed Quillan error as the cause.

Core contract, QR-schema, module, and route-status failures are rejected before Quillan’s handler executes.

## Import Safety

External-directory probes confirm that importing:

```python
import quillan.pds_module
```

and calling:

```python
get_module_profile()
```

produce no workspace or filesystem effects.

The provider path does not import:

```text
quillan.cli
quillan.cli_app
quillan.payload_validation
quillan.routing_review
pds_core.pds1
pds_core.qr_payload
cv2
pdf2image
reportlab
qrcode
```

## Validation

### Passing #337 checks

* Focused pytest: **321 passed, 4 skipped**
* Focused mypy: **0 errors in 11 explicitly named files**
* Focused Ruff
* Full Ruff
* Installed-profile discovery probe
* Import-safety probe
* Registration-validator contract and nonmutation
* Canonical route-ID validation
* Exact Core retention-event reconstruction
* Explicit Core `intake_date` override
* Control-free source-filename validation
* Public dispatch-result validation
* Canonical-root containment
* Real Windows junction tests
* Deterministic symlink branches
* Complete issuance lifecycle matrix
* Authorization-before-retained-source access
* Mutable roster and assignment independence
* Core dispatch result and wrapper-cause integration
* Unexpected programming-error propagation
* `git diff --check`

Four real symlink tests were skipped because Windows denied symlink creation with `WinError 1314`. Deterministic symlink-path tests and real Windows junction tests passed.

### Established later-ticket baseline

```text
Full pytest:
1225 passed
60 failed
11 skipped
39 collection errors

Full mypy:
28 errors in 5 legacy files
```

`run_tests.ps1` continues to stop at the established legacy import:

```text
ModuleNotFoundError: No module named 'pds_core.pds1'
```

The remaining failures belong to deferred:

* PDS1 scan parsing;
* scan metadata migration;
* routing-taxonomy migration;
* assignment and roster workflow migration;
* and downstream CLI/menu migration.

No remaining focused failure originates from #337.

## Scope Boundaries

This PR does not implement:

* scan-source selection;
* scan-folder enumeration;
* source retention orchestration;
* QR detection or decoding;
* PDS2 batch intake;
* mixed-module intake summaries;
* retained-page extraction;
* routed-evidence persistence;
* page-observation records;
* submission-manifest migration;
* submission assembly;
* scan-review migration;
* CLI/menu intake migration;
* plain-paper changes;
* PDS1 compatibility;
* Core modifications;
* ScoreForm modifications;
* package-version changes;
* or release preparation.

Those remain assigned to subsequent issues under #329.
