### PR TITLE
Migrate Quillan record and review services (#340)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Quillan
 
+> **Storage contract:** Quillan assignment, submission, review, feedback, and
+> assignment-report services use only
+> `classes/<class_id>/modules/quillan/work/<assignment_id>/`. See
+> [Module-qualified record services](docs/module_qualified_record_services.md)
+> for the canonical contexts, plain-paper behavior, export paths, and scan-review
+> ownership boundary. The former unqualified assignment tree is unsupported and
+> is never inspected or written.
+
 ## Installed PDS2 module boundary
 
 Quillan registers the `quillan` entry point in `paper_data_suite.modules` through

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -1,5 +1,12 @@
 # Quillan Data Contracts
 
+Quillan-owned assignment records and all dependent submission, review, and export
+records are rooted exclusively beneath
+`classes/<class_id>/modules/quillan/work/<assignment_id>/`. Contextual loaders
+validate identity and embedded paths before business services receive immutable
+record data; the unqualified assignment tree is not read or migrated. See
+[Module-qualified record services](module_qualified_record_services.md).
+
 ## Quillan response-page dispatch result
 
 `QuillanResponsePageDispatchResult` is a frozen, slotted runtime model. Its route ID

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -1,5 +1,12 @@
 # Quillan Development Plan
 
+The #340 service hard cutover centralizes assignment/student contexts, canonical
+record writers, review mutations, exports, Core-v2 scan-resolution interpretation,
+and Quillan post-dispatch occurrence storage beneath module-qualified work roots.
+It intentionally excludes the broad command, help, menu, and dashboard migration
+reserved for #341. See
+[Module-qualified record services](module_qualified_record_services.md).
+
 ## Project Definition
 
 Quillan is a local-first standards-based writing evidence capture system for teachers.

--- a/docs/module_qualified_record_services.md
+++ b/docs/module_qualified_record_services.md
@@ -1,0 +1,96 @@
+# Module-qualified record services
+
+Quillan identifies assignment work with an exact `ModuleWorkRef` whose module is
+`quillan`. The only supported work root is:
+
+```text
+classes/<class_id>/modules/quillan/work/<assignment_id>/
+```
+
+The unqualified development-era `classes/<class_id>/assignments/` tree is not a
+fallback, migration source, conflict source, or write destination. Quillan does
+not inspect it. Class rosters remain Core-owned at `classes/<class_id>/roster.csv`.
+
+## Records and contexts
+
+`quillan.work_paths` is the path-construction authority. `quillan.record_context`
+loads an assignment or a coherent assignment/submission/review context after
+preflighting the complete path chain. It distinguishes missing, invalid, orphaned,
+identity-mismatched, and unsafe records and returns recursively immutable record
+data. Every loaded record is a `LoadedJsonRecord` that binds its canonical path,
+workspace-relative path, exact source bytes, and parsed immutable model. Each file
+is read once per logical snapshot. Review loading explicitly requires, permits, or
+forbids an existing review.
+
+Canonical records are:
+
+```text
+<work root>/assignment.json
+<work root>/submissions/<student_id>/submission.json
+<work root>/submissions/<student_id>/review.json
+```
+
+Review records retain schema version 2 and must embed the exact module-qualified
+workspace-relative assignment and submission paths. Submission manifests retain
+schema version 1. Identity-based writers exclusively create or revision-guard the
+canonical record and verify the durable result. Updates acquire a same-directory
+guard, re-preflight, compare the snapshot revision, displace that exact revision,
+and install the prepared bytes exclusively. A concurrent target always wins. An
+installed target is never blindly rolled back; verification uncertainty reports
+the exact possibly durable path. Guard-cleanup failures separately report the
+stale lock path; a verified installed record remains in place, while an unchanged
+operation does not claim that it installed new bytes.
+
+Plain-paper submissions use the same record paths. They contain no issuance,
+route, page observation, retained scan, or routed evidence. Creation treats the
+empty manifest and review as a paired operation and compensates only a manifest
+proven to have been created by that operation. Review installation, contradictory
+bytes, or uncertain review durability always preserves the manifest so the
+operation cannot create an orphan review. Multi-class assignment writes journal
+each confirmed absence or original snapshot and conservatively compensate only
+bytes still proven to belong to the incomplete batch.
+
+## Review mutation and exports
+
+Review-unit, observation, rating, feedback, note, requirement, workflow-state,
+and export-metadata services load the shared context and persist through the
+canonical review writer. Page-management services update only the canonical
+manifest while preserving review data and teacher-controlled state.
+
+Student feedback is written only to:
+
+```text
+<work root>/submissions/<student_id>/exports/feedback.md
+<work root>/submissions/<student_id>/exports/feedback.pdf
+```
+
+Stored export metadata must equal those exact canonical paths. Assignment reports
+are written only to `exports/class_summary.csv`, `exports/standards_summary.csv`,
+and `exports/student_performance_summary.csv` beneath the work root. Report
+discovery considers only validated direct student directories beneath the
+canonical `submissions/` directory.
+
+## Scan-review ownership
+
+Core owns workspace-level routing-failure and scan-resolution records. Quillan
+interprets Core schema-version-2 metadata, establishes ownership from the exact
+route locator or target (or the bounded pre-dispatch ownership marker), derives
+work identity from the locator, and writes resolutions through Core's v2 factory
+and writer. Evidence must be an existing ordinary file at an exact canonical
+POSIX workspace-relative path.
+
+Failures after successful dispatch are not Core routing failures. Quillan stores
+each attributable observation, routed-evidence, assembly, mixed-issuance, or
+manifest failure as an append-only occurrence at:
+
+```text
+<work root>/scans/review/post_dispatch/<failure_id>.json
+```
+
+These records retain complete deterministic tuples of issuance, page, route,
+observation, scan, source-page, and possible-path provenance and are discovered
+through a distinct typed service. Each persisted result also carries its validated
+workspace root and exact Quillan work reference, which reconstruct both its
+absolute and relative paths. Core routing resolutions are never written for them. A teacher UI
+for resolving these occurrences belongs to issue #341; this service migration
+does not redesign commands, help, menus, or dashboards.

--- a/docs/pds2_scan_intake.md
+++ b/docs/pds2_scan_intake.md
@@ -1,5 +1,12 @@
 # Retained PDS2 Scan Intake
 
+Successful Quillan dispatch results persist observations, routed evidence, and
+issuance-authoritative manifests beneath the exact module-qualified work root.
+Failures in that post-dispatch layer are not converted into Core routing failures;
+they are preserved as append-only Quillan work-local occurrences. Core-v2 and
+Quillan ownership details are documented in
+[Module-qualified record services](module_qualified_record_services.md).
+
 This boundary accepts exactly `.pdf`, `.png`, `.jpg`, `.jpeg`, `.tif`, and
 `.tiff` sources. A file operation handles one source. Folder intake is
 nonrecursive, orders direct children by case-folded then exact name, skips

--- a/docs/response_page_observations.md
+++ b/docs/response_page_observations.md
@@ -1,5 +1,12 @@
 # Response-Page Observations
 
+Observation and routed-evidence records are Quillan-owned descendants of the
+exact module-qualified work root. Their paths are derived from the shared work
+identity; submission and review services do not reinterpret routed filenames.
+Post-dispatch persistence failures are stored separately from Core routing
+failures as append-only Quillan occurrences. See
+[Module-qualified record services](module_qualified_record_services.md).
+
 One durable Quillan page observation is identified by the deterministic SHA-256
 key `source_scan_id + source_page_number + route_id + page_id` under the domain
 `quillan-response-page-observation-v1`. Its ID is `obs_` plus the first 32

--- a/docs/scan_routing_design.md
+++ b/docs/scan_routing_design.md
@@ -1,5 +1,12 @@
 # Scan Routing Design
 
+Core continues to own workspace-level routing failures and scan resolutions.
+Quillan consumes Core schema-version-2 metadata and establishes ownership from
+exact locators, targets, or its bounded pre-dispatch marker. Failures after a
+successful Quillan dispatch use the distinct work-local post-dispatch occurrence
+contract described in
+[Module-qualified record services](module_qualified_record_services.md).
+
 ## Installed Quillan handler (#337)
 
 Core invokes the installed Quillan response-page handler with a validated

--- a/quillan/assignment_discovery.py
+++ b/quillan/assignment_discovery.py
@@ -13,6 +13,7 @@ from quillan.work_paths import (
     QuillanWorkPathError,
     _is_link_like,
     preflight_quillan_work_collection,
+    preflight_work_file_destination,
     quillan_work_paths,
 )
 
@@ -45,18 +46,33 @@ def discover_quillan_assignments(
     for entry in entries:
         try:
             validate_identifier(entry.name, "assignment_id")
-        except IdentifierValidationError:
+        except IdentifierValidationError as error:
+            discovered.append(
+                DiscoveredAssignment(
+                    entry.name,
+                    entry / "assignment.json",
+                    None,
+                    f"Invalid direct assignment child ID: {error}",
+                )
+            )
             continue
         path = quillan_work_paths(
             workspace_root, class_id, entry.name
         ).assignment_path
         try:
             if _is_link_like(entry) or not entry.is_dir():
-                continue
+                raise AssignmentConfigError(
+                    "Assignment work child is not an ordinary non-link directory."
+                )
+            preflight_work_file_destination(
+                workspace_root,
+                quillan_work_paths(workspace_root, class_id, entry.name).work_ref,
+                "assignment.json",
+            )
             if _is_link_like(path) or not path.is_file():
-                continue
+                raise AssignmentConfigError("Assignment config is missing.")
             assignment = load_assignment_config(path)
-        except (AssignmentConfigError, OSError) as error:
+        except (AssignmentConfigError, QuillanWorkPathError, OSError) as error:
             discovered.append(
                 DiscoveredAssignment(entry.name, path, None, str(error))
             )
@@ -69,6 +85,16 @@ def discover_quillan_assignments(
                     None,
                     "Path assignment_id does not match assignment config "
                     "assignment_id.",
+                )
+            )
+            continue
+        if class_id not in assignment["class_ids"]:
+            discovered.append(
+                DiscoveredAssignment(
+                    entry.name,
+                    path,
+                    None,
+                    "Assignment config class_ids does not include its containing class.",
                 )
             )
             continue

--- a/quillan/assignment_setup.py
+++ b/quillan/assignment_setup.py
@@ -12,7 +12,6 @@ from pds_core.standards import load_workspace_standards_library
 
 from quillan.assignments import (
     AssignmentConfigError,
-    load_assignment_config,
     validate_assignment_standards_selection,
 )
 from quillan.assignment_workflows import (
@@ -23,6 +22,13 @@ from quillan.assignment_workflows import (
     write_assignment_config,
 )
 from quillan.storage import assignment_config_path
+from quillan.record_context import (
+    canonical_workspace_root,
+    QuillanRecordContextError,
+    load_quillan_assignment_context,
+    mutable_json_copy,
+)
+from quillan.work_paths import quillan_work_ref
 
 
 @dataclass(frozen=True)
@@ -52,7 +58,7 @@ def plan_assignment_creation(
     allow_return_without_full_review: bool = True,
 ) -> AssignmentPlan:
     """Validate creation inputs without creating directories or files."""
-    root = Path(workspace_root).resolve(strict=False)
+    root = canonical_workspace_root(workspace_root)
     validate_identifier(class_id, "class_id")
     validate_identifier(assignment_id, "assignment_id")
     load_class_roster(root, class_id)
@@ -96,20 +102,19 @@ def load_canonical_assignment(
     workspace_root: str | Path, class_id: str, assignment_id: str
 ) -> AssignmentPlan:
     """Load and check one canonical assignment's path identity."""
-    root = Path(workspace_root).resolve(strict=False)
-    validate_identifier(class_id, "class_id")
-    validate_identifier(assignment_id, "assignment_id")
-    path = assignment_config_path(root, class_id, assignment_id)
-    assignment = load_assignment_config(path)
-    if assignment["assignment_id"] != assignment_id:
-        raise AssignmentConfigError(
-            "Path assignment_id does not match assignment config assignment_id."
+    try:
+        context = load_quillan_assignment_context(
+            workspace_root, quillan_work_ref(class_id, assignment_id)
         )
-    if class_id not in assignment["class_ids"]:
-        raise AssignmentConfigError(
-            "Path class_id is not included in assignment config class_ids."
-        )
-    return AssignmentPlan(root, class_id, assignment_id, path, assignment)
+    except QuillanRecordContextError as error:
+        raise AssignmentConfigError(str(error)) from error
+    return AssignmentPlan(
+        context.paths.workspace_root,
+        class_id,
+        assignment_id,
+        context.paths.assignment_path,
+        mutable_json_copy(context.assignment),
+    )
 
 
 def validate_canonical_assignment(plan: AssignmentPlan) -> None:

--- a/quillan/assignment_summary_context.py
+++ b/quillan/assignment_summary_context.py
@@ -4,19 +4,36 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any
 
 from pds_core.classes import load_class_roster
 from pds_core.rosters import RosterError, StudentRecord, student_display_name
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.routing_models import ModuleWorkRef
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
-from quillan.review_record import ReviewRecordError, load_review_record
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
+from quillan.assignments import AssignmentConfigError
+from quillan.record_context import (
+    InvalidReviewError,
+    InvalidSubmissionError,
+    MissingSubmissionError,
+    OrphanReviewError,
+    QuillanRecordContextError,
+    RecordIdentityMismatchError,
+    ReviewLoadingPolicy,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+    student_record_paths,
 )
-from quillan.storage import assignment_config_path, assignment_submissions_dir
+from quillan.work_paths import (
+    quillan_work_paths,
+    quillan_work_ref,
+    review_record_path as canonical_review_record_path,
+    student_submission_dir,
+    submission_manifest_path as canonical_submission_manifest_path,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,6 +44,8 @@ class SummaryStudent:
     display_name: str
     roster_status: str
     student_dir: Path
+    workspace_root: Path
+    work_ref: ModuleWorkRef
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,17 +63,20 @@ class LoadedStudentRecord:
 
 
 def assignment_path(workspace_root: Path, class_id: str, assignment_id: str) -> Path:
-    return assignment_config_path(workspace_root, class_id, assignment_id)
+    return quillan_work_paths(workspace_root, class_id, assignment_id).assignment_path
 
 
 def submissions_dir(workspace_root: Path, class_id: str, assignment_id: str) -> Path:
-    return assignment_submissions_dir(workspace_root, class_id, assignment_id)
+    return quillan_work_paths(workspace_root, class_id, assignment_id).submissions_dir
 
 
 def load_assignment(workspace_root: Path, class_id: str, assignment_id: str) -> dict[str, Any]:
     try:
-        assignment = load_assignment_config(assignment_path(workspace_root, class_id, assignment_id))
-    except (OSError, AssignmentConfigError) as error:
+        context = load_quillan_assignment_context(
+            workspace_root, quillan_work_ref(class_id, assignment_id)
+        )
+        assignment = mutable_json_copy(context.assignment)
+    except (OSError, AssignmentConfigError, QuillanRecordContextError) as error:
         raise ValueError(f"Could not load assignment config: {error}") from error
     if class_id not in assignment["class_ids"]:
         raise ValueError(f"Assignment {assignment_id!r} is not configured for class {class_id!r}.")
@@ -69,6 +91,7 @@ def discover_students(
     base_submissions_dir = submissions_dir(workspace_root, class_id, assignment_id)
     submission_ids = _submission_ids(base_submissions_dir)
     roster_students = _roster_students(workspace_root, class_id)
+    work_ref = quillan_work_ref(class_id, assignment_id)
     students: list[SummaryStudent] = []
 
     if roster_students is not None:
@@ -80,7 +103,11 @@ def discover_students(
                     student_id=roster_student.student_id,
                     display_name=student_display_name(roster_student),
                     roster_status="rostered",
-                    student_dir=base_submissions_dir / roster_student.student_id,
+                    student_dir=student_submission_dir(
+                        workspace_root, work_ref, roster_student.student_id
+                    ),
+                    workspace_root=workspace_root,
+                    work_ref=work_ref,
                 )
             )
         for student_id in sorted(submission_ids - roster_ids):
@@ -89,7 +116,11 @@ def discover_students(
                     student_id=student_id,
                     display_name=student_id,
                     roster_status="unrostered_submission",
-                    student_dir=base_submissions_dir / student_id,
+                    student_dir=student_submission_dir(
+                        workspace_root, work_ref, student_id
+                    ),
+                    workspace_root=workspace_root,
+                    work_ref=work_ref,
                 )
             )
         return tuple(students)
@@ -99,7 +130,9 @@ def discover_students(
             student_id=student_id,
             display_name=student_id,
             roster_status="roster_unavailable",
-            student_dir=base_submissions_dir / student_id,
+            student_dir=student_submission_dir(workspace_root, work_ref, student_id),
+            workspace_root=workspace_root,
+            work_ref=work_ref,
         )
         for student_id in sorted(submission_ids)
     )
@@ -114,41 +147,62 @@ def load_student_record(
     if student.roster_status == "unrostered_submission":
         warnings.append("unrostered_submission")
 
-    manifest_path = student.student_dir / "submission.json"
-    review_path = student.student_dir / "review.json"
+    try:
+        paths = student_record_paths(
+            student.workspace_root, student.work_ref, student.student_id
+        )
+    except QuillanRecordContextError:
+        return LoadedStudentRecord(
+            student,
+            canonical_submission_manifest_path(
+                student.workspace_root, student.work_ref, student.student_id
+            ),
+            canonical_review_record_path(
+                student.workspace_root, student.work_ref, student.student_id
+            ),
+            None,
+            None,
+            "false",
+            "false",
+            tuple((*warnings, "unsafe_path")),
+        )
+    manifest_path = paths.submission_manifest_path
+    review_path = paths.review_record_path
     submission: dict[str, Any] | None = None
     review: dict[str, Any] | None = None
     submission_valid = "false"
     review_valid = "false"
 
-    if not manifest_path.is_file():
+    try:
+        context = load_quillan_student_review_context(
+            student.workspace_root,
+            student.work_ref,
+            student.student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+        )
+    except MissingSubmissionError:
         warnings.append("missing_submission")
-    else:
-        try:
-            submission = load_submission_manifest(manifest_path)
+    except OrphanReviewError:
+        warnings.extend(("missing_submission", "invalid_review", "orphan_review"))
+    except InvalidSubmissionError:
+        warnings.append("invalid_submission")
+    except InvalidReviewError as error:
+        if error.submission_record is not None:
+            submission = mutable_json_copy(error.submission_record.value)
             submission_valid = "true"
-        except (OSError, SubmissionManifestError):
-            warnings.append("invalid_submission")
-        if submission is not None and _has_identity_mismatch(
-            submission, class_id, assignment_id, student.student_id
-        ):
-            warnings.append("identity_mismatch")
-            submission_valid = "false"
-
-    if submission_valid == "true":
-        if not review_path.is_file():
+        warnings.append("invalid_review")
+    except RecordIdentityMismatchError:
+        warnings.append("identity_mismatch")
+    except QuillanRecordContextError:
+        warnings.append("unsafe_path")
+    else:
+        submission = mutable_json_copy(context.submission)
+        submission_valid = "true"
+        if context.review is None:
             warnings.append("missing_review")
         else:
-            try:
-                review = load_review_record(review_path)
-                review_valid = "true"
-            except (OSError, ReviewRecordError):
-                warnings.append("invalid_review")
-            if review is not None and _has_identity_mismatch(
-                review, class_id, assignment_id, student.student_id
-            ):
-                warnings.append("identity_mismatch")
-                review_valid = "false"
+            review = mutable_json_copy(context.review)
+            review_valid = "true"
 
     return LoadedStudentRecord(
         student=student,
@@ -218,12 +272,28 @@ def feedback_status(
 
 
 def relative_path_for(path: Path, workspace_root: Path) -> str:
-    return path.resolve(strict=False).relative_to(workspace_root).as_posix()
+    return Path(os.path.abspath(path)).relative_to(workspace_root).as_posix()
 
 
 def _submission_ids(path: Path) -> set[str]:
     try:
-        return {entry.name for entry in path.iterdir() if entry.is_dir()}
+        if not os.path.lexists(path):
+            return set()
+        if _is_link_like(path) or not path.is_dir():
+            raise ValueError("Submission collection is not an ordinary directory.")
+        identifiers: set[str] = set()
+        for entry in path.iterdir():
+            if _is_link_like(entry) or not entry.is_dir():
+                raise ValueError(
+                    f"Invalid direct submission child: {entry.name}"
+                )
+            try:
+                identifiers.add(validate_identifier(entry.name, "student_id"))
+            except IdentifierValidationError as error:
+                raise ValueError(
+                    f"Invalid student submission child: {entry.name}"
+                ) from error
+        return identifiers
     except (FileNotFoundError, NotADirectoryError):
         return set()
     except OSError as error:
@@ -251,3 +321,8 @@ def _has_identity_mismatch(
             ("student_id", student_id),
         )
     )
+
+
+def _is_link_like(path: Path) -> bool:
+    is_junction = getattr(path, "is_junction", None)
+    return path.is_symlink() or bool(is_junction is not None and is_junction())

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -7,9 +7,10 @@ import os
 import re
 import unicodedata
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from pds_core.classes import ClassFolder, list_class_folders
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
@@ -26,6 +27,16 @@ from quillan.assignments import (
     AssignmentConfigError,
     load_assignment_config,
     validate_assignment_config,
+)
+from quillan.atomic_record_io import (
+    AtomicRecordDurabilityError,
+    create_exclusive_record,
+    revision_guarded_update,
+)
+from quillan.record_context import (
+    LoadedJsonRecord,
+    canonical_workspace_root,
+    load_quillan_assignment_context,
 )
 from quillan.assignment_picker import prompt_assignment_choice
 from quillan.storage import assignment_config_path
@@ -82,6 +93,29 @@ _DEFAULT_RATING_SCALE = {
     ],
 }
 _T = TypeVar("_T")
+
+
+class AssignmentBatchWriteError(AssignmentConfigError):
+    """A multi-class write failed, with conservative compensation details."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        possibly_durable_paths: tuple[Path, ...],
+        rollback_diagnostics: tuple[str, ...],
+    ) -> None:
+        super().__init__(message)
+        self.possibly_durable_paths = possibly_durable_paths
+        self.rollback_diagnostics = rollback_diagnostics
+
+
+@dataclass(slots=True)
+class _AssignmentWriteJournalEntry:
+    path: Path
+    original: LoadedJsonRecord | None
+    replacement_bytes: bytes
+    status: Literal["pending", "unchanged", "created", "updated"] = "pending"
 
 
 def suggest_assignment_id(title: str) -> str:
@@ -191,32 +225,254 @@ def write_assignment_config(
     overwrite: bool = False,
 ) -> Path:
     """Write a validated assignment config to its canonical shared path."""
+    return write_assignment_configs(
+        workspace_root, (class_id,), assignment, overwrite=overwrite
+    )[0]
+
+
+def write_assignment_configs(
+    workspace_root: str | Path,
+    class_ids: Sequence[str],
+    assignment: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> tuple[Path, ...]:
+    """Preflight all copies and conservatively compensate an incomplete batch."""
     assignment_data = dict(assignment)
     validate_assignment_config(assignment_data)
-    if class_id not in assignment_data["class_ids"]:
-        raise AssignmentConfigError(
-            "Assignment class_ids must include the selected class_id."
-        )
+    selected = tuple(class_ids)
+    if not selected or len(set(selected)) != len(selected):
+        raise AssignmentConfigError("class_ids must be nonempty and unique.")
+    for class_id in selected:
+        if class_id not in assignment_data["class_ids"]:
+            raise AssignmentConfigError(
+                "Assignment class_ids must include every selected class_id."
+            )
+    root = canonical_workspace_root(workspace_root)
     assignment_id = str(assignment_data["assignment_id"])
-    paths = quillan_work_paths(workspace_root, class_id, assignment_id)
-    path = paths.assignment_path
-    if path.is_file() and not path.is_symlink() and not overwrite:
-        raise FileExistsError(f"Assignment config already exists: {path}")
-    try:
-        preflight_managed_work_layout(paths)
-        preflight_work_file_destination(
-            workspace_root, paths.work_ref, "assignment.json"
-        )
-    except QuillanWorkPathError as error:
-        raise AssignmentConfigError(str(error)) from error
-    if not overwrite and os.path.lexists(path):
-        raise FileExistsError(f"Assignment config already exists: {path}")
-    initialize_managed_work_layout(paths)
-    path.write_text(
-        json.dumps(assignment_data, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
+    bundles = tuple(
+        quillan_work_paths(root, class_id, assignment_id)
+        for class_id in selected
     )
-    return path
+    originals: dict[Path, LoadedJsonRecord | None] = {}
+    for paths in bundles:
+        try:
+            preflight_managed_work_layout(paths)
+            preflight_work_file_destination(
+                root, paths.work_ref, "assignment.json"
+            )
+        except QuillanWorkPathError as error:
+            raise AssignmentConfigError(str(error)) from error
+        path = paths.assignment_path
+        if os.path.lexists(path):
+            if not overwrite:
+                raise FileExistsError(f"Assignment config already exists: {path}")
+            originals[path] = load_quillan_assignment_context(
+                root, paths.work_ref
+            ).assignment_record
+        else:
+            originals[path] = None
+    data = (
+        json.dumps(assignment_data, indent=2, ensure_ascii=False) + "\n"
+    ).encode("utf-8")
+    journal = [
+        _AssignmentWriteJournalEntry(
+            paths.assignment_path,
+            originals[paths.assignment_path],
+            data,
+        )
+        for paths in bundles
+    ]
+    try:
+        for paths in bundles:
+            initialize_managed_work_layout(paths)
+        for paths, entry in zip(bundles, journal, strict=True):
+            path = paths.assignment_path
+
+            def preflight(paths: Any = paths) -> None:
+                preflight_managed_work_layout(paths)
+                preflight_work_file_destination(
+                    root, paths.work_ref, "assignment.json"
+                )
+
+            original = originals[path]
+            if original is None:
+                result = create_exclusive_record(
+                    path,
+                    data,
+                    preflight=preflight,
+                    verify_bytes=lambda loaded: _verify_assignment_bytes(
+                        loaded, assignment_data
+                    ),
+                )
+            else:
+                result = revision_guarded_update(
+                    path,
+                    original.original_bytes,
+                    data,
+                    preflight=preflight,
+                    verify_bytes=lambda loaded: _verify_assignment_bytes(
+                        loaded, assignment_data
+                    ),
+                    lock_purpose="assignment-update",
+                )
+            entry.status = result.status
+    except Exception as error:
+        possible_paths: list[Path] = []
+        diagnostics: list[str] = []
+        if (
+            isinstance(error, AtomicRecordDurabilityError)
+            and error.possibly_durable_path is not None
+        ):
+            possible_paths.append(error.possibly_durable_path)
+        if isinstance(error, AtomicRecordDurabilityError) and error.possible_lock_path:
+            diagnostics.append(
+                f"Possible stale record guard: {error.possible_lock_path}"
+            )
+        for paths, entry in reversed(tuple(zip(bundles, journal, strict=True))):
+            if entry.status not in {"created", "updated"}:
+                continue
+            compensation_error, preserved = _compensate_assignment_entry(
+                root,
+                paths.work_ref,
+                entry,
+            )
+            if compensation_error is not None:
+                diagnostics.append(compensation_error)
+                possible_paths.extend(preserved)
+                error.add_note(compensation_error)
+        possible = tuple(dict.fromkeys(possible_paths))
+        suffix = ""
+        if possible:
+            suffix = " Possibly durable paths: " + "; ".join(map(str, possible))
+        if diagnostics:
+            suffix += " Rollback diagnostics: " + " | ".join(diagnostics)
+        raise AssignmentBatchWriteError(
+            f"Multi-class assignment write did not complete: {error}.{suffix}",
+            possibly_durable_paths=possible,
+            rollback_diagnostics=tuple(diagnostics),
+        ) from error
+    return tuple(paths.assignment_path for paths in bundles)
+
+
+def _compensate_assignment_entry(
+    root: Path,
+    work_ref: Any,
+    entry: _AssignmentWriteJournalEntry,
+) -> tuple[str | None, tuple[Path, ...]]:
+    """Undo only bytes still proven to belong to the current batch."""
+
+    def preflight() -> None:
+        preflight_work_file_destination(root, work_ref, "assignment.json")
+
+    if entry.status == "updated":
+        if entry.original is None:
+            return (
+                f"Updated assignment has no authoritative original snapshot: {entry.path}",
+                (entry.path,),
+            )
+        original_bytes = entry.original.original_bytes
+        try:
+            revision_guarded_update(
+                entry.path,
+                entry.replacement_bytes,
+                original_bytes,
+                preflight=preflight,
+                verify_bytes=lambda loaded: _verify_exact_bytes(
+                    loaded, original_bytes
+                ),
+                lock_purpose="assignment-compensation",
+            )
+        except Exception as error:
+            return (
+                f"Could not conservatively restore updated assignment "
+                f"{entry.path}: {error}",
+                (entry.path,),
+            )
+        return None, ()
+
+    if entry.status != "created":
+        return None, ()
+    displaced = entry.path.parent / (
+        f".{entry.path.name}.assignment-compensation.{os.urandom(16).hex()}.displaced"
+    )
+    try:
+        preflight()
+        if os.path.lexists(displaced):
+            raise OSError(f"compensation displacement already exists: {displaced}")
+        os.replace(entry.path, displaced)
+        actual = displaced.read_bytes()
+        if actual == entry.replacement_bytes:
+            displaced.unlink()
+            return None, ()
+        _restore_compensation_displacement(displaced, entry.path)
+        preserved = tuple(
+            path for path in (entry.path, displaced) if os.path.lexists(path)
+        )
+        return (
+            f"Created assignment changed before compensation and was preserved: "
+            f"{entry.path}",
+            preserved or (entry.path,),
+        )
+    except Exception as error:
+        if os.path.lexists(displaced):
+            try:
+                _restore_compensation_displacement(displaced, entry.path)
+            except OSError as restore_error:
+                error.add_note(f"Compensation restore also failed: {restore_error}")
+        preserved = tuple(
+            path for path in (entry.path, displaced) if os.path.lexists(path)
+        )
+        return (
+            f"Could not conservatively remove created assignment {entry.path}: {error}",
+            preserved or (entry.path,),
+        )
+
+
+def _restore_compensation_displacement(displaced: Path, target: Path) -> None:
+    """Restore displaced concurrent bytes exclusively, never overwriting a writer."""
+    if os.path.lexists(target):
+        return
+    try:
+        os.link(displaced, target)
+    except FileExistsError:
+        return
+    displaced.unlink()
+
+
+def _verify_exact_bytes(actual: bytes, expected: bytes) -> None:
+    if actual != expected:
+        raise AssignmentConfigError("Compensated assignment bytes did not verify.")
+
+
+def _verify_assignment_bytes(data: bytes, expected: dict[str, Any]) -> None:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise AssignmentConfigError(f"Duplicate assignment JSON key: {key}")
+            result[key] = value
+        return result
+
+    try:
+        loaded = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=reject_duplicates,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                AssignmentConfigError(f"Invalid JSON constant: {value}")
+            ),
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise AssignmentConfigError(
+            f"Persisted assignment is not strict JSON: {error}"
+        ) from error
+    if not isinstance(loaded, dict):
+        raise AssignmentConfigError("Persisted assignment is not an object.")
+    validate_assignment_config(loaded)
+    if loaded != expected:
+        raise AssignmentConfigError(
+            "Reloaded assignment differs from the committed model."
+        )
 
 
 def format_assignment_summary(
@@ -729,15 +985,14 @@ def prompt_create_assignment() -> int:
         overwrite = True
 
     try:
-        saved_paths = [
-            write_assignment_config(
+        saved_paths = list(
+            write_assignment_configs(
                 workspace_root,
-                class_id,
+                class_ids,
                 assignment,
                 overwrite=overwrite,
             )
-            for class_id in class_ids
-        ]
+        )
     except (AssignmentConfigError, OSError, FileExistsError) as error:
         print(f"Error: {error}")
         return 1

--- a/quillan/atomic_record_io.py
+++ b/quillan/atomic_record_io.py
@@ -1,0 +1,419 @@
+"""Low-level revision-guarded persistence for canonical Quillan records."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Literal
+
+
+class AtomicRecordError(OSError):
+    """A guarded canonical record operation failed before known completion."""
+
+
+class AtomicRecordConcurrencyError(AtomicRecordError):
+    """The target revision changed before this operation could install bytes."""
+
+
+class AtomicRecordDurabilityError(AtomicRecordError):
+    """An installed target may be durable and is deliberately preserved."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        possibly_durable_path: Path | None,
+        possible_lock_path: Path | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.possibly_durable_path = possibly_durable_path
+        self.possible_lock_path = possible_lock_path
+
+
+@dataclass(frozen=True, slots=True)
+class AtomicRecordResult:
+    path: Path
+    status: Literal["created", "updated", "unchanged"]
+
+
+Preflight = Callable[[], None]
+VerifyBytes = Callable[[bytes], None]
+
+
+def create_exclusive_record(
+    path: Path,
+    replacement_bytes: bytes,
+    *,
+    preflight: Preflight,
+    verify_bytes: VerifyBytes,
+) -> AtomicRecordResult:
+    """Install a same-directory temporary exclusively and verify exact bytes."""
+    _require_arguments(path, replacement_bytes)
+    preflight()
+    if os.path.lexists(path):
+        raise AtomicRecordConcurrencyError(f"Record already exists: {path}")
+    lock_path = path.parent / f".{path.name}.create.lock"
+    token = b"quillan-atomic-record-v1\0" + os.urandom(32)
+    lock_owned = False
+    temporary: Path | None = None
+    installed = False
+    outcome: Literal["created", "updated", "unchanged"] | None = None
+    primary: BaseException | None = None
+    try:
+        try:
+            with lock_path.open("xb") as lock_file:
+                lock_owned = True
+                lock_file.write(token)
+                lock_file.flush()
+                os.fsync(lock_file.fileno())
+        except FileExistsError as error:
+            raise AtomicRecordConcurrencyError(
+                f"Record creation guard already exists: {lock_path}"
+            ) from error
+        preflight()
+        if os.path.lexists(path):
+            raise AtomicRecordConcurrencyError(f"Record was concurrently created: {path}")
+        temporary = _write_temporary(path, replacement_bytes)
+        preflight()
+        if os.path.lexists(path):
+            raise AtomicRecordConcurrencyError(f"Record was concurrently created: {path}")
+        try:
+            os.link(temporary, path)
+        except FileExistsError as error:
+            raise AtomicRecordConcurrencyError(
+                f"Record was concurrently created: {path}"
+            ) from error
+        installed = True
+        try:
+            temporary.unlink()
+        except OSError as error:
+            raise AtomicRecordDurabilityError(
+                f"Record was installed but its owned temporary could not be removed: {error}",
+                possibly_durable_path=path,
+            ) from error
+        temporary = None
+        _verify_installed(path, replacement_bytes, preflight, verify_bytes)
+        outcome = "created"
+        return AtomicRecordResult(path, "created")
+    except Exception as error:
+        primary = error
+        if installed and not isinstance(error, AtomicRecordDurabilityError):
+            durable = AtomicRecordDurabilityError(
+                f"Record installation or verification is uncertain: {error}",
+                possibly_durable_path=path,
+            )
+            durable.__cause__ = error
+            primary = durable
+            raise durable
+        raise
+    finally:
+        active_error = primary if primary is not None else sys.exception()
+        _cleanup_owned_temporary(temporary, active_error)
+        if lock_owned:
+            _remove_owned_lock(
+                lock_path,
+                token,
+                target_path=path,
+                operation_status=outcome if outcome is not None else (
+                    "created" if installed else None
+                ),
+                primary=active_error,
+            )
+
+
+def revision_guarded_update(
+    path: Path,
+    expected_original_bytes: bytes,
+    replacement_bytes: bytes,
+    *,
+    preflight: Preflight,
+    verify_bytes: VerifyBytes,
+    lock_purpose: str,
+) -> AtomicRecordResult:
+    """Update only the exact loaded revision under a same-directory guard.
+
+    Once replacement occurs, this primitive never rolls older bytes back.  A
+    failure or concurrent edit after installation is preserved and reported as
+    possibly durable instead of risking another writer's data.
+    """
+    _require_arguments(path, replacement_bytes)
+    if type(expected_original_bytes) is not bytes:
+        raise TypeError("expected_original_bytes must be exact bytes.")
+    if type(lock_purpose) is not str or not lock_purpose:
+        raise TypeError("lock_purpose must be non-empty text.")
+    preflight()
+    _compare_revision(path, expected_original_bytes)
+    lock_path = path.parent / f".{path.name}.{lock_purpose}.lock"
+    token = b"quillan-atomic-record-v1\0" + os.urandom(32)
+    lock_owned = False
+    temporary: Path | None = None
+    displaced: Path | None = None
+    displaced_matches_expected = False
+    installed = False
+    outcome: Literal["created", "updated", "unchanged"] | None = None
+    primary: BaseException | None = None
+    try:
+        try:
+            with lock_path.open("xb") as lock_file:
+                lock_owned = True
+                lock_file.write(token)
+                lock_file.flush()
+                os.fsync(lock_file.fileno())
+        except FileExistsError as error:
+            raise AtomicRecordConcurrencyError(
+                f"Record update guard already exists: {lock_path}"
+            ) from error
+        preflight()
+        _compare_revision(path, expected_original_bytes)
+        if replacement_bytes == expected_original_bytes:
+            verify_bytes(expected_original_bytes)
+            outcome = "unchanged"
+            return AtomicRecordResult(path, "unchanged")
+        temporary = _write_temporary(path, replacement_bytes)
+        preflight()
+        _compare_revision(path, expected_original_bytes)
+        displaced = path.parent / (
+            f".{path.name}.{lock_purpose}.{token.hex()}.displaced"
+        )
+        if os.path.lexists(displaced):
+            raise AtomicRecordConcurrencyError(
+                f"Displaced-revision path unexpectedly exists: {displaced}"
+            )
+        os.replace(path, displaced)
+        displaced_actual = _read_ordinary_file(displaced)
+        if displaced_actual != expected_original_bytes:
+            raise AtomicRecordConcurrencyError(
+                "Record changed immediately before guarded displacement."
+            )
+        displaced_matches_expected = True
+        try:
+            os.link(temporary, path)
+        except FileExistsError as error:
+            raise AtomicRecordConcurrencyError(
+                "Record was concurrently recreated before exclusive installation."
+            ) from error
+        installed = True
+        try:
+            temporary.unlink()
+        except OSError as error:
+            raise AtomicRecordDurabilityError(
+                f"Updated record was installed but its temporary remains: {error}",
+                possibly_durable_path=path,
+            ) from error
+        temporary = None
+        _verify_installed(path, replacement_bytes, preflight, verify_bytes)
+        displaced.unlink()
+        displaced = None
+        outcome = "updated"
+        return AtomicRecordResult(path, "updated")
+    except Exception as error:
+        primary = error
+        if installed and not isinstance(error, AtomicRecordDurabilityError):
+            durable = AtomicRecordDurabilityError(
+                f"Updated record may be durable and was not rolled back: {error}",
+                possibly_durable_path=path,
+            )
+            durable.__cause__ = error
+            primary = durable
+            raise durable
+        raise
+    finally:
+        active_error = primary if primary is not None else sys.exception()
+        if displaced is not None and not installed and active_error is not None:
+            _restore_displaced_revision(
+                displaced,
+                path,
+                known_original=displaced_matches_expected,
+                primary=active_error,
+            )
+            if not os.path.lexists(displaced):
+                displaced = None
+        _cleanup_owned_temporary(temporary, active_error)
+        if displaced is not None and installed and displaced_matches_expected:
+            _cleanup_owned_temporary(displaced, active_error)
+        if lock_owned:
+            _remove_owned_lock(
+                lock_path,
+                token,
+                target_path=path,
+                operation_status=outcome if outcome is not None else (
+                    "updated" if installed else None
+                ),
+                primary=active_error,
+            )
+
+
+def _write_temporary(path: Path, data: bytes) -> Path:
+    descriptor = -1
+    temporary: Path | None = None
+    completed = False
+    try:
+        descriptor, name = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+        )
+        temporary = Path(name)
+        with os.fdopen(descriptor, "wb") as file:
+            descriptor = -1
+            file.write(data)
+            file.flush()
+            os.fsync(file.fileno())
+        completed = True
+        return temporary
+    finally:
+        if not completed:
+            active_error = sys.exception()
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError as error:
+                    if active_error is not None:
+                        active_error.add_note(
+                            f"Temporary descriptor cleanup also failed: {error}"
+                        )
+            if temporary is not None:
+                try:
+                    temporary.unlink(missing_ok=True)
+                except OSError as error:
+                    if active_error is not None:
+                        active_error.add_note(
+                            f"Owned temporary cleanup also failed: {error}"
+                        )
+
+
+def _verify_installed(
+    path: Path,
+    expected: bytes,
+    preflight: Preflight,
+    verify_bytes: VerifyBytes,
+) -> None:
+    preflight()
+    actual = _read_ordinary_file(path)
+    if actual != expected:
+        raise AtomicRecordConcurrencyError(
+            f"Installed record bytes changed before verification: {path}"
+        )
+    verify_bytes(actual)
+
+
+def _compare_revision(path: Path, expected: bytes) -> None:
+    actual = _read_ordinary_file(path)
+    if actual != expected:
+        raise AtomicRecordConcurrencyError(
+            f"Record changed after its snapshot was loaded: {path}"
+        )
+
+
+def _read_ordinary_file(path: Path) -> bytes:
+    if not os.path.lexists(path):
+        raise AtomicRecordConcurrencyError(f"Record is missing: {path}")
+    if _is_link_like(path) or not path.is_file():
+        raise AtomicRecordConcurrencyError(
+            f"Record is not an ordinary non-link file: {path}"
+        )
+    return path.read_bytes()
+
+
+def _cleanup_owned_temporary(
+    temporary: Path | None, primary: BaseException | None
+) -> None:
+    if temporary is None:
+        return
+    try:
+        temporary.unlink(missing_ok=True)
+    except OSError as error:
+        if primary is not None:
+            primary.add_note(f"Owned temporary cleanup also failed: {error}")
+        else:
+            raise AtomicRecordError(
+                f"Could not remove owned temporary file {temporary}: {error}"
+            ) from error
+
+
+def _restore_displaced_revision(
+    displaced: Path,
+    target: Path,
+    *,
+    known_original: bool,
+    primary: BaseException,
+) -> None:
+    """Restore exclusively, never replacing a concurrently recreated target."""
+    try:
+        if os.path.lexists(target):
+            if known_original:
+                displaced.unlink()
+            else:
+                primary.add_note(
+                    f"A concurrently displaced revision was preserved at {displaced}."
+                )
+            return
+        try:
+            os.link(displaced, target)
+        except FileExistsError:
+            if known_original:
+                displaced.unlink()
+            else:
+                primary.add_note(
+                    f"A concurrently displaced revision was preserved at {displaced}."
+                )
+            return
+        displaced.unlink()
+    except OSError as error:
+        primary.add_note(
+            f"Could not conservatively restore displaced revision {displaced}: {error}"
+        )
+
+
+def _remove_owned_lock(
+    lock_path: Path,
+    token: bytes,
+    *,
+    target_path: Path,
+    operation_status: Literal["created", "updated", "unchanged"] | None,
+    primary: BaseException | None,
+) -> None:
+    try:
+        if _is_link_like(lock_path) or not lock_path.is_file():
+            raise AtomicRecordError(f"Update guard changed filesystem type: {lock_path}")
+        if lock_path.read_bytes() != token:
+            raise AtomicRecordError(f"Update guard ownership changed: {lock_path}")
+        lock_path.unlink()
+    except OSError as error:
+        if primary is not None:
+            primary.add_note(
+                f"Owned record-guard cleanup also failed; possible stale lock "
+                f"{lock_path}: {error}"
+            )
+        else:
+            installed_path = (
+                target_path if operation_status in {"created", "updated"} else None
+            )
+            qualifier = (
+                f"The {operation_status} record remains installed and may be durable."
+                if installed_path is not None
+                else "No new record installation is claimed."
+            )
+            raise AtomicRecordDurabilityError(
+                f"Could not conservatively remove record guard {lock_path}: {error}. "
+                f"{qualifier}",
+                possibly_durable_path=installed_path,
+                possible_lock_path=lock_path,
+            ) from error
+
+
+def _require_arguments(path: Path, data: bytes) -> None:
+    if type(path) is not type(Path()) or not path.is_absolute():
+        raise TypeError("path must be an absolute Path.")
+    if type(data) is not bytes:
+        raise TypeError("replacement_bytes must be exact bytes.")
+
+
+def _is_link_like(path: Path) -> bool:
+    is_junction = getattr(path, "is_junction", None)
+    return path.is_symlink() or bool(is_junction is not None and is_junction())
+
+
+__all__: list[str] = []

--- a/quillan/class_summary_export.py
+++ b/quillan/class_summary_export.py
@@ -22,7 +22,15 @@ from quillan.assignment_summary_context import (
     relative_path_for,
     standard_column_keys,
 )
-from quillan.work_paths import quillan_work_paths
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    class_summary_path,
+    feedback_markdown_path,
+    feedback_pdf_path,
+    preflight_work_file_destination,
+    quillan_work_ref,
+)
+from quillan.record_context import canonical_workspace_root
 
 BASE_CSV_COLUMNS: Final[tuple[str, ...]] = (
     "class_id",
@@ -83,9 +91,9 @@ def class_summary_export_path(
     """Return the compatibility path for the comprehensive class summary."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
-    return quillan_work_paths(
-        workspace_root, class_id, assignment_id
-    ).exports_dir / "class_summary.csv"
+    return class_summary_path(
+        workspace_root, quillan_work_ref(class_id, assignment_id)
+    )
 
 
 def export_class_review_summary(
@@ -99,16 +107,29 @@ def export_class_review_summary(
     """Export one deterministic CSV row per rostered or discovered student."""
     normalized_created_at = _normalize_timestamp(created_at)
     try:
-        resolved_root = Path(workspace_root).resolve(strict=False)
+        resolved_root = canonical_workspace_root(workspace_root)
         output_path = class_summary_export_path(
             resolved_root, class_id, assignment_id
         )
         assignment = load_assignment(resolved_root, class_id, assignment_id)
+        expected_output = preflight_work_file_destination(
+            resolved_root,
+            quillan_work_ref(class_id, assignment_id),
+            Path("exports") / "class_summary.csv",
+        )
+        if output_path != expected_output:
+            raise ClassSummaryExportError("Class summary path is not canonical.")
         focus_standard_ids = list(assignment["focus_standard_ids"])
         column_keys, key_warnings = standard_column_keys(focus_standard_ids)
         labels = rating_labels(assignment)
         students = discover_students(resolved_root, class_id, assignment_id)
-    except (OSError, RuntimeError, ValueError, ClassSummaryExportError) as error:
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        QuillanWorkPathError,
+        ClassSummaryExportError,
+    ) as error:
         raise ClassSummaryExportError(str(error)) from error
 
     overwrote_existing = output_path.exists()
@@ -189,13 +210,17 @@ def _build_student_row(
     student = loaded.student
     review = loaded.review
     warnings = list(loaded.warnings) + list(key_warnings)
-    feedback_pdf_path = student.student_dir / "exports" / "feedback.pdf"
-    feedback_markdown_path = student.student_dir / "exports" / "feedback.md"
+    canonical_pdf_path = feedback_pdf_path(
+        workspace_root, student.work_ref, student.student_id
+    )
+    canonical_markdown_path = feedback_markdown_path(
+        workspace_root, student.work_ref, student.student_id
+    )
     pdf_path, pdf_status, pdf_stale, pdf_warnings = feedback_status(
-        workspace_root, review, "feedback_pdf", feedback_pdf_path
+        workspace_root, review, "feedback_pdf", canonical_pdf_path
     )
     md_path, md_status, md_stale, md_warnings = feedback_status(
-        workspace_root, review, "feedback_markdown", feedback_markdown_path
+        workspace_root, review, "feedback_markdown", canonical_markdown_path
     )
     warnings.extend(pdf_warnings)
     warnings.extend(md_warnings)

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -770,7 +770,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--evidence-path",
         help=(
             "Optional workspace-relative evidence path for evidence_filed; "
-            "the file is not copied or required to exist."
+            "it must be an existing ordinary non-link file in the affected work."
         ),
     )
     resolve_scan_review_parser.set_defaults(handler=handle_resolve_scan_review)

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -30,28 +30,30 @@ from reportlab.platypus import (
     TableStyle,
 )
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.review_record import (
     ReviewRecordError,
-    load_review_record,
     validate_review_record,
 )
 from quillan.review_record_paths import (
     ReviewRecordPathError,
-    review_record_path,
-    write_review_record,
+    persist_quillan_review_record,
 )
-from quillan.storage import assignment_config_path
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
-)
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_dir,
-    submission_manifest_path,
+from quillan.record_context import (
+    MissingReviewError,
+    MissingSubmissionError,
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
 )
 from quillan.submission_guidance import missing_submission_guidance
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    feedback_markdown_path,
+    feedback_pdf_path,
+    preflight_work_file_destination,
+    quillan_work_ref,
+)
 
 
 class FeedbackExportError(Exception):
@@ -136,10 +138,8 @@ def feedback_export_path(
     student_id: str,
 ) -> Path:
     """Return the canonical student-facing Markdown feedback export path."""
-    return (
-        submission_dir(workspace_root, class_id, assignment_id, student_id)
-        / "exports"
-        / "feedback.md"
+    return feedback_markdown_path(
+        workspace_root, quillan_work_ref(class_id, assignment_id), student_id
     )
 
 
@@ -150,10 +150,8 @@ def feedback_pdf_export_path(
     student_id: str,
 ) -> Path:
     """Return the canonical student-facing PDF feedback export path."""
-    return (
-        submission_dir(workspace_root, class_id, assignment_id, student_id)
-        / "exports"
-        / "feedback.pdf"
+    return feedback_pdf_path(
+        workspace_root, quillan_work_ref(class_id, assignment_id), student_id
     )
 
 
@@ -173,6 +171,9 @@ def export_student_feedback(
     )
     output_path = feedback_export_path(
         context["workspace_root"], class_id, assignment_id, student_id
+    )
+    _preflight_feedback_destination(
+        context["workspace_root"], class_id, assignment_id, student_id, output_path
     )
     feedback = _assemble_student_feedback(context)
     markdown = _render_feedback_markdown(feedback)
@@ -228,6 +229,17 @@ def export_student_feedback_pdf(
         if include_markdown_companion
         else None
     )
+    _preflight_feedback_destination(
+        context["workspace_root"], class_id, assignment_id, student_id, pdf_path
+    )
+    if markdown_path is not None:
+        _preflight_feedback_destination(
+            context["workspace_root"],
+            class_id,
+            assignment_id,
+            student_id,
+            markdown_path,
+        )
     existing_paths = [
         path for path in (pdf_path, markdown_path) if path is not None and path.exists()
     ]
@@ -291,77 +303,34 @@ def _load_export_context(
     created_at: str,
 ) -> dict[str, Any]:
     try:
-        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_workspace_root, class_id, assignment_id, student_id
+        work_ref = quillan_work_ref(class_id, assignment_id)
+        loaded = load_quillan_student_review_context(
+            workspace_root,
+            work_ref,
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED,
         )
-        record_path = review_record_path(
-            resolved_workspace_root, class_id, assignment_id, student_id
-        )
-        assignment_path = assignment_config_path(
-            resolved_workspace_root, class_id, assignment_id
-        )
-    except (
-        OSError,
-        RuntimeError,
-        SubmissionManifestPathError,
-        ReviewRecordPathError,
-    ) as error:
-        raise FeedbackExportError(str(error)) from error
-
-    if not manifest_path.exists():
-        raise FeedbackExportError(missing_submission_guidance())
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        raise FeedbackExportError(
-            f"Could not load submission manifest: {error}"
-        ) from error
-    _validate_identity(
-        manifest,
-        record_name="Submission manifest",
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-    )
-
-    if not record_path.exists():
+    except MissingSubmissionError as error:
+        raise FeedbackExportError(missing_submission_guidance()) from error
+    except MissingReviewError as error:
         raise FeedbackExportError(
             "Review record does not exist for "
             f"class={class_id}, assignment={assignment_id}, student={student_id}."
-        )
-    try:
-        review = load_review_record(record_path)
-    except (OSError, ReviewRecordError) as error:
-        raise FeedbackExportError(f"Could not load review record: {error}") from error
-    _validate_identity(
-        review,
-        record_name="Review record",
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-    )
-    try:
-        assignment = load_assignment_config(assignment_path)
-    except (AssignmentConfigError, OSError):
-        assignment = None
-    if assignment is not None:
-        if assignment["assignment_id"] != assignment_id:
-            raise FeedbackExportError(
-                "Assignment config assignment_id is "
-                f"{assignment['assignment_id']!r}, expected {assignment_id!r}."
-            )
-        if class_id not in assignment["class_ids"]:
-            raise FeedbackExportError(
-                f"Assignment config class_ids does not include {class_id!r}."
-            )
+        ) from error
+    except (OSError, RuntimeError, ValueError, QuillanRecordContextError) as error:
+        raise FeedbackExportError(str(error)) from error
+    assert loaded.review is not None
+    resolved_workspace_root = loaded.paths.workspace_root
+    record_path = loaded.paths.review_record_path
     return {
+        "record_context": loaded,
         "workspace_root": resolved_workspace_root,
-        "manifest_path": manifest_path,
+        "work_ref": work_ref,
+        "manifest_path": loaded.paths.submission_manifest_path,
         "record_path": record_path,
-        "manifest": manifest,
-        "review": review,
-        "assignment": assignment,
+        "manifest": mutable_json_copy(loaded.submission),
+        "review": mutable_json_copy(loaded.review),
+        "assignment": mutable_json_copy(loaded.assignment_context.assignment),
         "created_at": created_at,
         "class_id": class_id,
         "assignment_id": assignment_id,
@@ -377,11 +346,8 @@ def _assemble_student_feedback(context: dict[str, Any]) -> _StudentFeedback:
     student_id = context["student_id"]
     if review["review_state"] == "returned_without_full_review":
         unmet_requirements = _validated_returned_work_requirements(
-            context["workspace_root"],
-            class_id,
-            assignment_id,
             review,
-            assignment=assignment,
+            assignment,
         )
         returned_work = {
             "outcome": review["minimum_requirement_outcome"],
@@ -661,12 +627,8 @@ def _included_review_unit_observations(review: dict[str, Any]) -> list[dict[str,
 
 
 def _validated_returned_work_requirements(
-    workspace_root: Path,
-    class_id: str,
-    assignment_id: str,
     review: dict[str, Any],
-    *,
-    assignment: dict[str, Any] | None = None,
+    assignment: dict[str, Any],
 ) -> list[dict[str, Any]]:
     outcome = review["minimum_requirement_outcome"]
     if outcome["returned_without_full_review"] is not True:
@@ -679,15 +641,6 @@ def _validated_returned_work_requirements(
             "Returned-work export requires a non-empty outcome teacher note."
         )
 
-    if assignment is None:
-        try:
-            assignment = load_assignment_config(
-                assignment_config_path(workspace_root, class_id, assignment_id)
-            )
-        except (AssignmentConfigError, OSError) as error:
-            raise FeedbackExportError(
-                f"Could not load assignment config: {error}"
-            ) from error
     configured_keys = _configured_requirement_keys(assignment)
     unmet_requirements = [
         check
@@ -999,7 +952,7 @@ def _update_export_metadata(
     review["updated_at"] = created_at
     try:
         validate_review_record(review)
-        write_review_record(context["record_path"], review, overwrite=True)
+        persist_quillan_review_record(context["record_context"], review)
     except (ReviewRecordError, ReviewRecordPathError, OSError, ValueError) as error:
         raise FeedbackExportError(f"Could not update review export metadata: {error}") from error
 
@@ -1109,6 +1062,27 @@ def _write_feedback(path: Path, content: str, *, overwrite: bool) -> None:
                 temporary_path.unlink(missing_ok=True)
             except OSError:
                 pass
+
+
+def _preflight_feedback_destination(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    path: Path,
+) -> None:
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    filename = "feedback.pdf" if path.suffix == ".pdf" else "feedback.md"
+    try:
+        expected = preflight_work_file_destination(
+            workspace_root,
+            work_ref,
+            Path("submissions") / student_id / "exports" / filename,
+        )
+    except QuillanWorkPathError as error:
+        raise FeedbackExportError(str(error)) from error
+    if path != expected:
+        raise FeedbackExportError("Feedback export path is not canonical.")
 
 
 def _normalize_timestamp(value: datetime | str | None) -> str:

--- a/quillan/intake_assembly.py
+++ b/quillan/intake_assembly.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from pds_core.module_dispatch import RouteDispatchSuccess
 
 from quillan.pds2_scan_intake import QuillanScanIntakeSummary
+from quillan.pds_contract import QUILLAN_MODULE_ID
+from quillan.post_dispatch_review import (
+    PersistedPostDispatchReviewOccurrence,
+    create_post_dispatch_review_occurrence,
+)
 from quillan.response_page_dispatch import QuillanResponsePageDispatchResult
 from quillan.response_page_observation_persistence import (
     QuillanObservationPersistenceBatch,
@@ -17,7 +22,7 @@ from quillan.submission_observation_assembly import (
     QuillanSubmissionAssemblyBatch,
     assemble_quillan_scan_observations,
 )
-
+from quillan.work_paths import quillan_work_ref
 
 @dataclass(frozen=True, slots=True)
 class IntakeAssemblyTarget:
@@ -27,10 +32,32 @@ class IntakeAssemblyTarget:
 
 
 @dataclass(frozen=True, slots=True)
+class PostDispatchReviewPreservationBatch:
+    """Best-effort occurrence writes and explicit preservation diagnostics."""
+
+    persisted: tuple[PersistedPostDispatchReviewOccurrence, ...] = ()
+    failures: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if type(self.persisted) is not tuple or type(self.failures) is not tuple:
+            raise ValueError("Post-dispatch preservation collections must be tuples.")
+        if any(
+            type(item) is not PersistedPostDispatchReviewOccurrence
+            for item in self.persisted
+        ):
+            raise ValueError("Post-dispatch persisted members have the wrong type.")
+        if any(not isinstance(item, str) or not item for item in self.failures):
+            raise ValueError("Post-dispatch preservation failures must be text.")
+
+
+@dataclass(frozen=True, slots=True)
 class QuillanPostDispatchPersistenceResult:
     intake_summary: QuillanScanIntakeSummary
     observation_persistence: QuillanObservationPersistenceBatch
     submission_assembly: QuillanSubmissionAssemblyBatch
+    review_preservation: PostDispatchReviewPreservationBatch = field(
+        default_factory=PostDispatchReviewPreservationBatch
+    )
 
     def __post_init__(self) -> None:
         if type(self.intake_summary) is not QuillanScanIntakeSummary:
@@ -39,6 +66,8 @@ class QuillanPostDispatchPersistenceResult:
             raise ValueError("observation_persistence has the wrong type.")
         if type(self.submission_assembly) is not QuillanSubmissionAssemblyBatch:
             raise ValueError("submission_assembly has the wrong type.")
+        if type(self.review_preservation) is not PostDispatchReviewPreservationBatch:
+            raise ValueError("review_preservation has the wrong type.")
         if self.observation_persistence.intake_summary != self.intake_summary:
             raise ValueError("Persistence batch belongs to a different intake summary.")
         processed = len(self.observation_persistence.persisted) + len(
@@ -72,7 +101,7 @@ def assembly_targets_from_intake_summary(
         if (
             not isinstance(outcome, RouteDispatchSuccess)
             or type(outcome) is not RouteDispatchSuccess
-            or outcome.profile.module_id != "quillan"
+            or outcome.profile.module_id != QUILLAN_MODULE_ID
             or type(outcome.module_result) is not QuillanResponsePageDispatchResult
         ):
             continue
@@ -92,11 +121,130 @@ def persist_and_assemble_quillan_scan_successes(
     """Run the durable #339 layer without mutating #338 outcomes."""
     persistence = persist_quillan_scan_observations(workspace_root, intake_summary)
     assembly = assemble_quillan_scan_observations(workspace_root, persistence)
+    preservation = preserve_post_dispatch_review_occurrences(
+        workspace_root, intake_summary, persistence, assembly
+    )
     return QuillanPostDispatchPersistenceResult(
         intake_summary=intake_summary,
         observation_persistence=persistence,
         submission_assembly=assembly,
+        review_preservation=preservation,
     )
+
+
+def preserve_post_dispatch_review_occurrences(
+    workspace_root: Path,
+    intake_summary: QuillanScanIntakeSummary,
+    persistence: QuillanObservationPersistenceBatch,
+    assembly: QuillanSubmissionAssemblyBatch,
+) -> PostDispatchReviewPreservationBatch:
+    """Preserve every attributable post-dispatch failure without masking siblings."""
+    persisted: list[PersistedPostDispatchReviewOccurrence] = []
+    failures: list[str] = []
+    outcomes: dict[
+        tuple[str, int, str | None, str | None],
+        QuillanResponsePageDispatchResult,
+    ] = {
+        (
+            result.source_scan_id,
+            result.source_page_number,
+            result.route_id,
+            result.page_id,
+        ): result
+        for page in intake_summary.pages
+        if page.terminal_category == "dispatch_success"
+        and isinstance(page.dispatch_outcome, RouteDispatchSuccess)
+        and type(page.dispatch_outcome) is RouteDispatchSuccess
+        and page.dispatch_outcome.profile.module_id == QUILLAN_MODULE_ID
+        and type(page.dispatch_outcome.module_result)
+        is QuillanResponsePageDispatchResult
+        for result in (page.dispatch_outcome.module_result,)
+    }
+    for observation_failure in persistence.failures:
+        key = (
+            observation_failure.source_scan_id,
+            observation_failure.source_page_number,
+            observation_failure.route_id,
+            observation_failure.page_id,
+        )
+        result = outcomes.get(key)
+        if result is None:
+            failures.append(
+                "Could not attribute observation persistence failure to an exact "
+                f"Quillan work identity: {key!r}"
+            )
+            continue
+        try:
+            persisted.append(
+                create_post_dispatch_review_occurrence(
+                    workspace_root,
+                    quillan_work_ref(result.class_id, result.assignment_id),
+                    category="observation_persistence",
+                    stage="observation_persistence",
+                    failure_message=str(observation_failure.error),
+                    student_id=result.student_id,
+                    issuance_id=result.issuance_id,
+                    page_id=result.page_id,
+                    route_id=result.route_id,
+                    source_scan_id=result.source_scan_id,
+                    source_page_number=result.source_page_number,
+                    possible_observation_path=(
+                        observation_failure.possible_observation_path
+                    ),
+                    possible_evidence_path=observation_failure.possible_evidence_path,
+                    module_details={
+                        "failure_type": type(observation_failure.error).__name__
+                    },
+                )
+            )
+        except Exception as error:
+            failures.append(
+                f"Could not preserve observation failure {key!r}: {error}"
+            )
+    for assembly_failure in assembly.failures:
+        category = _post_dispatch_assembly_category(assembly_failure.category)
+        try:
+            persisted.append(
+                create_post_dispatch_review_occurrence(
+                    workspace_root,
+                    quillan_work_ref(
+                        assembly_failure.class_id, assembly_failure.assignment_id
+                    ),
+                    category=category,
+                    stage="submission_assembly",
+                    failure_message=assembly_failure.reason,
+                    student_id=assembly_failure.student_id,
+                    issuance_ids=assembly_failure.issuance_ids,
+                    page_ids=assembly_failure.page_ids,
+                    observation_ids=assembly_failure.observation_ids,
+                    source_scan_ids=assembly_failure.source_scan_ids,
+                    source_page_numbers=assembly_failure.source_page_numbers,
+                    possible_manifest_path=assembly_failure.possible_manifest_path,
+                    module_details={
+                        "assembly_category": assembly_failure.category,
+                        "failure_type": (
+                            type(assembly_failure.error).__name__
+                            if assembly_failure.error is not None
+                            else None
+                        ),
+                    },
+                )
+            )
+        except Exception as error:
+            failures.append(
+                "Could not preserve submission assembly failure "
+                f"{assembly_failure.class_id}/{assembly_failure.assignment_id}/"
+                f"{assembly_failure.student_id or 'unknown'}: {error}"
+            )
+    return PostDispatchReviewPreservationBatch(tuple(persisted), tuple(failures))
+
+
+def _post_dispatch_assembly_category(category: str) -> str:
+    if category == "mixed_issuances":
+        return "mixed_issuance"
+    if "manifest" in category or category in {"existing_plain_paper_submission"}:
+        return "manifest_conflict"
+    return "submission_assembly"
 
 
 def format_post_dispatch_persistence_result(
@@ -116,6 +264,8 @@ def format_post_dispatch_persistence_result(
         f"Submission manifests updated: {assembly.updated_count}",
         f"Submission manifests unchanged: {assembly.unchanged_count}",
         f"Submission assembly failures: {len(assembly.failures)}",
+        f"Post-dispatch review occurrences: {len(result.review_preservation.persisted)}",
+        f"Post-dispatch preservation failures: {len(result.review_preservation.failures)}",
     ]
     for failure in persistence.failures:
         lines.append(
@@ -129,13 +279,19 @@ def format_post_dispatch_persistence_result(
             f"student={assembly_failure.student_id or 'unknown'}; "
             f"category={assembly_failure.category}; reason={assembly_failure.reason}"
         )
+    lines.extend(
+        f"Post-dispatch preservation failure: {failure}"
+        for failure in result.review_preservation.failures
+    )
     return "\n".join(lines)
 
 
 __all__ = [
     "IntakeAssemblyTarget",
+    "PostDispatchReviewPreservationBatch",
     "QuillanPostDispatchPersistenceResult",
     "assembly_targets_from_intake_summary",
     "format_post_dispatch_persistence_result",
     "persist_and_assemble_quillan_scan_successes",
+    "preserve_post_dispatch_review_occurrences",
 ]

--- a/quillan/minimum_requirement_review.py
+++ b/quillan/minimum_requirement_review.py
@@ -6,9 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
-from quillan.review_record import ReviewRecordError, load_review_record
-from quillan.review_record_paths import ReviewRecordPathError, review_record_path
 from quillan.review_requirements import (
     ReviewRequirementError,
     UpdatedMinimumRequirementOutcome,
@@ -16,16 +13,15 @@ from quillan.review_requirements import (
     set_minimum_requirement_outcome,
     set_requirement_check,
 )
-from quillan.storage import assignment_config_path
 from quillan.submission_guidance import missing_submission_guidance
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
+from quillan.record_context import (
+    MissingSubmissionError,
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
 )
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
-)
+from quillan.work_paths import quillan_work_ref
 
 ExpectedValue = str | int | float
 OUTCOME_STATUSES = (
@@ -226,48 +222,24 @@ def load_minimum_requirement_review_context(
 ) -> MinimumRequirementReviewContext:
     """Load and validate canonical assignment, submission, and optional review."""
     try:
-        root = Path(workspace_root).resolve(strict=False)
-        assignment_path = assignment_config_path(root, class_id, assignment_id)
-        manifest_path = submission_manifest_path(root, class_id, assignment_id, student_id)
-        record_path = review_record_path(root, class_id, assignment_id, student_id)
-    except (OSError, RuntimeError, ValueError, SubmissionManifestPathError, ReviewRecordPathError) as error:
-        raise ReviewRequirementError(str(error)) from error
-
-    try:
-        assignment = load_assignment_config(assignment_path)
-    except (OSError, AssignmentConfigError) as error:
-        raise ReviewRequirementError(str(error)) from error
-    if assignment["assignment_id"] != assignment_id:
-        raise ReviewRequirementError(
-            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
+        loaded = load_quillan_student_review_context(
+            workspace_root,
+            quillan_work_ref(class_id, assignment_id),
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
         )
-    if class_id not in assignment["class_ids"]:
-        raise ReviewRequirementError(
-            f"Assignment config class_ids does not include {class_id!r}."
-        )
-
-    if not manifest_path.exists():
-        raise ReviewRequirementError(missing_submission_guidance())
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        raise ReviewRequirementError(f"Could not load submission manifest: {error}") from error
-    _validate_identity(
-        manifest,
-        "Submission manifest",
-        class_id,
-        assignment_id,
-        student_id,
-    )
-
-    review = None
+    except MissingSubmissionError as error:
+        raise ReviewRequirementError(missing_submission_guidance()) from error
+    except QuillanRecordContextError as error:
+        raise ReviewRequirementError(str(error)) from error
+    root = loaded.paths.workspace_root
+    assignment_path = loaded.assignment_context.paths.assignment_path
+    manifest_path = loaded.paths.submission_manifest_path
+    record_path = loaded.paths.review_record_path
+    assignment = mutable_json_copy(loaded.assignment_context.assignment)
+    review = None if loaded.review is None else mutable_json_copy(loaded.review)
     checks: tuple[dict[str, Any], ...] = ()
-    if record_path.exists():
-        try:
-            review = load_review_record(record_path)
-        except (OSError, ReviewRecordError) as error:
-            raise ReviewRequirementError(f"Could not load review record: {error}") from error
-        _validate_identity(review, "Review record", class_id, assignment_id, student_id)
+    if review is not None:
         checks = tuple(review["minimum_requirement_checks"])
 
     requirements = configured_requirements(assignment)

--- a/quillan/plain_paper_submission.py
+++ b/quillan/plain_paper_submission.py
@@ -4,26 +4,31 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import json
+import os
 from pathlib import Path
+import sys
 from typing import Any
 
 from pds_core.classes import load_class_roster
 from pds_core.identifiers import validate_identifier
 
-from quillan.assignments import load_assignment_config
+from quillan.record_context import (
+    QuillanRecordContextError,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    ReviewLoadingPolicy,
+    student_record_paths,
+)
 from quillan.review_record import build_empty_review_record, validate_review_record
 from quillan.review_record_paths import (
-    review_record_path,
-    write_review_record,
+    create_quillan_review_record,
 )
-from quillan.storage import assignment_config_path
 from quillan.submission_manifest import validate_submission_manifest
 from quillan.submission_manifest_paths import (
-    submission_manifest_path,
-    write_submission_manifest,
+    create_quillan_submission_manifest,
 )
 from quillan.work_paths import (
-    initialize_student_submission_dir,
     quillan_work_ref,
 )
 
@@ -34,6 +39,21 @@ PLAIN_PAPER_WORKFLOW = "plain_paper_submission"
 
 class PlainPaperSubmissionError(ValueError):
     """Raised when a plain-paper submission cannot be safely created."""
+
+
+class PlainPaperSubmissionDurabilityError(PlainPaperSubmissionError):
+    """A paired creation failed with exact possible durable destinations."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        possible_manifest_path: Path | None,
+        possible_review_path: Path | None,
+    ) -> None:
+        super().__init__(message)
+        self.possible_manifest_path = possible_manifest_path
+        self.possible_review_path = possible_review_path
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,7 +90,24 @@ def plan_plain_paper_submission(
     student_id: str,
 ) -> PlainPaperSubmissionPlan:
     """Validate a plain-paper submission request without writing files."""
-    root = Path(workspace_root).resolve(strict=False)
+    return _plan_plain_paper_submission(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        require_absent=True,
+    )
+
+
+def _plan_plain_paper_submission(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+    *,
+    require_absent: bool,
+) -> PlainPaperSubmissionPlan:
+    root = Path(os.path.abspath(Path(workspace_root)))
     for value, field in (
         (class_id, "class_id"),
         (assignment_id, "assignment_id"),
@@ -78,17 +115,12 @@ def plan_plain_paper_submission(
     ):
         validate_identifier(value, field)
 
-    assignment = load_assignment_config(
-        assignment_config_path(root, class_id, assignment_id)
-    )
-    if assignment["assignment_id"] != assignment_id:
-        raise PlainPaperSubmissionError(
-            "The selected assignment ID does not match its assignment config."
-        )
-    if class_id not in assignment["class_ids"]:
-        raise PlainPaperSubmissionError(
-            f"Class {class_id!r} is not included in assignment {assignment_id!r}."
-        )
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    try:
+        load_quillan_assignment_context(root, work_ref)
+        paths = student_record_paths(root, work_ref, student_id)
+    except QuillanRecordContextError as error:
+        raise PlainPaperSubmissionError(str(error)) from error
 
     roster = load_class_roster(root, class_id)
     if not any(student.student_id == student_id for student in roster.students):
@@ -96,14 +128,14 @@ def plan_plain_paper_submission(
             f"Student {student_id!r} is not in the roster for class {class_id!r}."
         )
 
-    manifest_path = submission_manifest_path(root, class_id, assignment_id, student_id)
-    review_path = review_record_path(root, class_id, assignment_id, student_id)
-    if manifest_path.exists():
+    manifest_path = paths.submission_manifest_path
+    review_path = paths.review_record_path
+    if require_absent and os.path.lexists(manifest_path):
         raise PlainPaperSubmissionError(
             "A submission record already exists for this student. "
             "Plain-paper submission was not created."
         )
-    if review_path.exists():
+    if require_absent and os.path.lexists(review_path):
         raise PlainPaperSubmissionError(
             "A review record exists without a submission manifest. "
             "Plain-paper submission was not created. Repair this student "
@@ -115,9 +147,9 @@ def plan_plain_paper_submission(
         assignment_id=assignment_id,
         student_id=student_id,
         submission_manifest_path=manifest_path,
-        submission_manifest_relative_path=manifest_path.relative_to(root).as_posix(),
+        submission_manifest_relative_path=paths.submission_relative_path,
         review_record_path=review_path,
-        review_record_relative_path=review_path.relative_to(root).as_posix(),
+        review_record_relative_path=paths.review_relative_path,
     )
 
 
@@ -130,8 +162,12 @@ def create_plain_paper_submission(
     created_at: datetime | str | None = None,
 ) -> CreatedPlainPaperSubmission:
     """Create an evidence-less manifest and empty v2 review record safely."""
-    plan = plan_plain_paper_submission(
-        workspace_root, class_id, assignment_id, student_id
+    plan = _plan_plain_paper_submission(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        require_absent=False,
     )
 
     timestamp = _timestamp(created_at)
@@ -165,19 +201,94 @@ def create_plain_paper_submission(
     }
     validate_submission_manifest(manifest)
     validate_review_record(review)
+    manifest_bytes = _manifest_bytes(manifest)
+    review_bytes = _review_bytes(review)
 
-    initialize_student_submission_dir(
-        workspace_root,
-        quillan_work_ref(class_id, assignment_id),
-        student_id,
-    )
-    write_submission_manifest(plan.submission_manifest_path, manifest)
+    manifest_state = _record_state(plan.submission_manifest_path, manifest_bytes)
+    review_state = _record_state(plan.review_record_path, review_bytes)
+    if (manifest_state, review_state) != ("absent", "absent"):
+        if (manifest_state, review_state) == ("installed", "installed"):
+            detail = "The exact durable plain-paper pair already exists."
+        elif manifest_state == "absent" and review_state != "absent":
+            detail = "A review exists without a submission manifest."
+        else:
+            detail = (
+                "Existing plain-paper destinations are incomplete or contradictory "
+                f"(manifest={manifest_state}, review={review_state})."
+            )
+        raise PlainPaperSubmissionDurabilityError(
+            f"Plain-paper submission already exists or requires repair. {detail}",
+            possible_manifest_path=(
+                plan.submission_manifest_path if manifest_state != "absent" else None
+            ),
+            possible_review_path=(
+                plan.review_record_path if review_state != "absent" else None
+            ),
+        )
+
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    assignment_context = load_quillan_assignment_context(workspace_root, work_ref)
     try:
-        write_review_record(plan.review_record_path, review)
-    except Exception:
-        # Restore the original no-record state if the paired write cannot finish.
-        plan.submission_manifest_path.unlink(missing_ok=True)
-        raise
+        create_quillan_submission_manifest(
+            assignment_context, student_id, manifest
+        )
+    except Exception as error:
+        possible_manifest = getattr(error, "possibly_durable_path", None)
+        raise PlainPaperSubmissionDurabilityError(
+            f"Could not create plain-paper submission manifest: {error}",
+            possible_manifest_path=possible_manifest,
+            possible_review_path=None,
+        ) from error
+
+    try:
+        review_context = load_quillan_student_review_context(
+            workspace_root,
+            work_ref,
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_MUST_BE_ABSENT,
+        )
+        create_quillan_review_record(review_context, review)
+    except Exception as error:
+        review_state = _record_state(plan.review_record_path, review_bytes)
+        if review_state == "absent":
+            compensation_error = _compensate_owned_manifest(
+                plan.submission_manifest_path,
+                manifest_bytes,
+                plan.review_record_path,
+            )
+            if compensation_error is None:
+                possible_manifest_path = None
+                possible_review_path = None
+            else:
+                error.add_note(compensation_error)
+                possible_manifest_path = (
+                    plan.submission_manifest_path
+                    if os.path.lexists(plan.submission_manifest_path)
+                    else None
+                )
+                post_compensation_review_state = _record_state(
+                    plan.review_record_path, review_bytes
+                )
+                possible_review_path = (
+                    plan.review_record_path
+                    if post_compensation_review_state != "absent"
+                    else None
+                )
+        else:
+            compensation_error = None
+            possible_manifest_path = plan.submission_manifest_path
+            possible_review_path = plan.review_record_path
+        diagnostic = (
+            f" Compensation diagnostic: {compensation_error}"
+            if compensation_error is not None
+            else ""
+        )
+        raise PlainPaperSubmissionDurabilityError(
+            f"Could not create paired plain-paper records: {error}. "
+            f"Review state: {review_state}.{diagnostic}",
+            possible_manifest_path=possible_manifest_path,
+            possible_review_path=possible_review_path,
+        ) from error
 
     return CreatedPlainPaperSubmission(
         class_id=class_id,
@@ -217,3 +328,135 @@ def _timestamp(value: datetime | str | None) -> str:
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         raise PlainPaperSubmissionError("created_at must be timezone-aware.")
     return value
+
+
+def _manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(
+            manifest,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _review_bytes(review: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(review, ensure_ascii=False, allow_nan=False, indent=2) + "\n"
+    ).encode("utf-8")
+
+
+def _record_state(path: Path, expected: bytes) -> str:
+    """Classify one paired destination without treating uncertainty as absence."""
+    try:
+        is_junction = getattr(path, "is_junction", None)
+        if not os.path.lexists(path):
+            return "absent"
+        if (
+            path.is_symlink()
+            or bool(is_junction is not None and is_junction())
+            or not path.is_file()
+        ):
+            return "contradictory"
+        return "installed" if path.read_bytes() == expected else "contradictory"
+    except OSError:
+        return "uncertain"
+
+
+def _compensate_owned_manifest(
+    manifest_path: Path,
+    expected_manifest_bytes: bytes,
+    review_path: Path,
+) -> str | None:
+    """Remove only this operation's manifest while holding the review create guard."""
+    review_lock = review_path.parent / f".{review_path.name}.create.lock"
+    token = b"quillan-plain-paper-compensation-v1\0" + os.urandom(32)
+    try:
+        with review_lock.open("xb") as lock_file:
+            lock_file.write(token)
+            lock_file.flush()
+            os.fsync(lock_file.fileno())
+    except OSError as error:
+        return f"Could not acquire review compensation guard {review_lock}: {error}"
+
+    diagnostic: str | None = None
+    try:
+        diagnostic = _compensate_manifest_under_guard(
+            manifest_path,
+            expected_manifest_bytes,
+            review_path,
+        )
+    finally:
+        primary_error = sys.exception()
+        try:
+            if review_lock.read_bytes() != token:
+                raise OSError("review compensation guard ownership changed")
+            review_lock.unlink()
+        except OSError as error:
+            lock_diagnostic = (
+                f"Possible stale review compensation guard {review_lock}: {error}"
+            )
+            if primary_error is not None:
+                primary_error.add_note(lock_diagnostic)
+            else:
+                diagnostic = (
+                    lock_diagnostic
+                    if diagnostic is None
+                    else f"{diagnostic}; {lock_diagnostic}"
+                )
+    return diagnostic
+
+
+def _compensate_manifest_under_guard(
+    manifest_path: Path,
+    expected_manifest_bytes: bytes,
+    review_path: Path,
+) -> str | None:
+    displaced = manifest_path.parent / (
+        f".{manifest_path.name}.plain-paper-compensation."
+        f"{os.urandom(16).hex()}.displaced"
+    )
+    try:
+        if _record_state(review_path, b"") != "absent":
+            return f"Review destination is no longer definitely absent: {review_path}"
+        if _record_state(manifest_path, expected_manifest_bytes) != "installed":
+            return (
+                "Manifest no longer contains the exact bytes installed by this "
+                f"operation: {manifest_path}"
+            )
+        os.replace(manifest_path, displaced)
+        if displaced.read_bytes() != expected_manifest_bytes:
+            _restore_displaced_manifest(displaced, manifest_path)
+            return f"Manifest changed during compensation and was preserved: {manifest_path}"
+        if os.path.lexists(manifest_path):
+            displaced.unlink()
+            return (
+                "A concurrent manifest now owns the canonical destination; only the "
+                f"current operation's displaced bytes were removed: {manifest_path}"
+            )
+        displaced.unlink()
+        if os.path.lexists(manifest_path):
+            return f"A concurrent manifest was preserved after compensation: {manifest_path}"
+        if _record_state(review_path, b"") != "absent":
+            return f"Review appeared during guarded compensation: {review_path}"
+        return None
+    except OSError as error:
+        if os.path.lexists(displaced):
+            try:
+                _restore_displaced_manifest(displaced, manifest_path)
+            except OSError as restore_error:
+                error.add_note(f"Manifest restore also failed: {restore_error}")
+        return f"Manifest compensation failed: {error}"
+
+
+def _restore_displaced_manifest(displaced: Path, target: Path) -> None:
+    if os.path.lexists(target):
+        return
+    try:
+        os.link(displaced, target)
+    except FileExistsError:
+        return
+    displaced.unlink()

--- a/quillan/post_dispatch_review.py
+++ b/quillan/post_dispatch_review.py
@@ -1,0 +1,892 @@
+"""Append-only, durability-aware Quillan post-dispatch review records."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+import json
+import os
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Final, cast
+from uuid import uuid4
+
+from pds_core.identifiers import validate_identifier
+from pds_core.routing_models import ModuleWorkRef
+
+from quillan.atomic_record_io import (
+    AtomicRecordConcurrencyError,
+    AtomicRecordDurabilityError,
+    AtomicRecordError,
+    create_exclusive_record,
+)
+from quillan.pds_contract import QUILLAN_MODULE_ID
+from quillan.record_context import canonical_workspace_root
+from quillan.scan_review_resolution import QuillanReviewItem, discover_scan_review_items
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    post_dispatch_review_dir,
+    post_dispatch_review_path,
+    preflight_work_directory_destination,
+    preflight_work_file_destination,
+    quillan_work_paths,
+    quillan_work_ref,
+    response_page_observation_path,
+    submission_manifest_path,
+)
+
+POST_DISPATCH_SCHEMA_VERSION: Final = "1"
+POST_DISPATCH_RECORD_TYPE: Final = "post_dispatch_review_occurrence"
+POST_DISPATCH_CATEGORIES: Final[frozenset[str]] = frozenset(
+    {
+        "observation_persistence",
+        "routed_evidence_persistence",
+        "submission_assembly",
+        "mixed_issuance",
+        "manifest_conflict",
+        "post_dispatch_integrity",
+    }
+)
+
+
+class PostDispatchReviewError(RuntimeError):
+    """Raised when a post-dispatch occurrence is invalid or durability is uncertain."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        possibly_durable_path: Path | None = None,
+        possible_lock_path: Path | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.possibly_durable_path = possibly_durable_path
+        self.possible_lock_path = possible_lock_path
+
+
+class QuillanReviewSource(str, Enum):
+    CORE_ROUTING = "core_routing"
+    POST_DISPATCH = "post_dispatch"
+    BOTH = "both"
+
+
+@dataclass(frozen=True, slots=True)
+class PostDispatchReviewOccurrence:
+    failure_id: str
+    category: str
+    stage: str
+    created_at: str
+    class_id: str
+    assignment_id: str
+    student_id: str | None
+    issuance_ids: tuple[str, ...]
+    page_ids: tuple[str, ...]
+    route_ids: tuple[str, ...]
+    observation_ids: tuple[str, ...]
+    source_scan_ids: tuple[str, ...]
+    source_page_numbers: tuple[int, ...]
+    possible_observation_paths: tuple[str, ...]
+    possible_evidence_paths: tuple[str, ...]
+    possible_manifest_paths: tuple[str, ...]
+    failure_message: str
+    module_details: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        _identifier(self.failure_id, "failure_id")
+        _identifier(self.class_id, "class_id")
+        _identifier(self.assignment_id, "assignment_id")
+        if self.student_id is not None:
+            _identifier(self.student_id, "student_id")
+        if (
+            type(self.category) is not str
+            or self.category not in POST_DISPATCH_CATEGORIES
+        ):
+            raise PostDispatchReviewError("Occurrence category is invalid.")
+        if (
+            type(self.stage) is not str
+            or not self.stage
+            or self.stage != self.stage.strip()
+        ):
+            raise PostDispatchReviewError("Occurrence stage must be nonempty text.")
+        if (
+            type(self.failure_message) is not str
+            or not self.failure_message
+            or self.failure_message != self.failure_message.strip()
+        ):
+            raise PostDispatchReviewError(
+                "Occurrence failure_message must be nonempty text."
+            )
+        _timestamp(self.created_at)
+        for field in (
+            "issuance_ids",
+            "page_ids",
+            "route_ids",
+            "observation_ids",
+            "source_scan_ids",
+        ):
+            values = getattr(self, field)
+            _identity_tuple(values, field)
+        _positive_integer_tuple(self.source_page_numbers, "source_page_numbers")
+        for field in (
+            "possible_observation_paths",
+            "possible_evidence_paths",
+            "possible_manifest_paths",
+        ):
+            values = getattr(self, field)
+            if type(values) is not tuple or any(
+                type(item) is not str or not item for item in values
+            ):
+                raise PostDispatchReviewError(f"{field} contains invalid path text.")
+            if values != tuple(sorted(set(values))):
+                raise PostDispatchReviewError(
+                    f"{field} must be a deterministic unique text tuple."
+                )
+        frozen = _freeze_json_mapping(self.module_details)
+        object.__setattr__(self, "module_details", frozen)
+
+    @property
+    def issuance_id(self) -> str | None:
+        return _sole(self.issuance_ids)
+
+    @property
+    def page_id(self) -> str | None:
+        return _sole(self.page_ids)
+
+    @property
+    def route_id(self) -> str | None:
+        return _sole(self.route_ids)
+
+    @property
+    def observation_id(self) -> str | None:
+        return _sole(self.observation_ids)
+
+    @property
+    def source_scan_id(self) -> str | None:
+        return _sole(self.source_scan_ids)
+
+    @property
+    def source_page_number(self) -> int | None:
+        return _sole(self.source_page_numbers)
+
+    @property
+    def possible_observation_path(self) -> str | None:
+        return _sole(self.possible_observation_paths)
+
+    @property
+    def possible_evidence_path(self) -> str | None:
+        return _sole(self.possible_evidence_paths)
+
+    @property
+    def possible_manifest_path(self) -> str | None:
+        return _sole(self.possible_manifest_paths)
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedPostDispatchReviewOccurrence:
+    workspace_root: Path
+    work_ref: ModuleWorkRef
+    occurrence: PostDispatchReviewOccurrence
+    path: Path
+    relative_path: str
+
+    def __post_init__(self) -> None:
+        if type(self.occurrence) is not PostDispatchReviewOccurrence:
+            raise PostDispatchReviewError("Persisted occurrence has the wrong type.")
+        if type(self.workspace_root) is not type(Path()):
+            raise PostDispatchReviewError(
+                "Persisted occurrence workspace_root must be an exact Path."
+            )
+        try:
+            canonical_root = canonical_workspace_root(self.workspace_root)
+        except (OSError, ValueError) as error:
+            raise PostDispatchReviewError(str(error)) from error
+        if canonical_root != self.workspace_root:
+            raise PostDispatchReviewError(
+                "Persisted occurrence workspace_root must be canonical."
+            )
+        if type(self.work_ref) is not ModuleWorkRef:
+            raise PostDispatchReviewError(
+                "Persisted occurrence work_ref must be an exact ModuleWorkRef."
+            )
+        try:
+            canonical_ref = quillan_work_ref(
+                self.occurrence.class_id,
+                self.occurrence.assignment_id,
+            )
+        except (AttributeError, ValueError) as error:
+            raise PostDispatchReviewError(str(error)) from error
+        if self.work_ref != canonical_ref:
+            raise PostDispatchReviewError(
+                "Persisted occurrence work_ref disagrees with occurrence identity."
+            )
+        if type(self.path) is not type(Path()) or not self.path.is_absolute():
+            raise PostDispatchReviewError("Persisted occurrence path must be absolute.")
+        expected_path = post_dispatch_review_path(
+            self.workspace_root,
+            self.work_ref,
+            self.occurrence.failure_id,
+        )
+        if self.path != expected_path:
+            raise PostDispatchReviewError(
+                "Persisted occurrence path is not its exact canonical destination."
+            )
+        _relative_posix(self.relative_path)
+        if self.relative_path != self.path.relative_to(self.workspace_root).as_posix():
+            raise PostDispatchReviewError(
+                "Persisted occurrence relative_path is not exact."
+            )
+        try:
+            preflight_work_file_destination(
+                self.workspace_root,
+                self.work_ref,
+                Path("scans") / "review" / "post_dispatch" / self.path.name,
+            )
+        except QuillanWorkPathError as error:
+            raise PostDispatchReviewError(str(error)) from error
+
+
+@dataclass(frozen=True, slots=True)
+class PostDispatchReviewDiscovery:
+    items: tuple[PersistedPostDispatchReviewOccurrence, ...]
+    warnings: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _typed_tuple(self.items, PersistedPostDispatchReviewOccurrence, "items")
+        _text_tuple(self.warnings, "warnings", unique=False)
+        identities = tuple(item.occurrence.failure_id for item in self.items)
+        if len(set(identities)) != len(identities):
+            raise PostDispatchReviewError("Discovery contains duplicate failure IDs.")
+        if self.items != tuple(
+            sorted(
+                self.items,
+                key=lambda item: (
+                    item.occurrence.created_at,
+                    item.occurrence.failure_id,
+                ),
+            )
+        ):
+            raise PostDispatchReviewError("Discovery items are not deterministic.")
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanOwnedReviewDiscovery:
+    items: tuple[QuillanReviewItem | PersistedPostDispatchReviewOccurrence, ...]
+    core_warnings: tuple[str, ...]
+    post_dispatch_warnings: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.items) is not tuple or any(
+            type(item) not in {QuillanReviewItem, PersistedPostDispatchReviewOccurrence}
+            for item in self.items
+        ):
+            raise PostDispatchReviewError("Combined review items have invalid types.")
+        _text_tuple(self.core_warnings, "core_warnings", unique=False)
+        _text_tuple(
+            self.post_dispatch_warnings,
+            "post_dispatch_warnings",
+            unique=False,
+        )
+
+
+def create_post_dispatch_review_occurrence(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    *,
+    category: str,
+    stage: str,
+    failure_message: str,
+    student_id: str | None = None,
+    issuance_id: str | None = None,
+    page_id: str | None = None,
+    route_id: str | None = None,
+    observation_id: str | None = None,
+    source_scan_id: str | None = None,
+    source_page_number: int | None = None,
+    issuance_ids: tuple[str, ...] = (),
+    page_ids: tuple[str, ...] = (),
+    route_ids: tuple[str, ...] = (),
+    observation_ids: tuple[str, ...] = (),
+    source_scan_ids: tuple[str, ...] = (),
+    source_page_numbers: tuple[int, ...] = (),
+    possible_observation_path: str | Path | None = None,
+    possible_evidence_path: str | Path | None = None,
+    possible_manifest_path: str | Path | None = None,
+    possible_observation_paths: tuple[str | Path, ...] = (),
+    possible_evidence_paths: tuple[str | Path, ...] = (),
+    possible_manifest_paths: tuple[str | Path, ...] = (),
+    module_details: Mapping[str, object] | None = None,
+    created_at: datetime | str | None = None,
+) -> PersistedPostDispatchReviewOccurrence:
+    """Append one occurrence beneath a strictly preflighted affected work root."""
+    root = canonical_workspace_root(workspace_root)
+    if type(work_ref) is not ModuleWorkRef:
+        raise PostDispatchReviewError("work_ref must be an exact ModuleWorkRef.")
+    canonical_ref = quillan_work_ref(work_ref.class_id, work_ref.work_id)
+    if work_ref != canonical_ref:
+        raise PostDispatchReviewError("work_ref must be an exact Quillan work reference.")
+    if student_id is not None:
+        validate_identifier(student_id, "student_id")
+    all_issuance_ids = _merge_identity(issuance_ids, issuance_id, "issuance_ids")
+    all_page_ids = _merge_identity(page_ids, page_id, "page_ids")
+    all_route_ids = _merge_identity(route_ids, route_id, "route_ids")
+    all_observation_ids = _merge_identity(
+        observation_ids, observation_id, "observation_ids"
+    )
+    all_source_scan_ids = _merge_identity(
+        source_scan_ids, source_scan_id, "source_scan_ids"
+    )
+    all_source_page_numbers = _merge_numbers(
+        source_page_numbers, source_page_number
+    )
+    observation_values = _merge_paths(
+        possible_observation_paths, possible_observation_path
+    )
+    evidence_values = _merge_paths(possible_evidence_paths, possible_evidence_path)
+    manifest_values = _merge_paths(possible_manifest_paths, possible_manifest_path)
+    normalized_paths = {
+        "possible_observation_paths": _possible_paths(
+            root,
+            work_ref,
+            observation_values,
+            kind="observation",
+            student_id=student_id,
+            observation_ids=all_observation_ids,
+        ),
+        "possible_evidence_paths": _possible_paths(
+            root,
+            work_ref,
+            evidence_values,
+            kind="evidence",
+            student_id=student_id,
+            observation_ids=all_observation_ids,
+        ),
+        "possible_manifest_paths": _possible_paths(
+            root,
+            work_ref,
+            manifest_values,
+            kind="manifest",
+            student_id=student_id,
+            observation_ids=all_observation_ids,
+        ),
+    }
+    timestamp = _timestamp(created_at)
+    directory = _prepare_directory(root, work_ref)
+    for _ in range(8):
+        failure_id = f"failure_{uuid4().hex}"
+        occurrence = PostDispatchReviewOccurrence(
+            failure_id=failure_id,
+            category=category,
+            stage=stage.strip() if isinstance(stage, str) else stage,
+            created_at=timestamp,
+            class_id=work_ref.class_id,
+            assignment_id=work_ref.work_id,
+            student_id=student_id,
+            failure_message=(
+                failure_message.strip()
+                if isinstance(failure_message, str)
+                else failure_message
+            ),
+            module_details={} if module_details is None else module_details,
+            issuance_ids=all_issuance_ids,
+            page_ids=all_page_ids,
+            route_ids=all_route_ids,
+            observation_ids=all_observation_ids,
+            source_scan_ids=all_source_scan_ids,
+            source_page_numbers=all_source_page_numbers,
+            **normalized_paths,
+        )
+        target = post_dispatch_review_path(root, work_ref, failure_id)
+        if os.path.lexists(target):
+            continue
+        return _write_occurrence(root, work_ref, directory, occurrence)
+    raise PostDispatchReviewError("Could not allocate a unique occurrence ID.")
+
+
+def discover_post_dispatch_review_occurrences(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> PostDispatchReviewDiscovery:
+    root = canonical_workspace_root(workspace_root)
+    canonical_ref = quillan_work_ref(work_ref.class_id, work_ref.work_id)
+    if type(work_ref) is not ModuleWorkRef or work_ref != canonical_ref:
+        raise PostDispatchReviewError("work_ref must be an exact Quillan work reference.")
+    directory = post_dispatch_review_dir(root, work_ref)
+    if not os.path.lexists(directory):
+        preflight_work_directory_destination(
+            root, work_ref, Path("scans") / "review" / "post_dispatch"
+        )
+        return PostDispatchReviewDiscovery((), ())
+    try:
+        preflight_work_directory_destination(
+            root, work_ref, Path("scans") / "review" / "post_dispatch"
+        )
+    except QuillanWorkPathError as error:
+        return PostDispatchReviewDiscovery((), (f"Unsafe review directory: {error}",))
+    items: list[PersistedPostDispatchReviewOccurrence] = []
+    warnings: list[str] = []
+    try:
+        children = tuple(sorted(directory.iterdir(), key=lambda item: item.name))
+    except OSError as error:
+        return PostDispatchReviewDiscovery((), (f"Could not inspect review directory: {error}",))
+    seen: set[str] = set()
+    for path in children:
+        if path.suffix != ".json":
+            continue
+        try:
+            preflight_work_file_destination(
+                root,
+                work_ref,
+                Path("scans") / "review" / "post_dispatch" / path.name,
+            )
+            data = path.read_bytes()
+            occurrence = _occurrence_from_bytes(data, root, work_ref)
+            if path != post_dispatch_review_path(root, work_ref, occurrence.failure_id):
+                raise PostDispatchReviewError("filename and failure_id disagree")
+            if occurrence.failure_id in seen:
+                raise PostDispatchReviewError("duplicate failure_id")
+            seen.add(occurrence.failure_id)
+            items.append(
+                PersistedPostDispatchReviewOccurrence(
+                    root,
+                    work_ref,
+                    occurrence,
+                    path,
+                    path.relative_to(root).as_posix(),
+                )
+            )
+        except (
+            PostDispatchReviewError,
+            QuillanWorkPathError,
+            OSError,
+            UnicodeError,
+            ValueError,
+        ) as error:
+            warnings.append(f"Skipped malformed occurrence {path.name}: {error}")
+    items.sort(key=lambda item: (item.occurrence.created_at, item.occurrence.failure_id))
+    return PostDispatchReviewDiscovery(tuple(items), tuple(warnings))
+
+
+def discover_quillan_owned_review_items(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    *,
+    source: QuillanReviewSource = QuillanReviewSource.BOTH,
+    include_resolved_core: bool = False,
+) -> QuillanOwnedReviewDiscovery:
+    if type(source) is not QuillanReviewSource:
+        raise PostDispatchReviewError("source must be a QuillanReviewSource.")
+    core_items: tuple[QuillanReviewItem, ...] = ()
+    core_warnings: tuple[str, ...] = ()
+    post_items: tuple[PersistedPostDispatchReviewOccurrence, ...] = ()
+    post_warnings: tuple[str, ...] = ()
+    if source in {QuillanReviewSource.CORE_ROUTING, QuillanReviewSource.BOTH}:
+        core = discover_scan_review_items(
+            workspace_root,
+            include_resolved=include_resolved_core,
+            class_id=work_ref.class_id,
+            assignment_id=work_ref.work_id,
+        )
+        core_items, core_warnings = core.items, core.warnings
+    if source in {QuillanReviewSource.POST_DISPATCH, QuillanReviewSource.BOTH}:
+        post = discover_post_dispatch_review_occurrences(workspace_root, work_ref)
+        post_items, post_warnings = post.items, post.warnings
+    return QuillanOwnedReviewDiscovery(
+        (*core_items, *post_items), core_warnings, post_warnings
+    )
+
+
+def _prepare_directory(root: Path, work_ref: ModuleWorkRef) -> Path:
+    try:
+        directory = preflight_work_directory_destination(
+            root, work_ref, Path("scans") / "review" / "post_dispatch"
+        )
+        directory.mkdir(parents=True, exist_ok=True)
+        preflight_work_directory_destination(
+            root, work_ref, Path("scans") / "review" / "post_dispatch"
+        )
+    except (OSError, QuillanWorkPathError) as error:
+        raise PostDispatchReviewError(str(error)) from error
+    return directory
+
+
+def _write_occurrence(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    directory: Path,
+    occurrence: PostDispatchReviewOccurrence,
+) -> PersistedPostDispatchReviewOccurrence:
+    path = post_dispatch_review_path(root, work_ref, occurrence.failure_id)
+    data = _occurrence_bytes(occurrence)
+
+    def preflight() -> None:
+        if canonical_workspace_root(root) != root:
+            raise PostDispatchReviewError("Workspace root identity changed.")
+        expected_directory = preflight_work_directory_destination(
+            root, work_ref, Path("scans") / "review" / "post_dispatch"
+        )
+        if expected_directory != directory:
+            raise PostDispatchReviewError("Review directory identity changed.")
+        preflight_work_file_destination(
+            root,
+            work_ref,
+            Path("scans") / "review" / "post_dispatch" / path.name,
+        )
+
+    try:
+        create_exclusive_record(
+            path,
+            data,
+            preflight=preflight,
+            verify_bytes=lambda loaded: _verify_occurrence_bytes(
+                loaded, root, work_ref, occurrence
+            ),
+        )
+    except AtomicRecordConcurrencyError as error:
+        raise PostDispatchReviewError(f"Occurrence collision: {error}") from error
+    except AtomicRecordDurabilityError as error:
+        raise PostDispatchReviewError(
+            str(error),
+            possibly_durable_path=error.possibly_durable_path,
+            possible_lock_path=error.possible_lock_path,
+        ) from error
+    except (AtomicRecordError, OSError, QuillanWorkPathError) as error:
+        raise PostDispatchReviewError(f"Could not persist occurrence: {error}") from error
+    return PersistedPostDispatchReviewOccurrence(
+        root,
+        work_ref,
+        occurrence,
+        path,
+        path.relative_to(root).as_posix(),
+    )
+
+
+def _occurrence_bytes(occurrence: PostDispatchReviewOccurrence) -> bytes:
+    value = {
+        "schema_version": POST_DISPATCH_SCHEMA_VERSION,
+        "record_type": POST_DISPATCH_RECORD_TYPE,
+        "module_id": QUILLAN_MODULE_ID,
+        **{
+            field: _thaw(getattr(occurrence, field))
+            for field in occurrence.__dataclass_fields__
+        },
+    }
+    return (
+        json.dumps(value, ensure_ascii=False, allow_nan=False, indent=2, sort_keys=True)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _verify_occurrence_bytes(
+    data: bytes,
+    root: Path,
+    work_ref: ModuleWorkRef,
+    expected: PostDispatchReviewOccurrence,
+) -> None:
+    if _occurrence_from_bytes(data, root, work_ref) != expected:
+        raise PostDispatchReviewError(
+            "Reloaded occurrence differs from the committed model."
+        )
+
+
+def _occurrence_from_bytes(
+    data: bytes, root: Path, work_ref: ModuleWorkRef
+) -> PostDispatchReviewOccurrence:
+    def pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise PostDispatchReviewError(f"Duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> Any:
+        raise PostDispatchReviewError(f"Invalid JSON constant: {value}")
+
+    try:
+        value = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=pairs_hook,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise PostDispatchReviewError(f"Occurrence is not strict JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise PostDispatchReviewError("Occurrence must be an object.")
+    fixed = {"schema_version", "record_type", "module_id"}
+    fields = set(PostDispatchReviewOccurrence.__dataclass_fields__)
+    if set(value) != fixed | fields:
+        raise PostDispatchReviewError("Occurrence fields are not exact.")
+    if (
+        value["schema_version"] != POST_DISPATCH_SCHEMA_VERSION
+        or value["record_type"] != POST_DISPATCH_RECORD_TYPE
+        or value["module_id"] != QUILLAN_MODULE_ID
+        or value["class_id"] != work_ref.class_id
+        or value["assignment_id"] != work_ref.work_id
+    ):
+        raise PostDispatchReviewError("Occurrence fixed identity is invalid.")
+    tuple_fields = {
+        "issuance_ids",
+        "page_ids",
+        "route_ids",
+        "observation_ids",
+        "source_scan_ids",
+        "source_page_numbers",
+        "possible_observation_paths",
+        "possible_evidence_paths",
+        "possible_manifest_paths",
+    }
+    for field in tuple_fields:
+        if not isinstance(value[field], list):
+            raise PostDispatchReviewError(f"Occurrence {field} must be an array.")
+    occurrence = PostDispatchReviewOccurrence(
+        failure_id=cast(str, value["failure_id"]),
+        category=cast(str, value["category"]),
+        stage=cast(str, value["stage"]),
+        created_at=cast(str, value["created_at"]),
+        class_id=cast(str, value["class_id"]),
+        assignment_id=cast(str, value["assignment_id"]),
+        student_id=cast(str | None, value["student_id"]),
+        issuance_ids=tuple(cast(list[str], value["issuance_ids"])),
+        page_ids=tuple(cast(list[str], value["page_ids"])),
+        route_ids=tuple(cast(list[str], value["route_ids"])),
+        observation_ids=tuple(cast(list[str], value["observation_ids"])),
+        source_scan_ids=tuple(cast(list[str], value["source_scan_ids"])),
+        source_page_numbers=tuple(
+            cast(list[int], value["source_page_numbers"])
+        ),
+        possible_observation_paths=tuple(
+            cast(list[str], value["possible_observation_paths"])
+        ),
+        possible_evidence_paths=tuple(
+            cast(list[str], value["possible_evidence_paths"])
+        ),
+        possible_manifest_paths=tuple(
+            cast(list[str], value["possible_manifest_paths"])
+        ),
+        failure_message=cast(str, value["failure_message"]),
+        module_details=cast(Mapping[str, object], value["module_details"]),
+    )
+    for item in occurrence.possible_observation_paths:
+        _possible_paths(root, work_ref, (item,), kind="observation", student_id=occurrence.student_id, observation_ids=occurrence.observation_ids)
+    for item in occurrence.possible_evidence_paths:
+        _possible_paths(root, work_ref, (item,), kind="evidence", student_id=occurrence.student_id, observation_ids=occurrence.observation_ids)
+    for item in occurrence.possible_manifest_paths:
+        _possible_paths(root, work_ref, (item,), kind="manifest", student_id=occurrence.student_id, observation_ids=occurrence.observation_ids)
+    return occurrence
+
+
+def _possible_paths(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    values: tuple[str | Path, ...],
+    *,
+    kind: str,
+    student_id: str | None,
+    observation_ids: object,
+) -> tuple[str, ...]:
+    normalized: list[str] = []
+    work_root = quillan_work_paths(root, work_ref.class_id, work_ref.work_id).work_root
+    for value in values:
+        if not isinstance(value, (str, Path)):
+            raise PostDispatchReviewError("Possible durable path has the wrong type.")
+        path = Path(value)
+        absolute = path if path.is_absolute() else root / path
+        absolute = Path(os.path.abspath(absolute))
+        try:
+            work_relative = absolute.relative_to(work_root)
+            workspace_relative = absolute.relative_to(root).as_posix()
+        except ValueError as error:
+            raise PostDispatchReviewError(
+                "Possible durable paths must remain in the affected Quillan work root."
+            ) from error
+        try:
+            preflight_work_file_destination(root, work_ref, work_relative)
+        except QuillanWorkPathError as error:
+            raise PostDispatchReviewError(str(error)) from error
+        if kind == "observation":
+            if not work_relative.as_posix().startswith("scans/observations/"):
+                raise PostDispatchReviewError("Possible observation path is noncanonical.")
+            ids = cast(tuple[str, ...], observation_ids)
+            if len(ids) == 1 and absolute != response_page_observation_path(
+                root, work_ref, ids[0]
+            ):
+                raise PostDispatchReviewError(
+                    "Possible observation path disagrees with observation identity."
+                )
+        elif kind == "evidence":
+            if not work_relative.as_posix().startswith("scans/evidence/"):
+                raise PostDispatchReviewError("Possible evidence path is noncanonical.")
+            if student_id is not None and f"response_{student_id}_" not in absolute.name:
+                raise PostDispatchReviewError(
+                    "Possible evidence path disagrees with student identity."
+                )
+        elif kind == "manifest":
+            if student_id is None or absolute != submission_manifest_path(
+                root, work_ref, student_id
+            ):
+                raise PostDispatchReviewError("Possible manifest path is noncanonical.")
+        else:
+            raise PostDispatchReviewError("Unknown possible-path class.")
+        normalized.append(workspace_relative)
+    return tuple(sorted(set(normalized)))
+
+
+def _merge_identity(
+    values: tuple[str, ...], value: str | None, field: str
+) -> tuple[str, ...]:
+    if type(values) is not tuple:
+        raise PostDispatchReviewError(f"{field} must be a tuple.")
+    combined = values + (() if value is None else (value,))
+    if any(type(item) is not str for item in combined):
+        raise PostDispatchReviewError(f"{field} contains non-text identity.")
+    result = tuple(sorted(set(combined)))
+    _identity_tuple(result, field)
+    return result
+
+
+def _merge_numbers(values: tuple[int, ...], value: int | None) -> tuple[int, ...]:
+    if type(values) is not tuple:
+        raise PostDispatchReviewError("source_page_numbers must be a tuple.")
+    combined = values + (() if value is None else (value,))
+    if any(type(item) is not int for item in combined):
+        raise PostDispatchReviewError(
+            "source_page_numbers must contain exact integers."
+        )
+    result = tuple(sorted(set(combined)))
+    _positive_integer_tuple(result, "source_page_numbers")
+    return result
+
+
+def _merge_paths(
+    values: tuple[str | Path, ...], value: str | Path | None
+) -> tuple[str | Path, ...]:
+    if type(values) is not tuple:
+        raise PostDispatchReviewError("Possible durable paths must be tuples.")
+    return values + (() if value is None else (value,))
+
+
+def _identity_tuple(values: object, field: str) -> None:
+    if type(values) is not tuple:
+        raise PostDispatchReviewError(f"{field} must be an exact tuple.")
+    for value in values:
+        if type(value) is not str:
+            raise PostDispatchReviewError(f"{field} contains non-text identity.")
+        _identifier(value, field.removesuffix("s"))
+    if values != tuple(sorted(set(values))):
+        raise PostDispatchReviewError(f"{field} must be deterministic and unique.")
+
+
+def _positive_integer_tuple(values: object, field: str) -> None:
+    if type(values) is not tuple or any(
+        type(value) is not int or value < 1 for value in values
+    ):
+        raise PostDispatchReviewError(f"{field} must contain positive integers.")
+    if values != tuple(sorted(set(values))):
+        raise PostDispatchReviewError(f"{field} must be deterministic and unique.")
+
+
+def _identifier(value: object, field: str) -> None:
+    if type(value) is not str:
+        raise PostDispatchReviewError(f"{field} must be exact identifier text.")
+    try:
+        validate_identifier(value, field)
+    except ValueError as error:
+        raise PostDispatchReviewError(str(error)) from error
+
+
+def _timestamp(value: datetime | str | None) -> str:
+    candidate: datetime | str = datetime.now(timezone.utc) if value is None else value
+    if isinstance(candidate, datetime):
+        if candidate.tzinfo is None or candidate.utcoffset() is None:
+            raise PostDispatchReviewError("created_at must be timezone-aware.")
+        return candidate.isoformat(timespec="microseconds")
+    if type(candidate) is not str:
+        raise PostDispatchReviewError("created_at must be a datetime or string.")
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as error:
+        raise PostDispatchReviewError("created_at must be ISO 8601 text.") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise PostDispatchReviewError("created_at must be timezone-aware.")
+    return candidate
+
+
+def _freeze_json_mapping(value: Mapping[str, object]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise PostDispatchReviewError("module_details must be an object.")
+    frozen: dict[str, object] = {}
+    for key, item in value.items():
+        if type(key) is not str:
+            raise PostDispatchReviewError(
+                "module_details keys must be exact strings."
+            )
+        if key in frozen:
+            raise PostDispatchReviewError(f"Duplicate module_details key: {key}")
+        frozen[key] = _freeze(item)
+    return MappingProxyType(frozen)
+
+
+def _freeze(value: object) -> object:
+    if isinstance(value, Mapping):
+        return _freeze_json_mapping(cast(Mapping[str, object], value))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    if value is None or type(value) in {str, int, float, bool}:
+        if type(value) is float and (value != value or abs(value) == float("inf")):
+            raise PostDispatchReviewError("module_details must be strict JSON.")
+        return value
+    raise PostDispatchReviewError("module_details must be strict JSON.")
+
+
+def _thaw(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+def _relative_posix(value: str) -> None:
+    if type(value) is not str or not value or "\\" in value:
+        raise PostDispatchReviewError("relative_path is not canonical POSIX text.")
+    path = Path(value)
+    if (
+        path.is_absolute()
+        or path.as_posix() != value
+        or any(part in {".", ".."} for part in path.parts)
+    ):
+        raise PostDispatchReviewError("relative_path is not canonical POSIX text.")
+
+
+def _typed_tuple(values: object, expected: type[object], field: str) -> None:
+    if type(values) is not tuple or any(type(item) is not expected for item in values):
+        raise PostDispatchReviewError(f"{field} has invalid runtime types.")
+
+
+def _text_tuple(values: object, field: str, *, unique: bool) -> None:
+    if type(values) is not tuple or any(type(item) is not str for item in values):
+        raise PostDispatchReviewError(f"{field} must be an exact text tuple.")
+    if unique and values != tuple(sorted(set(values))):
+        raise PostDispatchReviewError(f"{field} must be deterministic and unique.")
+
+
+def _sole(values: tuple[Any, ...]) -> Any | None:
+    return values[0] if len(values) == 1 else None
+
+
+__all__ = [
+    "POST_DISPATCH_CATEGORIES",
+    "POST_DISPATCH_RECORD_TYPE",
+    "POST_DISPATCH_SCHEMA_VERSION",
+    "PersistedPostDispatchReviewOccurrence",
+    "PostDispatchReviewDiscovery",
+    "PostDispatchReviewError",
+    "PostDispatchReviewOccurrence",
+    "QuillanOwnedReviewDiscovery",
+    "QuillanReviewSource",
+    "create_post_dispatch_review_occurrence",
+    "discover_quillan_owned_review_items",
+    "discover_post_dispatch_review_occurrences",
+]

--- a/quillan/record_context.py
+++ b/quillan/record_context.py
@@ -1,0 +1,744 @@
+"""Canonical assignment, submission, and review record service contexts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+import json
+import os
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, TypeAlias, cast
+
+from pds_core.identifiers import validate_identifier
+from pds_core.routing_models import ModuleWorkRef
+
+from quillan.assignments import AssignmentConfigError, validate_assignment_config
+from quillan.review_record import ReviewRecordError, validate_review_record
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    validate_submission_manifest,
+)
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    _preflight_arbitrary_file_destination,
+    feedback_markdown_path,
+    feedback_pdf_path,
+    preflight_work_file_destination,
+    quillan_work_paths,
+    quillan_work_ref,
+    review_record_path,
+    student_exports_dir,
+    student_submission_dir,
+    submission_manifest_path,
+)
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | tuple["JsonValue", ...] | Mapping[str, "JsonValue"]
+
+
+class QuillanRecordContextError(ValueError):
+    """Base error for canonical Quillan record-context operations."""
+
+
+class UnsafeRecordPathError(QuillanRecordContextError):
+    """A canonical path chain is unsafe, linked, escaped, or the wrong type."""
+
+
+class MissingAssignmentError(QuillanRecordContextError):
+    """The canonical module-qualified assignment record is missing."""
+
+
+class InvalidAssignmentError(QuillanRecordContextError):
+    """The canonical assignment record is invalid."""
+
+
+class MissingSubmissionError(QuillanRecordContextError):
+    """The canonical submission manifest is missing."""
+
+
+class InvalidSubmissionError(QuillanRecordContextError):
+    """The canonical submission manifest is invalid."""
+
+
+class MissingReviewError(QuillanRecordContextError):
+    """A required canonical review record is missing."""
+
+
+class InvalidReviewError(QuillanRecordContextError):
+    """The canonical review record is invalid."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        submission_record: LoadedJsonRecord | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.submission_record = submission_record
+
+
+class OrphanReviewError(QuillanRecordContextError):
+    """A review exists without its canonical submission manifest."""
+
+
+class RecordIdentityMismatchError(QuillanRecordContextError):
+    """A loaded record does not match the requested work identity."""
+
+
+class ReviewAlreadyExistsError(QuillanRecordContextError):
+    """A review exists when the operation requires it to be absent."""
+
+
+class ReviewLoadingPolicy(str, Enum):
+    """Explicit review-presence policy for student-context loading."""
+
+    REVIEW_REQUIRED = "review_required"
+    REVIEW_OPTIONAL = "review_optional"
+    REVIEW_MUST_BE_ABSENT = "review_must_be_absent"
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedJsonRecord:
+    """One validated JSON model inseparably bound to its source bytes."""
+
+    path: Path
+    relative_path: str
+    original_bytes: bytes
+    value: Mapping[str, JsonValue]
+
+    def __post_init__(self) -> None:
+        if type(self.path) is not type(Path()) or not self.path.is_absolute():
+            raise QuillanRecordContextError("Loaded record path must be an absolute Path.")
+        if type(self.relative_path) is not str or not self.relative_path:
+            raise QuillanRecordContextError(
+                "Loaded record relative_path must be non-empty POSIX text."
+            )
+        relative = Path(self.relative_path)
+        if (
+            relative.is_absolute()
+            or "\\" in self.relative_path
+            or self.relative_path != relative.as_posix()
+            or any(part in {"", ".", ".."} for part in relative.parts)
+        ):
+            raise QuillanRecordContextError(
+                "Loaded record relative_path must be canonical workspace-relative POSIX text."
+            )
+        if type(self.original_bytes) is not bytes:
+            raise QuillanRecordContextError("Loaded record original_bytes must be exact bytes.")
+        if type(self.value) is not type(MappingProxyType({})):
+            raise QuillanRecordContextError(
+                "Loaded record value must be a recursively immutable mapping."
+            )
+        if not _is_recursively_frozen(self.value):
+            raise QuillanRecordContextError(
+                "Loaded record value contains mutable or non-JSON data."
+            )
+        parsed = _strict_json_object(self.original_bytes, self.path)
+        if _freeze_mapping(parsed) != self.value:
+            raise QuillanRecordContextError(
+                "Loaded record value does not agree with original_bytes."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanAssignmentRecordPaths:
+    """Exact canonical record paths for one Quillan assignment."""
+
+    workspace_root: Path
+    work_ref: ModuleWorkRef
+    work_root: Path
+    assignment_path: Path
+    submissions_dir: Path
+    scans_dir: Path
+    exports_dir: Path
+
+    def __post_init__(self) -> None:
+        _require_absolute_workspace_root(self.workspace_root)
+        expected = quillan_work_paths(
+            self.workspace_root, self.work_ref.class_id, self.work_ref.work_id
+        )
+        if self.work_ref != expected.work_ref:
+            raise QuillanRecordContextError("Assignment path work_ref is not canonical.")
+        actual = (
+            self.work_root,
+            self.assignment_path,
+            self.submissions_dir,
+            self.scans_dir,
+            self.exports_dir,
+        )
+        canonical = (
+            expected.work_root,
+            expected.assignment_path,
+            expected.submissions_dir,
+            expected.scans_dir,
+            expected.exports_dir,
+        )
+        if actual != canonical:
+            raise QuillanRecordContextError("Assignment record paths are not canonical.")
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanStudentRecordPaths:
+    """Exact canonical record and export paths for one student."""
+
+    workspace_root: Path
+    work_ref: ModuleWorkRef
+    student_id: str
+    student_dir: Path
+    submission_manifest_path: Path
+    review_record_path: Path
+    exports_dir: Path
+    feedback_markdown_path: Path
+    feedback_pdf_path: Path
+
+    @property
+    def assignment_relative_path(self) -> str:
+        """Return the exact canonical workspace-relative assignment path."""
+        return quillan_work_paths(
+            Path(), self.work_ref.class_id, self.work_ref.work_id
+        ).assignment_path.as_posix()
+
+    @property
+    def submission_relative_path(self) -> str:
+        """Return the exact canonical workspace-relative manifest path."""
+        return submission_manifest_path(
+            Path(), self.work_ref, self.student_id
+        ).as_posix()
+
+    @property
+    def review_relative_path(self) -> str:
+        """Return the exact canonical workspace-relative review path."""
+        return review_record_path(Path(), self.work_ref, self.student_id).as_posix()
+
+    def __post_init__(self) -> None:
+        _require_absolute_workspace_root(self.workspace_root)
+        validate_identifier(self.student_id, "student_id")
+        expected = (
+            student_submission_dir(self.workspace_root, self.work_ref, self.student_id),
+            submission_manifest_path(self.workspace_root, self.work_ref, self.student_id),
+            review_record_path(self.workspace_root, self.work_ref, self.student_id),
+            student_exports_dir(self.workspace_root, self.work_ref, self.student_id),
+            feedback_markdown_path(self.workspace_root, self.work_ref, self.student_id),
+            feedback_pdf_path(self.workspace_root, self.work_ref, self.student_id),
+        )
+        actual = (
+            self.student_dir,
+            self.submission_manifest_path,
+            self.review_record_path,
+            self.exports_dir,
+            self.feedback_markdown_path,
+            self.feedback_pdf_path,
+        )
+        if actual != expected:
+            raise QuillanRecordContextError("Student record paths are not canonical.")
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanAssignmentRecordContext:
+    """One validated assignment and its immutable canonical path bundle."""
+
+    paths: QuillanAssignmentRecordPaths
+    assignment_record: LoadedJsonRecord
+
+    @property
+    def assignment(self) -> Mapping[str, JsonValue]:
+        return self.assignment_record.value
+
+    def __post_init__(self) -> None:
+        if type(self.paths) is not QuillanAssignmentRecordPaths:
+            raise QuillanRecordContextError("paths must be exact assignment record paths.")
+        record = self.assignment_record
+        if type(record) is not LoadedJsonRecord:
+            raise QuillanRecordContextError("assignment_record must be a LoadedJsonRecord.")
+        if record.path != self.paths.assignment_path:
+            raise QuillanRecordContextError("Assignment snapshot path is not canonical.")
+        expected_relative = self.paths.assignment_path.relative_to(
+            self.paths.workspace_root
+        ).as_posix()
+        if record.relative_path != expected_relative:
+            raise QuillanRecordContextError("Assignment snapshot relative path is not canonical.")
+        try:
+            validate_assignment_config(mutable_json_copy(record.value))
+        except AssignmentConfigError as error:
+            raise QuillanRecordContextError(str(error)) from error
+        _validate_assignment_identity(record.value, self.paths.work_ref)
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanStudentReviewContext:
+    """One coherent assignment, submission, and optional review context."""
+
+    assignment_context: QuillanAssignmentRecordContext
+    paths: QuillanStudentRecordPaths
+    submission_record: LoadedJsonRecord
+    review_record: LoadedJsonRecord | None
+    review_policy: ReviewLoadingPolicy
+
+    @property
+    def submission(self) -> Mapping[str, JsonValue]:
+        return self.submission_record.value
+
+    @property
+    def review(self) -> Mapping[str, JsonValue] | None:
+        return None if self.review_record is None else self.review_record.value
+
+    def __post_init__(self) -> None:
+        if type(self.assignment_context) is not QuillanAssignmentRecordContext:
+            raise QuillanRecordContextError(
+                "assignment_context must be an exact QuillanAssignmentRecordContext."
+            )
+        if type(self.paths) is not QuillanStudentRecordPaths:
+            raise QuillanRecordContextError("paths must be exact student record paths.")
+        if self.paths.workspace_root != self.assignment_context.paths.workspace_root:
+            raise QuillanRecordContextError("Student and assignment workspace roots differ.")
+        if self.paths.work_ref != self.assignment_context.paths.work_ref:
+            raise QuillanRecordContextError("Student and assignment work identities differ.")
+        if type(self.review_policy) is not ReviewLoadingPolicy:
+            raise QuillanRecordContextError("review_policy must be a ReviewLoadingPolicy.")
+        _validate_snapshot_path(
+            self.submission_record,
+            self.paths.submission_manifest_path,
+            self.paths.workspace_root,
+            "Submission",
+        )
+        _validate_student_identity(
+            self.submission_record.value,
+            self.paths.work_ref,
+            self.paths.student_id,
+            "Submission manifest",
+        )
+        try:
+            validate_submission_manifest(mutable_json_copy(self.submission_record.value))
+        except SubmissionManifestError as error:
+            raise QuillanRecordContextError(str(error)) from error
+        if self.review_record is None:
+            if self.review_policy is ReviewLoadingPolicy.REVIEW_REQUIRED:
+                raise QuillanRecordContextError(
+                    "A required-review context cannot omit its review snapshot."
+                )
+            return
+        if self.review_policy is ReviewLoadingPolicy.REVIEW_MUST_BE_ABSENT:
+            raise QuillanRecordContextError(
+                "A review-must-be-absent context cannot contain a review snapshot."
+            )
+        _validate_snapshot_path(
+            self.review_record,
+            self.paths.review_record_path,
+            self.paths.workspace_root,
+            "Review",
+        )
+        _validate_student_identity(
+            self.review_record.value,
+            self.paths.work_ref,
+            self.paths.student_id,
+            "Review record",
+        )
+        try:
+            validate_review_record(mutable_json_copy(self.review_record.value))
+        except ReviewRecordError as error:
+            raise QuillanRecordContextError(str(error)) from error
+        if self.review_record.value["assignment_path"] != self.paths.assignment_relative_path:
+            raise QuillanRecordContextError("Review assignment_path is not canonical.")
+        if (
+            self.review_record.value["submission_manifest_path"]
+            != self.paths.submission_relative_path
+        ):
+            raise QuillanRecordContextError(
+                "Review submission_manifest_path is not canonical."
+            )
+        _validate_review_export_paths(self.review_record.value, self.paths)
+
+
+def assignment_record_paths(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> QuillanAssignmentRecordPaths:
+    """Construct and preflight one exact assignment path context."""
+    if not isinstance(work_ref, ModuleWorkRef):
+        raise QuillanRecordContextError("work_ref must be a ModuleWorkRef.")
+    root = _canonical_workspace_root(workspace_root)
+    expected_ref = quillan_work_ref(work_ref.class_id, work_ref.work_id)
+    if work_ref != expected_ref:
+        raise QuillanRecordContextError("work_ref must be an exact Quillan work reference.")
+    paths = quillan_work_paths(root, work_ref.class_id, work_ref.work_id)
+    return QuillanAssignmentRecordPaths(
+        workspace_root=root,
+        work_ref=paths.work_ref,
+        work_root=paths.work_root,
+        assignment_path=paths.assignment_path,
+        submissions_dir=paths.submissions_dir,
+        scans_dir=paths.scans_dir,
+        exports_dir=paths.exports_dir,
+    )
+
+
+def student_record_paths(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+) -> QuillanStudentRecordPaths:
+    """Construct and preflight one exact student path context."""
+    assignment_paths = assignment_record_paths(workspace_root, work_ref)
+    root = assignment_paths.workspace_root
+    validate_identifier(student_id, "student_id")
+    try:
+        preflight_work_file_destination(
+            root, work_ref, Path("submissions") / student_id / "submission.json"
+        )
+        preflight_work_file_destination(
+            root, work_ref, Path("submissions") / student_id / "review.json"
+        )
+        preflight_work_file_destination(
+            root,
+            work_ref,
+            Path("submissions") / student_id / "exports" / "feedback.md",
+        )
+        preflight_work_file_destination(
+            root,
+            work_ref,
+            Path("submissions") / student_id / "exports" / "feedback.pdf",
+        )
+    except QuillanWorkPathError as error:
+        raise UnsafeRecordPathError(str(error)) from error
+    return QuillanStudentRecordPaths(
+        workspace_root=root,
+        work_ref=work_ref,
+        student_id=student_id,
+        student_dir=student_submission_dir(root, work_ref, student_id),
+        submission_manifest_path=submission_manifest_path(root, work_ref, student_id),
+        review_record_path=review_record_path(root, work_ref, student_id),
+        exports_dir=student_exports_dir(root, work_ref, student_id),
+        feedback_markdown_path=feedback_markdown_path(root, work_ref, student_id),
+        feedback_pdf_path=feedback_pdf_path(root, work_ref, student_id),
+    )
+
+
+def load_quillan_assignment_context(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> QuillanAssignmentRecordContext:
+    """Load only the canonical module-qualified Quillan assignment record."""
+    paths = assignment_record_paths(workspace_root, work_ref)
+    try:
+        preflight_work_file_destination(paths.workspace_root, work_ref, "assignment.json")
+    except QuillanWorkPathError as error:
+        raise UnsafeRecordPathError(str(error)) from error
+    if not os.path.lexists(paths.assignment_path):
+        raise MissingAssignmentError(
+            f"Assignment config not found: {paths.assignment_path}"
+        )
+    try:
+        assignment_record = _load_json_record(
+            paths.assignment_path,
+            paths.workspace_root,
+            validate_assignment_config,
+        )
+    except (AssignmentConfigError, OSError, UnicodeError, ValueError) as error:
+        raise InvalidAssignmentError(str(error)) from error
+    _validate_assignment_identity(assignment_record.value, work_ref)
+    return QuillanAssignmentRecordContext(paths, assignment_record)
+
+
+def load_quillan_student_review_context(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+    *,
+    review_policy: ReviewLoadingPolicy = ReviewLoadingPolicy.REVIEW_OPTIONAL,
+) -> QuillanStudentReviewContext:
+    """Load one coherent canonical student context under an explicit review policy."""
+    if not isinstance(review_policy, ReviewLoadingPolicy):
+        raise QuillanRecordContextError("review_policy must be a ReviewLoadingPolicy.")
+    assignment_context = load_quillan_assignment_context(workspace_root, work_ref)
+    paths = student_record_paths(
+        assignment_context.paths.workspace_root, work_ref, student_id
+    )
+    manifest_exists = os.path.lexists(paths.submission_manifest_path)
+    review_exists = os.path.lexists(paths.review_record_path)
+    if not manifest_exists:
+        if review_exists:
+            raise OrphanReviewError(
+                "A review record exists without its canonical submission manifest."
+            )
+        raise MissingSubmissionError(
+            f"Submission manifest not found: {paths.submission_manifest_path}"
+        )
+    try:
+        submission_record = _load_json_record(
+            paths.submission_manifest_path,
+            paths.workspace_root,
+            validate_submission_manifest,
+        )
+    except (SubmissionManifestError, OSError, UnicodeError, ValueError) as error:
+        raise InvalidSubmissionError(str(error)) from error
+    _validate_student_identity(
+        submission_record.value, work_ref, student_id, "Submission manifest"
+    )
+
+    review_record: LoadedJsonRecord | None = None
+    if review_exists:
+        if review_policy is ReviewLoadingPolicy.REVIEW_MUST_BE_ABSENT:
+            raise ReviewAlreadyExistsError(
+                f"Review record already exists: {paths.review_record_path}"
+            )
+        try:
+            review_record = _load_json_record(
+                paths.review_record_path,
+                paths.workspace_root,
+                validate_review_record,
+            )
+        except (ReviewRecordError, OSError, UnicodeError, ValueError) as error:
+            raise InvalidReviewError(
+                str(error), submission_record=submission_record
+            ) from error
+        review_value = review_record.value
+        _validate_student_identity(review_value, work_ref, student_id, "Review record")
+        if review_value["assignment_path"] != paths.assignment_relative_path:
+            raise InvalidReviewError(
+                "Review assignment_path is not canonical.",
+                submission_record=submission_record,
+            )
+        if review_value["submission_manifest_path"] != paths.submission_relative_path:
+            raise InvalidReviewError(
+                "Review submission_manifest_path is not canonical.",
+                submission_record=submission_record,
+            )
+        try:
+            _validate_review_export_paths(review_value, paths)
+        except InvalidReviewError as error:
+            raise InvalidReviewError(
+                str(error), submission_record=submission_record
+            ) from error
+    elif review_policy is ReviewLoadingPolicy.REVIEW_REQUIRED:
+        raise MissingReviewError(f"Review record not found: {paths.review_record_path}")
+
+    return QuillanStudentReviewContext(
+        assignment_context=assignment_context,
+        paths=paths,
+        submission_record=submission_record,
+        review_record=review_record,
+        review_policy=review_policy,
+    )
+
+
+def mutable_json_copy(value: Mapping[str, JsonValue]) -> dict[str, Any]:
+    """Return an isolated mutable JSON-native copy of an immutable context record."""
+    return cast(dict[str, Any], _thaw(value))
+
+
+def canonical_workspace_root(workspace_root: str | Path) -> Path:
+    """Validate and return the supplied existing non-link workspace root."""
+    return _canonical_workspace_root(workspace_root)
+
+
+def _canonical_workspace_root(workspace_root: str | Path) -> Path:
+    if not isinstance(workspace_root, (str, Path)):
+        raise QuillanRecordContextError("workspace_root must be a string or Path.")
+    root = Path(os.path.abspath(Path(workspace_root)))
+    _require_absolute_workspace_root(root)
+    if not os.path.lexists(root):
+        raise UnsafeRecordPathError(f"Workspace root does not exist: {root}")
+    if _is_link_like(root) or not root.is_dir():
+        raise UnsafeRecordPathError(
+            f"Workspace root must be an ordinary non-link directory: {root}"
+        )
+    return root
+
+
+def _require_absolute_workspace_root(root: Path) -> None:
+    if not isinstance(root, Path) or not root.is_absolute():
+        raise QuillanRecordContextError("workspace_root must be an absolute Path.")
+    if root != Path(os.path.abspath(root)):
+        raise QuillanRecordContextError("workspace_root must be canonical.")
+
+
+def _validate_student_identity(
+    record: Mapping[str, Any],
+    work_ref: ModuleWorkRef,
+    student_id: str,
+    record_name: str,
+) -> None:
+    expected = {
+        "class_id": work_ref.class_id,
+        "assignment_id": work_ref.work_id,
+        "student_id": student_id,
+    }
+    for field, identity in expected.items():
+        if record[field] != identity:
+            raise RecordIdentityMismatchError(
+                f"{record_name} {field} is {record[field]!r}, expected {identity!r}."
+            )
+
+
+def _validate_assignment_identity(
+    assignment: Mapping[str, Any], work_ref: ModuleWorkRef
+) -> None:
+    if assignment["assignment_id"] != work_ref.work_id:
+        raise RecordIdentityMismatchError(
+            "Path assignment_id does not match assignment config assignment_id."
+        )
+    class_ids = assignment["class_ids"]
+    if not isinstance(class_ids, (list, tuple)) or work_ref.class_id not in class_ids:
+        raise RecordIdentityMismatchError(
+            f"Class {work_ref.class_id!r} is not included in assignment "
+            f"{work_ref.work_id!r}."
+        )
+
+
+def _validate_snapshot_path(
+    record: LoadedJsonRecord,
+    path: Path,
+    workspace_root: Path,
+    name: str,
+) -> None:
+    if type(record) is not LoadedJsonRecord:
+        raise QuillanRecordContextError(f"{name} record must be a LoadedJsonRecord.")
+    if record.path != path:
+        raise QuillanRecordContextError(f"{name} snapshot path is not canonical.")
+    if record.relative_path != path.relative_to(workspace_root).as_posix():
+        raise QuillanRecordContextError(
+            f"{name} snapshot relative path is not canonical."
+        )
+
+
+def _load_json_record(
+    path: Path,
+    workspace_root: Path,
+    validator: Any,
+) -> LoadedJsonRecord:
+    try:
+        _preflight_arbitrary_file_destination(path)
+    except QuillanWorkPathError as error:
+        raise UnsafeRecordPathError(str(error)) from error
+    try:
+        original_bytes = path.read_bytes()
+    except OSError:
+        raise
+    value = _strict_json_object(original_bytes, path)
+    validator(value)
+    return LoadedJsonRecord(
+        path=path,
+        relative_path=path.relative_to(workspace_root).as_posix(),
+        original_bytes=original_bytes,
+        value=_freeze_mapping(value),
+    )
+
+
+def _strict_json_object(data: bytes, path: Path) -> dict[str, Any]:
+    def pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"Duplicate JSON object key {key!r}: {path}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> Any:
+        raise ValueError(f"Invalid JSON constant {value!r}: {path}")
+
+    try:
+        text = data.decode("utf-8")
+        value = json.loads(
+            text,
+            object_pairs_hook=pairs_hook,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(
+            f"Record is not valid JSON (strict UTF-8): {path}: {error}"
+        ) from error
+    if not isinstance(value, dict):
+        raise ValueError(f"Record must be a JSON object: {path}")
+    return cast(dict[str, Any], value)
+
+
+def _validate_review_export_paths(
+    review: Mapping[str, Any],
+    paths: QuillanStudentRecordPaths,
+) -> None:
+    exports = review.get("exports")
+    if not isinstance(exports, Mapping):
+        return
+    expected = {
+        "feedback_markdown": paths.feedback_markdown_path.relative_to(
+            paths.workspace_root
+        ).as_posix(),
+        "feedback_pdf": paths.feedback_pdf_path.relative_to(
+            paths.workspace_root
+        ).as_posix(),
+    }
+    for field, canonical_path in expected.items():
+        metadata = exports.get(field)
+        if isinstance(metadata, Mapping) and metadata.get("path") != canonical_path:
+            raise InvalidReviewError(f"Review exports.{field}.path is not canonical.")
+
+
+def _freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, JsonValue]:
+    return MappingProxyType({key: _freeze(item) for key, item in value.items()})
+
+
+def _freeze(value: Any) -> JsonValue:
+    if isinstance(value, dict):
+        return _freeze_mapping(value)
+    if isinstance(value, list):
+        return tuple(_freeze(item) for item in value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise QuillanRecordContextError("Loaded record contains a non-JSON value.")
+
+
+def _thaw(value: JsonValue) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+def _is_recursively_frozen(value: Any) -> bool:
+    if type(value) is type(MappingProxyType({})):
+        mapping = cast(Mapping[str, Any], value)
+        return all(
+            type(key) is str and _is_recursively_frozen(item)
+            for key, item in mapping.items()
+        )
+    if type(value) is tuple:
+        return all(_is_recursively_frozen(item) for item in value)
+    if value is None or type(value) in {str, int, float, bool}:
+        return not (type(value) is float and (value != value or abs(value) == float("inf")))
+    return False
+
+
+def _is_link_like(path: Path) -> bool:
+    is_junction = getattr(path, "is_junction", None)
+    return path.is_symlink() or bool(is_junction is not None and is_junction())
+
+
+__all__ = [
+    "InvalidAssignmentError",
+    "InvalidReviewError",
+    "InvalidSubmissionError",
+    "JsonValue",
+    "LoadedJsonRecord",
+    "MissingAssignmentError",
+    "MissingReviewError",
+    "MissingSubmissionError",
+    "OrphanReviewError",
+    "QuillanAssignmentRecordContext",
+    "QuillanAssignmentRecordPaths",
+    "QuillanRecordContextError",
+    "QuillanStudentRecordPaths",
+    "QuillanStudentReviewContext",
+    "RecordIdentityMismatchError",
+    "ReviewAlreadyExistsError",
+    "ReviewLoadingPolicy",
+    "UnsafeRecordPathError",
+    "assignment_record_paths",
+    "canonical_workspace_root",
+    "load_quillan_assignment_context",
+    "load_quillan_student_review_context",
+    "mutable_json_copy",
+    "student_record_paths",
+]

--- a/quillan/review_dashboard.py
+++ b/quillan/review_dashboard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from collections import Counter
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any, Final
 
@@ -16,20 +17,28 @@ from quillan.assignment_submission_assembly import (
     discover_assignment_routed_evidence_status,
 )
 from quillan.assignment_summary_context import feedback_status, relative_path_for
-from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.storage import assignment_config_path
 from quillan.feedback_export import feedback_export_path, feedback_pdf_export_path
 from quillan.plain_paper_submission import is_plain_paper_submission
-from quillan.review_record import ReviewRecordError, load_review_record
 from quillan.review_status_display import review_progress_status
+from quillan.record_context import (
+    InvalidReviewError,
+    InvalidSubmissionError,
+    MissingSubmissionError,
+    OrphanReviewError,
+    QuillanRecordContextError,
+    RecordIdentityMismatchError,
+    ReviewLoadingPolicy,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+    student_record_paths,
+)
 from quillan.scan_review_resolution import (
     ScanReviewResolutionError,
     discover_scan_review_items,
 )
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
-)
+from quillan.work_paths import _is_link_like, quillan_work_ref
 
 DASHBOARD_SCHEMA_VERSION: Final = "1"
 DASHBOARD_RECORD_TYPE: Final = "quillan_assignment_review_dashboard"
@@ -148,21 +157,13 @@ def build_assignment_review_dashboard(
         validate_identifier(assignment_id, "assignment_id")
     except ValueError as error:
         raise ReviewDashboardError(str(error)) from error
-    root = Path(workspace_root).resolve(strict=False)
-    assignment_path = assignment_config_path(root, class_id, assignment_id)
+    work_ref = quillan_work_ref(class_id, assignment_id)
     try:
-        assignment = load_assignment_config(assignment_path)
-    except (OSError, AssignmentConfigError) as error:
+        assignment_context = load_quillan_assignment_context(workspace_root, work_ref)
+        root = assignment_context.paths.workspace_root
+        assignment = mutable_json_copy(assignment_context.assignment)
+    except (OSError, QuillanRecordContextError) as error:
         raise ReviewDashboardError(f"Could not load assignment: {error}") from error
-    if assignment["assignment_id"] != assignment_id:
-        raise ReviewDashboardError(
-            f"Assignment identity mismatch: expected {assignment_id!r}, "
-            f"found {assignment['assignment_id']!r}."
-        )
-    if class_id not in assignment["class_ids"]:
-        raise ReviewDashboardError(
-            f"Assignment {assignment_id!r} is not configured for class {class_id!r}."
-        )
 
     warnings: list[DashboardWarning] = []
     roster_students: tuple[Any, ...] | None
@@ -172,7 +173,7 @@ def build_assignment_review_dashboard(
         roster_students = None
         warnings.append(DashboardWarning("roster_unavailable", str(error)))
 
-    submissions_dir = assignment_path.parent / "submissions"
+    submissions_dir = assignment_context.paths.submissions_dir
     submission_ids = _directory_ids(submissions_dir)
     try:
         routed = discover_assignment_routed_evidence_status(
@@ -194,92 +195,106 @@ def build_assignment_review_dashboard(
     review_files_present = 0
     orphaned_reviews = 0
     for student_id in ordered_ids:
-        student_dir = submissions_dir / student_id
-        manifest_path = student_dir / "submission.json"
-        review_path = student_dir / "review.json"
+        try:
+            paths = student_record_paths(root, work_ref, student_id)
+        except QuillanRecordContextError as error:
+            raise ReviewDashboardError(
+                f"Unsafe student record path for {student_id!r}: {error}"
+            ) from error
+        manifest_path = paths.submission_manifest_path
+        review_path = paths.review_record_path
         manifest_relative = relative_path_for(manifest_path, root)
         review_relative = relative_path_for(review_path, root)
         student_warnings: list[str] = []
         manifest: dict[str, Any] | None = None
-        submission_status = "missing"
-        if manifest_path.is_file():
-            submission_files_present += 1
-            try:
-                loaded = load_submission_manifest(manifest_path)
-            except (OSError, SubmissionManifestError) as error:
-                submission_status = "invalid"
-                student_warnings.append("invalid_submission")
-                warnings.append(
-                    DashboardWarning(
-                        "invalid_submission", str(error), manifest_relative, student_id
-                    )
-                )
-            else:
-                if _identity_mismatch(loaded, class_id, assignment_id, student_id):
-                    submission_status = "identity_mismatch"
-                    student_warnings.append("submission_identity_mismatch")
-                    warnings.append(
-                        DashboardWarning(
-                            "submission_identity_mismatch",
-                            "Submission identity does not match its canonical path.",
-                            manifest_relative,
-                            student_id,
-                        )
-                    )
-                else:
-                    submission_status = "valid"
-                    manifest = loaded
-                    valid_manifests[student_id] = loaded
-                    assembled_paths.update(_manifest_evidence_paths(root, loaded))
-        elif student_id in roster_ids:
-            student_warnings.append("missing_submission")
-
         review: dict[str, Any] | None = None
-        review_status = "missing" if manifest is not None else "unavailable"
-        if review_path.is_file():
+        submission_status = "missing"
+        review_status = "unavailable"
+        try:
+            record_context = load_quillan_student_review_context(
+                root,
+                work_ref,
+                student_id,
+                review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+            )
+        except MissingSubmissionError as error:
+            review_status = "unavailable"
+            if student_id in roster_ids:
+                student_warnings.append("missing_submission")
+            warnings.append(
+                DashboardWarning("missing_submission", str(error), manifest_relative, student_id)
+            )
+        except OrphanReviewError as error:
+            review_status = "orphaned"
+            orphaned_reviews += 1
             review_files_present += 1
-            if manifest is None:
-                review_status = "orphaned"
-                orphaned_reviews += 1
-                student_warnings.append("review_without_valid_submission")
-                warnings.append(
-                    DashboardWarning(
-                        "review_without_valid_submission",
-                        "Review record exists without a valid adjacent submission.",
-                        review_relative,
-                        student_id,
-                    )
+            student_warnings.append("review_without_valid_submission")
+            warnings.append(
+                DashboardWarning(
+                    "review_without_valid_submission",
+                    str(error),
+                    review_relative,
+                    student_id,
                 )
+            )
+        except InvalidSubmissionError as error:
+            submission_status = "invalid"
+            submission_files_present += 1
+            review_status = "unavailable"
+            student_warnings.append("invalid_submission")
+            warnings.append(
+                DashboardWarning("invalid_submission", str(error), manifest_relative, student_id)
+            )
+        except InvalidReviewError as error:
+            submission_status = "valid"
+            submission_files_present += 1
+            review_status = "invalid"
+            review_files_present += 1
+            student_warnings.append("invalid_review")
+            warnings.append(
+                DashboardWarning("invalid_review", str(error), review_relative, student_id)
+            )
+            if error.submission_record is not None:
+                manifest = mutable_json_copy(error.submission_record.value)
+                valid_manifests[student_id] = manifest
+                assembled_paths.update(_manifest_evidence_paths(root, manifest))
+        except RecordIdentityMismatchError as error:
+            submission_status = "identity_mismatch"
+            review_status = "identity_mismatch"
+            student_warnings.append("record_identity_mismatch")
+            warnings.append(
+                DashboardWarning(
+                    "record_identity_mismatch",
+                    str(error),
+                    manifest_relative,
+                    student_id,
+                )
+            )
+        except QuillanRecordContextError as error:
+            submission_status = "identity_mismatch"
+            review_status = "identity_mismatch"
+            student_warnings.append("record_identity_or_path_mismatch")
+            warnings.append(
+                DashboardWarning(
+                    "record_identity_or_path_mismatch",
+                    str(error),
+                    manifest_relative,
+                    student_id,
+                )
+            )
+        else:
+            submission_files_present += 1
+            submission_status = "valid"
+            manifest = mutable_json_copy(record_context.submission)
+            valid_manifests[student_id] = manifest
+            assembled_paths.update(_manifest_evidence_paths(root, manifest))
+            if record_context.review is None:
+                review_status = "missing"
+                student_warnings.append("missing_review")
             else:
-                try:
-                    loaded_review = load_review_record(review_path)
-                except (OSError, ReviewRecordError) as error:
-                    review_status = "invalid"
-                    student_warnings.append("invalid_review")
-                    warnings.append(
-                        DashboardWarning(
-                            "invalid_review", str(error), review_relative, student_id
-                        )
-                    )
-                else:
-                    if _identity_mismatch(
-                        loaded_review, class_id, assignment_id, student_id
-                    ):
-                        review_status = "identity_mismatch"
-                        student_warnings.append("review_identity_mismatch")
-                        warnings.append(
-                            DashboardWarning(
-                                "review_identity_mismatch",
-                                "Review identity does not match its canonical path.",
-                                review_relative,
-                                student_id,
-                            )
-                        )
-                    else:
-                        review_status = "valid"
-                        review = loaded_review
-        elif manifest is not None:
-            student_warnings.append("missing_review")
+                review_files_present += 1
+                review_status = "valid"
+                review = mutable_json_copy(record_context.review)
 
         page_counts = Counter({state: 0 for state in PAGE_STATES})
         present_unselected = 0
@@ -766,7 +781,20 @@ def _student_population(
 
 def _directory_ids(path: Path) -> set[str]:
     try:
-        return {entry.name for entry in path.iterdir() if entry.is_dir()}
+        if not os.path.lexists(path):
+            return set()
+        if _is_link_like(path) or not path.is_dir():
+            raise ReviewDashboardError(
+                f"Submission collection is not an ordinary directory: {path}"
+            )
+        identifiers: set[str] = set()
+        for entry in path.iterdir():
+            if _is_link_like(entry) or not entry.is_dir():
+                raise ReviewDashboardError(
+                    f"Invalid direct submission child: {entry.name}"
+                )
+            identifiers.add(validate_identifier(entry.name, "student_id"))
+        return identifiers
     except (FileNotFoundError, NotADirectoryError):
         return set()
     except OSError as error:
@@ -790,7 +818,7 @@ def _identity_mismatch(
 
 def _manifest_evidence_paths(root: Path, manifest: dict[str, Any]) -> set[Path]:
     return {
-        (root / item["routed_evidence_path"]).resolve(strict=False)
+        Path(os.path.abspath(root / item["routed_evidence_path"]))
         for page in manifest["pages"]
         for item in page["evidence"]
     }
@@ -813,7 +841,7 @@ def _routed_file_status(
     for student_id, items in evidence_by_student.items():
         for item in items:
             path = Path(item.routed_evidence_path)
-            resolved = (root / path).resolve(strict=False)
+            resolved = Path(os.path.abspath(root / path))
             if resolved in assembled:
                 continue
             relative = relative_path_for(resolved, root)

--- a/quillan/review_feedback.py
+++ b/quillan/review_feedback.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.focus_standard_comments import (
     FocusStandardCommentError,
     SavedReusableFocusStandardComment,
@@ -19,19 +18,18 @@ from quillan.focus_standard_comments import (
     load_comment_set,
     lookup_comments,
 )
-from quillan.review_record import ReviewRecordError, load_review_record, validate_review_record
+from quillan.review_record import ReviewRecordError, validate_review_record
 from quillan.review_record_paths import (
     ReviewRecordPathError,
-    review_record_path,
-    write_review_record,
+    persist_quillan_review_record,
 )
-from quillan.storage import assignment_config_path
-from quillan.submission_guidance import missing_submission_guidance
-from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
+from quillan.record_context import (
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
 )
+from quillan.work_paths import quillan_work_ref
 
 _SEQUENTIAL_FEEDBACK_COMMENT_ID = re.compile(r"^feedback_comment_(\d{4})$")
 
@@ -513,56 +511,25 @@ def _load_context(
     assignment_id: str,
     student_id: str,
 ) -> dict[str, Any]:
+    work_ref = quillan_work_ref(class_id, assignment_id)
     try:
-        resolved_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_root, class_id, assignment_id, student_id
+        loaded = load_quillan_student_review_context(
+            workspace_root,
+            work_ref,
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED,
         )
-        record_path = review_record_path(
-            resolved_root, class_id, assignment_id, student_id
-        )
-        assignment_path = assignment_config_path(resolved_root, class_id, assignment_id)
-    except (
-        OSError,
-        RuntimeError,
-        SubmissionManifestPathError,
-        ReviewRecordPathError,
-    ) as error:
+    except QuillanRecordContextError as error:
         raise ReviewFeedbackError(str(error)) from error
-    try:
-        assignment = load_assignment_config(assignment_path)
-    except (OSError, AssignmentConfigError) as error:
-        raise ReviewFeedbackError(str(error)) from error
-    if assignment["assignment_id"] != assignment_id:
-        raise ReviewFeedbackError(
-            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
-        )
-    if class_id not in assignment["class_ids"]:
-        raise ReviewFeedbackError(
-            f"Assignment config class_ids does not include {class_id!r}."
-        )
-    if not manifest_path.exists():
-        raise ReviewFeedbackError(missing_submission_guidance())
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        raise ReviewFeedbackError(str(error)) from error
-    _validate_identity(
-        manifest,
-        record_name="Submission manifest",
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-    )
-    if not record_path.exists():
-        raise ReviewFeedbackError(
-            "A review record must exist before composing feedback."
-        )
+    assert loaded.review is not None
     return {
-        "workspace_root": resolved_root,
-        "manifest_path": manifest_path,
-        "record_path": record_path,
-        "assignment": assignment,
+        "record_context": loaded,
+        "workspace_root": loaded.paths.workspace_root,
+        "work_ref": work_ref,
+        "manifest_path": loaded.paths.submission_manifest_path,
+        "record_path": loaded.paths.review_record_path,
+        "assignment": mutable_json_copy(loaded.assignment_context.assignment),
+        "review": mutable_json_copy(loaded.review),
         "class_id": class_id,
         "assignment_id": assignment_id,
         "student_id": student_id,
@@ -570,24 +537,13 @@ def _load_context(
 
 
 def _load_existing_review(context: dict[str, Any]) -> dict[str, Any]:
-    try:
-        review = load_review_record(context["record_path"])
-    except (OSError, ReviewRecordError) as error:
-        raise ReviewFeedbackError(f"Could not load review record: {error}") from error
-    _validate_identity(
-        review,
-        record_name="Review record",
-        class_id=context["class_id"],
-        assignment_id=context["assignment_id"],
-        student_id=context["student_id"],
-    )
-    return copy.deepcopy(review)
+    return copy.deepcopy(context["review"])
 
 
 def _write_review(context: dict[str, Any], review: dict[str, Any]) -> None:
     try:
         validate_review_record(review)
-        write_review_record(context["record_path"], review, overwrite=True)
+        persist_quillan_review_record(context["record_context"], review)
     except (
         OSError,
         RuntimeError,

--- a/quillan/review_notes.py
+++ b/quillan/review_notes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -12,24 +11,21 @@ from typing import Any
 from quillan.review_record import (
     ReviewRecordError,
     build_empty_review_record,
-    load_review_record,
     validate_review_record,
 )
 from quillan.review_record_paths import (
     ReviewRecordPathError,
-    review_record_path,
-    write_review_record,
+    persist_quillan_review_record,
 )
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
-)
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
+from quillan.record_context import (
+    MissingSubmissionError,
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
 )
 from quillan.submission_guidance import missing_submission_guidance
-from quillan.work_paths import relative_assignment_path
+from quillan.work_paths import quillan_work_ref
 
 _SEQUENTIAL_NOTE_ID = re.compile(r"^note_(\d{4})$")
 
@@ -65,70 +61,29 @@ def add_review_note(
     normalized_text = _normalize_text(text)
     normalized_created_at = _normalize_timestamp(created_at)
 
+    work_ref = quillan_work_ref(class_id, assignment_id)
     try:
-        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_workspace_root,
-            class_id,
-            assignment_id,
+        context = load_quillan_student_review_context(
+            workspace_root,
+            work_ref,
             student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
         )
-        record_path = review_record_path(
-            resolved_workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-        )
-    except (
-        OSError,
-        RuntimeError,
-        SubmissionManifestPathError,
-        ReviewRecordPathError,
-    ) as error:
+    except MissingSubmissionError as error:
+        raise ReviewNoteError(missing_submission_guidance()) from error
+    except (QuillanRecordContextError, OSError, RuntimeError, ValueError) as error:
         raise ReviewNoteError(str(error)) from error
 
-    if not manifest_path.exists():
-        raise ReviewNoteError(missing_submission_guidance())
-
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        raise ReviewNoteError(
-            f"Could not load submission manifest: {error}"
-        ) from error
-    _validate_identity(
-        manifest,
-        record_name="Submission manifest",
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-    )
-
-    if record_path.exists():
-        try:
-            review = load_review_record(record_path)
-        except (OSError, ReviewRecordError) as error:
-            raise ReviewNoteError(
-                f"Could not load review record: {error}"
-            ) from error
-        _validate_identity(
-            review,
-            record_name="Review record",
-            class_id=class_id,
-            assignment_id=assignment_id,
-            student_id=student_id,
-        )
-        updated_review = copy.deepcopy(review)
+    record_path = context.paths.review_record_path
+    if context.review is not None:
+        updated_review = mutable_json_copy(context.review)
     else:
-        manifest_relative_path = _workspace_relative_path(
-            manifest_path, resolved_workspace_root, "submission manifest"
-        )
         updated_review = build_empty_review_record(
             class_id=class_id,
             assignment_id=assignment_id,
             student_id=student_id,
-            submission_manifest_path=manifest_relative_path,
-            assignment_path=relative_assignment_path(class_id, assignment_id),
+            submission_manifest_path=context.paths.submission_relative_path,
+            assignment_path=context.paths.assignment_relative_path,
             created_at=normalized_created_at,
         )
 
@@ -146,14 +101,8 @@ def add_review_note(
 
     try:
         validate_review_record(updated_review)
-        write_review_record(
-            record_path,
-            updated_review,
-            overwrite=record_path.exists(),
-        )
-        record_relative_path = _workspace_relative_path(
-            record_path, resolved_workspace_root, "review record"
-        )
+        persisted = persist_quillan_review_record(context, updated_review)
+        record_relative_path = persisted.relative_path
     except (
         OSError,
         RuntimeError,

--- a/quillan/review_observations.py
+++ b/quillan/review_observations.py
@@ -12,18 +12,15 @@ from typing import Any
 from quillan.review_record import (
     ReviewRecordError,
     build_empty_review_record,
-    load_review_record,
     validate_review_record,
 )
-from quillan.review_record_paths import (
-    ReviewRecordPathError,
-    write_review_record,
-)
+from quillan.review_record_paths import ReviewRecordPathError, persist_quillan_review_record
 from quillan.review_unit_management import (
     ReviewUnitManagementError,
     load_review_unit_context,
     validate_review_unit_definitions,
 )
+from quillan.work_paths import quillan_work_ref
 
 _SEQUENTIAL_OBSERVATION_ID = re.compile(r"^observation_(\d{4})$")
 
@@ -379,12 +376,15 @@ def _load_context(
     except ReviewUnitManagementError as error:
         raise ReviewObservationError(str(error)) from error
     return {
+        "record_context": loaded.record_context,
         "workspace_root": loaded.workspace_root,
         "manifest_path": loaded.submission_manifest_path,
         "record_path": loaded.review_record_path,
         "assignment_path": loaded.assignment_path,
         "assignment": loaded.assignment,
         "manifest": loaded.manifest,
+        "review": loaded.review,
+        "work_ref": quillan_work_ref(class_id, assignment_id),
         "class_id": class_id,
         "assignment_id": assignment_id,
         "student_id": student_id,
@@ -392,8 +392,7 @@ def _load_context(
 
 
 def _load_or_create_review(context: dict[str, Any], created_at: str) -> dict[str, Any]:
-    record_path = context["record_path"]
-    if record_path.exists():
+    if context["review"] is not None:
         return _load_existing_review(context)
     return build_empty_review_record(
         class_id=context["class_id"],
@@ -410,31 +409,15 @@ def _load_or_create_review(context: dict[str, Any], created_at: str) -> dict[str
 
 
 def _load_existing_review(context: dict[str, Any]) -> dict[str, Any]:
-    record_path = context["record_path"]
-    if not record_path.exists():
+    if context["review"] is None:
         raise ReviewObservationError("Review units must be defined before recording observations.")
-    try:
-        review = load_review_record(record_path)
-    except (OSError, ReviewRecordError) as error:
-        raise ReviewObservationError(f"Could not load review record: {error}") from error
-    _validate_identity(
-        review,
-        record_name="Review record",
-        class_id=context["class_id"],
-        assignment_id=context["assignment_id"],
-        student_id=context["student_id"],
-    )
-    return copy.deepcopy(review)
+    return copy.deepcopy(context["review"])
 
 
 def _write_review(context: dict[str, Any], review: dict[str, Any]) -> None:
     try:
         validate_review_record(review)
-        write_review_record(
-            context["record_path"],
-            review,
-            overwrite=context["record_path"].exists(),
-        )
+        persist_quillan_review_record(context["record_context"], review)
     except (
         OSError,
         RuntimeError,

--- a/quillan/review_ratings.py
+++ b/quillan/review_ratings.py
@@ -8,20 +8,18 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
-from quillan.review_record import ReviewRecordError, load_review_record, validate_review_record
+from quillan.review_record import ReviewRecordError, validate_review_record
 from quillan.review_record_paths import (
     ReviewRecordPathError,
-    review_record_path,
-    write_review_record,
+    persist_quillan_review_record,
 )
-from quillan.storage import assignment_config_path
-from quillan.submission_guidance import missing_submission_guidance
-from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
+from quillan.record_context import (
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
 )
+from quillan.work_paths import quillan_work_ref
 
 
 class ReviewRatingError(Exception):
@@ -300,54 +298,25 @@ def _load_context(
     assignment_id: str,
     student_id: str,
 ) -> dict[str, Any]:
+    work_ref = quillan_work_ref(class_id, assignment_id)
     try:
-        resolved_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_root, class_id, assignment_id, student_id
+        loaded = load_quillan_student_review_context(
+            workspace_root,
+            work_ref,
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED,
         )
-        record_path = review_record_path(
-            resolved_root, class_id, assignment_id, student_id
-        )
-        assignment_path = assignment_config_path(resolved_root, class_id, assignment_id)
-    except (
-        OSError,
-        RuntimeError,
-        SubmissionManifestPathError,
-        ReviewRecordPathError,
-    ) as error:
+    except QuillanRecordContextError as error:
         raise ReviewRatingError(str(error)) from error
-
-    if not manifest_path.exists():
-        raise ReviewRatingError(missing_submission_guidance())
-    if not record_path.exists():
-        raise ReviewRatingError("A review record must exist before recording ratings.")
-
-    try:
-        manifest = load_submission_manifest(manifest_path)
-        assignment = load_assignment_config(assignment_path)
-    except (OSError, SubmissionManifestError, AssignmentConfigError) as error:
-        raise ReviewRatingError(str(error)) from error
-
-    _validate_identity(
-        manifest,
-        record_name="Submission manifest",
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-    )
-    if class_id not in assignment["class_ids"]:
-        raise ReviewRatingError(
-            f"Assignment config class_ids does not include {class_id!r}."
-        )
-    if assignment["assignment_id"] != assignment_id:
-        raise ReviewRatingError(
-            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
-        )
+    assert loaded.review is not None
     return {
-        "workspace_root": resolved_root,
-        "manifest_path": manifest_path,
-        "record_path": record_path,
-        "assignment": assignment,
+        "record_context": loaded,
+        "workspace_root": loaded.paths.workspace_root,
+        "work_ref": work_ref,
+        "manifest_path": loaded.paths.submission_manifest_path,
+        "record_path": loaded.paths.review_record_path,
+        "assignment": mutable_json_copy(loaded.assignment_context.assignment),
+        "review": mutable_json_copy(loaded.review),
         "class_id": class_id,
         "assignment_id": assignment_id,
         "student_id": student_id,
@@ -355,24 +324,13 @@ def _load_context(
 
 
 def _load_existing_review(context: dict[str, Any]) -> dict[str, Any]:
-    try:
-        review = load_review_record(context["record_path"])
-    except (OSError, ReviewRecordError) as error:
-        raise ReviewRatingError(f"Could not load review record: {error}") from error
-    _validate_identity(
-        review,
-        record_name="Review record",
-        class_id=context["class_id"],
-        assignment_id=context["assignment_id"],
-        student_id=context["student_id"],
-    )
-    return copy.deepcopy(review)
+    return copy.deepcopy(context["review"])
 
 
 def _write_review(context: dict[str, Any], review: dict[str, Any]) -> None:
     try:
         validate_review_record(review)
-        write_review_record(context["record_path"], review, overwrite=True)
+        persist_quillan_review_record(context["record_context"], review)
     except (
         OSError,
         RuntimeError,

--- a/quillan/review_record_paths.py
+++ b/quillan/review_record_paths.py
@@ -1,14 +1,26 @@
-"""Canonical paths and safe writing for Quillan submission review records."""
+"""Domain-aware canonical persistence for Quillan review records."""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 import json
 import os
-import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
-from quillan.review_record import validate_review_record
+from quillan.atomic_record_io import (
+    AtomicRecordConcurrencyError,
+    AtomicRecordDurabilityError,
+    AtomicRecordError,
+    create_exclusive_record,
+    revision_guarded_update,
+)
+from quillan.record_context import (
+    QuillanStudentReviewContext,
+    student_record_paths,
+)
+from quillan.review_record import ReviewRecordError, validate_review_record
 from quillan.work_paths import (
     QuillanWorkPathError,
     _preflight_arbitrary_file_destination,
@@ -19,7 +31,123 @@ from quillan.work_paths import (
 
 
 class ReviewRecordPathError(ValueError):
-    """Raised when a review record path or write operation is invalid."""
+    """Raised when a contextual review write is invalid or uncertain."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        possibly_durable_path: Path | None = None,
+        possible_lock_path: Path | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.possibly_durable_path = possibly_durable_path
+        self.possible_lock_path = possible_lock_path
+
+
+class ReviewRecordConcurrencyError(ReviewRecordPathError):
+    """The canonical review changed after its context snapshot was loaded."""
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedReviewRecord:
+    """Exact location and outcome of one contextual review write."""
+
+    path: Path
+    relative_path: str
+    status: Literal["created", "updated", "unchanged"]
+
+    def __post_init__(self) -> None:
+        if type(self.path) is not type(Path()) or not self.path.is_absolute():
+            raise ReviewRecordPathError("Persisted review path must be absolute.")
+        if type(self.relative_path) is not str or not self.relative_path:
+            raise ReviewRecordPathError("Persisted review relative path is required.")
+        if self.status not in {"created", "updated", "unchanged"}:
+            raise ReviewRecordPathError("Persisted review status is invalid.")
+
+
+def create_quillan_review_record(
+    context: QuillanStudentReviewContext,
+    record: Mapping[str, object],
+) -> PersistedReviewRecord:
+    """Create a review only for a validated assignment and submission context."""
+    _require_context(context)
+    if context.review_record is not None:
+        raise ReviewRecordPathError("Review creation context already has a review.")
+    record_data = dict(record)
+    _validate_review_for_context(record_data, context)
+    data = _canonical_review_bytes(record_data)
+    path = context.paths.review_record_path
+    try:
+        result = create_exclusive_record(
+            path,
+            data,
+            preflight=lambda: _preflight_context_target(context),
+            verify_bytes=lambda loaded: _verify_review_bytes(loaded, record_data),
+        )
+    except AtomicRecordConcurrencyError as error:
+        raise ReviewRecordConcurrencyError(str(error)) from error
+    except AtomicRecordDurabilityError as error:
+        raise ReviewRecordPathError(
+            str(error),
+            possibly_durable_path=error.possibly_durable_path,
+            possible_lock_path=error.possible_lock_path,
+        ) from error
+    except (AtomicRecordError, OSError) as error:
+        raise ReviewRecordPathError(str(error)) from error
+    return PersistedReviewRecord(
+        path,
+        context.paths.review_relative_path,
+        result.status,
+    )
+
+
+def update_quillan_review_record(
+    context: QuillanStudentReviewContext,
+    record: Mapping[str, object],
+) -> PersistedReviewRecord:
+    """Update only the exact review revision carried by ``context``."""
+    _require_context(context)
+    if context.review_record is None:
+        raise ReviewRecordPathError("Review update requires a loaded review snapshot.")
+    record_data = dict(record)
+    _validate_review_for_context(record_data, context)
+    data = _canonical_review_bytes(record_data)
+    path = context.paths.review_record_path
+    try:
+        result = revision_guarded_update(
+            path,
+            context.review_record.original_bytes,
+            data,
+            preflight=lambda: _preflight_context_target(context),
+            verify_bytes=lambda loaded: _verify_review_bytes(loaded, record_data),
+            lock_purpose="review-update",
+        )
+    except AtomicRecordConcurrencyError as error:
+        raise ReviewRecordConcurrencyError(str(error)) from error
+    except AtomicRecordDurabilityError as error:
+        raise ReviewRecordPathError(
+            str(error),
+            possibly_durable_path=error.possibly_durable_path,
+            possible_lock_path=error.possible_lock_path,
+        ) from error
+    except (AtomicRecordError, OSError) as error:
+        raise ReviewRecordPathError(str(error)) from error
+    return PersistedReviewRecord(
+        path,
+        context.paths.review_relative_path,
+        result.status,
+    )
+
+
+def persist_quillan_review_record(
+    context: QuillanStudentReviewContext,
+    record: Mapping[str, object],
+) -> PersistedReviewRecord:
+    """Persist through a validated context; raw path creation is not supported."""
+    if context.review_record is None:
+        return create_quillan_review_record(context, record)
+    return update_quillan_review_record(context, record)
 
 
 def review_record_dir(
@@ -30,8 +158,9 @@ def review_record_dir(
 ) -> Path:
     """Return the canonical directory for one student's review record."""
     try:
-        work_ref = quillan_work_ref(class_id, assignment_id)
-        return student_submission_dir(workspace_root, work_ref, student_id)
+        return student_submission_dir(
+            workspace_root, quillan_work_ref(class_id, assignment_id), student_id
+        )
     except ValueError as error:
         raise ReviewRecordPathError(str(error)) from error
 
@@ -44,8 +173,9 @@ def review_record_path(
 ) -> Path:
     """Return the canonical review.json path for one student."""
     try:
-        work_ref = quillan_work_ref(class_id, assignment_id)
-        return work_review_record_path(workspace_root, work_ref, student_id)
+        return work_review_record_path(
+            workspace_root, quillan_work_ref(class_id, assignment_id), student_id
+        )
     except ValueError as error:
         raise ReviewRecordPathError(str(error)) from error
 
@@ -56,66 +186,132 @@ def write_review_record(
     *,
     overwrite: bool = False,
 ) -> Path:
-    """Validate and safely write a review record as UTF-8 JSON."""
+    """Low-level compatibility writer for fixtures and record initialization.
+
+    Canonical runtime services must use the context-aware create/update APIs.
+    """
     validate_review_record(record)
-    review_path = Path(path)
-
+    target = Path(os.path.abspath(Path(path)))
     try:
-        _preflight_arbitrary_file_destination(review_path)
-    except QuillanWorkPathError as error:
-        raise ReviewRecordPathError(str(error)) from error
+        _preflight_arbitrary_file_destination(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        def preflight() -> None:
+            _preflight_arbitrary_file_destination(target)
 
-    if not overwrite and review_path.exists():
-        raise ReviewRecordPathError(f"Review record already exists: {review_path}")
-
-    parent = review_path.parent
-    try:
-        parent.mkdir(parents=True, exist_ok=True)
-    except OSError as error:
+        data = _canonical_review_bytes(record)
+        if overwrite:
+            if not os.path.lexists(target):
+                raise ReviewRecordPathError(
+                    f"Review record does not exist for overwrite: {target}"
+                )
+            expected = target.read_bytes()
+            revision_guarded_update(
+                target,
+                expected,
+                data,
+                preflight=preflight,
+                verify_bytes=lambda loaded: _verify_review_bytes(loaded, record),
+                lock_purpose="low-level-review-update",
+            )
+        else:
+            create_exclusive_record(
+                target,
+                data,
+                preflight=preflight,
+                verify_bytes=lambda loaded: _verify_review_bytes(loaded, record),
+            )
+    except AtomicRecordConcurrencyError as error:
+        raise ReviewRecordConcurrencyError(str(error)) from error
+    except AtomicRecordDurabilityError as error:
         raise ReviewRecordPathError(
-            f"Could not create review record directory {parent}: {error}"
+            str(error),
+            possibly_durable_path=error.possibly_durable_path,
+            possible_lock_path=error.possible_lock_path,
         ) from error
-    if not parent.is_dir():
+    except (AtomicRecordError, QuillanWorkPathError, OSError) as error:
+        raise ReviewRecordPathError(str(error)) from error
+    return target
+
+
+def _require_context(context: QuillanStudentReviewContext) -> None:
+    if type(context) is not QuillanStudentReviewContext:
         raise ReviewRecordPathError(
-            f"Review record parent is not a directory: {parent}"
+            "context must be an exact QuillanStudentReviewContext."
         )
 
-    temporary_path: Path | None = None
+
+def _validate_review_for_context(
+    record: dict[str, Any], context: QuillanStudentReviewContext
+) -> None:
+    validate_review_record(record)
+    expected = {
+        "class_id": context.paths.work_ref.class_id,
+        "assignment_id": context.paths.work_ref.work_id,
+        "student_id": context.paths.student_id,
+        "assignment_path": context.paths.assignment_relative_path,
+        "submission_manifest_path": context.paths.submission_relative_path,
+    }
+    for field, value in expected.items():
+        if record[field] != value:
+            raise ReviewRecordPathError(
+                f"Review record {field} does not match its validated context."
+            )
+
+
+def _preflight_context_target(context: QuillanStudentReviewContext) -> None:
+    paths = student_record_paths(
+        context.paths.workspace_root,
+        context.paths.work_ref,
+        context.paths.student_id,
+    )
+    if paths.review_record_path != context.paths.review_record_path:
+        raise ReviewRecordPathError("Review context destination changed.")
+
+
+def _canonical_review_bytes(record: dict[str, Any]) -> bytes:
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            newline="\n",
-            prefix=f".{review_path.name}.",
-            suffix=".tmp",
-            dir=parent,
-            delete=False,
-        ) as temporary_file:
-            temporary_path = Path(temporary_file.name)
-            json.dump(record, temporary_file, ensure_ascii=False, indent=2)
-            temporary_file.write("\n")
-            temporary_file.flush()
-            os.fsync(temporary_file.fileno())
+        return (
+            json.dumps(record, ensure_ascii=False, allow_nan=False, indent=2) + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise ReviewRecordPathError(f"Could not serialize review record: {error}") from error
 
-        if overwrite:
-            os.replace(temporary_path, review_path)
-        else:
-            os.link(temporary_path, review_path)
-            temporary_path.unlink()
-        temporary_path = None
-    except FileExistsError as error:
-        raise ReviewRecordPathError(
-            f"Review record already exists: {review_path}"
-        ) from error
-    except (OSError, TypeError, ValueError) as error:
-        raise ReviewRecordPathError(
-            f"Could not write review record {review_path}: {error}"
-        ) from error
-    finally:
-        if temporary_path is not None:
-            try:
-                temporary_path.unlink(missing_ok=True)
-            except OSError:
-                pass
 
-    return review_path
+def _verify_review_bytes(data: bytes, expected: dict[str, Any]) -> None:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ReviewRecordError(f"Duplicate review JSON key: {key}")
+            value[key] = item
+        return value
+
+    try:
+        loaded = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=reject_duplicates,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ReviewRecordError(f"Invalid JSON constant: {value}")
+            ),
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise ReviewRecordPathError(f"Persisted review is not strict JSON: {error}") from error
+    if not isinstance(loaded, dict):
+        raise ReviewRecordPathError("Persisted review is not a JSON object.")
+    validate_review_record(loaded)
+    if loaded != expected:
+        raise ReviewRecordPathError(
+            "Reloaded review record differs from the committed model."
+        )
+
+
+__all__ = [
+    "PersistedReviewRecord",
+    "ReviewRecordConcurrencyError",
+    "ReviewRecordPathError",
+    "create_quillan_review_record",
+    "persist_quillan_review_record",
+    "review_record_dir",
+    "review_record_path",
+    "update_quillan_review_record",
+]

--- a/quillan/review_requirements.py
+++ b/quillan/review_requirements.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import math
 import re
 from dataclasses import dataclass
@@ -13,24 +12,21 @@ from typing import Any
 from quillan.review_record import (
     ReviewRecordError,
     build_empty_review_record,
-    load_review_record,
     validate_review_record,
 )
 from quillan.review_record_paths import (
     ReviewRecordPathError,
-    review_record_path,
-    write_review_record,
+    persist_quillan_review_record,
+)
+from quillan.record_context import (
+    QuillanRecordContextError,
+    QuillanStudentReviewContext,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
 )
 from quillan.submission_guidance import missing_submission_guidance
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
-)
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
-)
-from quillan.work_paths import relative_assignment_path
+from quillan.work_paths import quillan_work_ref
 
 _SEQUENTIAL_REQUIREMENT_CHECK_ID = re.compile(r"^requirement_check_(\d{4})$")
 
@@ -96,60 +92,12 @@ def set_requirement_check(
     normalized_note = _normalize_optional_string(teacher_note, "teacher_note")
     normalized_updated_at = _normalize_timestamp(updated_at)
 
-    try:
-        resolved_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_root,
-            class_id,
-            assignment_id,
-            student_id,
-        )
-        record_path = review_record_path(
-            resolved_root,
-            class_id,
-            assignment_id,
-            student_id,
-        )
-    except (
-        OSError,
-        RuntimeError,
-        SubmissionManifestPathError,
-        ReviewRecordPathError,
-    ) as error:
-        raise ReviewRequirementError(str(error)) from error
-
-    if not manifest_path.exists():
-        raise ReviewRequirementError(missing_submission_guidance())
-
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        raise ReviewRequirementError(
-            f"Could not load submission manifest: {error}"
-        ) from error
-    _validate_identity(
-        manifest,
-        record_name="Submission manifest",
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
+    context = _load_mutation_context(
+        workspace_root, class_id, assignment_id, student_id
     )
-
-    if record_path.exists():
-        try:
-            review = load_review_record(record_path)
-        except (OSError, ReviewRecordError) as error:
-            raise ReviewRequirementError(
-                f"Could not load review record: {error}"
-            ) from error
-        _validate_identity(
-            review,
-            record_name="Review record",
-            class_id=class_id,
-            assignment_id=assignment_id,
-            student_id=student_id,
-        )
-        updated_review = copy.deepcopy(review)
+    record_path = context.paths.review_record_path
+    if context.review is not None:
+        updated_review = mutable_json_copy(context.review)
         if updated_review["review_state"] == "not_started":
             updated_review["review_state"] = "requirements_checked"
     else:
@@ -157,10 +105,8 @@ def set_requirement_check(
             class_id=class_id,
             assignment_id=assignment_id,
             student_id=student_id,
-            submission_manifest_path=_workspace_relative_path(
-                manifest_path, resolved_root, "submission manifest"
-            ),
-            assignment_path=relative_assignment_path(class_id, assignment_id),
+            submission_manifest_path=context.paths.submission_relative_path,
+            assignment_path=context.paths.assignment_relative_path,
             created_at=normalized_updated_at,
         )
         updated_review["review_state"] = "requirements_checked"
@@ -200,14 +146,8 @@ def set_requirement_check(
 
     try:
         validate_review_record(updated_review)
-        write_review_record(
-            record_path,
-            updated_review,
-            overwrite=record_path.exists(),
-        )
-        relative_path = _workspace_relative_path(
-            record_path, resolved_root, "review record"
-        )
+        persisted = persist_quillan_review_record(context, updated_review)
+        relative_path = persisted.relative_path
     except (
         OSError,
         RuntimeError,
@@ -268,69 +208,19 @@ def set_minimum_requirement_outcome(
             "allow_return_without_full_review must be a boolean when provided."
         )
 
-    try:
-        resolved_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_root,
-            class_id,
-            assignment_id,
-            student_id,
-        )
-        record_path = review_record_path(
-            resolved_root,
-            class_id,
-            assignment_id,
-            student_id,
-        )
-    except (
-        OSError,
-        RuntimeError,
-        SubmissionManifestPathError,
-        ReviewRecordPathError,
-    ) as error:
-        raise ReviewRequirementError(str(error)) from error
-
-    if not manifest_path.exists():
-        raise ReviewRequirementError(missing_submission_guidance())
-
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        raise ReviewRequirementError(
-            f"Could not load submission manifest: {error}"
-        ) from error
-    _validate_identity(
-        manifest,
-        record_name="Submission manifest",
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
+    context = _load_mutation_context(
+        workspace_root, class_id, assignment_id, student_id
     )
-
-    if record_path.exists():
-        try:
-            review = load_review_record(record_path)
-        except (OSError, ReviewRecordError) as error:
-            raise ReviewRequirementError(
-                f"Could not load review record: {error}"
-            ) from error
-        _validate_identity(
-            review,
-            record_name="Review record",
-            class_id=class_id,
-            assignment_id=assignment_id,
-            student_id=student_id,
-        )
-        updated_review = copy.deepcopy(review)
+    record_path = context.paths.review_record_path
+    if context.review is not None:
+        updated_review = mutable_json_copy(context.review)
     else:
         updated_review = build_empty_review_record(
             class_id=class_id,
             assignment_id=assignment_id,
             student_id=student_id,
-            submission_manifest_path=_workspace_relative_path(
-                manifest_path, resolved_root, "submission manifest"
-            ),
-            assignment_path=relative_assignment_path(class_id, assignment_id),
+            submission_manifest_path=context.paths.submission_relative_path,
+            assignment_path=context.paths.assignment_relative_path,
             created_at=normalized_updated_at,
         )
 
@@ -362,14 +252,8 @@ def set_minimum_requirement_outcome(
 
     try:
         validate_review_record(updated_review)
-        write_review_record(
-            record_path,
-            updated_review,
-            overwrite=record_path.exists(),
-        )
-        relative_path = _workspace_relative_path(
-            record_path, resolved_root, "review record"
-        )
+        persisted = persist_quillan_review_record(context, updated_review)
+        relative_path = persisted.relative_path
     except (
         OSError,
         RuntimeError,
@@ -393,6 +277,25 @@ def set_minimum_requirement_outcome(
         teacher_note=normalized_note,
         updated_at=normalized_updated_at,
     )
+
+
+def _load_mutation_context(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> QuillanStudentReviewContext:
+    try:
+        return load_quillan_student_review_context(
+            workspace_root,
+            quillan_work_ref(class_id, assignment_id),
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+        )
+    except QuillanRecordContextError as error:
+        if "Submission manifest not found" in str(error):
+            raise ReviewRequirementError(missing_submission_guidance()) from error
+        raise ReviewRequirementError(str(error)) from error
 
 
 def _normalize_required_string(value: str, field: str) -> str:

--- a/quillan/review_unit_management.py
+++ b/quillan/review_unit_management.py
@@ -7,16 +7,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-from quillan.assignments import AssignmentConfigError, load_assignment_config
-from quillan.review_record import ReviewRecordError, load_review_record
-from quillan.review_record_paths import ReviewRecordPathError, review_record_path
-from quillan.storage import assignment_config_path
-from quillan.submission_guidance import missing_submission_guidance
-from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
+from quillan.record_context import (
+    QuillanRecordContextError,
+    QuillanStudentReviewContext,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
 )
+from quillan.work_paths import quillan_work_ref
 
 _ALLOWED_UNIT_FIELDS = frozenset({"sequence", "label", "page_number", "evidence_id"})
 
@@ -52,6 +50,7 @@ class ReviewUnitContext:
     assignment: dict[str, Any]
     manifest: dict[str, Any]
     review: dict[str, Any] | None
+    record_context: QuillanStudentReviewContext
 
     @property
     def unit_type(self) -> str:
@@ -107,53 +106,32 @@ def load_review_unit_context(
 ) -> ReviewUnitContext:
     """Load canonical review-unit context without writing anything."""
     try:
-        root = Path(workspace_root).resolve(strict=False)
-        assignment_path = assignment_config_path(root, class_id, assignment_id)
-        manifest_path = submission_manifest_path(root, class_id, assignment_id, student_id)
-        record_path = review_record_path(root, class_id, assignment_id, student_id)
-    except (OSError, RuntimeError, ValueError, SubmissionManifestPathError, ReviewRecordPathError) as error:
+        loaded = load_quillan_student_review_context(
+            workspace_root,
+            quillan_work_ref(class_id, assignment_id),
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+        )
+    except (QuillanRecordContextError, OSError, RuntimeError, ValueError) as error:
         raise ReviewUnitManagementError(str(error)) from error
 
-    try:
-        assignment = load_assignment_config(assignment_path)
-    except (OSError, AssignmentConfigError) as error:
-        raise ReviewUnitManagementError(str(error)) from error
-    if assignment["assignment_id"] != assignment_id:
-        raise ReviewUnitManagementError(
-            f"Assignment config assignment_id is {assignment['assignment_id']!r}, expected {assignment_id!r}."
-        )
-    if class_id not in assignment["class_ids"]:
-        raise ReviewUnitManagementError(
-            f"Assignment config class_ids does not include {class_id!r}."
-        )
-
-    if not manifest_path.exists():
-        raise ReviewUnitManagementError(missing_submission_guidance())
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        raise ReviewUnitManagementError(f"Could not load submission manifest: {error}") from error
-    _validate_identity(manifest, "Submission manifest", class_id, assignment_id, student_id)
-
-    review = None
-    if record_path.exists():
-        try:
-            review = load_review_record(record_path)
-        except (OSError, ReviewRecordError) as error:
-            raise ReviewUnitManagementError(f"Could not load review record: {error}") from error
-        _validate_identity(review, "Review record", class_id, assignment_id, student_id)
+    root = loaded.paths.workspace_root
+    assignment = mutable_json_copy(loaded.assignment_context.assignment)
+    manifest = mutable_json_copy(loaded.submission)
+    review = None if loaded.review is None else mutable_json_copy(loaded.review)
 
     return ReviewUnitContext(
         workspace_root=root,
         class_id=class_id,
         assignment_id=assignment_id,
         student_id=student_id,
-        assignment_path=assignment_path,
-        submission_manifest_path=manifest_path,
-        review_record_path=record_path,
+        assignment_path=loaded.assignment_context.paths.assignment_path,
+        submission_manifest_path=loaded.paths.submission_manifest_path,
+        review_record_path=loaded.paths.review_record_path,
         assignment=assignment,
         manifest=manifest,
         review=review,
+        record_context=loaded,
     )
 
 

--- a/quillan/review_workflow_state.py
+++ b/quillan/review_workflow_state.py
@@ -18,12 +18,14 @@ from quillan.review_record import (
     build_empty_review_record,
     validate_review_record,
 )
-from quillan.review_record_paths import ReviewRecordPathError, write_review_record
+from quillan.review_record_paths import (
+    ReviewRecordPathError,
+    persist_quillan_review_record,
+)
 from quillan.review_unit_management import (
     ReviewUnitManagementError,
     load_review_unit_context,
 )
-
 REVIEW_WORKFLOW_STATES = (
     "not_started",
     "requirements_checked",
@@ -121,11 +123,7 @@ def set_review_workflow_state(
     updated_review["updated_at"] = normalized_updated_at
     try:
         validate_review_record(updated_review)
-        write_review_record(
-            context.review_record_path,
-            updated_review,
-            overwrite=not review_was_created,
-        )
+        persist_quillan_review_record(context.record_context, updated_review)
     except (ReviewRecordError, ReviewRecordPathError, OSError, ValueError) as error:
         raise ReviewWorkflowStateError(f"Could not write review record: {error}") from error
 

--- a/quillan/scan_review_preservation.py
+++ b/quillan/scan_review_preservation.py
@@ -169,7 +169,10 @@ def _persist_page(
                 failure_id=failure_id,
                 created_at=created_at,
                 detected_payload=page.raw_payload_text,
-                module_details={"failure_origin": origin},
+                module_details={
+                    "failure_origin": origin,
+                    "failure_owner": "quillan",
+                },
             )
         stage = (
             "dispatch_integration"
@@ -235,7 +238,10 @@ def _persist_source_error(
             detected_payload=None,
             route_locator=None,
             target=None,
-            module_details={"failure_origin": "source_page_loading"},
+            module_details={
+                "failure_origin": "source_page_loading",
+                "failure_owner": "quillan",
+            },
         )
 
     return _write_fresh(
@@ -362,7 +368,10 @@ def _module_details(
     page: QuillanScanPageOutcome,
     origin: str,
 ) -> dict[str, str]:
-    details = {"failure_origin": origin[:100]}
+    details = {
+        "failure_origin": origin[:100],
+        "failure_owner": "quillan",
+    }
     if page.decode_method is not None:
         details["decode_method"] = page.decode_method[:200]
     if (

--- a/quillan/scan_review_resolution.py
+++ b/quillan/scan_review_resolution.py
@@ -1,42 +1,70 @@
-"""Discover and resolve Quillan scan-routing review records."""
+"""Discover and resolve Quillan-owned Core schema-v2 scan-review records."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Final
 
+from pds_core.identifiers import validate_identifier
+from pds_core.route_registrations import load_route_registration
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef, RouteLocator
 from pds_core.scan_failure_metadata import (
+    ROUTING_FAILURE_SCHEMA_VERSION,
     RoutingFailureMetadata,
     RoutingFailureMetadataError,
-    routing_failure_metadata_from_dict,
+    load_routing_failure_metadata,
+    routing_failure_metadata_path,
 )
 from pds_core.scan_resolution_metadata import (
+    SCAN_RESOLUTION_SCHEMA_VERSION,
     ScanResolutionMetadata,
     ScanResolutionMetadataError,
     ScanResolutionMetadataWriteError,
+    create_scan_resolution_metadata,
     scan_resolution_metadata_dir,
-    scan_resolution_metadata_from_dict,
+    load_scan_resolution_metadata,
     scan_resolution_metadata_path,
     write_scan_resolution_metadata,
 )
 from pds_core.scan_routes import routing_review_dir
 
+from quillan.pds_contract import (
+    QUILLAN_MODULE_ID,
+    RESPONSE_PAGE_CONTRACT_VERSION,
+    RESPONSE_PAGE_RECORD_KIND,
+)
+from quillan.printable_response_persistence import (
+    PrintableResponsePersistenceError,
+    load_printable_response_page,
+)
+from quillan.work_paths import quillan_work_paths
+from quillan.work_paths import (
+    _preflight_arbitrary_file_destination,
+    _preflight_path_chain,
+)
+
 
 QUILLAN_RESOLUTION_ACTIONS: Final[tuple[str, ...]] = (
+    "route_selected",
+    "route_corrected",
+    "evidence_filed",
     "rescan_needed",
     "cannot_route",
-    "mixed_assignment",
-    "evidence_filed",
     "dismissed_duplicate",
+    "deferred",
     "other",
     "defer",
+    "mixed_assignment",
 )
 
 DEFAULT_RESOLUTION_MESSAGES: Final[dict[str, str]] = {
+    "route_selected": "Teacher selected the intended route.",
+    "route_corrected": "Teacher corrected the intended route.",
     "rescan_needed": "Teacher marked this scan/page for rescan.",
     "cannot_route": "Teacher marked this scan/page as unable to route safely.",
     "mixed_assignment": "Teacher marked this scan/source as mixed assignment.",
@@ -44,6 +72,7 @@ DEFAULT_RESOLUTION_MESSAGES: Final[dict[str, str]] = {
         "Teacher marked this evidence as filed outside the automatic route-scan flow."
     ),
     "dismissed_duplicate": "Teacher dismissed this review item as a duplicate.",
+    "deferred": "Teacher deferred this review item for later.",
     "defer": "Teacher deferred this review item for later.",
 }
 
@@ -54,7 +83,7 @@ class ScanReviewResolutionError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class QuillanReviewItem:
-    """One valid Quillan routing failure plus its latest resolution state."""
+    """One validated Quillan-owned Core routing failure and latest resolution."""
 
     failure_id: str
     failure_metadata_path: Path
@@ -87,7 +116,7 @@ class QuillanReviewItem:
 
 @dataclass(frozen=True, slots=True)
 class QuillanResolutionResult:
-    """Provenance for one newly written shared resolution record."""
+    """Provenance for one newly written exact Core-v2 resolution record."""
 
     resolution_id: str
     resolution_metadata_path: Path
@@ -114,52 +143,58 @@ def discover_scan_review_items(
     failure_category: str | None = None,
     limit: int | None = None,
 ) -> QuillanReviewDiscovery:
-    """Discover valid Quillan review items without mutating workspace data."""
+    """Discover exact Core-v2 Quillan review items without mutation."""
     root = _workspace_root(workspace_root)
-    if limit is not None and (isinstance(limit, bool) or limit < 1):
+    if class_id is not None:
+        validate_identifier(class_id, "class_id")
+    if assignment_id is not None:
+        validate_identifier(assignment_id, "assignment_id")
+    if limit is not None and (
+        isinstance(limit, bool) or not isinstance(limit, int) or limit < 1
+    ):
         raise ScanReviewResolutionError("limit must be a positive integer.")
 
     failures, failure_warnings = _load_failures(root)
-    resolutions, resolution_warnings = _load_resolutions(root)
+    resolutions, resolution_warnings = _load_resolutions(root, failures)
     latest_by_failure: dict[str, tuple[ScanResolutionMetadata, Path]] = {}
-    for resolution_metadata, path in resolutions:
-        current = latest_by_failure.get(resolution_metadata.failure_id)
-        if current is None or _resolution_order(
-            resolution_metadata, path
-        ) > _resolution_order(
+    for resolution, path in resolutions:
+        current = latest_by_failure.get(resolution.failure_id)
+        if current is None or _resolution_order(resolution, path) > _resolution_order(
             current[0], current[1]
         ):
-            latest_by_failure[resolution_metadata.failure_id] = (
-                resolution_metadata,
-                path,
-            )
+            latest_by_failure[resolution.failure_id] = (resolution, path)
 
     items: list[QuillanReviewItem] = []
-    for failure_metadata, path in failures:
-        latest = latest_by_failure.get(failure_metadata.failure_id)
+    enrichment_warnings: list[str] = []
+    for failure, path in failures:
+        latest = latest_by_failure.get(failure.failure_id)
         if latest is not None and latest[0].resolution_status == "resolved":
             if not include_resolved:
                 continue
-        if class_id is not None and failure_metadata.class_id != class_id:
-            continue
-        if (
-            assignment_id is not None
-            and failure_metadata.assignment_id != assignment_id
+        work_ref = _failure_work_ref(failure)
+        if class_id is not None and (
+            work_ref is None or work_ref.class_id != class_id
         ):
             continue
-        if (
-            failure_category is not None
-            and failure_metadata.failure_category != failure_category
+        if assignment_id is not None and (
+            work_ref is None or work_ref.work_id != assignment_id
         ):
             continue
-        items.append(_review_item(root, failure_metadata, path, latest))
+        if failure_category is not None and failure.failure_category != failure_category:
+            continue
+        student_id, warning = _student_identity(root, failure, work_ref)
+        if warning is not None:
+            enrichment_warnings.append(warning)
+        items.append(_review_item(root, failure, path, latest, work_ref, student_id))
 
     items.sort(key=lambda item: (item.created_at, item.failure_id))
     if limit is not None:
         items = items[:limit]
     return QuillanReviewDiscovery(
         items=tuple(items),
-        warnings=tuple((*failure_warnings, *resolution_warnings)),
+        warnings=tuple(
+            (*failure_warnings, *resolution_warnings, *enrichment_warnings)
+        ),
     )
 
 
@@ -181,35 +216,40 @@ def resolve_scan_review_item(
     action: str,
     message: str | None = None,
     evidence_path: str | Path | None = None,
+    route_locator: RouteLocator | None = None,
+    target: ModuleRecordRef | None = None,
     resolved_at: datetime | None = None,
 ) -> QuillanResolutionResult:
-    """Write an immutable Core resolution record for one Quillan failure."""
+    """Write an immutable exact Core-v2 resolution for one Quillan failure."""
     root = _workspace_root(workspace_root)
     if action not in QUILLAN_RESOLUTION_ACTIONS:
         raise ScanReviewResolutionError(
             "Unsupported Quillan scan review action: " + str(action)
         )
     normalized_message = _resolution_message(action, message)
-    evidence_relative = _evidence_path(evidence_path)
-    if evidence_relative is not None and action != "evidence_filed":
+    status, metadata_action = _mapped_action(action)
+
+    failures, warnings = _load_failures(root)
+    matches = [(metadata, path) for metadata, path in failures if metadata.failure_id == failure_id]
+    if len(matches) != 1:
+        warning_suffix = f" Discovery warnings: {'; '.join(warnings)}" if warnings else ""
+        if not matches:
+            raise ScanReviewResolutionError(
+                f"No valid Quillan scan review item has failure ID {failure_id}."
+                + warning_suffix
+            )
+        raise ScanReviewResolutionError(
+            f"Multiple Quillan scan review records use failure ID {failure_id}."
+        )
+    failure, _ = matches[0]
+    work_ref = _failure_work_ref(failure)
+    evidence_relative = _evidence_path(root, work_ref, evidence_path)
+    if evidence_relative is not None and metadata_action != "evidence_filed":
         raise ScanReviewResolutionError(
             "evidence_path may only be used with the evidence_filed action."
         )
 
-    discovery = discover_scan_review_items(root, include_resolved=True)
-    matches = [item for item in discovery.items if item.failure_id == failure_id]
-    if not matches:
-        raise ScanReviewResolutionError(
-            f"No valid Quillan scan review item has failure ID {failure_id}."
-        )
-    if len(matches) != 1:
-        raise ScanReviewResolutionError(
-            f"Multiple Quillan scan review records use failure ID {failure_id}."
-        )
-    item = matches[0]
     timestamp = _utc_timestamp(resolved_at)
-    status = "deferred" if action == "defer" else "resolved"
-    metadata_action = "other" if action == "defer" else action
     resolution_id = _resolution_id(
         failure_id=failure_id,
         status=status,
@@ -217,39 +257,35 @@ def resolve_scan_review_item(
         message=normalized_message,
         timestamp=timestamp,
     )
+    module_details = {
+        "resolved_by": "teacher",
+        "resolution_origin": "quillan_scan_review",
+        "original_failure_category": failure.failure_category,
+        "original_failure_stage": failure.stage,
+        "teacher_selected_action": action,
+    }
+    resolution_locator, resolution_target = _resolution_route(
+        root,
+        failure,
+        action,
+        route_locator,
+        target,
+    )
     try:
-        metadata = ScanResolutionMetadata(
-            schema_version="1",
+        metadata = create_scan_resolution_metadata(
+            failure,
             resolution_id=resolution_id,
-            failure_id=item.failure_id,
-            failure_metadata_path=item.failure_metadata_relative_path,
             resolution_status=status,
             resolution_action=metadata_action,
             resolved_at=timestamp.isoformat(timespec="microseconds"),
             resolution_message=normalized_message,
-            module_details={
-                "resolved_by": "teacher",
-                "resolution_origin": "quillan_scan_review",
-                "original_failure_category": item.failure_category,
-                "original_failure_stage": item.stage,
-                "teacher_selected_action": action,
-            },
-            module=item.module or "quillan",
-            source_scan_id=item.source_scan_id,
-            source_sha256=item.source_sha256,
-            source_filename=item.source_filename,
-            retained_source_path=item.retained_source_path,
-            review_copy_path=item.review_copy_path,
+            route_locator=resolution_locator,
+            target=resolution_target,
             resolution_evidence_path=evidence_relative,
-            source_page_number=item.source_page_number,
-            class_id=item.class_id,
-            assignment_id=item.assignment_id,
-            student_id=item.student_id,
+            module_details=module_details,
         )
-        expected = scan_resolution_metadata_path(root, resolution_id).resolve(
-            strict=False
-        )
-        written = write_scan_resolution_metadata(root, metadata).resolve(strict=False)
+        expected = scan_resolution_metadata_path(root, resolution_id)
+        written = write_scan_resolution_metadata(root, metadata)
     except (
         ScanResolutionMetadataError,
         ScanResolutionMetadataWriteError,
@@ -262,7 +298,7 @@ def resolve_scan_review_item(
         ) from error
     if written != expected:
         raise ScanReviewResolutionError(
-            "Shared scan resolution writer returned an unexpected path."
+            "Core scan-resolution writer returned an unexpected path."
         )
     return QuillanResolutionResult(
         resolution_id=resolution_id,
@@ -279,43 +315,232 @@ def _load_failures(
 ) -> tuple[list[tuple[RoutingFailureMetadata, Path]], list[str]]:
     records: list[tuple[RoutingFailureMetadata, Path]] = []
     warnings: list[str] = []
-    review_dir = routing_review_dir(root)
-    if not review_dir.exists():
-        return records, warnings
-    for path in sorted(review_dir.glob("*.json"), key=lambda value: value.name):
+    for path in _json_children(routing_review_dir(root), "review", warnings):
+        failure_id = path.stem
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                raise RoutingFailureMetadataError("record must be a JSON object.")
-            metadata = routing_failure_metadata_from_dict(data)
-        except (OSError, UnicodeError, json.JSONDecodeError, RoutingFailureMetadataError) as error:
+            if routing_failure_metadata_path(root, failure_id) != path:
+                raise RoutingFailureMetadataError(
+                    "filename is not the exact canonical failure path"
+                )
+            metadata = load_routing_failure_metadata(root, failure_id)
+            if metadata.schema_version != ROUTING_FAILURE_SCHEMA_VERSION:
+                raise RoutingFailureMetadataError("failure schema_version is not 2")
+            if metadata.failure_id != failure_id:
+                raise RoutingFailureMetadataError("filename and failure_id disagree")
+        except (
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+            RoutingFailureMetadataError,
+            RuntimeError,
+            ValueError,
+        ) as error:
             warnings.append(f"Skipped unreadable review record {path.name}: {error}")
             continue
-        if metadata.stage != "quillan_route_review":
+        if not _is_quillan_failure(metadata):
             continue
-        records.append((metadata, path.resolve(strict=False)))
-    return records, warnings
+        records.append((metadata, path))
+    return _reject_duplicate_failures(records, warnings), warnings
 
 
 def _load_resolutions(
     root: Path,
+    failures: list[tuple[RoutingFailureMetadata, Path]],
 ) -> tuple[list[tuple[ScanResolutionMetadata, Path]], list[str]]:
     records: list[tuple[ScanResolutionMetadata, Path]] = []
     warnings: list[str] = []
     directory = scan_resolution_metadata_dir(root)
-    if not directory.exists():
-        return records, warnings
-    for path in sorted(directory.glob("*.json"), key=lambda value: value.name):
+    failure_by_id = {item.failure_id: item for item, _ in failures}
+    for path in _json_children(directory, "resolution", warnings):
+        resolution_id = path.stem
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                raise ScanResolutionMetadataError("record must be a JSON object.")
-            metadata = scan_resolution_metadata_from_dict(data)
-        except (OSError, UnicodeError, json.JSONDecodeError, ScanResolutionMetadataError) as error:
+            if scan_resolution_metadata_path(root, resolution_id) != path:
+                raise ScanResolutionMetadataError(
+                    "filename is not the exact canonical resolution path"
+                )
+            metadata = load_scan_resolution_metadata(root, resolution_id)
+            if metadata.schema_version != SCAN_RESOLUTION_SCHEMA_VERSION:
+                raise ScanResolutionMetadataError("resolution schema_version is not 2")
+            if metadata.resolution_id != resolution_id:
+                raise ScanResolutionMetadataError("filename and resolution_id disagree")
+            failure = failure_by_id.get(metadata.failure_id)
+            if failure is None:
+                raise ScanResolutionMetadataError(
+                    "resolution references an absent valid failure"
+                )
+            _validate_resolution_linkage(root, metadata, failure)
+        except (
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+            ScanResolutionMetadataError,
+            RuntimeError,
+            ValueError,
+        ) as error:
             warnings.append(f"Skipped unreadable resolution record {path.name}: {error}")
             continue
-        records.append((metadata, path.resolve(strict=False)))
-    return records, warnings
+        records.append((metadata, path))
+    return _reject_duplicate_resolutions(records, warnings), warnings
+
+
+def _json_children(
+    directory: Path, description: str, warnings: list[str]
+) -> tuple[Path, ...]:
+    if not os.path.lexists(directory):
+        return ()
+    try:
+        _preflight_path_chain(
+            root=Path(directory.anchor), target=directory, expect_file=False
+        )
+    except Exception as error:
+        warnings.append(f"Skipped unsafe {description} directory: {error}")
+        return ()
+    if _is_link_like(directory) or not directory.is_dir():
+        warnings.append(
+            f"Skipped unsafe {description} directory: {directory}"
+        )
+        return ()
+    try:
+        children = tuple(sorted(directory.iterdir(), key=lambda value: value.name))
+    except OSError as error:
+        warnings.append(f"Could not inspect {description} directory: {error}")
+        return ()
+    result: list[Path] = []
+    for child in children:
+        if child.suffix != ".json":
+            continue
+        try:
+            _preflight_arbitrary_file_destination(child)
+        except Exception:
+            warnings.append(f"Skipped unsafe {description} record {child.name}.")
+            continue
+        if _is_link_like(child) or not child.is_file():
+            warnings.append(f"Skipped unsafe {description} record {child.name}.")
+            continue
+        result.append(child)
+    return tuple(result)
+
+
+def _reject_duplicate_failures(
+    records: list[tuple[RoutingFailureMetadata, Path]], warnings: list[str]
+) -> list[tuple[RoutingFailureMetadata, Path]]:
+    counts: dict[str, int] = {}
+    for metadata, _ in records:
+        counts[metadata.failure_id] = counts.get(metadata.failure_id, 0) + 1
+    duplicate_ids = {failure_id for failure_id, count in counts.items() if count > 1}
+    for failure_id in sorted(duplicate_ids):
+        warnings.append(f"Skipped duplicate failure ID {failure_id}.")
+    return [item for item in records if item[0].failure_id not in duplicate_ids]
+
+
+def _reject_duplicate_resolutions(
+    records: list[tuple[ScanResolutionMetadata, Path]], warnings: list[str]
+) -> list[tuple[ScanResolutionMetadata, Path]]:
+    counts: dict[str, int] = {}
+    for metadata, _ in records:
+        counts[metadata.resolution_id] = counts.get(metadata.resolution_id, 0) + 1
+    duplicate_ids = {
+        resolution_id for resolution_id, count in counts.items() if count > 1
+    }
+    for resolution_id in sorted(duplicate_ids):
+        warnings.append(f"Skipped duplicate resolution ID {resolution_id}.")
+    return [item for item in records if item[0].resolution_id not in duplicate_ids]
+
+
+def _validate_resolution_linkage(
+    root: Path,
+    resolution: ScanResolutionMetadata,
+    failure: RoutingFailureMetadata,
+) -> None:
+    expected_failure_path = routing_failure_metadata_path(
+        root, failure.failure_id
+    ).relative_to(root).as_posix()
+    if resolution.failure_metadata_path != expected_failure_path:
+        raise ScanResolutionMetadataError(
+            "resolution failure_metadata_path is not canonical"
+        )
+    provenance_fields = (
+        "source_filename",
+        "source_scan_id",
+        "source_sha256",
+        "retained_source_path",
+        "review_copy_path",
+        "source_page_number",
+    )
+    if any(
+        getattr(resolution, field) != getattr(failure, field)
+        for field in provenance_fields
+    ):
+        raise ScanResolutionMetadataError("resolution source provenance is forged")
+    resolved_at = datetime.fromisoformat(resolution.resolved_at)
+    created_at = datetime.fromisoformat(failure.created_at)
+    if resolved_at < created_at:
+        raise ScanResolutionMetadataError("resolution predates its failure")
+
+
+def _is_quillan_failure(failure: RoutingFailureMetadata) -> bool:
+    locator = failure.route_locator
+    target = failure.target
+    if locator is not None or target is not None:
+        modules = {
+            value.module_id for value in (locator, target) if value is not None
+        }
+        return modules == {QUILLAN_MODULE_ID}
+    details = failure.module_details
+    if details.get("failure_owner") != QUILLAN_MODULE_ID:
+        return False
+    marker = (
+        details.get("failure_origin"),
+        failure.scope,
+        failure.stage,
+        failure.failure_category,
+    )
+    exact_markers = {
+        ("source_page_loading", "scan", "source_page_loading", "source_unreadable"),
+        ("source_page_loading", "page", "source_page_loading", "source_unreadable"),
+        ("qr_detection", "page", "qr_detection", "payload_missing"),
+        ("qr_detection", "page", "qr_detection", "payload_unreadable"),
+        ("payload_parsing", "page", "payload_parsing", "payload_invalid"),
+        (
+            "payload_parsing",
+            "page",
+            "payload_parsing",
+            "payload_schema_unsupported",
+        ),
+        ("payload_parsing", "page", "payload_parsing", "payload_too_large"),
+        ("payload_parsing", "page", "payload_parsing", "payload_unreadable"),
+    }
+    return marker in exact_markers
+
+
+def _failure_work_ref(failure: RoutingFailureMetadata) -> ModuleWorkRef | None:
+    locator = failure.route_locator
+    if locator is None or locator.module_id != QUILLAN_MODULE_ID:
+        return None
+    return locator.work
+
+
+def _student_identity(
+    root: Path,
+    failure: RoutingFailureMetadata,
+    work_ref: ModuleWorkRef | None,
+) -> tuple[str | None, str | None]:
+    target = failure.target
+    if (
+        work_ref is None
+        or target is None
+        or target.module_id != QUILLAN_MODULE_ID
+        or target.record_kind != RESPONSE_PAGE_RECORD_KIND
+    ):
+        return None, None
+    try:
+        page = load_printable_response_page(root, work_ref, target.record_id)
+    except PrintableResponsePersistenceError as error:
+        return None, (
+            f"Could not enrich failure {failure.failure_id} from its exact "
+            f"response-page target: {error}"
+        )
+    return page.student_id, None
 
 
 def _review_item(
@@ -323,6 +548,8 @@ def _review_item(
     failure: RoutingFailureMetadata,
     path: Path,
     latest: tuple[ScanResolutionMetadata, Path] | None,
+    work_ref: ModuleWorkRef | None,
+    student_id: str | None,
 ) -> QuillanReviewItem:
     resolution, resolution_path = latest if latest is not None else (None, None)
     return QuillanReviewItem(
@@ -333,7 +560,7 @@ def _review_item(
         failure_message=failure.failure_message,
         stage=failure.stage,
         created_at=failure.created_at,
-        module=failure.module,
+        module=QUILLAN_MODULE_ID,
         source_filename=failure.source_filename,
         retained_source_path=failure.retained_source_path,
         review_copy_path=failure.review_copy_path,
@@ -341,12 +568,16 @@ def _review_item(
         source_sha256=failure.source_sha256,
         source_page_number=failure.source_page_number,
         detected_payload=failure.detected_payload,
-        payload_page_number=failure.payload_page_number,
-        class_id=failure.class_id,
-        assignment_id=failure.assignment_id,
-        student_id=failure.student_id,
-        latest_resolution_status=(None if resolution is None else resolution.resolution_status),
-        latest_resolution_action=(None if resolution is None else resolution.resolution_action),
+        payload_page_number=None,
+        class_id=None if work_ref is None else work_ref.class_id,
+        assignment_id=None if work_ref is None else work_ref.work_id,
+        student_id=student_id,
+        latest_resolution_status=(
+            None if resolution is None else resolution.resolution_status
+        ),
+        latest_resolution_action=(
+            None if resolution is None else resolution.resolution_action
+        ),
         latest_resolution_path=(
             None if resolution_path is None else _relative(resolution_path, root)
         ),
@@ -362,28 +593,146 @@ def _resolution_order(
 
 def _workspace_root(value: str | Path) -> Path:
     try:
-        root = Path(value).resolve(strict=True)
+        root = Path(os.path.abspath(Path(value)))
     except (OSError, TypeError, ValueError) as error:
         raise ScanReviewResolutionError(f"Invalid workspace root: {error}") from error
-    if not root.is_dir():
+    if not os.path.lexists(root) or _is_link_like(root) or not root.is_dir():
         raise ScanReviewResolutionError(
-            f"Workspace root is not an existing directory: {root}"
+            f"Workspace root is not an ordinary existing directory: {root}"
         )
     return root
 
 
-def _evidence_path(value: str | Path | None) -> str | None:
+def _evidence_path(
+    root: Path,
+    work_ref: ModuleWorkRef | None,
+    value: str | Path | None,
+) -> str | None:
     if value is None:
         return None
-    try:
-        path = Path(value)
-    except (TypeError, ValueError) as error:
-        raise ScanReviewResolutionError(f"Invalid evidence_path: {error}") from error
-    if path.is_absolute():
+    if not isinstance(value, (str, Path)):
+        raise ScanReviewResolutionError("evidence_path must be a string or Path.")
+    text = str(value)
+    posix = PurePosixPath(text)
+    windows = PureWindowsPath(text)
+    if (
+        not text
+        or "\\" in text
+        or posix.is_absolute()
+        or windows.is_absolute()
+        or windows.drive
+        or any(component in {"", ".", ".."} for component in posix.parts)
+        or posix.as_posix() != text
+    ):
         raise ScanReviewResolutionError(
-            "evidence_path must be relative to the workspace root."
+            "evidence_path must be canonical workspace-relative POSIX text."
         )
-    return path.as_posix()
+    absolute = root.joinpath(*posix.parts)
+    try:
+        absolute.relative_to(root)
+    except ValueError as error:
+        raise ScanReviewResolutionError("evidence_path escapes the workspace.") from error
+    if not os.path.lexists(absolute) or _is_link_like(absolute) or not absolute.is_file():
+        raise ScanReviewResolutionError(
+            "evidence_path must name an ordinary existing non-link file."
+        )
+    try:
+        _preflight_arbitrary_file_destination(absolute)
+    except Exception as error:
+        raise ScanReviewResolutionError(
+            f"evidence_path has an unsafe ancestor: {error}"
+        ) from error
+    if work_ref is not None:
+        work_root = quillan_work_paths(
+            root, work_ref.class_id, work_ref.work_id
+        ).work_root
+        try:
+            absolute.relative_to(work_root)
+        except ValueError as error:
+            raise ScanReviewResolutionError(
+                "evidence_path is outside the selected Quillan work root."
+            ) from error
+    return text
+
+
+def _resolution_route(
+    root: Path,
+    failure: RoutingFailureMetadata,
+    action: str,
+    locator: RouteLocator | None,
+    target: ModuleRecordRef | None,
+) -> tuple[RouteLocator | None, ModuleRecordRef | None]:
+    route_action = action in {"route_selected", "route_corrected"}
+    if not route_action:
+        if locator is not None or target is not None:
+            raise ScanReviewResolutionError(
+                "route_locator and target are only valid for route actions."
+            )
+        return None, None
+    if type(locator) is not RouteLocator:
+        raise ScanReviewResolutionError(
+            f"{action} requires an exact Core RouteLocator."
+        )
+    if type(target) is not ModuleRecordRef:
+        raise ScanReviewResolutionError(
+            f"{action} requires an exact Core ModuleRecordRef target."
+        )
+    if locator.schema != "PDS2" or locator.module_id != QUILLAN_MODULE_ID:
+        raise ScanReviewResolutionError(
+            "route_locator must be an exact PDS2 Quillan locator."
+        )
+    if (
+        target.module_id != QUILLAN_MODULE_ID
+        or target.record_kind != RESPONSE_PAGE_RECORD_KIND
+        or target.contract_version != RESPONSE_PAGE_CONTRACT_VERSION
+    ):
+        raise ScanReviewResolutionError(
+            "target is not a supported Quillan response-page reference."
+        )
+    failure_work = _failure_work_ref(failure)
+    if failure_work is not None and locator.work != failure_work:
+        raise ScanReviewResolutionError(
+            "Corrected route crosses the failure's exact class or assignment."
+        )
+    if action == "route_corrected" and (
+        failure.route_locator == locator and failure.target == target
+    ):
+        raise ScanReviewResolutionError(
+            "route_corrected must change the failure's route or target."
+        )
+    try:
+        registration = load_route_registration(root, locator)
+    except Exception as error:
+        raise ScanReviewResolutionError(
+            f"route_locator does not identify a valid canonical route: {error}"
+        ) from error
+    if registration.locator != locator or registration.target != target:
+        raise ScanReviewResolutionError(
+            "route_locator and target do not identify the same registered route."
+        )
+    try:
+        page = load_printable_response_page(root, locator.work, target.record_id)
+    except PrintableResponsePersistenceError as error:
+        raise ScanReviewResolutionError(
+            f"route target is not a valid canonical response page: {error}"
+        ) from error
+    if (
+        page.class_id != locator.class_id
+        or page.assignment_id != locator.work_id
+        or page.page_id != target.record_id
+    ):
+        raise ScanReviewResolutionError(
+            "route target contradicts the selected work identity."
+        )
+    return locator, target
+
+
+def _mapped_action(action: str) -> tuple[str, str]:
+    if action in {"defer", "deferred"}:
+        return "deferred", "deferred"
+    if action == "mixed_assignment":
+        return "resolved", "other"
+    return "resolved", action
 
 
 def _resolution_message(action: str, value: str | None) -> str:
@@ -421,8 +770,26 @@ def _resolution_id(
 
 def _relative(path: Path, root: Path) -> str:
     try:
-        return path.resolve(strict=False).relative_to(root).as_posix()
+        return path.relative_to(root).as_posix()
     except ValueError as error:
         raise ScanReviewResolutionError(
             "Scan review metadata path is outside the workspace root."
         ) from error
+
+
+def _is_link_like(path: Path) -> bool:
+    is_junction = getattr(path, "is_junction", None)
+    return path.is_symlink() or bool(is_junction is not None and is_junction())
+
+
+__all__ = [
+    "DEFAULT_RESOLUTION_MESSAGES",
+    "QUILLAN_RESOLUTION_ACTIONS",
+    "QuillanResolutionResult",
+    "QuillanReviewDiscovery",
+    "QuillanReviewItem",
+    "ScanReviewResolutionError",
+    "discover_scan_review_items",
+    "list_scan_review_items",
+    "resolve_scan_review_item",
+]

--- a/quillan/standards_summary_export.py
+++ b/quillan/standards_summary_export.py
@@ -28,7 +28,14 @@ from quillan.assignment_summary_context import (
     relative_path_for,
     standard_column_keys,
 )
-from quillan.work_paths import quillan_work_paths
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    feedback_pdf_path,
+    preflight_work_file_destination,
+    quillan_work_ref,
+    standards_summary_path,
+)
+from quillan.record_context import canonical_workspace_root
 
 CSV_COLUMNS: Final[tuple[str, ...]] = (
     "class_id",
@@ -87,9 +94,9 @@ def standards_summary_export_path(
     """Return the canonical assignment-local standards summary CSV path."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
-    return quillan_work_paths(
-        workspace_root, class_id, assignment_id
-    ).exports_dir / "standards_summary.csv"
+    return standards_summary_path(
+        workspace_root, quillan_work_ref(class_id, assignment_id)
+    )
 
 
 def export_standards_summary(
@@ -103,16 +110,31 @@ def export_standards_summary(
     """Export assignment-local Focus Standard rating aggregates."""
     normalized_created_at = _normalize_timestamp(created_at)
     try:
-        resolved_root = Path(workspace_root).resolve(strict=False)
+        resolved_root = canonical_workspace_root(workspace_root)
         output_path = standards_summary_export_path(
             resolved_root, class_id, assignment_id
         )
         assignment = load_assignment(resolved_root, class_id, assignment_id)
+        expected_output = preflight_work_file_destination(
+            resolved_root,
+            quillan_work_ref(class_id, assignment_id),
+            Path("exports") / "standards_summary.csv",
+        )
+        if output_path != expected_output:
+            raise StandardsSummaryExportError(
+                "Standards summary path is not canonical."
+            )
         focus_standard_ids = list(assignment["focus_standard_ids"])
         column_keys, key_warnings = standard_column_keys(focus_standard_ids)
         values = rating_values(assignment)
         students = discover_students(resolved_root, class_id, assignment_id)
-    except (OSError, RuntimeError, ValueError, StandardsSummaryExportError) as error:
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        QuillanWorkPathError,
+        StandardsSummaryExportError,
+    ) as error:
         raise StandardsSummaryExportError(str(error)) from error
 
     overwrote_existing = output_path.exists()
@@ -203,7 +225,11 @@ def _build_row(
         if review is None:
             continue
         students_with_valid_reviews += 1
-        pdf_path = record.student.student_dir / "exports" / "feedback.pdf"
+        pdf_path = feedback_pdf_path(
+            workspace_root,
+            record.student.work_ref,
+            record.student.student_id,
+        )
         _, pdf_status, _, _ = feedback_status(
             workspace_root, review, "feedback_pdf", pdf_path
         )

--- a/quillan/student_performance_summary_export.py
+++ b/quillan/student_performance_summary_export.py
@@ -21,7 +21,13 @@ from quillan.assignment_summary_context import (
     rating_labels,
     relative_path_for,
 )
-from quillan.work_paths import quillan_work_paths
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    preflight_work_file_destination,
+    quillan_work_ref,
+    student_performance_summary_path,
+)
+from quillan.record_context import canonical_workspace_root
 
 MISSING_RATING = ""
 BASE_CSV_COLUMNS = (
@@ -62,9 +68,9 @@ def student_performance_summary_export_path(
     """Return the assignment-local student performance summary CSV path."""
     _validate_identifier(class_id, "class_id")
     _validate_identifier(assignment_id, "assignment_id")
-    return quillan_work_paths(
-        workspace_root, class_id, assignment_id
-    ).exports_dir / "student_performance_summary.csv"
+    return student_performance_summary_path(
+        workspace_root, quillan_work_ref(class_id, assignment_id)
+    )
 
 
 def export_student_performance_summary(
@@ -78,9 +84,18 @@ def export_student_performance_summary(
     """Export one compact row per rostered or discovered student."""
     timestamp = _normalize_timestamp(created_at)
     try:
-        root = Path(workspace_root).resolve(strict=False)
+        root = canonical_workspace_root(workspace_root)
         path = student_performance_summary_export_path(root, class_id, assignment_id)
         assignment = load_assignment(root, class_id, assignment_id)
+        expected_path = preflight_work_file_destination(
+            root,
+            quillan_work_ref(class_id, assignment_id),
+            Path("exports") / "student_performance_summary.csv",
+        )
+        if path != expected_path:
+            raise StudentPerformanceSummaryExportError(
+                "Student performance summary path is not canonical."
+            )
         standard_ids = list(assignment["focus_standard_ids"])
         labels = rating_labels(assignment)
         records = [
@@ -88,7 +103,13 @@ def export_student_performance_summary(
             for student in discover_students(root, class_id, assignment_id)
         ]
         headers, metadata_missing = _standard_headers(root, standard_ids)
-    except (OSError, RuntimeError, ValueError, StudentPerformanceSummaryExportError) as error:
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        QuillanWorkPathError,
+        StudentPerformanceSummaryExportError,
+    ) as error:
         raise StudentPerformanceSummaryExportError(str(error)) from error
 
     existed = path.exists()

--- a/quillan/student_review_status.py
+++ b/quillan/student_review_status.py
@@ -14,14 +14,24 @@ from pds_core.rosters import RosterError, student_display_name
 
 from quillan.assignment_submission_assembly import discover_assignment_routed_evidence_status
 from quillan.assignment_summary_context import feedback_status, relative_path_for
-from quillan.assignments import AssignmentConfigError, load_assignment_config
-from quillan.storage import assignment_config_path
 from quillan.feedback_export import feedback_export_path, feedback_pdf_export_path
 from quillan.minimum_requirement_review import configured_requirements
 from quillan.plain_paper_submission import is_plain_paper_submission
-from quillan.review_record import ReviewRecordError, load_review_record
 from quillan.review_status_display import review_progress_status
-from quillan.submission_manifest import SubmissionManifestError, load_submission_manifest
+from quillan.record_context import (
+    InvalidReviewError,
+    InvalidSubmissionError,
+    MissingSubmissionError,
+    OrphanReviewError,
+    QuillanRecordContextError,
+    RecordIdentityMismatchError,
+    ReviewLoadingPolicy,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+    student_record_paths,
+)
+from quillan.work_paths import quillan_work_ref
 
 REVIEW_STATUS_SCHEMA_VERSION: Final = "1"
 REVIEW_STATUS_RECORD_TYPE: Final = "quillan_student_review_status"
@@ -83,20 +93,15 @@ def build_student_review_status(
     except ValueError as error:
         raise StudentReviewStatusError(str(error)) from error
 
-    root = Path(workspace_root).resolve(strict=False)
-    assignment_path = assignment_config_path(root, class_id, assignment_id)
+    work_ref = quillan_work_ref(class_id, assignment_id)
     try:
-        assignment = load_assignment_config(assignment_path)
-    except (OSError, AssignmentConfigError) as error:
+        assignment_context = load_quillan_assignment_context(workspace_root, work_ref)
+        root = assignment_context.paths.workspace_root
+        assignment_path = assignment_context.paths.assignment_path
+        assignment = mutable_json_copy(assignment_context.assignment)
+        paths = student_record_paths(root, work_ref, student_id)
+    except (OSError, QuillanRecordContextError) as error:
         raise StudentReviewStatusError(f"Could not load assignment: {error}") from error
-    if assignment["assignment_id"] != assignment_id:
-        raise StudentReviewStatusError(
-            f"Assignment identity mismatch: expected {assignment_id!r}, found {assignment['assignment_id']!r}."
-        )
-    if class_id not in assignment["class_ids"]:
-        raise StudentReviewStatusError(
-            f"Assignment {assignment_id!r} is not configured for class {class_id!r}."
-        )
 
     warnings: list[str] = []
     display_name = student_id
@@ -125,27 +130,47 @@ def build_student_review_status(
         routed_count = None
         warnings.append("routed_evidence_unavailable")
 
-    student_dir = assignment_path.parent / "submissions" / student_id
-    manifest_path = student_dir / "submission.json"
-    review_path = student_dir / "review.json"
-    manifest, submission_status = _load_record(
-        manifest_path,
-        load_submission_manifest,
-        class_id,
-        assignment_id,
-        student_id,
-        "submission",
-        warnings,
-    )
-    review, review_status = _load_record(
-        review_path,
-        load_review_record,
-        class_id,
-        assignment_id,
-        student_id,
-        "review",
-        warnings,
-    )
+    manifest_path = paths.submission_manifest_path
+    review_path = paths.review_record_path
+    manifest: dict[str, Any] | None = None
+    review: dict[str, Any] | None = None
+    submission_status = "missing"
+    review_status = "missing"
+    try:
+        record_context = load_quillan_student_review_context(
+            root,
+            work_ref,
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+        )
+    except MissingSubmissionError:
+        pass
+    except OrphanReviewError:
+        review_status = "orphaned"
+        warnings.append("review_without_valid_submission")
+    except InvalidSubmissionError:
+        submission_status = "invalid"
+        warnings.append("invalid_submission")
+    except InvalidReviewError as error:
+        submission_status = "valid"
+        review_status = "invalid"
+        warnings.append("invalid_review")
+        if error.submission_record is not None:
+            manifest = mutable_json_copy(error.submission_record.value)
+    except RecordIdentityMismatchError:
+        submission_status = "identity_mismatch"
+        review_status = "identity_mismatch"
+        warnings.append("identity_mismatch")
+    except QuillanRecordContextError:
+        submission_status = "invalid"
+        review_status = "invalid"
+        warnings.append("unsafe_path")
+    else:
+        manifest = mutable_json_copy(record_context.submission)
+        submission_status = "valid"
+        if record_context.review is not None:
+            review = mutable_json_copy(record_context.review)
+            review_status = "valid"
     needs_assembly = None if routed_count is None else bool(routed_count) and manifest is None
     if needs_assembly:
         warnings.append("routed_evidence_needs_assembly")
@@ -153,7 +178,7 @@ def build_student_review_status(
         warnings.append("missing_submission")
     if review_status == "missing":
         warnings.append("missing_review")
-    orphaned = review_path.is_file() and manifest is None
+    orphaned = review_status == "orphaned"
     if orphaned:
         warnings.append("review_without_valid_submission")
 
@@ -189,30 +214,6 @@ def build_student_review_status(
         review=_freeze(review_section),
         warnings=tuple(dict.fromkeys(warnings)),
     )
-
-
-def _load_record(
-    path: Path,
-    loader: Any,
-    class_id: str,
-    assignment_id: str,
-    student_id: str,
-    kind: str,
-    warnings: list[str],
-) -> tuple[dict[str, Any] | None, str]:
-    if not path.is_file():
-        return None, "missing"
-    try:
-        record = loader(path)
-    except (OSError, SubmissionManifestError, ReviewRecordError):
-        warnings.append(f"invalid_{kind}")
-        return None, "invalid"
-    if any(record[key] != expected for key, expected in (
-        ("class_id", class_id), ("assignment_id", assignment_id), ("student_id", student_id)
-    )):
-        warnings.append(f"{kind}_identity_mismatch")
-        return None, "identity_mismatch"
-    return cast(dict[str, Any], record), "valid"
 
 
 def _submission_section(
@@ -528,3 +529,4 @@ def _value(value: object) -> str:
 
 def _yes_no(value: object) -> str:
     return "unavailable" if value is None else "yes" if value is True else "no"
+    ReviewLoadingPolicy,

--- a/quillan/submission_manifest_paths.py
+++ b/quillan/submission_manifest_paths.py
@@ -7,7 +7,23 @@ import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from collections.abc import Mapping
 from typing import Any, Literal
+
+from pds_core.routing_models import ModuleWorkRef
+
+from quillan.atomic_record_io import (
+    AtomicRecordConcurrencyError,
+    AtomicRecordDurabilityError,
+    AtomicRecordError,
+    create_exclusive_record,
+    revision_guarded_update,
+)
+from quillan.record_context import (
+    QuillanAssignmentRecordContext,
+    QuillanStudentReviewContext,
+    student_record_paths,
+)
 
 from quillan.submission_manifest import (
     SubmissionManifestError,
@@ -18,6 +34,7 @@ from quillan.work_paths import (
     QuillanWorkPathError,
     _preflight_arbitrary_file_destination,
     quillan_work_ref,
+    initialize_student_submission_dir,
     student_submission_dir,
     submission_manifest_path as work_submission_manifest_path,
 )
@@ -25,6 +42,17 @@ from quillan.work_paths import (
 
 class SubmissionManifestPathError(ValueError):
     """Raised when a submission manifest path or write operation is invalid."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        possibly_durable_path: Path | None = None,
+        possible_lock_path: Path | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.possibly_durable_path = possibly_durable_path
+        self.possible_lock_path = possible_lock_path
 
 
 class SubmissionManifestConcurrencyError(SubmissionManifestPathError):
@@ -35,6 +63,59 @@ class SubmissionManifestConcurrencyError(SubmissionManifestPathError):
 class PersistedSubmissionManifest:
     path: Path
     status: Literal["created", "updated", "unchanged"]
+
+
+def create_quillan_submission_manifest(
+    assignment_context: QuillanAssignmentRecordContext,
+    student_id: str,
+    manifest: Mapping[str, object],
+) -> PersistedSubmissionManifest:
+    """Create only beneath a validated canonical assignment context."""
+    if type(assignment_context) is not QuillanAssignmentRecordContext:
+        raise SubmissionManifestPathError(
+            "assignment_context must be an exact QuillanAssignmentRecordContext."
+        )
+    work_ref = assignment_context.paths.work_ref
+    manifest_data = dict(manifest)
+    _validate_manifest_identity(manifest_data, work_ref, student_id)
+    initialize_student_submission_dir(
+        assignment_context.paths.workspace_root, work_ref, student_id
+    )
+    paths = student_record_paths(
+        assignment_context.paths.workspace_root, work_ref, student_id
+    )
+    return _persist_submission_manifest(
+        paths.submission_manifest_path,
+        manifest_data,
+        preflight=lambda: student_record_paths(
+            assignment_context.paths.workspace_root, work_ref, student_id
+        ),
+    )
+
+
+def update_quillan_submission_manifest(
+    context: QuillanStudentReviewContext,
+    manifest: Mapping[str, object],
+) -> PersistedSubmissionManifest:
+    """Revision-guard an update using the manifest snapshot in ``context``."""
+    if type(context) is not QuillanStudentReviewContext:
+        raise SubmissionManifestPathError(
+            "context must be an exact QuillanStudentReviewContext."
+        )
+    manifest_data = dict(manifest)
+    _validate_manifest_identity(
+        manifest_data, context.paths.work_ref, context.paths.student_id
+    )
+    return _persist_submission_manifest(
+        context.paths.submission_manifest_path,
+        manifest_data,
+        expected_original_bytes=context.submission_record.original_bytes,
+        preflight=lambda: student_record_paths(
+            context.paths.workspace_root,
+            context.paths.work_ref,
+            context.paths.student_id,
+        ),
+    )
 
 
 def submission_dir(
@@ -117,131 +198,55 @@ def persist_submission_manifest(
     *,
     expected_original_bytes: bytes | None = None,
 ) -> PersistedSubmissionManifest:
-    """Atomically create or revision-guard update a validated manifest."""
-    validate_submission_manifest(manifest)
-    manifest_path = Path(path)
-    try:
-        _preflight_arbitrary_file_destination(manifest_path)
-    except QuillanWorkPathError as error:
-        raise SubmissionManifestPathError(str(error)) from error
-    parent = manifest_path.parent
-    try:
-        parent.mkdir(parents=True, exist_ok=True)
-        _preflight_arbitrary_file_destination(manifest_path)
-    except (OSError, QuillanWorkPathError) as error:
-        raise SubmissionManifestPathError(
-            f"Could not prepare submission manifest directory {parent}: {error}"
-        ) from error
-    data = _canonical_manifest_bytes(manifest)
-    if expected_original_bytes is None:
-        if os.path.lexists(manifest_path):
-            raise SubmissionManifestPathError(
-                f"Submission manifest already exists: {manifest_path}"
-            )
-        create_temporary = _write_manifest_temporary(manifest_path, data)
-        try:
-            os.link(create_temporary, manifest_path)
-            create_temporary.unlink()
-        except FileExistsError as error:
-            raise SubmissionManifestConcurrencyError(
-                f"Submission manifest was concurrently created: {manifest_path}"
-            ) from error
-        except OSError as error:
-            raise SubmissionManifestPathError(
-                f"Could not install submission manifest {manifest_path}: {error}"
-            ) from error
-        finally:
-            try:
-                create_temporary.unlink(missing_ok=True)
-            except OSError:
-                pass
-        try:
-            _reload_compare(manifest_path, manifest, data)
-        except Exception:
-            if (
-                not _is_link_like(manifest_path)
-                and manifest_path.is_file()
-                and manifest_path.read_bytes() == data
-            ):
-                manifest_path.unlink()
-            raise
-        return PersistedSubmissionManifest(manifest_path, "created")
+    """Low-level compatibility writer; canonical services use contexts instead."""
+    manifest_path = Path(os.path.abspath(Path(path)))
+    return _persist_submission_manifest(
+        manifest_path,
+        manifest,
+        expected_original_bytes=expected_original_bytes,
+        preflight=lambda: _preflight_arbitrary_file_destination(manifest_path),
+    )
 
-    if not isinstance(expected_original_bytes, bytes):
-        raise SubmissionManifestPathError(
-            "expected_original_bytes must be bytes or None."
-        )
-    current_bytes = _read_safe_manifest_bytes(manifest_path)
-    if current_bytes == expected_original_bytes and _existing_manifest_matches(
-        manifest_path, manifest
-    ):
-        return PersistedSubmissionManifest(manifest_path, "unchanged")
-    if data == expected_original_bytes:
-        if _read_safe_manifest_bytes(manifest_path) != expected_original_bytes:
-            raise SubmissionManifestConcurrencyError(
-                "Submission manifest changed before unchanged-state verification."
-            )
-        _reload_compare(manifest_path, manifest, data)
-        return PersistedSubmissionManifest(manifest_path, "unchanged")
-    lock_path = parent / f".{manifest_path.name}.assembly.lock"
-    lock_created = False
-    temporary: Path | None = None
+
+def _persist_submission_manifest(
+    manifest_path: Path,
+    manifest: dict[str, Any],
+    *,
+    expected_original_bytes: bytes | None = None,
+    preflight: Any,
+) -> PersistedSubmissionManifest:
+    """Atomically persist a preselected destination with guarded verification."""
+    validate_submission_manifest(manifest)
     try:
-        if os.path.lexists(lock_path):
-            raise SubmissionManifestConcurrencyError(
-                f"Submission assembly lock already exists: {lock_path}"
+        preflight()
+        data = _canonical_manifest_bytes(manifest)
+        if expected_original_bytes is None:
+            result = create_exclusive_record(
+                manifest_path,
+                data,
+                preflight=preflight,
+                verify_bytes=lambda loaded: _verify_manifest_bytes(loaded, manifest),
             )
-        with lock_path.open("xb") as lock_file:
-            lock_created = True
-            lock_file.write(b"quillan-submission-assembly-v1\n")
-            lock_file.flush()
-            os.fsync(lock_file.fileno())
-        if _read_safe_manifest_bytes(manifest_path) != expected_original_bytes:
-            raise SubmissionManifestConcurrencyError(
-                "Submission manifest changed after assembly loaded it."
+        else:
+            result = revision_guarded_update(
+                manifest_path,
+                expected_original_bytes,
+                data,
+                preflight=preflight,
+                verify_bytes=lambda loaded: _verify_manifest_bytes(loaded, manifest),
+                lock_purpose="submission-update",
             )
-        temporary = _write_manifest_temporary(manifest_path, data)
-        if _read_safe_manifest_bytes(manifest_path) != expected_original_bytes:
-            raise SubmissionManifestConcurrencyError(
-                "Submission manifest changed before atomic replacement."
-            )
-        os.replace(temporary, manifest_path)
-        temporary = None
-        try:
-            _reload_compare(manifest_path, manifest, data)
-        except Exception as error:
-            try:
-                _restore_manifest_bytes(manifest_path, expected_original_bytes)
-            except Exception as rollback_error:
-                raise SubmissionManifestPathError(
-                    "Updated manifest verification failed and original-byte "
-                    f"restoration failed: {rollback_error}"
-                ) from error
-            raise
-        return PersistedSubmissionManifest(manifest_path, "updated")
-    except SubmissionManifestPathError:
-        raise
-    except OSError as error:
+    except AtomicRecordConcurrencyError as error:
+        raise SubmissionManifestConcurrencyError(str(error)) from error
+    except AtomicRecordDurabilityError as error:
         raise SubmissionManifestPathError(
-            f"Could not atomically update submission manifest {manifest_path}: {error}"
+            str(error),
+            possibly_durable_path=error.possibly_durable_path,
+            possible_lock_path=error.possible_lock_path,
         ) from error
-    finally:
-        if temporary is not None:
-            try:
-                temporary.unlink(missing_ok=True)
-            except OSError:
-                pass
-        if lock_created:
-            try:
-                if _is_link_like(lock_path) or not lock_path.is_file():
-                    raise SubmissionManifestPathError(
-                        f"Assembly lock changed filesystem type: {lock_path}"
-                    )
-                lock_path.unlink()
-            except OSError as error:
-                raise SubmissionManifestPathError(
-                    f"Could not remove submission assembly lock {lock_path}: {error}"
-                ) from error
+    except (AtomicRecordError, QuillanWorkPathError, OSError) as error:
+        raise SubmissionManifestPathError(str(error)) from error
+    return PersistedSubmissionManifest(manifest_path, result.status)
 
 
 def _canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
@@ -262,6 +267,39 @@ def _canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
         ) from error
 
 
+def _verify_manifest_bytes(data: bytes, expected: dict[str, Any]) -> None:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise SubmissionManifestError(f"Duplicate manifest JSON key: {key}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> Any:
+        raise SubmissionManifestError(f"Invalid JSON constant: {value}")
+
+    try:
+        loaded = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=reject_duplicates,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise SubmissionManifestPathError(
+            f"Persisted submission manifest is not strict JSON: {error}"
+        ) from error
+    if not isinstance(loaded, dict):
+        raise SubmissionManifestPathError(
+            "Persisted submission manifest is not a JSON object."
+        )
+    validate_submission_manifest(loaded)
+    if loaded != expected:
+        raise SubmissionManifestPathError(
+            "Reloaded submission manifest differs from the committed model."
+        )
+
+
 def _write_manifest_temporary(path: Path, data: bytes) -> Path:
     descriptor, name = tempfile.mkstemp(
         prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
@@ -276,6 +314,32 @@ def _write_manifest_temporary(path: Path, data: bytes) -> Path:
         temporary.unlink(missing_ok=True)
         raise
     return temporary
+
+
+def _validate_manifest_identity(
+    manifest: dict[str, Any], work_ref: ModuleWorkRef, student_id: str
+) -> None:
+    validate_submission_manifest(manifest)
+    try:
+        canonical_ref = quillan_work_ref(work_ref.class_id, work_ref.work_id)
+    except (AttributeError, ValueError) as error:
+        raise SubmissionManifestPathError(
+            "work_ref must be an exact Quillan ModuleWorkRef."
+        ) from error
+    if work_ref != canonical_ref:
+        raise SubmissionManifestPathError(
+            "work_ref must be an exact Quillan ModuleWorkRef."
+        )
+    expected = {
+        "class_id": work_ref.class_id,
+        "assignment_id": work_ref.work_id,
+        "student_id": student_id,
+    }
+    for field, value in expected.items():
+        if manifest[field] != value:
+            raise SubmissionManifestPathError(
+                f"Submission manifest {field} does not match its canonical identity."
+            )
 
 
 def _restore_manifest_bytes(path: Path, data: bytes) -> None:
@@ -333,11 +397,11 @@ def _is_link_like(path: Path) -> bool:
 
 
 __all__ = [
+    "create_quillan_submission_manifest",
     "PersistedSubmissionManifest",
     "SubmissionManifestConcurrencyError",
     "SubmissionManifestPathError",
-    "persist_submission_manifest",
     "submission_dir",
     "submission_manifest_path",
-    "write_submission_manifest",
+    "update_quillan_submission_manifest",
 ]

--- a/quillan/submission_observation_assembly.py
+++ b/quillan/submission_observation_assembly.py
@@ -45,24 +45,27 @@ from quillan.response_page_observations import (
     list_quillan_page_observations,
     validate_observation_id,
 )
+from quillan.record_context import (
+    QuillanRecordContextError,
+    QuillanStudentReviewContext,
+    ReviewLoadingPolicy,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+)
 from quillan.submission_manifest import (
     PDS2_SUBMISSION_ENTRY_METHOD,
     SubmissionManifestError,
-    load_submission_manifest,
     validate_submission_manifest,
 )
 from quillan.submission_manifest_paths import (
     SubmissionManifestConcurrencyError,
     SubmissionManifestPathError,
-    _read_safe_manifest_bytes,
-    persist_submission_manifest,
+    create_quillan_submission_manifest,
     submission_manifest_path,
+    update_quillan_submission_manifest,
 )
 from quillan.work_paths import quillan_work_ref
-from quillan.work_paths import (
-    QuillanWorkPathError,
-    _preflight_arbitrary_file_destination,
-)
 
 ASSEMBLY_FAILURE_CATEGORIES: Final[frozenset[str]] = frozenset(
     {
@@ -436,6 +439,24 @@ def _assemble_submission_manifests_uncontained(
 ) -> QuillanSubmissionAssemblyBatch:
     """Discover observations and independently assemble affected students."""
     root = Path(workspace_root)
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    try:
+        assignment_context = load_quillan_assignment_context(root, work_ref)
+    except QuillanRecordContextError as error:
+        return QuillanSubmissionAssemblyBatch(
+            (),
+            (
+                _failure(
+                    "identity_conflict",
+                    class_id,
+                    assignment_id,
+                    None,
+                    (),
+                    f"Canonical assignment context failed: {error}",
+                    error,
+                ),
+            ),
+        )
     try:
         all_observations = list_quillan_page_observations(root, class_id, assignment_id)
     except QuillanObservationDiscoveryError as error:
@@ -503,14 +524,18 @@ def _assemble_submission_manifests_uncontained(
             root, class_id, assignment_id, student_id
         )
         existing: dict[str, Any] | None = None
-        original_bytes: bytes | None = None
+        student_context: QuillanStudentReviewContext | None = None
         existing_issuance_id: str | None = None
         if os.path.lexists(manifest_path):
             try:
-                _preflight_arbitrary_file_destination(manifest_path)
-                original_bytes = _read_safe_manifest_bytes(manifest_path)
-                existing = load_submission_manifest(manifest_path)
-            except (OSError, QuillanWorkPathError, SubmissionManifestError) as error:
+                student_context = load_quillan_student_review_context(
+                    root,
+                    work_ref,
+                    student_id,
+                    review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+                )
+                existing = mutable_json_copy(student_context.submission)
+            except (OSError, QuillanRecordContextError) as error:
                 failures.append(
                     _failure(
                         "existing_manifest_invalid",
@@ -683,11 +708,17 @@ def _assemble_submission_manifests_uncontained(
                 observations=student_observations,
                 timestamp=timestamp,
             )
-            persisted = persist_submission_manifest(
-                manifest_path,
-                merged,
-                expected_original_bytes=original_bytes,
-            )
+            if student_context is None:
+                persisted = create_quillan_submission_manifest(
+                    assignment_context,
+                    student_id,
+                    merged,
+                )
+            else:
+                persisted = update_quillan_submission_manifest(
+                    student_context,
+                    merged,
+                )
         except SubmissionManifestConcurrencyError as error:
             failures.append(
                 _failure(

--- a/quillan/submission_page_management.py
+++ b/quillan/submission_page_management.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime
+import os
 from pathlib import Path
 from typing import Any, cast
 
@@ -12,16 +13,24 @@ from pds_core.identifiers import IdentifierValidationError, validate_identifier
 
 from quillan.submission_manifest import (
     SubmissionManifestError,
-    load_submission_manifest,
     validate_submission_manifest,
 )
 from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
-    submission_manifest_path,
-    write_submission_manifest,
+    update_quillan_submission_manifest,
 )
 from quillan.plain_paper_submission import is_plain_paper_submission
 from quillan.submission_guidance import missing_submission_guidance
+from quillan.record_context import (
+    canonical_workspace_root,
+    MissingSubmissionError,
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    QuillanStudentReviewContext,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+)
+from quillan.work_paths import quillan_work_ref
 
 _PRESERVED_EXCLUSION_KEY = "quillan_before_page_exclusion"
 
@@ -104,7 +113,7 @@ def load_submission_page_context(
     student_id: str,
 ) -> SubmissionPageContext:
     """Load one student's canonical manifest without inspecting evidence files."""
-    path, manifest = _load_manifest(
+    path, manifest, _ = _load_manifest(
         workspace_root, class_id, assignment_id, student_id
     )
     pages = tuple(
@@ -123,9 +132,9 @@ def load_submission_page_context(
             key=lambda item: int(item["page_number"]),
         )
     )
-    root = Path(workspace_root).resolve(strict=False)
+    root = canonical_workspace_root(workspace_root)
     try:
-        relative_path = path.resolve(strict=False).relative_to(root).as_posix()
+        relative_path = Path(os.path.abspath(path)).relative_to(root).as_posix()
     except (OSError, ValueError):
         relative_path = str(path)
     details = cast(dict[str, Any], manifest["module_details"])
@@ -161,7 +170,7 @@ def exclude_submission_page(
     page_number: int,
 ) -> ManagedSubmissionPage:
     """Exclude one page from active review without deleting evidence."""
-    manifest_path, manifest, page = _load_page(
+    manifest_path, manifest, page, record_context = _load_page(
         workspace_root, class_id, assignment_id, student_id, page_number
     )
     if page["page_state"] == "excluded":
@@ -176,7 +185,13 @@ def exclude_submission_page(
     for evidence in _evidence_items(updated_page):
         _preserve_evidence_state_before_exclusion(evidence)
     return _write_result(
-        manifest_path, updated, updated_page, previous_page=page, action="excluded"
+        workspace_root,
+        manifest_path,
+        updated,
+        updated_page,
+        previous_page=page,
+        action="excluded",
+        record_context=record_context,
     )
 
 
@@ -188,7 +203,7 @@ def restore_excluded_submission_page(
     page_number: int,
 ) -> ManagedSubmissionPage:
     """Return one excluded page to the active review set when unambiguous."""
-    manifest_path, manifest, page = _load_page(
+    manifest_path, manifest, page, record_context = _load_page(
         workspace_root, class_id, assignment_id, student_id, page_number
     )
     if page["page_state"] != "excluded":
@@ -224,11 +239,13 @@ def restore_excluded_submission_page(
         )
         updated_page["page_state"] = _restored_page_state(evidence)
     return _write_result(
+        workspace_root,
         manifest_path,
         updated,
         updated_page,
         previous_page=page,
         action="restored",
+        record_context=record_context,
         restore_source=(
             "preserved pre-exclusion metadata"
             if used_preserved_state
@@ -245,7 +262,7 @@ def mark_submission_page_needs_rescan(
     page_number: int,
 ) -> ManagedSubmissionPage:
     """Mark one page as needing a corrected scan without deleting evidence."""
-    manifest_path, manifest, page = _load_page(
+    manifest_path, manifest, page, record_context = _load_page(
         workspace_root, class_id, assignment_id, student_id, page_number
     )
     if page["page_state"] == "needs_rescan":
@@ -262,11 +279,13 @@ def mark_submission_page_needs_rescan(
         evidence["evidence_role"] = "candidate"
         evidence["evidence_state"] = "needs_rescan"
     return _write_result(
+        workspace_root,
         manifest_path,
         updated,
         updated_page,
         previous_page=page,
         action="marked needs rescan",
+        record_context=record_context,
     )
 
 
@@ -276,7 +295,7 @@ def _load_page(
     assignment_id: str,
     student_id: str,
     page_number: int,
-) -> tuple[Path, dict[str, Any], dict[str, Any]]:
+) -> tuple[Path, dict[str, Any], dict[str, Any], QuillanStudentReviewContext]:
     _validate_identity(class_id, assignment_id, student_id)
     if (
         isinstance(page_number, bool)
@@ -284,10 +303,10 @@ def _load_page(
         or page_number < 1
     ):
         raise SubmissionPageManagementError("Page number must be a positive integer.")
-    path, manifest = _load_manifest(
+    path, manifest, record_context = _load_manifest(
         workspace_root, class_id, assignment_id, student_id
     )
-    return path, manifest, _page_by_number(manifest, page_number)
+    return path, manifest, _page_by_number(manifest, page_number), record_context
 
 
 def _load_manifest(
@@ -295,25 +314,23 @@ def _load_manifest(
     class_id: str,
     assignment_id: str,
     student_id: str,
-) -> tuple[Path, dict[str, Any]]:
+) -> tuple[Path, dict[str, Any], QuillanStudentReviewContext]:
     _validate_identity(class_id, assignment_id, student_id)
-    path = submission_manifest_path(workspace_root, class_id, assignment_id, student_id)
     try:
-        manifest = load_submission_manifest(path)
-    except (SubmissionManifestError, OSError) as error:
-        guidance = f" {missing_submission_guidance()}" if not path.exists() else ""
-        raise SubmissionPageManagementError(
-            f"Could not load submission record: {error}{guidance}"
-        ) from error
-    if (
-        manifest["class_id"] != class_id
-        or manifest["assignment_id"] != assignment_id
-        or manifest["student_id"] != student_id
-    ):
-        raise SubmissionPageManagementError(
-            "Submission record identity does not match the selected student."
+        context = load_quillan_student_review_context(
+            workspace_root,
+            quillan_work_ref(class_id, assignment_id),
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
         )
-    return path, manifest
+    except MissingSubmissionError as error:
+        raise SubmissionPageManagementError(missing_submission_guidance()) from error
+    except (QuillanRecordContextError, OSError) as error:
+        raise SubmissionPageManagementError(
+            f"Could not load submission record: {error}"
+        ) from error
+    path = context.paths.submission_manifest_path
+    return path, mutable_json_copy(context.submission), context
 
 
 def _page_by_number(manifest: dict[str, Any], page_number: int) -> dict[str, Any]:
@@ -403,18 +420,20 @@ def _restored_page_state(evidence: list[dict[str, Any]]) -> str:
 
 
 def _write_result(
+    workspace_root: str | Path,
     manifest_path: Path,
     manifest: dict[str, Any],
     page: dict[str, Any],
     *,
     previous_page: dict[str, Any],
     action: str,
+    record_context: QuillanStudentReviewContext,
     restore_source: str | None = None,
 ) -> ManagedSubmissionPage:
     manifest["updated_at"] = datetime.now(UTC).isoformat()
     try:
         validate_submission_manifest(manifest)
-        write_submission_manifest(manifest_path, manifest, overwrite=True)
+        update_quillan_submission_manifest(record_context, manifest)
     except (SubmissionManifestError, SubmissionManifestPathError, OSError) as error:
         raise SubmissionPageManagementError(
             f"Page change was not saved: {error}"

--- a/quillan/submission_review_opening.py
+++ b/quillan/submission_review_opening.py
@@ -7,15 +7,15 @@ from pathlib import Path
 from typing import Any
 
 from quillan.evidence_opening import EvidenceOpeningError, open_workspace_evidence
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
-)
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
+from quillan.record_context import (
+    MissingSubmissionError,
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
 )
 from quillan.submission_guidance import missing_submission_guidance
+from quillan.work_paths import quillan_work_ref
 
 
 class SubmissionReviewOpeningError(Exception):
@@ -86,41 +86,26 @@ def open_student_submission_for_review(
 ) -> OpenedSubmissionReview:
     """Open selected routed evidence files for one submission."""
     try:
-        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_workspace_root,
-            class_id,
-            assignment_id,
+        context = load_quillan_student_review_context(
+            workspace_root,
+            quillan_work_ref(class_id, assignment_id),
             student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
         )
-    except (OSError, RuntimeError, SubmissionManifestPathError) as error:
+    except MissingSubmissionError as error:
+        raise SubmissionReviewOpeningError(missing_submission_guidance()) from error
+    except (OSError, RuntimeError, QuillanRecordContextError) as error:
         raise SubmissionReviewOpeningError(str(error)) from error
-
-    if not manifest_path.exists():
-        raise SubmissionReviewOpeningError(missing_submission_guidance())
-
-    try:
-        manifest = load_submission_manifest(manifest_path)
-    except (OSError, SubmissionManifestError) as error:
-        raise SubmissionReviewOpeningError(
-            f"Could not load submission manifest: {error}"
-        ) from error
-
-    _validate_manifest_identity(
-        manifest,
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-    )
+    resolved_workspace_root = context.paths.workspace_root
+    manifest_path = context.paths.submission_manifest_path
+    manifest = mutable_json_copy(context.submission)
     selected_pages = selected_submission_evidence_pages(
         manifest,
         page_number=page_number,
     )
 
     try:
-        manifest_relative_path = manifest_path.resolve(strict=False).relative_to(
-            resolved_workspace_root
-        ).as_posix()
+        manifest_relative_path = context.paths.submission_relative_path
     except (EvidenceOpeningError, OSError, RuntimeError, ValueError) as error:
         raise SubmissionReviewOpeningError(
             f"Could not resolve submission manifest path: {error}"

--- a/quillan/submission_review_state.py
+++ b/quillan/submission_review_state.py
@@ -11,15 +11,21 @@ from typing import Any
 from quillan.submission_manifest import (
     ALLOWED_SUBMISSION_STATES,
     SubmissionManifestError,
-    load_submission_manifest,
     validate_submission_manifest,
 )
 from quillan.submission_manifest_paths import (
     SubmissionManifestPathError,
-    submission_manifest_path,
-    write_submission_manifest,
+    update_quillan_submission_manifest,
 )
 from quillan.submission_guidance import missing_submission_guidance
+from quillan.record_context import (
+    MissingSubmissionError,
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+)
+from quillan.work_paths import quillan_work_ref
 
 
 class SubmissionReviewStateError(Exception):
@@ -56,41 +62,21 @@ def update_submission_review_state(
             f"Invalid lightweight submission state {state!r}. Allowed states: {allowed}."
         )
 
+    work_ref = quillan_work_ref(class_id, assignment_id)
     try:
-        resolved_workspace_root = Path(workspace_root).resolve(strict=False)
-        manifest_path = submission_manifest_path(
-            resolved_workspace_root,
-            class_id,
-            assignment_id,
+        context = load_quillan_student_review_context(
+            workspace_root,
+            work_ref,
             student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
         )
-    except (OSError, RuntimeError, SubmissionManifestPathError) as error:
+    except MissingSubmissionError as error:
+        raise SubmissionReviewStateError(missing_submission_guidance()) from error
+    except (OSError, RuntimeError, QuillanRecordContextError) as error:
         raise SubmissionReviewStateError(str(error)) from error
-
-    if not manifest_path.exists():
-        raise SubmissionReviewStateError(missing_submission_guidance())
-
-    try:
-        relative_path = manifest_path.resolve(strict=False).relative_to(
-            resolved_workspace_root
-        ).as_posix()
-        manifest = load_submission_manifest(manifest_path)
-    except (
-        OSError,
-        RuntimeError,
-        ValueError,
-        SubmissionManifestError,
-    ) as error:
-        raise SubmissionReviewStateError(
-            f"Could not load submission manifest: {error}"
-        ) from error
-
-    _validate_manifest_identity(
-        manifest,
-        class_id=class_id,
-        assignment_id=assignment_id,
-        student_id=student_id,
-    )
+    manifest_path = context.paths.submission_manifest_path
+    relative_path = context.paths.submission_relative_path
+    manifest = mutable_json_copy(context.submission)
     normalized_updated_at = _normalize_timestamp(updated_at)
     previous_state = manifest["submission_state"]
     updated_manifest = copy.deepcopy(manifest)
@@ -99,11 +85,7 @@ def update_submission_review_state(
 
     try:
         validate_submission_manifest(updated_manifest)
-        write_submission_manifest(
-            manifest_path,
-            updated_manifest,
-            overwrite=True,
-        )
+        update_quillan_submission_manifest(context, updated_manifest)
     except (
         OSError,
         RuntimeError,

--- a/quillan/submission_status.py
+++ b/quillan/submission_status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any
 
@@ -12,9 +13,15 @@ from quillan.assignment_submission_assembly import (
     SkippedRoutedEvidenceFile,
     discover_assignment_routed_evidence_status,
 )
-from quillan.storage import assignment_submissions_dir
+from quillan.record_context import (
+    ReviewLoadingPolicy,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+    student_record_paths,
+)
 from quillan.response_page_observations import QuillanResponsePageObservation
-from quillan.submission_manifest import load_submission_manifest
+from quillan.work_paths import _is_link_like, quillan_work_ref
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,7 +78,9 @@ def list_assignment_submission_status(
     validate_identifier(assignment_id, "assignment_id")
     _validate_expected_pages(expected_pages)
 
-    root = Path(workspace_root).resolve(strict=False)
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    assignment_context = load_quillan_assignment_context(workspace_root, work_ref)
+    root = assignment_context.paths.workspace_root
     manifests = _load_assignment_manifests(
         root, class_id, assignment_id
     )
@@ -139,35 +148,39 @@ def _load_assignment_manifests(
     class_id: str,
     assignment_id: str,
 ) -> dict[str, tuple[Path, dict[str, Any]]]:
-    submissions_dir = assignment_submissions_dir(
-        root, class_id, assignment_id
-    )
-    if not submissions_dir.exists():
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    assignment_context = load_quillan_assignment_context(root, work_ref)
+    submissions_dir = assignment_context.paths.submissions_dir
+    if not os.path.lexists(submissions_dir):
         return {}
-    if not submissions_dir.is_dir():
+    if _is_link_like(submissions_dir) or not submissions_dir.is_dir():
         raise NotADirectoryError(
-            f"Assignment submissions path is not a directory: {submissions_dir}"
+            "Assignment submissions path is not an ordinary non-link directory: "
+            f"{submissions_dir}"
         )
 
     manifests: dict[str, tuple[Path, dict[str, Any]]] = {}
     for student_dir in sorted(
         submissions_dir.iterdir(), key=lambda path: path.name.casefold()
     ):
-        if not student_dir.is_dir():
-            continue
-        manifest_path = student_dir / "submission.json"
-        if not manifest_path.exists():
-            continue
         student_id = student_dir.name
         validate_identifier(student_id, "student_id")
-        manifest = load_submission_manifest(manifest_path)
-        _validate_manifest_identity(
-            manifest,
-            class_id=class_id,
-            assignment_id=assignment_id,
-            student_id=student_id,
-            path=manifest_path,
+        if _is_link_like(student_dir) or not student_dir.is_dir():
+            raise NotADirectoryError(
+                f"Invalid direct student submission child: {student_dir}"
+            )
+        manifest_path = student_record_paths(
+            root, work_ref, student_id
+        ).submission_manifest_path
+        if not os.path.lexists(manifest_path):
+            continue
+        context = load_quillan_student_review_context(
+            root,
+            work_ref,
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
         )
+        manifest = mutable_json_copy(context.submission)
         manifests[student_id] = (manifest_path, manifest)
     return manifests
 
@@ -294,4 +307,4 @@ def _validate_expected_pages(expected_pages: int | None) -> None:
 
 
 def _resolved_evidence_path(root: Path, value: str | Path) -> Path:
-    return (root / Path(value)).resolve(strict=False)
+    return Path(os.path.abspath(root / Path(value)))

--- a/quillan/work_paths.py
+++ b/quillan/work_paths.py
@@ -279,6 +279,97 @@ def review_record_path(
     )
 
 
+def student_exports_dir(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+) -> Path:
+    """Return one student's canonical export directory without filesystem I/O."""
+    validated_work = _require_quillan_work_ref(work_ref)
+    validated_student_id = validate_identifier(student_id, "student_id")
+    return safe_module_work_descendant(
+        workspace_root,
+        validated_work,
+        Path("submissions") / validated_student_id / "exports",
+    )
+
+
+def feedback_markdown_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+) -> Path:
+    """Return one student's canonical Markdown feedback path."""
+    return student_exports_dir(workspace_root, work_ref, student_id) / "feedback.md"
+
+
+def feedback_pdf_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    student_id: str,
+) -> Path:
+    """Return one student's canonical PDF feedback path."""
+    return student_exports_dir(workspace_root, work_ref, student_id) / "feedback.pdf"
+
+
+def class_summary_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> Path:
+    """Return the canonical comprehensive class-summary CSV path."""
+    return safe_module_work_descendant(
+        workspace_root,
+        _require_quillan_work_ref(work_ref),
+        Path("exports") / "class_summary.csv",
+    )
+
+
+def standards_summary_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> Path:
+    """Return the canonical standards-summary CSV path."""
+    return safe_module_work_descendant(
+        workspace_root,
+        _require_quillan_work_ref(work_ref),
+        Path("exports") / "standards_summary.csv",
+    )
+
+
+def student_performance_summary_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> Path:
+    """Return the canonical student-performance-summary CSV path."""
+    return safe_module_work_descendant(
+        workspace_root,
+        _require_quillan_work_ref(work_ref),
+        Path("exports") / "student_performance_summary.csv",
+    )
+
+
+def post_dispatch_review_dir(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> Path:
+    """Return the Quillan-owned post-dispatch review occurrence directory."""
+    return safe_module_work_descendant(
+        workspace_root,
+        _require_quillan_work_ref(work_ref),
+        Path("scans") / "review" / "post_dispatch",
+    )
+
+
+def post_dispatch_review_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    failure_id: str,
+) -> Path:
+    """Return one canonical immutable post-dispatch occurrence path."""
+    validated_id = validate_identifier(failure_id, "failure_id")
+    return post_dispatch_review_dir(workspace_root, work_ref) / f"{validated_id}.json"
+
+
 def relative_assignment_path(class_id: str, assignment_id: str) -> str:
     """Return the canonical workspace-relative assignment record path."""
     return quillan_work_paths(Path(), class_id, assignment_id).assignment_path.as_posix()
@@ -292,6 +383,36 @@ def relative_submission_manifest_path(
     """Return the canonical workspace-relative submission manifest path."""
     work_ref = quillan_work_ref(class_id, assignment_id)
     return submission_manifest_path(Path(), work_ref, student_id).as_posix()
+
+
+def relative_review_record_path(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> str:
+    """Return the canonical workspace-relative review record path."""
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    return review_record_path(Path(), work_ref, student_id).as_posix()
+
+
+def relative_feedback_markdown_path(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> str:
+    """Return the canonical workspace-relative Markdown feedback path."""
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    return feedback_markdown_path(Path(), work_ref, student_id).as_posix()
+
+
+def relative_feedback_pdf_path(
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> str:
+    """Return the canonical workspace-relative PDF feedback path."""
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    return feedback_pdf_path(Path(), work_ref, student_id).as_posix()
 
 
 def preflight_managed_work_layout(paths: QuillanWorkPaths) -> QuillanWorkPaths:
@@ -489,16 +610,24 @@ def _lexists(path: Path) -> bool:
 __all__ = [
     "QuillanWorkPathError",
     "QuillanWorkPaths",
+    "class_summary_path",
+    "feedback_markdown_path",
+    "feedback_pdf_path",
     "initialize_managed_work_layout",
     "initialize_student_submission_dir",
     "preflight_managed_work_layout",
     "preflight_quillan_work_collection",
     "preflight_work_file_destination",
     "preflight_work_directory_destination",
+    "post_dispatch_review_dir",
+    "post_dispatch_review_path",
     "quillan_work_collection_dir",
     "quillan_work_paths",
     "quillan_work_ref",
     "relative_assignment_path",
+    "relative_feedback_markdown_path",
+    "relative_feedback_pdf_path",
+    "relative_review_record_path",
     "relative_submission_manifest_path",
     "response_page_observation_path",
     "response_page_observations_dir",
@@ -508,6 +637,9 @@ __all__ = [
     "routed_evidence_path",
     "routed_evidence_root",
     "review_record_path",
+    "standards_summary_path",
+    "student_exports_dir",
+    "student_performance_summary_path",
     "student_submission_dir",
     "submission_manifest_path",
 ]

--- a/tests/observation_test_support.py
+++ b/tests/observation_test_support.py
@@ -11,10 +11,16 @@ from quillan.pds2_scan_intake import QuillanScanPageOutcome
 from quillan.pds_module import get_module_profile
 from quillan.route_handler import handle_quillan_response_page_route
 from tests.test_route_handler import route_context
+from tests.review_test_support import _write_assignment
 
 
 def successful_image_page(root: Path, *, pages: int = 1) -> QuillanScanPageOutcome:
     resolution, _ = route_context(root, pages=pages)
+    _write_assignment(
+        root,
+        class_id=resolution.locator.class_id,
+        assignment_id=resolution.locator.work_id,
+    )
     write_route_registration(root, resolution.registration)
     selected = root / "selected.png"
     selected.write_bytes(b"synthetic retained image bytes")
@@ -45,6 +51,11 @@ def successful_pdf_pages(
     source_page_numbers: tuple[int, ...] = (1, 2),
 ) -> tuple[QuillanScanPageOutcome, ...]:
     resolution, _ = route_context(root)
+    _write_assignment(
+        root,
+        class_id=resolution.locator.class_id,
+        assignment_id=resolution.locator.work_id,
+    )
     write_route_registration(root, resolution.registration)
     selected = root / "selected.pdf"
     document = canvas.Canvas(str(selected), pagesize=(200, 200))

--- a/tests/review_test_support.py
+++ b/tests/review_test_support.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 from typing import Any
 
 from quillan.review_record import build_empty_review_record
@@ -16,6 +17,62 @@ CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
 STUDENT_ID = "00107"
 TIMESTAMP = "2026-06-22T14:20:00+00:00"
+
+
+def _write_assignment(
+    workspace: Path,
+    *,
+    class_id: str = CLASS_ID,
+    assignment_id: str = ASSIGNMENT_ID,
+) -> Path:
+    """Write the canonical assignment required by contextual review services."""
+    path = (
+        workspace
+        / "classes"
+        / class_id
+        / "modules"
+        / "quillan"
+        / "work"
+        / assignment_id
+        / "assignment.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    assignment = {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": assignment_id,
+        "title": "Synthetic Essay",
+        "class_ids": [class_id],
+        "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
+        "standards_profile_id": "synthetic_profile",
+        "focus_standard_ids": ["synthetic:W.A"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
+        "basic_requirements": {"paragraphs_min": 5},
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+    path.write_text(json.dumps(assignment), encoding="utf-8")
+    return path
 
 
 def _manifest(student_id: str = STUDENT_ID) -> dict[str, Any]:

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from datetime import datetime, timezone
 import os
 from pathlib import Path
+from typing import Any, cast
 
 from pds_core.classes import write_class_roster
 from pds_core.rosters import create_roster
@@ -23,6 +24,7 @@ from quillan.assignments import (
     load_assignment_config,
     validate_assignment_config,
 )
+from quillan.assignment_workflows import AssignmentBatchWriteError
 from quillan.menu_navigation import QuitQuillan, ReturnToMainMenu
 from quillan.work_paths import quillan_work_paths
 
@@ -231,6 +233,181 @@ def test_write_assignment_config_uses_canonical_path(tmp_path: Path) -> None:
     )
     assert load_assignment_config(path) == assignment
     assert path.read_text(encoding="utf-8").endswith("\n")
+
+
+def _assignment_path(root: Path, class_id: str) -> Path:
+    return (
+        root
+        / "classes"
+        / class_id
+        / "modules"
+        / "quillan"
+        / "work"
+        / "literary_analysis_essay"
+        / "assignment.json"
+    )
+
+
+def test_multiclass_second_create_failure_completely_compensates_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    classes = ("english_12_p3", "english_12_p4")
+    assignment = _assignment(class_ids=list(classes))
+    original_create = cast(Any, getattr(workflows, "create_exclusive_record"))
+
+    def fail_second(path: Path, *args: object, **kwargs: object) -> Any:
+        if "english_12_p4" in path.parts:
+            raise OSError("second class failed before installation")
+        return original_create(path, *args, **kwargs)
+
+    monkeypatch.setattr(workflows, "create_exclusive_record", fail_second)
+
+    with pytest.raises(AssignmentBatchWriteError) as captured:
+        workflows.write_assignment_configs(tmp_path, classes, assignment)
+
+    assert captured.value.possibly_durable_paths == ()
+    assert not _assignment_path(tmp_path, classes[0]).exists()
+    assert not _assignment_path(tmp_path, classes[1]).exists()
+
+
+def test_multiclass_third_failure_compensates_all_earlier_creates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    classes = ("english_12_p3", "english_12_p4", "english_12_p5")
+    assignment = _assignment(class_ids=list(classes))
+    original_create = cast(Any, getattr(workflows, "create_exclusive_record"))
+
+    def fail_third(path: Path, *args: object, **kwargs: object) -> Any:
+        if "english_12_p5" in path.parts:
+            raise OSError("third class failed")
+        return original_create(path, *args, **kwargs)
+
+    monkeypatch.setattr(workflows, "create_exclusive_record", fail_third)
+
+    with pytest.raises(AssignmentBatchWriteError) as captured:
+        workflows.write_assignment_configs(tmp_path, classes, assignment)
+
+    assert captured.value.possibly_durable_paths == ()
+    assert not any(_assignment_path(tmp_path, class_id).exists() for class_id in classes)
+
+
+def test_multiclass_mixed_create_update_batch_compensates_exact_original(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    classes = ("english_12_p3", "english_12_p4", "english_12_p5")
+    original_assignment = _assignment(class_ids=list(classes))
+    original_assignment["student_prompt"] = "Original prompt."
+    original_path = workflows.write_assignment_config(
+        tmp_path, classes[0], original_assignment
+    )
+    original_bytes = original_path.read_bytes()
+    replacement = _assignment(class_ids=list(classes))
+    replacement["student_prompt"] = "Replacement prompt."
+    original_create = cast(Any, getattr(workflows, "create_exclusive_record"))
+
+    def fail_third(path: Path, *args: object, **kwargs: object) -> Any:
+        if "english_12_p5" in path.parts:
+            raise OSError("third class failed")
+        return original_create(path, *args, **kwargs)
+
+    monkeypatch.setattr(workflows, "create_exclusive_record", fail_third)
+
+    with pytest.raises(AssignmentBatchWriteError) as captured:
+        workflows.write_assignment_configs(
+            tmp_path, classes, replacement, overwrite=True
+        )
+
+    assert captured.value.possibly_durable_paths == ()
+    assert original_path.read_bytes() == original_bytes
+    assert not _assignment_path(tmp_path, classes[1]).exists()
+    assert not _assignment_path(tmp_path, classes[2]).exists()
+
+
+def test_multiclass_compensation_refuses_concurrent_edit_of_updated_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    classes = ("english_12_p3", "english_12_p4")
+    original_assignment = _assignment(class_ids=list(classes))
+    first_path = workflows.write_assignment_config(
+        tmp_path, classes[0], original_assignment
+    )
+    replacement = _assignment(class_ids=list(classes))
+    replacement["student_prompt"] = "Replacement prompt."
+    original_create = cast(Any, getattr(workflows, "create_exclusive_record"))
+
+    def edit_first_then_fail(path: Path, *args: object, **kwargs: object) -> Any:
+        if "english_12_p4" in path.parts:
+            first_path.write_bytes(b"concurrent updated assignment")
+            raise OSError("second class failed")
+        return original_create(path, *args, **kwargs)
+
+    monkeypatch.setattr(workflows, "create_exclusive_record", edit_first_then_fail)
+
+    with pytest.raises(AssignmentBatchWriteError) as captured:
+        workflows.write_assignment_configs(
+            tmp_path, classes, replacement, overwrite=True
+        )
+
+    assert first_path.read_bytes() == b"concurrent updated assignment"
+    assert captured.value.possibly_durable_paths == (first_path,)
+    assert captured.value.rollback_diagnostics
+
+
+def test_multiclass_compensation_refuses_concurrent_edit_of_created_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    classes = ("english_12_p3", "english_12_p4")
+    first_path = _assignment_path(tmp_path, classes[0])
+    assignment = _assignment(class_ids=list(classes))
+    original_create = cast(Any, getattr(workflows, "create_exclusive_record"))
+
+    def edit_first_then_fail(path: Path, *args: object, **kwargs: object) -> Any:
+        if "english_12_p4" in path.parts:
+            first_path.write_bytes(b"concurrent created assignment")
+            raise OSError("second class failed")
+        return original_create(path, *args, **kwargs)
+
+    monkeypatch.setattr(workflows, "create_exclusive_record", edit_first_then_fail)
+
+    with pytest.raises(AssignmentBatchWriteError) as captured:
+        workflows.write_assignment_configs(tmp_path, classes, assignment)
+
+    assert first_path.read_bytes() == b"concurrent created assignment"
+    assert first_path in captured.value.possibly_durable_paths
+    assert captured.value.rollback_diagnostics
+
+
+def test_multiclass_compensation_filesystem_failure_reports_exact_durable_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    classes = ("english_12_p3", "english_12_p4")
+    first_path = _assignment_path(tmp_path, classes[0])
+    assignment = _assignment(class_ids=list(classes))
+    original_create = cast(Any, getattr(workflows, "create_exclusive_record"))
+    original_replace = os.replace
+
+    def fail_second(path: Path, *args: object, **kwargs: object) -> Any:
+        if "english_12_p4" in path.parts:
+            raise OSError("second class failed")
+        return original_create(path, *args, **kwargs)
+
+    def fail_compensation(source: Path, target: Path) -> None:
+        if source == first_path and "assignment-compensation" in target.name:
+            raise OSError("synthetic compensation filesystem failure")
+        original_replace(source, target)
+
+    monkeypatch.setattr(workflows, "create_exclusive_record", fail_second)
+    monkeypatch.setattr(os, "replace", fail_compensation)
+
+    with pytest.raises(AssignmentBatchWriteError) as captured:
+        workflows.write_assignment_configs(tmp_path, classes, assignment)
+
+    assert first_path in captured.value.possibly_durable_paths
+    assert first_path.is_file()
+    assert any(
+        "compensation filesystem failure" in diagnostic
+        for diagnostic in captured.value.rollback_diagnostics
+    )
 
 
 def test_write_assignment_config_allows_included_multi_class_path(

--- a/tests/test_atomic_record_io.py
+++ b/tests/test_atomic_record_io.py
@@ -1,0 +1,180 @@
+"""Fault-injection tests for guarded canonical-record lock cleanup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from collections.abc import Callable
+from typing import NoReturn
+
+import pytest
+
+from quillan.atomic_record_io import (
+    AtomicRecordDurabilityError,
+    create_exclusive_record,
+    revision_guarded_update,
+)
+
+
+def _preflight() -> None:
+    return None
+
+
+def _verify(expected: bytes) -> Callable[[bytes], None]:
+    def verify(actual: bytes) -> None:
+        assert actual == expected
+
+    return verify
+
+
+def _fail_only_lock_unlink(
+    monkeypatch: pytest.MonkeyPatch, lock_path: Path
+) -> None:
+    original_unlink = Path.unlink
+
+    def unlink(path: Path, missing_ok: bool = False) -> None:
+        if path == lock_path:
+            raise OSError("synthetic lock unlink failure")
+        original_unlink(path, missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", unlink)
+
+
+def test_lock_unlink_failure_after_create_reports_durable_and_stale_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = (tmp_path / "record.json").absolute()
+    lock_path = target.parent / ".record.json.create.lock"
+    _fail_only_lock_unlink(monkeypatch, lock_path)
+
+    with pytest.raises(AtomicRecordDurabilityError) as captured:
+        create_exclusive_record(
+            target,
+            b"created",
+            preflight=_preflight,
+            verify_bytes=_verify(b"created"),
+        )
+
+    assert captured.value.possibly_durable_path == target
+    assert captured.value.possible_lock_path == lock_path
+    assert target.read_bytes() == b"created"
+    assert lock_path.is_file()
+
+
+def test_lock_unlink_failure_after_update_preserves_installed_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = (tmp_path / "record.json").absolute()
+    target.write_bytes(b"original")
+    lock_path = target.parent / ".record.json.update.lock"
+    _fail_only_lock_unlink(monkeypatch, lock_path)
+
+    with pytest.raises(AtomicRecordDurabilityError) as captured:
+        revision_guarded_update(
+            target,
+            b"original",
+            b"replacement",
+            preflight=_preflight,
+            verify_bytes=_verify(b"replacement"),
+            lock_purpose="update",
+        )
+
+    assert captured.value.possibly_durable_path == target
+    assert captured.value.possible_lock_path == lock_path
+    assert target.read_bytes() == b"replacement"
+    assert lock_path.is_file()
+
+
+def test_lock_unlink_failure_after_unchanged_reports_only_stale_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = (tmp_path / "record.json").absolute()
+    target.write_bytes(b"same")
+    lock_path = target.parent / ".record.json.unchanged.lock"
+    _fail_only_lock_unlink(monkeypatch, lock_path)
+
+    with pytest.raises(AtomicRecordDurabilityError) as captured:
+        revision_guarded_update(
+            target,
+            b"same",
+            b"same",
+            preflight=_preflight,
+            verify_bytes=_verify(b"same"),
+            lock_purpose="unchanged",
+        )
+
+    assert captured.value.possibly_durable_path is None
+    assert captured.value.possible_lock_path == lock_path
+    assert "No new record installation is claimed" in str(captured.value)
+    assert target.read_bytes() == b"same"
+
+
+def test_primary_persistence_failure_keeps_primary_and_attaches_lock_diagnostic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = (tmp_path / "record.json").absolute()
+    lock_path = target.parent / ".record.json.create.lock"
+    _fail_only_lock_unlink(monkeypatch, lock_path)
+
+    def fail_verification(_actual: bytes) -> NoReturn:
+        raise ValueError("synthetic primary verification failure")
+
+    with pytest.raises(AtomicRecordDurabilityError) as captured:
+        create_exclusive_record(
+            target,
+            b"installed",
+            preflight=_preflight,
+            verify_bytes=fail_verification,
+        )
+
+    assert isinstance(captured.value.__cause__, ValueError)
+    assert "primary verification failure" in str(captured.value.__cause__)
+    assert any(str(lock_path) in note for note in captured.value.__notes__)
+    assert target.read_bytes() == b"installed"
+    assert lock_path.is_file()
+
+
+def test_changed_lock_token_is_preserved_and_reported(
+    tmp_path: Path,
+) -> None:
+    target = (tmp_path / "record.json").absolute()
+    lock_path = target.parent / ".record.json.create.lock"
+
+    def change_token(actual: bytes) -> None:
+        assert actual == b"installed"
+        lock_path.write_bytes(b"another owner")
+
+    with pytest.raises(AtomicRecordDurabilityError) as captured:
+        create_exclusive_record(
+            target,
+            b"installed",
+            preflight=_preflight,
+            verify_bytes=change_token,
+        )
+
+    assert captured.value.possibly_durable_path == target
+    assert captured.value.possible_lock_path == lock_path
+    assert lock_path.read_bytes() == b"another owner"
+    assert target.read_bytes() == b"installed"
+
+
+@pytest.mark.parametrize("interrupt", [KeyboardInterrupt(), SystemExit(7), GeneratorExit()])
+def test_base_exceptions_propagate_without_relabeling_and_preserve_installed_bytes(
+    tmp_path: Path,
+    interrupt: BaseException,
+) -> None:
+    target = (tmp_path / "record.json").absolute()
+
+    def interrupt_verification(_actual: bytes) -> NoReturn:
+        raise interrupt
+
+    with pytest.raises(type(interrupt)) as captured:
+        create_exclusive_record(
+            target,
+            b"installed",
+            preflight=_preflight,
+            verify_bytes=interrupt_verification,
+        )
+
+    assert captured.value is interrupt
+    assert target.read_bytes() == b"installed"
+    assert not list(tmp_path.glob("*.lock"))

--- a/tests/test_cli_feedback_export.py
+++ b/tests/test_cli_feedback_export.py
@@ -9,8 +9,13 @@ import pytest
 from quillan.cli import main
 import quillan.cli_app.handlers.exports as cli_exports
 from quillan.feedback_export import feedback_export_path, feedback_pdf_export_path
-from tests.review_test_support import _write_manifest, _write_review
+from tests.review_test_support import _write_assignment, _write_manifest, _write_review
 from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID, _review
+
+
+@pytest.fixture(autouse=True)
+def canonical_assignment(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
 
 
 def test_cli_exports_feedback_and_prints_summary(

--- a/tests/test_cli_pages.py
+++ b/tests/test_cli_pages.py
@@ -10,15 +10,22 @@ import pytest
 
 import quillan.cli_app.handlers.pages as page_handlers
 from quillan.cli_app.main import main
+from quillan.review_record import build_empty_review_record
 from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
 )
+from tests.review_test_support import _write_assignment
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
 STUDENT_ID = "stu_0001"
 TIMESTAMP = "2026-07-13T12:00:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def canonical_assignment(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
 
 
 def _evidence(evidence_id: str, page_number: int, role: str) -> dict[str, Any]:
@@ -237,7 +244,14 @@ def test_cli_mutations_report_transition_and_preserve_submission_state(
 ) -> None:
     path = _write(tmp_path)
     review = path.with_name("review.json")
-    review.write_bytes(b'{"review_state":"in_progress"}\n')
+    review_record = build_empty_review_record(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        created_at=TIMESTAMP,
+    )
+    review_record["review_state"] = "observations_in_progress"
+    review.write_text(json.dumps(review_record), encoding="utf-8")
     review_before = review.read_bytes()
     _configure_workspace(monkeypatch, tmp_path)
     args = [CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--page", "1", "--yes"]

--- a/tests/test_cli_review_lifecycle_smoke.py
+++ b/tests/test_cli_review_lifecycle_smoke.py
@@ -361,5 +361,5 @@ def test_complete_review_lifecycle_uses_only_direct_noninteractive_cli(
     assert exit_results == [0] * 12
     assert not list(tmp_path.rglob("*.csv")) or list(tmp_path.rglob("*.csv")) == [roster_path]
     assert not list(tmp_path.rglob("feedback.md"))
-    assert not list(tmp_path.rglob("*scan*"))
+    assert not [path for path in tmp_path.rglob("*scan*") if path.is_file()]
     assert not list(tmp_path.rglob("*evidence*"))

--- a/tests/test_cli_scan_review_resolution.py
+++ b/tests/test_cli_scan_review_resolution.py
@@ -80,11 +80,37 @@ def test_cli_writes_only_json_resolution_metadata(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _write_failure(workspace)
+    evidence = (
+        workspace
+        / "classes"
+        / "english12_p3"
+        / "modules"
+        / "quillan"
+        / "work"
+        / "essay_01"
+        / "handled"
+        / "source.pdf"
+    )
+    evidence.parent.mkdir(parents=True)
+    evidence.write_bytes(b"evidence")
+    relative_evidence = evidence.relative_to(workspace).as_posix()
     assert main(
-        ["resolve-scan-review", FAILURE_ID, "--action", "evidence_filed", "--evidence-path", "handled/source.pdf"]
+        [
+            "resolve-scan-review",
+            FAILURE_ID,
+            "--action",
+            "evidence_filed",
+            "--evidence-path",
+            relative_evidence,
+        ]
     ) == 0
     capsys.readouterr()
     files = list((workspace / "scans" / "review" / "resolutions").iterdir())
     assert len(files) == 1
     assert files[0].suffix == ".json"
-    assert json.loads(files[0].read_text(encoding="utf-8"))["resolution_evidence_path"] == "handled/source.pdf"
+    assert (
+        json.loads(files[0].read_text(encoding="utf-8"))[
+            "resolution_evidence_path"
+        ]
+        == relative_evidence
+    )

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -40,6 +40,11 @@ STANDARD_DESCRIPTION = (
 )
 
 
+@pytest.fixture(autouse=True)
+def canonical_assignment(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+
+
 def _write_assignment(root: Path) -> None:
     assignment_dir = root / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID
     assignment_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_plain_paper_submission.py
+++ b/tests/test_plain_paper_submission.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -10,11 +11,14 @@ from quillan.cli_app import parser as cli_parser
 from quillan.cli_app.handlers import submissions as cli_submissions
 from quillan.cli_app.main import main
 from quillan.plain_paper_submission import (
+    PlainPaperSubmissionDurabilityError,
     PlainPaperSubmissionError,
     create_plain_paper_submission,
 )
 from quillan.review_record import load_review_record
 import quillan.review_menu as review_menu
+import quillan.plain_paper_submission as plain_paper_submission
+import quillan.review_record_paths as review_record_paths
 from quillan.submission_manifest import load_submission_manifest
 from quillan.submission_status import list_assignment_submission_status
 
@@ -133,12 +137,16 @@ def test_does_not_overwrite_existing_submission(workspace: Path) -> None:
     )
     original = created.submission_manifest_path.read_bytes()
 
-    with pytest.raises(PlainPaperSubmissionError, match="already exists"):
+    original_review = created.review_record_path.read_bytes()
+    with pytest.raises(PlainPaperSubmissionDurabilityError, match="already exists") as caught:
         create_plain_paper_submission(
             workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
         )
 
     assert created.submission_manifest_path.read_bytes() == original
+    assert created.review_record_path.read_bytes() == original_review
+    assert caught.value.possible_manifest_path == created.submission_manifest_path
+    assert caught.value.possible_review_path == created.review_record_path
 
 
 def test_rejects_orphan_review_without_writing_manifest(workspace: Path) -> None:
@@ -164,6 +172,197 @@ def test_rejects_orphan_review_without_writing_manifest(workspace: Path) -> None
 
     assert review_path.read_text(encoding="utf-8") == "existing review"
     assert not (student_dir / "submission.json").exists()
+
+
+def _student_paths(workspace: Path) -> tuple[Path, Path]:
+    directory = (
+        workspace
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "quillan"
+        / "work"
+        / ASSIGNMENT_ID
+        / "submissions"
+        / STUDENT_ID
+    )
+    return directory / "submission.json", directory / "review.json"
+
+
+def _assert_no_orphan_review(manifest_path: Path, review_path: Path) -> None:
+    assert not review_path.exists() or manifest_path.is_file()
+
+
+def test_review_failure_before_installation_compensates_owned_manifest(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path, review_path = _student_paths(workspace)
+    primary = RuntimeError("review failed before installation")
+    monkeypatch.setattr(
+        plain_paper_submission,
+        "create_quillan_review_record",
+        lambda *_args: (_ for _ in ()).throw(primary),
+    )
+
+    with pytest.raises(PlainPaperSubmissionDurabilityError) as captured:
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert captured.value.__cause__ is primary
+    assert captured.value.possible_manifest_path is None
+    assert captured.value.possible_review_path is None
+    assert not manifest_path.exists()
+    assert not review_path.exists()
+    _assert_no_orphan_review(manifest_path, review_path)
+
+
+def test_review_link_then_temporary_cleanup_failure_preserves_exact_pair(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path, review_path = _student_paths(workspace)
+    original_unlink = Path.unlink
+
+    def fail_review_temporary(path: Path, missing_ok: bool = False) -> None:
+        if path.name.startswith(".review.json.") and path.suffix == ".tmp":
+            raise OSError("review temporary cleanup failed")
+        original_unlink(path, missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_review_temporary)
+
+    with pytest.raises(PlainPaperSubmissionDurabilityError) as captured:
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert captured.value.possible_manifest_path == manifest_path
+    assert captured.value.possible_review_path == review_path
+    assert manifest_path.is_file()
+    assert load_review_record(review_path)["student_id"] == STUDENT_ID
+    _assert_no_orphan_review(manifest_path, review_path)
+
+
+def test_review_reload_failure_preserves_installed_pair(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path, review_path = _student_paths(workspace)
+    monkeypatch.setattr(
+        review_record_paths,
+        "_verify_review_bytes",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("reload failed")),
+    )
+
+    with pytest.raises(PlainPaperSubmissionDurabilityError) as captured:
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert captured.value.possible_manifest_path == manifest_path
+    assert captured.value.possible_review_path == review_path
+    assert manifest_path.is_file() and review_path.is_file()
+    _assert_no_orphan_review(manifest_path, review_path)
+
+
+def test_review_changed_after_installation_preserves_contradictory_pair(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path, review_path = _student_paths(workspace)
+
+    def replace_after_install(_data: bytes, _expected: object) -> None:
+        review_path.write_bytes(b"concurrent review bytes")
+        raise RuntimeError("review changed after installation")
+
+    monkeypatch.setattr(review_record_paths, "_verify_review_bytes", replace_after_install)
+
+    with pytest.raises(PlainPaperSubmissionDurabilityError, match="contradictory") as captured:
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert captured.value.possible_manifest_path == manifest_path
+    assert captured.value.possible_review_path == review_path
+    assert manifest_path.is_file()
+    assert review_path.read_bytes() == b"concurrent review bytes"
+    _assert_no_orphan_review(manifest_path, review_path)
+
+
+def test_manifest_compensation_refuses_concurrent_byte_change(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path, review_path = _student_paths(workspace)
+
+    def change_manifest_then_fail(*_args: object) -> None:
+        manifest_path.write_bytes(b"concurrent manifest bytes")
+        raise RuntimeError("review pre-install failure")
+
+    monkeypatch.setattr(
+        plain_paper_submission,
+        "create_quillan_review_record",
+        change_manifest_then_fail,
+    )
+
+    with pytest.raises(PlainPaperSubmissionDurabilityError) as captured:
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert manifest_path.read_bytes() == b"concurrent manifest bytes"
+    assert not review_path.exists()
+    assert captured.value.possible_manifest_path == manifest_path
+    assert captured.value.possible_review_path is None
+    assert captured.value.__cause__ is not None
+    assert captured.value.__cause__.__notes__
+    _assert_no_orphan_review(manifest_path, review_path)
+
+
+def test_manifest_compensation_failure_preserves_primary_and_manifest(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path, review_path = _student_paths(workspace)
+    primary = RuntimeError("primary review failure")
+    monkeypatch.setattr(
+        plain_paper_submission,
+        "create_quillan_review_record",
+        lambda *_args: (_ for _ in ()).throw(primary),
+    )
+    original_replace = os.replace
+
+    def fail_manifest_displacement(source: Path, target: Path) -> None:
+        if source == manifest_path:
+            raise OSError("synthetic compensation failure")
+        original_replace(source, target)
+
+    monkeypatch.setattr(os, "replace", fail_manifest_displacement)
+
+    with pytest.raises(PlainPaperSubmissionDurabilityError) as captured:
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert captured.value.__cause__ is primary
+    assert any("compensation failed" in note for note in primary.__notes__)
+    assert captured.value.possible_manifest_path == manifest_path
+    assert captured.value.possible_review_path is None
+    assert manifest_path.is_file() and not review_path.exists()
+    _assert_no_orphan_review(manifest_path, review_path)
+
+
+def test_retry_after_orphan_or_contradictory_state_preserves_existing_bytes(
+    workspace: Path,
+) -> None:
+    manifest_path, review_path = _student_paths(workspace)
+    review_path.parent.mkdir(parents=True)
+    review_path.write_bytes(b"orphan review")
+
+    with pytest.raises(PlainPaperSubmissionDurabilityError) as captured:
+        create_plain_paper_submission(
+            workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
+        )
+
+    assert captured.value.possible_manifest_path is None
+    assert captured.value.possible_review_path == review_path
+    assert review_path.read_bytes() == b"orphan review"
+    assert not manifest_path.exists()
 
 
 def test_status_and_evidence_opening_are_teacher_friendly(

--- a/tests/test_post_dispatch_review.py
+++ b/tests/test_post_dispatch_review.py
@@ -1,0 +1,325 @@
+"""Tests for append-only work-scoped post-dispatch review occurrences."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+import tempfile
+
+import pytest
+from pds_core.routing_models import ModuleWorkRef
+
+from quillan.post_dispatch_review import (
+    PersistedPostDispatchReviewOccurrence,
+    PostDispatchReviewError,
+    QuillanReviewSource,
+    create_post_dispatch_review_occurrence,
+    discover_quillan_owned_review_items,
+    discover_post_dispatch_review_occurrences,
+)
+from quillan.work_paths import post_dispatch_review_dir, quillan_work_ref
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID
+import quillan.post_dispatch_review as post_dispatch_review
+
+
+def _ref() -> ModuleWorkRef:
+    return quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+
+def test_occurrences_are_append_only_unique_and_discoverable(tmp_path: Path) -> None:
+    evidence = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "quillan"
+        / "work"
+        / ASSIGNMENT_ID
+        / "scans"
+        / "evidence"
+        / "iss_0123456789abcdef0123456789abcdef"
+        / f"response_{STUDENT_ID}_pg_001__obs_0123456789abcdef0123456789abcdef.png"
+    )
+    first = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="routed_evidence_persistence",
+        stage="observation_persistence",
+        failure_message="synthetic disk failure",
+        student_id=STUDENT_ID,
+        source_scan_id="scan_001",
+        source_page_number=1,
+        possible_evidence_path=evidence,
+    )
+    second = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="submission_assembly",
+        stage="submission_assembly",
+        failure_message="synthetic assembly failure",
+        student_id=STUDENT_ID,
+    )
+
+    discovery = discover_post_dispatch_review_occurrences(tmp_path, _ref())
+
+    assert first.path != second.path
+    assert len(discovery.items) == 2
+    assert not discovery.warnings
+    assert all(item.path.read_bytes() for item in discovery.items)
+    stored = json.loads(first.path.read_text(encoding="utf-8"))
+    assert stored["class_id"] == CLASS_ID
+    assert stored["assignment_id"] == ASSIGNMENT_ID
+    assert stored["possible_evidence_paths"][0].startswith(
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
+    )
+
+
+def test_possible_durable_path_cannot_escape_affected_work(tmp_path: Path) -> None:
+    with pytest.raises(PostDispatchReviewError, match="affected Quillan work root"):
+        create_post_dispatch_review_occurrence(
+            tmp_path,
+            _ref(),
+            category="post_dispatch_integrity",
+            stage="verification",
+            failure_message="uncertain write",
+            possible_manifest_path=tmp_path / "outside.json",
+        )
+
+
+def test_discovery_reports_malformed_records_without_hiding_valid_items(
+    tmp_path: Path,
+) -> None:
+    created = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="manifest_conflict",
+        stage="submission_assembly",
+        failure_message="conflict",
+    )
+    malformed = post_dispatch_review_dir(tmp_path, _ref()) / "failure_bad.json"
+    malformed.write_text("{not-json", encoding="utf-8")
+
+    discovery = discover_post_dispatch_review_occurrences(tmp_path, _ref())
+
+    assert [item.path for item in discovery.items] == [created.path]
+    assert len(discovery.warnings) == 1
+    assert "failure_bad.json" in discovery.warnings[0]
+
+
+def test_combined_discovery_keeps_post_dispatch_schema_typed(tmp_path: Path) -> None:
+    created = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="post_dispatch_integrity",
+        stage="verification",
+        failure_message="uncertain durable state",
+    )
+
+    discovery = discover_quillan_owned_review_items(
+        tmp_path, _ref(), source=QuillanReviewSource.POST_DISPATCH
+    )
+
+    assert discovery.items == (created,)
+    assert discovery.core_warnings == ()
+
+
+def test_multi_identity_failure_provenance_is_not_collapsed(tmp_path: Path) -> None:
+    created = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="mixed_issuance",
+        stage="submission_assembly",
+        failure_message="mixed",
+        issuance_ids=(
+            "iss_0123456789abcdef0123456789abcdef",
+            "iss_1123456789abcdef0123456789abcdef",
+        ),
+        observation_ids=(
+            "obs_0123456789abcdef0123456789abcdef",
+            "obs_1123456789abcdef0123456789abcdef",
+        ),
+        source_page_numbers=(1, 2),
+    )
+    assert len(created.occurrence.issuance_ids) == 2
+    assert created.occurrence.issuance_id is None
+    stored = json.loads(created.path.read_text(encoding="utf-8"))
+    assert len(stored["observation_ids"]) == 2
+
+
+def test_temporary_allocation_failure_is_translated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        tempfile,
+        "mkstemp",
+        lambda **_kwargs: (_ for _ in ()).throw(OSError("allocation failed")),
+    )
+    with pytest.raises(PostDispatchReviewError, match="allocation failed"):
+        create_post_dispatch_review_occurrence(
+            tmp_path,
+            _ref(),
+            category="post_dispatch_integrity",
+            stage="verification",
+            failure_message="failure",
+        )
+
+
+def test_reload_failure_reports_exact_possibly_durable_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        post_dispatch_review,
+        "_verify_occurrence_bytes",
+        lambda *_args: (_ for _ in ()).throw(PostDispatchReviewError("reload failed")),
+    )
+    with pytest.raises(PostDispatchReviewError) as captured:
+        create_post_dispatch_review_occurrence(
+            tmp_path,
+            _ref(),
+            category="post_dispatch_integrity",
+            stage="verification",
+            failure_message="failure",
+        )
+    assert captured.value.possibly_durable_path is not None
+    assert captured.value.possibly_durable_path.is_file()
+
+
+def test_persisted_occurrence_carries_exact_workspace_and_work_authority(
+    tmp_path: Path,
+) -> None:
+    created = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="post_dispatch_integrity",
+        stage="verification",
+        failure_message="failure",
+    )
+
+    assert created.workspace_root == tmp_path.absolute()
+    assert created.work_ref == _ref()
+    assert created.path == (
+        created.workspace_root / Path(created.relative_path)
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "wrong/path.json",
+        "C:/absolute/path.json",
+        ".",
+        "../outside.json",
+        "classes/../outside.json",
+        r"classes\wrong\path.json",
+    ],
+)
+def test_persisted_occurrence_rejects_nonexact_relative_paths(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    created = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="post_dispatch_integrity",
+        stage="verification",
+        failure_message="failure",
+    )
+
+    with pytest.raises(PostDispatchReviewError):
+        PersistedPostDispatchReviewOccurrence(
+            created.workspace_root,
+            created.work_ref,
+            created.occurrence,
+            created.path,
+            relative_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "path_kind",
+    ["another_workspace", "another_class", "another_assignment", "sibling_module", "wrong_filename"],
+)
+def test_persisted_occurrence_rejects_alternative_absolute_destinations(
+    tmp_path: Path,
+    path_kind: str,
+) -> None:
+    created = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="post_dispatch_integrity",
+        stage="verification",
+        failure_message="failure",
+    )
+    if path_kind == "another_workspace":
+        alternative = tmp_path / "another_workspace" / Path(created.relative_path)
+    elif path_kind == "another_class":
+        alternative = Path(
+            str(created.path).replace(CLASS_ID, "english10_p9", 1)
+        )
+    elif path_kind == "another_assignment":
+        alternative = Path(
+            str(created.path).replace(ASSIGNMENT_ID, "other_assignment", 1)
+        )
+    elif path_kind == "sibling_module":
+        relative_parts = list(Path(created.relative_path).parts)
+        module_index = relative_parts.index("modules") + 1
+        relative_parts[module_index] = "scoreform"
+        alternative = created.workspace_root.joinpath(*relative_parts)
+    else:
+        alternative = created.path.with_name("failure_wrong.json")
+
+    with pytest.raises(PostDispatchReviewError, match="canonical destination"):
+        PersistedPostDispatchReviewOccurrence(
+            created.workspace_root,
+            created.work_ref,
+            created.occurrence,
+            alternative,
+            alternative.relative_to(tmp_path).as_posix(),
+        )
+
+
+@pytest.mark.parametrize(
+    "module_details",
+    [{1: "numeric"}, {1: "numeric", "1": "text"}],
+)
+def test_module_details_rejects_non_string_and_colliding_keys(
+    tmp_path: Path,
+    module_details: dict[object, object],
+) -> None:
+    created = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="post_dispatch_integrity",
+        stage="verification",
+        failure_message="failure",
+    )
+
+    with pytest.raises(PostDispatchReviewError, match="keys must be exact strings"):
+        replace(created.occurrence, module_details=module_details)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("stage", " verification"),
+        ("stage", "verification "),
+        ("failure_message", " failure"),
+        ("failure_message", "failure "),
+    ],
+)
+def test_occurrence_rejects_stage_and_message_outer_whitespace(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    created = create_post_dispatch_review_occurrence(
+        tmp_path,
+        _ref(),
+        category="post_dispatch_integrity",
+        stage="verification",
+        failure_message="failure",
+    )
+
+    with pytest.raises(PostDispatchReviewError):
+        replace(created.occurrence, **{field: value})  # type: ignore[arg-type]

--- a/tests/test_printable_response_workflows.py
+++ b/tests/test_printable_response_workflows.py
@@ -194,8 +194,12 @@ def test_discovery_is_direct_deterministic_and_module_isolated(
 
     assert [choice.assignment_id for choice in choices] == [
         "A_assignment",
+        "nested",
         "z_assignment",
     ]
+    assert choices[1].title is None
+    assert choices[1].class_ids == ()
+    assert choices[1].error is not None
     assert legacy.is_file()
 
 

--- a/tests/test_record_context.py
+++ b/tests/test_record_context.py
@@ -1,0 +1,226 @@
+"""Tests for canonical immutable Quillan record contexts."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from pds_core.routing_models import ModuleWorkRef
+
+from quillan.record_context import (
+    InvalidReviewError,
+    MissingReviewError,
+    OrphanReviewError,
+    ReviewAlreadyExistsError,
+    ReviewLoadingPolicy,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+)
+from quillan.review_record_paths import (
+    ReviewRecordConcurrencyError,
+    ReviewRecordPathError,
+    update_quillan_review_record,
+)
+import quillan.atomic_record_io as atomic_record_io
+from quillan.work_paths import quillan_work_ref
+from tests.review_test_support import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STUDENT_ID,
+    TIMESTAMP,
+    _review,
+    _write_assignment,
+    _write_manifest,
+    _write_review,
+)
+
+
+def _ref() -> ModuleWorkRef:
+    return quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+
+def test_assignment_context_uses_only_module_qualified_record(tmp_path: Path) -> None:
+    canonical = _write_assignment(tmp_path)
+    legacy = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "assignments"
+        / ASSIGNMENT_ID
+        / "assignment.json"
+    )
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("{not-json", encoding="utf-8")
+
+    context = load_quillan_assignment_context(tmp_path, _ref())
+
+    assert context.paths.assignment_path == canonical
+    assert context.assignment["assignment_id"] == ASSIGNMENT_ID
+
+
+def test_student_context_is_recursively_immutable(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    _write_review(tmp_path, _review())
+
+    context = load_quillan_student_review_context(
+        tmp_path, _ref(), STUDENT_ID, review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED
+    )
+
+    with pytest.raises(TypeError):
+        context.submission["student_id"] = "changed"  # type: ignore[index]
+    assert isinstance(context.submission["pages"], tuple)
+    assert context.paths.submission_relative_path.startswith(
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
+    )
+
+
+def test_review_presence_policies_are_explicit(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+
+    with pytest.raises(MissingReviewError):
+        load_quillan_student_review_context(
+            tmp_path,
+            _ref(),
+            STUDENT_ID,
+            review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED,
+        )
+
+    _write_review(tmp_path, _review())
+    with pytest.raises(ReviewAlreadyExistsError):
+        load_quillan_student_review_context(
+            tmp_path,
+            _ref(),
+            STUDENT_ID,
+            review_policy=ReviewLoadingPolicy.REVIEW_MUST_BE_ABSENT,
+        )
+
+
+def test_orphan_review_is_distinguished(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_review(tmp_path, _review())
+
+    with pytest.raises(OrphanReviewError):
+        load_quillan_student_review_context(tmp_path, _ref(), STUDENT_ID)
+
+
+def test_noncanonical_feedback_export_metadata_is_rejected(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    review = _review()
+    review["exports"]["feedback_markdown"] = {
+        "path": "elsewhere/feedback.md",
+        "generated_at": TIMESTAMP,
+        "source_review_updated_at": TIMESTAMP,
+        "module_details": {},
+    }
+    path = _write_review(tmp_path, review)
+    assert json.loads(path.read_text(encoding="utf-8"))["exports"]
+
+    with pytest.raises(InvalidReviewError, match="feedback_markdown.path"):
+        load_quillan_student_review_context(tmp_path, _ref(), STUDENT_ID)
+
+
+def test_snapshot_bytes_and_immutable_model_are_exactly_bound(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    _write_review(tmp_path, _review())
+    context = load_quillan_student_review_context(
+        tmp_path,
+        _ref(),
+        STUDENT_ID,
+        review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED,
+    )
+    assert context.review_record is not None
+    assert json.loads(context.review_record.original_bytes) == mutable_json_copy(
+        context.review_record.value
+    )
+    with pytest.raises(ValueError, match="does not agree"):
+        replace(context.review_record, original_bytes=b"{}")
+
+
+def test_concurrent_edit_after_context_load_is_preserved(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    path = _write_review(tmp_path, _review())
+    context = load_quillan_student_review_context(
+        tmp_path,
+        _ref(),
+        STUDENT_ID,
+        review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED,
+    )
+    updated = _review()
+    updated["module_details"] = {"writer": "service"}
+    concurrent = _review()
+    concurrent["module_details"] = {"writer": "concurrent"}
+    concurrent_bytes = (json.dumps(concurrent, indent=2) + "\n").encode()
+    path.write_bytes(concurrent_bytes)
+
+    with pytest.raises(ReviewRecordConcurrencyError):
+        update_quillan_review_record(context, updated)
+    assert path.read_bytes() == concurrent_bytes
+
+
+def test_concurrent_edit_immediately_before_displacement_is_restored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    path = _write_review(tmp_path, _review())
+    context = load_quillan_student_review_context(
+        tmp_path,
+        _ref(),
+        STUDENT_ID,
+        review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED,
+    )
+    updated = _review()
+    updated["module_details"] = {"writer": "service"}
+    concurrent = _review()
+    concurrent["module_details"] = {"writer": "concurrent-before-replace"}
+    concurrent_bytes = (json.dumps(concurrent, indent=2) + "\n").encode()
+    original_replace = os.replace
+
+    def inject_before_replace(source: str | Path, target: str | Path) -> None:
+        if Path(source) == path and str(target).endswith(".displaced"):
+            path.write_bytes(concurrent_bytes)
+        original_replace(source, target)
+
+    monkeypatch.setattr(os, "replace", inject_before_replace)
+    with pytest.raises(ReviewRecordConcurrencyError):
+        update_quillan_review_record(context, updated)
+    assert path.read_bytes() == concurrent_bytes
+
+
+def test_concurrent_edit_after_install_is_not_rolled_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_assignment(tmp_path)
+    _write_manifest(tmp_path)
+    path = _write_review(tmp_path, _review())
+    context = load_quillan_student_review_context(
+        tmp_path,
+        _ref(),
+        STUDENT_ID,
+        review_policy=ReviewLoadingPolicy.REVIEW_REQUIRED,
+    )
+    updated = _review()
+    updated["module_details"] = {"writer": "service"}
+    concurrent = _review()
+    concurrent["module_details"] = {"writer": "concurrent-after-install"}
+    concurrent_bytes = (json.dumps(concurrent, indent=2) + "\n").encode()
+    original_verify = atomic_record_io._verify_installed
+
+    def inject_before_verify(*args: object, **kwargs: object) -> None:
+        path.write_bytes(concurrent_bytes)
+        original_verify(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(atomic_record_io, "_verify_installed", inject_before_verify)
+    with pytest.raises(ReviewRecordPathError) as captured:
+        update_quillan_review_record(context, updated)
+    assert captured.value.possibly_durable_path == path
+    assert path.read_bytes() == concurrent_bytes

--- a/tests/test_review_notes.py
+++ b/tests/test_review_notes.py
@@ -16,6 +16,7 @@ from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
 )
+from tests.review_test_support import _write_assignment
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
@@ -23,6 +24,11 @@ STUDENT_ID = "00107"
 ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
 FIRST_NOTE_TIMESTAMP = "2026-06-22T13:30:00-04:00"
 SECOND_NOTE_TIMESTAMP = "2026-06-22T14:00:00-04:00"
+
+
+@pytest.fixture(autouse=True)
+def canonical_assignment(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
 
 
 def _manifest() -> dict[str, Any]:

--- a/tests/test_review_requirements.py
+++ b/tests/test_review_requirements.py
@@ -19,6 +19,7 @@ from quillan.submission_manifest_paths import (
     submission_manifest_path,
     write_submission_manifest,
 )
+from tests.review_test_support import _write_assignment
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
@@ -26,6 +27,11 @@ STUDENT_ID = "00107"
 ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
 FIRST_TIMESTAMP = "2026-06-29T12:00:00+00:00"
 SECOND_TIMESTAMP = "2026-06-29T13:00:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def canonical_assignment(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
 
 
 def _manifest() -> dict[str, Any]:

--- a/tests/test_scan_review_resolution.py
+++ b/tests/test_scan_review_resolution.py
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from pds_core.route_registrations import write_route_registration
+from pds_core.routing_models import (
+    ModuleRecordRef,
+    ModuleWorkRef,
+    RouteLocator,
+    RouteRegistration,
+)
 from pds_core.scan_failure_metadata import RoutingFailureMetadata, write_routing_failure_metadata
 from pds_core.scan_resolution_metadata import (
     scan_resolution_metadata_from_dict,
@@ -17,6 +25,7 @@ from quillan.scan_review_resolution import (
     discover_scan_review_items,
     resolve_scan_review_item,
 )
+from tests.test_route_handler import route_context
 
 FAILURE_ID = "failure_20260711T120000000000Z_a1b2c3d4e5f6"
 
@@ -26,11 +35,12 @@ def _write_failure(
     *,
     failure_id: str = FAILURE_ID,
     stage: str = "quillan_route_review",
+    module_id: str = "quillan",
 ) -> Path:
     return write_routing_failure_metadata(
         root,
         RoutingFailureMetadata(
-            schema_version="1",
+            schema_version="2",
             failure_id=failure_id,
             scope="page",
             stage=stage,
@@ -38,18 +48,19 @@ def _write_failure(
             failure_category="payload_missing",
             failure_message="No QR payload was found.",
             source_filename="teacher_scan.pdf",
+            route_locator=RouteLocator(
+                "PDS2",
+                ModuleWorkRef(module_id, "english12_p3", "essay_01"),
+                "route_a1b2c3d4e5f6",
+            ),
+            target=None,
             module_details={"failure_origin": "qr_decode"},
-            module="quillan",
             source_scan_id="scan_001",
             source_sha256="a" * 64,
             retained_source_path="scans/source/2026-07-11/teacher_scan.pdf",
             review_copy_path="scans/review/teacher_scan_page_2.pdf",
             source_page_number=2,
             detected_payload=None,
-            payload_page_number=None,
-            class_id="english12_p3",
-            assignment_id="essay_01",
-            student_id="stu_001",
         ),
     )
 
@@ -62,6 +73,7 @@ def test_discovery_lists_valid_quillan_items_and_skips_bad_or_other_records(
         tmp_path,
         failure_id="failure_20260711T120001000000Z_b1b2c3d4e5f6",
         stage="scoreform_route_review",
+        module_id="scoreform",
     )
     malformed = tmp_path / "scans" / "review" / "malformed.json"
     malformed.write_text("{not json", encoding="utf-8")
@@ -81,11 +93,11 @@ def test_discovery_lists_valid_quillan_items_and_skips_bad_or_other_records(
     [
         ("rescan_needed", "resolved", "rescan_needed"),
         ("cannot_route", "resolved", "cannot_route"),
-        ("mixed_assignment", "resolved", "mixed_assignment"),
+        ("mixed_assignment", "resolved", "other"),
         ("evidence_filed", "resolved", "evidence_filed"),
         ("dismissed_duplicate", "resolved", "dismissed_duplicate"),
         ("other", "resolved", "other"),
-        ("defer", "deferred", "other"),
+        ("defer", "deferred", "deferred"),
     ],
 )
 def test_resolution_actions_write_shared_metadata(
@@ -96,7 +108,22 @@ def test_resolution_actions_write_shared_metadata(
 ) -> None:
     _write_failure(tmp_path)
     message = "Teacher decision." if action == "other" else None
-    evidence_path = "handled/teacher_scan.pdf" if action == "evidence_filed" else None
+    evidence_path = None
+    if action == "evidence_filed":
+        evidence = (
+            tmp_path
+            / "classes"
+            / "english12_p3"
+            / "modules"
+            / "quillan"
+            / "work"
+            / "essay_01"
+            / "handled"
+            / "teacher_scan.pdf"
+        )
+        evidence.parent.mkdir(parents=True)
+        evidence.write_bytes(b"evidence")
+        evidence_path = evidence.relative_to(tmp_path).as_posix()
 
     result = resolve_scan_review_item(
         tmp_path,
@@ -113,11 +140,10 @@ def test_resolution_actions_write_shared_metadata(
     assert metadata.resolution_status == expected_status
     assert metadata.resolution_action == expected_action
     assert metadata.retained_source_path == "scans/source/2026-07-11/teacher_scan.pdf"
-    assert (metadata.class_id, metadata.assignment_id, metadata.student_id) == (
-        "english12_p3",
-        "essay_01",
-        "stu_001",
-    )
+    assert metadata.schema_version == "2"
+    # Core-v2 no-final-route actions intentionally do not copy a failure route.
+    assert metadata.route_locator is None
+    assert metadata.target is None
     assert metadata.resolution_evidence_path == evidence_path
 
 
@@ -171,3 +197,94 @@ def test_resolution_rejects_missing_failure(tmp_path: Path) -> None:
             "failure_missing",
             action="cannot_route",
         )
+
+
+def _write_routed_failure(
+    root: Path,
+) -> tuple[RouteLocator, ModuleRecordRef, RouteRegistration]:
+    resolution, _ = route_context(root)
+    write_route_registration(root, resolution.registration)
+    registration = resolution.registration
+    write_routing_failure_metadata(
+        root,
+        RoutingFailureMetadata(
+            schema_version="2",
+            failure_id=FAILURE_ID,
+            scope="page",
+            stage="dispatch",
+            created_at="2026-07-11T12:00:00+00:00",
+            failure_category="route_mismatch",
+            failure_message="Teacher routing decision required.",
+            source_filename="teacher_scan.pdf",
+            source_scan_id="scan_001",
+            source_sha256="a" * 64,
+            retained_source_path="scans/source/2026-07-21/teacher_scan.pdf",
+            review_copy_path=None,
+            source_page_number=1,
+            detected_payload="PDS2",
+            route_locator=registration.locator,
+            target=registration.target,
+            module_details={"failure_owner": "quillan"},
+        ),
+    )
+    return registration.locator, registration.target, registration
+
+
+def test_route_selected_requires_explicit_registered_locator_and_target(
+    tmp_path: Path,
+) -> None:
+    locator, target, _ = _write_routed_failure(tmp_path)
+    with pytest.raises(ScanReviewResolutionError, match="requires an exact"):
+        resolve_scan_review_item(tmp_path, FAILURE_ID, action="route_selected")
+
+    result = resolve_scan_review_item(
+        tmp_path,
+        FAILURE_ID,
+        action="route_selected",
+        route_locator=locator,
+        target=target,
+    )
+    assert result.resolution_action == "route_selected"
+
+
+def test_route_corrected_requires_a_changed_registered_route(tmp_path: Path) -> None:
+    locator, target, registration = _write_routed_failure(tmp_path)
+    corrected_locator = RouteLocator(
+        "PDS2",
+        locator.work,
+        "route_ffffffffffffffffffffffffffffffff",
+    )
+    corrected_registration = replace(
+        registration,
+        locator=corrected_locator,
+        target=target,
+    )
+    write_route_registration(tmp_path, corrected_registration)
+
+    result = resolve_scan_review_item(
+        tmp_path,
+        FAILURE_ID,
+        action="route_corrected",
+        route_locator=corrected_locator,
+        target=target,
+    )
+    assert result.resolution_action == "route_corrected"
+
+
+def test_strict_core_loader_skips_duplicate_keys_without_hiding_sibling(
+    tmp_path: Path,
+) -> None:
+    valid = _write_failure(tmp_path)
+    duplicate_path = valid.with_name(
+        "failure_20260711T120002000000Z_c1b2c3d4e5f6.json"
+    )
+    text = valid.read_text(encoding="utf-8").replace(
+        '"failure_id":',
+        '"failure_id": "failure_20260711T120002000000Z_c1b2c3d4e5f6",\n  "failure_id":',
+        1,
+    )
+    duplicate_path.write_text(text, encoding="utf-8")
+
+    discovery = discover_scan_review_items(tmp_path)
+    assert [item.failure_id for item in discovery.items] == [FAILURE_ID]
+    assert any("invalid JSON" in warning for warning in discovery.warnings)

--- a/tests/test_student_review_status.py
+++ b/tests/test_student_review_status.py
@@ -71,10 +71,10 @@ def test_invalid_sibling_is_isolated_and_output_is_deterministic(tmp_path: Path)
     assert "invalid_review" not in _document(tmp_path)["warnings"]
 
 
-def test_orphaned_review_is_validated_independently(tmp_path: Path) -> None:
+def test_orphaned_review_is_rejected_by_canonical_context(tmp_path: Path) -> None:
     _write_assignment(tmp_path)
     _write_json(_student_dir(tmp_path, "00100") / "review.json", _review("not_started", "00100"))
     document = _document(tmp_path)
-    assert document["review"]["status"] == "valid"
+    assert document["review"]["status"] == "orphaned"
     assert document["review"]["orphaned"] is True
     assert "review_without_valid_submission" in document["warnings"]

--- a/tests/test_submission_observation_assembly.py
+++ b/tests/test_submission_observation_assembly.py
@@ -54,6 +54,7 @@ from quillan.work_paths import (
     routed_evidence_path,
 )
 from tests.observation_test_support import successful_image_page, successful_pdf_pages
+from tests.review_test_support import _write_assignment
 
 
 def test_observation_assembly_creates_then_leaves_manifest_unchanged(
@@ -127,6 +128,11 @@ def test_new_duplicate_preserves_teacher_needs_rescan_state(tmp_path: Path) -> N
     observation = first.observation
     assembled = assemble_quillan_submission_manifests(
         tmp_path, observation.class_id, observation.assignment_id
+    )
+    _write_assignment(
+        tmp_path,
+        class_id=observation.class_id,
+        assignment_id=observation.assignment_id,
     )
     assert assembled.assembled[0].status == "created"
     mark_submission_page_needs_rescan(
@@ -553,13 +559,13 @@ def test_typed_student_stage_failures_emit_their_public_category(
     elif category == "manifest_concurrency_conflict":
         monkeypatch.setattr(
             observation_assembly,
-            "persist_submission_manifest",
+                "create_quillan_submission_manifest",
             raise_error(SubmissionManifestConcurrencyError("concurrent")),
         )
     else:
         monkeypatch.setattr(
             observation_assembly,
-            "persist_submission_manifest",
+                "create_quillan_submission_manifest",
             raise_error(SubmissionManifestPathError("write")),
         )
     result = assemble_quillan_submission_manifests(

--- a/tests/test_submission_page_management.py
+++ b/tests/test_submission_page_management.py
@@ -28,11 +28,17 @@ from quillan.submission_page_management import (
     restore_excluded_submission_page,
 )
 from tests.observation_test_support import successful_pdf_pages
+from tests.review_test_support import _review, _write_assignment
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
 STUDENT_ID = "stu_0001"
 TIMESTAMP = "2026-06-22T12:00:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def canonical_assignment(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
 
 
 def _evidence(
@@ -203,7 +209,9 @@ def test_mark_page_needs_rescan_preserves_review_record(
 ) -> None:
     path = _write_manifest(tmp_path)
     review_path = path.with_name("review.json")
-    review_path.write_text('{"review_state": "in_progress"}', encoding="utf-8")
+    review_path.write_text(
+        json.dumps(_review("observations_in_progress", STUDENT_ID)), encoding="utf-8"
+    )
     before = review_path.read_bytes()
 
     result = mark_submission_page_needs_rescan(
@@ -257,7 +265,9 @@ def test_write_os_error_is_wrapped_without_partial_manifest(
     def fail_write(*_args: object, **_kwargs: object) -> Path:
         raise OSError("disk full")
 
-    monkeypatch.setattr(page_management, "write_submission_manifest", fail_write)
+    monkeypatch.setattr(
+        page_management, "update_quillan_submission_manifest", fail_write
+    )
 
     with pytest.raises(SubmissionPageManagementError, match="disk full"):
         exclude_submission_page(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, 1)
@@ -274,6 +284,11 @@ def test_observation_backed_exclude_rescan_restore_and_needs_rescan(
     created = assemble_quillan_submission_manifests(
         tmp_path, identity.class_id, identity.assignment_id
     ).assembled[0]
+    _write_assignment(
+        tmp_path,
+        class_id=identity.class_id,
+        assignment_id=identity.assignment_id,
+    )
     assert (
         load_submission_page_context(
             tmp_path, identity.class_id, identity.assignment_id, identity.student_id

--- a/tests/test_submission_review_opening.py
+++ b/tests/test_submission_review_opening.py
@@ -22,6 +22,7 @@ from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
     open_student_submission_for_review,
 )
+from tests.review_test_support import _write_assignment
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
@@ -30,6 +31,11 @@ EVIDENCE_PATH = (
     f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/scans/"
     "response_00107_pg_001.pdf"
 )
+
+
+@pytest.fixture(autouse=True)
+def canonical_assignment(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
 
 
 def _evidence(

--- a/tests/test_submission_review_state.py
+++ b/tests/test_submission_review_state.py
@@ -27,12 +27,18 @@ from quillan.submission_review_state import (
     UpdatedSubmissionReviewState,
     update_submission_review_state,
 )
+from tests.review_test_support import _write_assignment
 
 CLASS_ID = "english12_p3_synthetic"
 ASSIGNMENT_ID = "essay_01_synthetic"
 STUDENT_ID = "00107"
 ORIGINAL_TIMESTAMP = "2026-06-20T12:00:00+00:00"
 UPDATED_TIMESTAMP = "2026-06-22T15:30:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def canonical_assignment(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
 
 
 def _manifest() -> dict[str, Any]:
@@ -305,7 +311,7 @@ def test_write_failure_is_wrapped_and_original_remains(
 
     monkeypatch.setattr(
         quillan.submission_review_state,
-        "write_submission_manifest",
+        "update_quillan_submission_manifest",
         fail_write,
     )
 

--- a/tests/test_submission_status.py
+++ b/tests/test_submission_status.py
@@ -10,10 +10,11 @@ from quillan.response_page_observation_persistence import (
 from quillan.submission_observation_assembly import (
     assemble_quillan_submission_manifests,
 )
-from quillan.submission_manifest import SubmissionManifestError
+from quillan.record_context import InvalidSubmissionError
 from quillan.submission_manifest_paths import submission_manifest_path
 from quillan.submission_status import list_assignment_submission_status
 from tests.observation_test_support import successful_image_page
+from tests.review_test_support import _write_assignment
 
 
 def test_status_lists_observed_and_assembled_student_without_writes(
@@ -25,6 +26,11 @@ def test_status_lists_observed_and_assembled_student_without_writes(
     observation = persisted.observation
     assembled = assemble_quillan_submission_manifests(
         tmp_path, observation.class_id, observation.assignment_id
+    )
+    _write_assignment(
+        tmp_path,
+        class_id=observation.class_id,
+        assignment_id=observation.assignment_id,
     )
     assert not assembled.failures
     before = assembled.assembled[0].manifest_path.read_bytes()
@@ -38,6 +44,11 @@ def test_status_lists_observed_and_assembled_student_without_writes(
 
 
 def test_status_is_empty_without_observations_or_manifests(tmp_path: Path) -> None:
+    _write_assignment(
+        tmp_path,
+        class_id="class_synthetic",
+        assignment_id="assignment_synthetic",
+    )
     status = list_assignment_submission_status(
         tmp_path, "class_synthetic", "assignment_synthetic"
     )
@@ -47,12 +58,17 @@ def test_status_is_empty_without_observations_or_manifests(tmp_path: Path) -> No
 
 
 def test_invalid_existing_manifest_remains_a_status_error(tmp_path: Path) -> None:
+    _write_assignment(
+        tmp_path,
+        class_id="class_synthetic",
+        assignment_id="assignment_synthetic",
+    )
     path = submission_manifest_path(
         tmp_path, "class_synthetic", "assignment_synthetic", "student_001"
     )
     path.parent.mkdir(parents=True)
     path.write_text("{not json", encoding="utf-8")
-    with pytest.raises(SubmissionManifestError, match="not valid JSON"):
+    with pytest.raises(InvalidSubmissionError, match="not valid JSON"):
         list_assignment_submission_status(
             tmp_path, "class_synthetic", "assignment_synthetic"
         )

--- a/tests/test_v06_reviewable_evidence_smoke.py
+++ b/tests/test_v06_reviewable_evidence_smoke.py
@@ -18,6 +18,7 @@ from quillan.submission_review_opening import open_student_submission_for_review
 from quillan.submission_review_state import update_submission_review_state
 from quillan.submission_status import list_assignment_submission_status
 from tests.observation_test_support import successful_image_page
+from tests.review_test_support import _write_assignment
 
 
 def test_legacy_caller_metadata_assembly_api_is_absent() -> None:
@@ -39,6 +40,11 @@ def test_observation_backed_evidence_remains_reviewable_and_non_destructive(
         observation.class_id,
         observation.assignment_id,
         timestamp="2026-07-21T12:00:00+00:00",
+    )
+    _write_assignment(
+        tmp_path,
+        class_id=observation.class_id,
+        assignment_id=observation.assignment_id,
     )
     assert not assembled.failures
     manifest_path = assembled.assembled[0].manifest_path


### PR DESCRIPTION
## Summary

Migrates Quillan’s canonical assignment, submission, review, page-management, feedback, reporting, and scan-review services to module-qualified storage.

Closes #340.

Related to #329.

## Module-Qualified Storage

Quillan-owned assignment data now uses only:

```text
classes/<class_id>/modules/quillan/work/<assignment_id>/
```

Migrated services no longer read, write, discover, merge, copy, or convert records from the former unqualified assignment tree.

Sibling-module workspaces remain isolated.

## Canonical Record Contexts

Adds immutable, byte-coupled contexts for:

* assignment records;
* student submission manifests;
* review records;
* student export paths;
* and canonical workspace/work identity.

Each loaded record binds together:

* its canonical absolute path;
* its workspace-relative POSIX path;
* the exact original bytes;
* and a recursively immutable validated model.

Business services use these contexts rather than reconstructing paths or re-reading expected revision bytes independently.

## Atomic Record Persistence

Adds shared low-level guarded persistence supporting:

* exclusive creation;
* exact revision comparison;
* same-directory temporary files;
* atomic replacement;
* reload verification;
* concurrency detection;
* owned lock verification;
* conservative displaced-record restoration;
* durable-path reporting;
* stale-lock reporting;
* and non-destructive cleanup.

`KeyboardInterrupt`, `SystemExit`, and other `BaseException` subclasses are not relabeled as ordinary persistence errors.

## Assignment Services

Assignment creation, loading, discovery, and multi-class writes now use canonical Quillan work paths.

Multi-class writes:

* preflight every destination before mutation;
* journal creates and updates;
* compensate only bytes proven to belong to the current operation;
* preserve concurrent edits;
* and report every possibly durable path when compensation cannot be completed safely.

## Submission and Plain-Paper Services

Submission manifest creation and updates require validated assignment and student identity.

Plain-paper submissions remain fully supported without:

* PDS2 pages;
* routes;
* issuance records;
* page observations;
* retained scans;
* or digital evidence.

Plain-paper manifest and review creation operate as a conservative paired transaction. Review uncertainty never causes deletion of a required manifest or creation of an orphan review.

## Review Services

Review creation and mutation now use canonical student contexts and exact original-byte snapshots.

The migration covers:

* minimum requirements;
* review units;
* observations;
* ratings;
* feedback;
* private notes;
* workflow state;
* review opening;
* review status;
* and dashboard foundations.

Existing teacher-controlled review behavior and record schemas are preserved.

## Page Management

Page exclusion, restoration, needs-rescan handling, evidence selection, and replacement behavior now update manifests through guarded canonical persistence.

The migration preserves:

* issuance identity;
* observation records;
* routed evidence;
* duplicate candidates;
* selected evidence;
* exclusion metadata;
* and teacher-controlled state.

## Feedback and Reports

Feedback Markdown and PDF files use canonical student export paths.

Assignment reports use canonical assignment export paths and contextual student-record loading.

Review export metadata is rejected when it points to:

* another student;
* another class or assignment;
* a sibling module;
* the legacy assignment tree;
* or a noncanonical path.

## Core-v2 Scan Review

Scan-review discovery and resolution now use PDS Core schema-version-2 failure and resolution models.

The service:

* loads records through Core’s strict loaders;
* validates filename and stored identity;
* validates failure-resolution linkage and provenance;
* derives Quillan ownership from exact routes, targets, or bounded predispatch markers;
* keeps unscoped failures unscoped;
* enriches student identity only through immutable response-page targets;
* supports explicit route selection and correction;
* validates resolution evidence paths;
* and preserves Core-owned records unchanged.

## Post-Dispatch Review

Adds append-only Quillan-owned review occurrences for failures after successful Core dispatch, including:

* observation persistence;
* routed-evidence persistence;
* submission assembly;
* mixed issuances;
* manifest conflicts;
* and post-dispatch integrity failures.

Occurrences retain complete deterministic identity tuples and exact possible durable paths beneath the affected module-qualified work root.

They remain distinct from Core routing failures and scan resolutions.

## Legacy Hard Cutover

Tests verify that migrated services ignore contradictory and legacy-only records beneath:

```text
classes/<class_id>/assignments/<assignment_id>/
```

Legacy and sibling-module sentinels remain unchanged.

No dual-path compatibility or legacy migration was added.

## Validation

Passing validation includes:

* focused Ruff;
* full Ruff;
* focused mypy across 58 files;
* full mypy across 226 files;
* focused pytest: 325 passed;
* full pytest: 1,802 passed;
* `run_tests.ps1`: 1,802 passed;
* plain-paper transaction fault injection;
* multi-class assignment compensation;
* concurrent-edit preservation;
* lock-cleanup durability;
* Core-v2 scan-resolution coverage;
* route-selection and route-correction coverage;
* post-dispatch occurrence durability;
* legacy-tree isolation;
* sibling-module isolation;
* real Windows junction coverage;
* import-safety probes;
* and `git diff --check`.

The 17 skips are privilege-dependent Windows symlink tests. Real Windows junction tests pass.

## Scope

This PR does not add:

* PDS1 support;
* legacy record migration;
* dual-path compatibility;
* OCR or grading automation;
* automatic duplicate selection;
* changes to PDS Core;
* changes to ScoreForm;
* broad #341 CLI/menu redesign;
* package-version changes;
* release preparation;
* publication or deployment.
