### PR TITLE
Migrate Quillan CLI and menu workflows (#341)

### DIFF
--- a/docs/assignment_contract.md
+++ b/docs/assignment_contract.md
@@ -45,7 +45,7 @@ data ever needs conversion.
 The current assignment file location remains:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+<PDS workspace root>/classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
 The assignment record contains `class_ids`, which may include one or more class IDs.
@@ -201,7 +201,7 @@ Rules:
 * must be a non-empty array of strings;
 * every value must follow the shared `pds-core` identifier policy;
 * duplicate class IDs are invalid;
-* if the assignment is stored under `classes/<class_id>/assignments/<assignment_id>/assignment.json`, the path class ID must appear in `class_ids`.
+* if the assignment is stored under `classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json`, the path class ID must appear in `class_ids`.
 
 Example:
 

--- a/docs/assignment_reporting_contract.md
+++ b/docs/assignment_reporting_contract.md
@@ -75,7 +75,7 @@ rating each student received on each assignment Focus Standard without
 including internal record paths or routine workflow diagnostics.
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/student_performance_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/student_performance_summary.csv
 ```
 
 It contains student identity, review status, minimum-requirement status,
@@ -92,8 +92,8 @@ requirement status, feedback export status, and detailed Focus Standard fields.
 Suggested paths:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.pdf
 ```
 
 ### Standards Summary
@@ -103,8 +103,8 @@ A teacher-facing summary of Focus Standard performance for one class and one ass
 Suggested paths:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.pdf
 ```
 
 ### Assignment Results Manifest
@@ -114,7 +114,7 @@ A machine-readable, assignment-local handoff artifact that records what Quillan 
 Suggested path:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/assignment_results_manifest.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/assignment_results_manifest.json
 ```
 
 The assignment results manifest is forward-looking. It should make future Paper Data Suite reporting integration easier without making Quillan responsible for cross-assignment or cross-module reporting.
@@ -208,7 +208,7 @@ Rules:
 ### Assignment Record
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/assignment.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
 Reports use assignment data for:
@@ -235,7 +235,7 @@ as the default order for standards columns, standards rows, and manifest standar
 ### Submission Manifests
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
 ```
 
 Reports may use submission manifests for:
@@ -255,7 +255,7 @@ Reports must not expose detailed routed evidence paths or retained-source proven
 ### Review Records
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json
 ```
 
 Target reports use schema version `2` review records.
@@ -286,8 +286,8 @@ Reports must not include:
 Reports may check for student feedback exports at:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
 Reports may use feedback export metadata stored in:
@@ -517,8 +517,8 @@ It is not:
 ### Suggested Paths
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.pdf
 ```
 
 ### Row Population
@@ -669,8 +669,8 @@ It is not:
 ### Suggested Paths
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.pdf
 ```
 
 ### Row Population
@@ -883,7 +883,7 @@ It is not:
 ### Suggested Path
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/assignment_results_manifest.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/assignment_results_manifest.json
 ```
 
 ### Top-Level Shape
@@ -897,7 +897,7 @@ Target top-level shape:
   "record_type": "assignment_results_manifest",
   "class_id": "english_10_simulation",
   "assignment_id": "coming-of-age_literary_analysis",
-  "assignment_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/assignment.json",
+  "assignment_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/assignment.json",
   "standards_profile_id": "english10_2023_njsls_ela",
   "focus_standard_ids": [
     "njsls-ela:RL.CR.9-10.1",
@@ -947,7 +947,7 @@ Example:
 
 ```json
 {
-  "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/exports/class_summary.csv",
+  "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/exports/class_summary.csv",
   "format": "csv",
   "generated_at": "2026-07-02T00:00:00+00:00",
   "stale": false,
@@ -984,10 +984,10 @@ Target shape:
   "student_id": "10001",
   "student_display_name": "Sample Student",
   "roster_status": "rostered",
-  "submission_manifest_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/submission.json",
+  "submission_manifest_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/submission.json",
   "submission_state": "reviewed",
   "submission_valid": true,
-  "review_record_path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/review.json",
+  "review_record_path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/review.json",
   "review_state": "ready_for_export",
   "review_valid": true,
   "minimum_requirement_status": "met",
@@ -1002,12 +1002,12 @@ Target shape:
   ],
   "feedback_exports": {
     "feedback_pdf": {
-      "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/exports/feedback.pdf",
+      "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/exports/feedback.pdf",
       "status": "present",
       "stale": false
     },
     "feedback_markdown": {
-      "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/exports/feedback.md",
+      "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/exports/feedback.md",
       "status": "present",
       "stale": false
     }
@@ -1268,7 +1268,7 @@ Example:
 ```json
 {
   "feedback_pdf": {
-    "path": "classes/english_10_simulation/assignments/coming-of-age_literary_analysis/submissions/10001/exports/feedback.pdf",
+    "path": "classes/english_10_simulation/modules/quillan/work/coming-of-age_literary_analysis/submissions/10001/exports/feedback.pdf",
     "status": "present",
     "stale": false
   }
@@ -1310,7 +1310,7 @@ Quillan should not implement those broader reports.
 
 Quillan's responsibility ends at assignment-local summaries and assignment-local handoff metadata.
 
-## Relationship to Legacy Runtime
+## Historical Relationship to Legacy Runtime (superseded)
 
 Legacy runtime exports produced:
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -204,7 +204,7 @@ words or paragraphs, detect required elements, run OCR or AI, infer outcomes,
 grade, score, create observations or ratings, or compose feedback. The list
 command writes nothing. The two set commands may create or replace only the
 canonical
-`classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json`,
+`classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json`,
 through the validated atomic review-record writer. They do not modify the
 assignment, submission manifest, roster, evidence, scans, exports, reports, or
 other suite data.
@@ -250,20 +250,20 @@ quillan roster add-student <class_id> --student-id <student_id> --last-name <nam
 quillan roster update-student <class_id> <student_id> [--last-name <name>] [--first-name <name>] [--period <period>] [--field <column=value> ...] (--yes | --dry-run)
 quillan roster remove-student <class_id> <student_id> (--yes | --dry-run)
 quillan printable-responses generate <class_id> <assignment_id> [--pages-per-student N] [--overwrite] (--yes | --dry-run)
-quillan validate-assignment <path>
 quillan route-scan <source-image-or-pdf-or-folder>
 quillan list-scan-review [--include-resolved] [--limit N] [--class-id <class_id>] [--assignment-id <assignment_id>] [--failure-category <category>]
-quillan resolve-scan-review <failure_id> --action <action> [--message "..."] [--evidence-path <workspace-relative-path>]
-quillan decode-scan <source-file> [--hide-payload]
+quillan resolve-scan-review <failure_id> --action <action> [--message "..."] [--evidence-path <workspace-relative-path>] [--route-id <route_id> --route-class-id <class_id> --route-assignment-id <assignment_id>]
+quillan list-post-dispatch-review <class_id> <assignment_id> [--include-resolved] [--limit N] [--category <category>]
+quillan resolve-post-dispatch-review <class_id> <assignment_id> <failure_id> --action <action> [--message "..."]
+quillan decode-scan <source-file> [--show-payload]
 quillan assemble-submissions <class_id> <assignment_id>
 quillan create-plain-paper-submission <class_id> <assignment_id> <student_id> [--yes | --dry-run]
-quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+quillan list-submissions <class_id> <assignment_id>
 quillan pages list <class_id> <assignment_id> <student_id>
 quillan pages exclude <class_id> <assignment_id> <student_id> --page N --yes
 quillan pages restore <class_id> <assignment_id> <student_id> --page N --yes
 quillan pages mark-needs-rescan <class_id> <assignment_id> <student_id> --page N --yes
-quillan open-evidence <workspace-relative-evidence-path>
-quillan open-submission <class_id> <assignment_id> <student_id> [--page N]
+quillan open-submission <class_id> <assignment_id> <student_id> [--page N] [--evidence-id <evidence_id>]
 quillan set-review-state <class_id> <assignment_id> <student_id> <state>
 quillan add-note <class_id> <assignment_id> <student_id> --text "..."
 quillan export-feedback <class_id> <assignment_id> <student_id> [--format markdown|pdf|both] [--overwrite]
@@ -615,7 +615,7 @@ or fill applicability, evidence presence, ratings, rationales, or feedback
 choices.
 
 List writes nothing. Set and mark-complete may modify only
-`classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json`
+`classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json`
 through the shared validated atomic writer. Completion changes only
 `review_state` and `updated_at`; it preserves units, observations, minimum-
 requirement data, overall ratings, feedback and comments, private notes, export
@@ -674,7 +674,7 @@ Observation readiness is not a completion gate. Both write commands reject a
 changes.
 
 List writes nothing. Set and mark-complete may modify only canonical
-`classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json`
+`classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json`
 through the validated atomic writer. They do not modify assignments,
 submission manifests, rosters, evidence, scans, observations, feedback
 composition, exports, reports, Core, or ScoreForm. They do not open evidence,
@@ -786,33 +786,17 @@ older records missing required schema-version-2 fields and do not normalize or
 rewrite them.
 
 These commands write or inspect only
-`classes/<class_id>/assignments/<assignment_id>/assignment.json`; they do not
+`classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json`; they do not
 create submission, review, evidence, scan, export, Core, or ScoreForm data.
 
-### `validate-assignment`
+### Retired raw-path interfaces
 
-```powershell
-quillan validate-assignment <path>
-```
-
-Loads a UTF-8 JSON assignment configuration and applies Quillan's current
-structural assignment validation rules. Cross-file validation against the
-shared `pds-core` workspace standards library is available through Quillan's
-assignment standards-selection helper, but this CLI command does not currently
-load the workspace standards library. The structural rules require
-timezone-aware ISO 8601 `created_at` and `updated_at` strings and an object-valued
-`module_details` field. Missing legacy fields are rejected without changing the
-input file.
-
-On success, it writes this form to standard output:
-
-```text
-Valid assignment config: <assignment_id>
-```
-
-It is read-only. It does not create an assignment directory, copy the
-configuration into the workspace, or validate referenced files as a complete
-cross-file workflow.
+`validate-assignment <path>` and `open-evidence <path>` are not public
+commands. Assignment inspection and validation require the canonical
+`<class_id> <assignment_id>` identity. Evidence opening requires the canonical
+`<class_id> <assignment_id> <student_id>` identity and may be narrowed by
+logical page and evidence ID. Argparse rejects the retired command names with
+exit status 2.
 
 ### `workspace show`
 
@@ -910,6 +894,29 @@ Menu workflows should orchestrate reusable application functions. They should
 not become the only route to core operations, and they should not duplicate
 business rules that already live in CLI handlers or domain modules.
 
+**The menu should look and feel like a modern application menu, not a dump of
+CLI commands or a legacy operator console.** Menus therefore use staged list,
+detail, action, confirmation, and result screens with compact labels and a
+small number of context-relevant choices.
+
+**Screen clearing and redrawing after a teacher selects an option is the
+default. Information remains visible only when it is essential or directly
+useful for the teacher's current action.** This is a mandatory behavioral
+contract, not a visual suggestion:
+
+* parent menus are compact;
+* selection lists are compact;
+* detail appears only after selection;
+* action screens are focused on the selected identity and current task;
+* confirmation screens are concise;
+* result workflows clear before rendering the result;
+* result screens are concise, then pause for acknowledgment;
+* returning redraws the parent screen without accumulated child output;
+* direct non-interactive CLI commands are exempt from terminal screen clearing;
+  and
+* context is retained intentionally only when it is needed for the teacher's
+  current decision.
+
 #### Assignment Management
 
 Assignment Management provides:
@@ -925,7 +932,7 @@ Creation selects one class with an existing canonical roster, prompts for the
 fields in the active schema version `2` assignment config contract, and writes:
 
 ```text
-<workspace_root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+<workspace_root>/classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
 Assignment creation prompts for:
@@ -950,8 +957,9 @@ from that profile and stored as durable pds-core `standard_id` values.
 
 An existing config is replaced only after exact `OVERWRITE` confirmation.
 
-View/validate accepts an explicit JSON path, uses the existing assignment
-loader and validator, prints a concise summary, and does not rewrite the file.
+View/validate selects a canonical class and assignment identity, uses the
+existing assignment loader and validator, prints a concise summary, and does
+not rewrite the file. It does not accept an arbitrary assignment JSON path.
 
 These workflows do not add assignment editing, deletion, import, scoring,
 feedback, generic tagging, reports, scan routing, OCR, or AI.
@@ -1067,7 +1075,8 @@ The first Review Student Work menu provides:
 ```text
 1. Assignment Review Actions
 2. Scan Intake / Route Paper Responses
-3. Back
+R. Resolve Scan Review Items
+B. Back
 ```
 
 The workflow lists available classes from the active workspace, lists
@@ -1381,8 +1390,12 @@ The command does not move, delete, or archive source files after folder
 intake. The Scan Intake / Route Paper Responses menu invokes this same
 QR-aware intake path.
 
-Scan intake writes Core-v2 failure occurrence records but no successful page
-observations, routed evidence, submission manifests, or submissions. See
+The direct command and menu both return the same typed full-workflow result.
+Successful Quillan dispatches persist immutable observations and assemble
+issuance-authoritative submissions. Pre-dispatch failures remain Core-owned;
+post-dispatch persistence, assembly, and review-preservation failures are
+preserved as immutable Quillan occurrences beneath the exact module-qualified
+work root. No caller callback or second assembly pass is used. See
 [`pds2_scan_intake.md`](pds2_scan_intake.md).
 
 ## Scan Review Resolution
@@ -1395,23 +1408,49 @@ unreadable metadata is skipped with a warning count instead of making the
 entire listing fail.
 
 `quillan resolve-scan-review <failure_id> --action <action>` accepts
-`rescan_needed`, `cannot_route`, `mixed_assignment`, `evidence_filed`,
-`dismissed_duplicate`, `other`, or `defer`. Common actions have safe default
-messages; `other` requires `--message`. `--evidence-path` is accepted only with
-`evidence_filed` and must be workspace-relative.
+`route_selected`, `route_corrected`, `rescan_needed`, `cannot_route`,
+`evidence_filed`, `dismissed_duplicate`, `deferred`, or `other` (with the
+documented `defer` and `mixed_assignment` aliases retained by Core). Common
+actions have safe default messages; `other` requires `--message`.
+`--evidence-path` is accepted only with `evidence_filed` and must be
+workspace-relative. Route actions require an exact current registered route
+identity through `--route-id`, `--route-class-id`, and
+`--route-assignment-id`; the service reloads and validates that route before
+writing the resolution.
 
 The command writes a new exclusive-create Core resolution record under
 `scans/review/resolutions/`. It does not change the referenced failure record,
 retained scan, submission manifest, submission review state, or teacher review
 record. The interactive **Review Student Work > Resolve Scan Review Items**
-path provides the same decisions with compact list, detail, action, note, and
-result screens.
+path discovers assignment work with active Quillan post-dispatch occurrences.
+After compact work selection it enters the sole active source directly or,
+when both sources exist, offers Core routing problems, Quillan post-dispatch
+problems, and all active problems. Compact list, detail, contextual action,
+confirmation, and result screens follow the mandatory clear/redraw contract.
+
+`quillan list-post-dispatch-review <class_id> <assignment_id>` lists immutable
+Quillan-owned occurrences for one exact module-qualified work root. Resolved
+items are hidden by default, deferred items remain visible, and category,
+limit, and include-resolved filters are deterministic. `quillan
+resolve-post-dispatch-review` appends a schema-version-1 Quillan resolution;
+it never changes the occurrence, Core review records, observations, evidence,
+manifests, or teacher reviews. Generic direct actions are `rescan_needed`,
+`record_corrected`, `cannot_recover`,
+`dismissed_duplicate`, `deferred`, and `other`; `other` requires a message.
+The generic direct command does not accept `resolved_after_retry` because a
+caller may not assert a successful retry. For safe occurrence categories, the
+menu can retry the existing shared submission-assembly service, show its typed
+result, and only after success ask whether to append `resolved_after_retry`
+with bounded operation, work, student/issuance, result-status, and timestamp
+provenance. Retry success never resolves an occurrence automatically. The menu
+also provides read-only current status and validated occurrence-owned possible
+evidence/manifest opening without arbitrary-path input or automatic resolution.
 
 ## Submission Assembly and Status
 
 ```powershell
 quillan assemble-submissions <class_id> <assignment_id>
-quillan list-submissions <class_id> <assignment_id> [--expected-pages N]
+quillan list-submissions <class_id> <assignment_id>
 ```
 
 `assemble-submissions` discovers strict immutable observation JSON, verifies its
@@ -1447,15 +1486,14 @@ are mutually exclusive.
 ## Evidence and Submission Opening
 
 ```powershell
-quillan open-evidence <workspace-relative-evidence-path>
-quillan open-submission <class_id> <assignment_id> <student_id>
+quillan open-submission <class_id> <assignment_id> <student_id> [--page N] [--evidence-id <evidence_id>]
 ```
 
-`open-evidence` opens one existing file that resolves inside the active
-workspace.
-
-`open-submission` validates one canonical manifest and opens its single
-selected evidence item.
+`open-submission` validates one canonical manifest. With no narrowing option it
+opens each selected page evidence item. `--page` narrows by logical page;
+`--evidence-id` selects an exact evidence candidate within that canonical
+submission identity. Raw workspace-relative paths are not accepted as public
+identity.
 
 Both commands are read-only. They do not inspect content, select evidence,
 score work, tag work, create review records, generate feedback, or update
@@ -1569,8 +1607,8 @@ This direct command requires valid matching canonical `submission.json` and
 `review.json` records, then writes the selected derived artifact or artifacts:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
 `--format` accepts `markdown`, `pdf`, or `both`. The default is `markdown` for
@@ -1604,7 +1642,7 @@ submission manifests, review records, and feedback export metadata, then
 writes:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
 ```
 
 Rows follow roster order when a roster is available, then discovered
@@ -1643,7 +1681,7 @@ This command reads the assignment's configured Focus Standards, discovered
 or rostered student records, and feedback export metadata, then writes:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
 ```
 
 It validates each available `submission.json` and `review.json`, counts
@@ -1696,37 +1734,30 @@ direct CLI handlers. It does not implement a parallel export system.
 
 ## Output and Error Handling
 
-Human-readable command results are the current output contract. Quillan does
-not yet provide a machine-readable `--json` mode, and scripts should not
-assume that prose, whitespace, or field ordering will remain stable before
-1.0.
+Human-readable command results are the default output contract. The
+`review-dashboard` and `review-status` commands also provide stable
+schema-version-1 JSON projections through `--format json`; other prose output
+should not be treated as a machine-readable schema.
 
 The intended convention is:
 
 * successful results and requested help go to standard output;
 * usage and argument-parsing errors go to standard error;
-* operational or validation failures produce a concise, actionable message;
+* expected operational or validation failures go to standard error, produce a
+  concise actionable message, and exit 1;
 * expected user errors do not display a Python traceback; and
 * diagnostics should distinguish invalid input from an internal programming
   failure.
 
-Current validation failures are reported with these prefixes:
-
-```text
-Invalid assignment config: ...
-```
-
-Current workspace-resolution failures use:
+Expected failures use:
 
 ```text
 Error: ...
 ```
 
-At present, validation failures are emitted to standard error by the console
-entry point, while `workspace show` operational failures are printed to
-standard output. This is an existing pre-1.0 inconsistency, not a requirement
-for new commands. New and revised handlers should converge on standard error
-for failures, with tests updated alongside the behavior.
+Artifact paths in teacher-facing output are canonical workspace-relative POSIX
+paths. Absolute host paths are not an artifact identity and are not printed as
+successful workflow results.
 
 Unexpected exceptions indicate defects and are not converted into a success
 status. Sensitive classroom data must not be added to routine diagnostics,

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -123,7 +123,12 @@ Examples and tests should use:
 * synthetic scores;
 * synthetic teacher comments.
 
-## Original Architecture Sketch
+## Historical Architecture Sketch (superseded)
+
+This architecture and the implementation sequence that follows record earlier
+project planning. They are historical, not the current CLI, menu, storage, or
+PDS2 routing contract. Current behavior is defined by `docs/cli_contract.md`,
+`docs/workspace_lifecycle.md`, and `docs/pds2_scan_intake.md`.
 
 The list below records the initial planning decomposition. The current source
 tree uses focused modules such as `review_record.py`, `review_notes.py`,
@@ -203,7 +208,7 @@ Current responsibility:
 Individual student PDFs, scan routing, OCR, review, scoring, feedback, reports,
 AI, and a direct printable CLI command remain out of scope.
 
-### Scan routing
+### Historical scan routing plan (superseded by PDS2)
 
 Future Quillan scan routing must use the shared active scan contract defined by
 `pds-core`. Canonical active retained sources belong in
@@ -213,10 +218,11 @@ than canonical source retention.
 
 `pds-core` owns shared source retention, review paths, failure metadata and
 categories, copy-first behavior, no-overwrite rules, and provenance semantics.
-Quillan owns interpretation of its `PDS1` response payloads, response-page
-validation, routed student evidence layout, submission assembly, completeness
-and rescan decisions, and any future OCR behavior. Quillan-specific failure
-details belong under the shared record's `module_details`.
+Historically, Quillan interpreted its `PDS1` response payloads and owned the
+then-planned routed evidence layout. That interface is superseded. Current
+intake accepts only strict Core PDS2 locators; Core parses and resolves them,
+while Quillan validates dispatched response pages, persists observations and
+routed evidence, and assembles issuance-authoritative submissions.
 
 The first version `1` reviewable-evidence submission manifest contract is
 documented, with loading, validation, canonical Quillan-owned path helpers,
@@ -273,13 +279,12 @@ It writes shared `pds-core` failure records under `scans/review/`, preserves
 route failure and evidence filing context, and records workspace-relative
 retained-source provenance when available. It does not copy review artifacts.
 
-The direct
-`quillan route-scan <source-file> --payload "<PDS1|...>"` command is
-implemented for one selected source and an already-decoded payload. It
-orchestrates the existing parser, planner, evidence filer, and review adapters.
-QR extraction, PDF splitting, OCR, menu integration, and batch routing remain
-unimplemented. Assignment submission assembly is available through a focused
-Python API and `quillan assemble-submissions`; it is not part of `route-scan`.
+Historical implementation note (superseded): an earlier direct
+`quillan route-scan <source-file> --payload "<PDS1|...>"` form accepted an
+already-decoded legacy payload. It is not a supported command. Current
+`quillan route-scan <source>` performs retained-source PDS2 decoding, Core
+dispatch, observation/evidence persistence, submission assembly, and failure
+preservation through the shared workflow service.
 
 ### `submissions.py`
 
@@ -435,9 +440,9 @@ Completed work:
 * Add the Roster Management submenu using shared `pds-core` contracts.
 * Add the Printable Response Pages submenu for combined class-packet
   generation.
-* Add a direct `route-scan` command for already-decoded Quillan PDS1 payloads.
-* Add `assemble-submissions`, `list-submissions`, `open-evidence`,
-  `open-submission`, and `set-review-state`.
+* Add direct retained-source `route-scan` and `decode-scan` PDS2 workflows.
+* Add `assemble-submissions`, issuance-driven `list-submissions`,
+  identity-based `open-submission`, and `set-review-state`.
 * Add CLI tests.
 
 Remaining possible work:
@@ -462,8 +467,8 @@ Planned work:
 
 Likely first commands:
 
-* `quillan validate-assignment <path>`
-* later: `quillan create-assignment`
+* `quillan assignment validate <class_id> <assignment_id>`
+* `quillan assignment create <class_id> <assignment_id> ...`
 
 ### Phase 6 â€” Submissions and Requirements
 
@@ -479,10 +484,9 @@ Completed reviewable-evidence work:
   changing only `submission_state` and `updated_at`.
 * Preserve retained-source provenance and workspace-relative artifact paths.
 * Open individual workspace-relative evidence files safely through the shared
-  `pds-core` local opener. Implemented as a low-level helper,
-  `quillan open-evidence`, and the read-only student-aware
-  `quillan open-submission`, which currently requires exactly one selected
-  evidence item and does not update review state. State changes occur only
+  `pds-core` local opener. The public read-only workflow is the student-aware,
+  identity-based `quillan open-submission`, optionally narrowed by logical page
+  and evidence ID, and it does not update review state. State changes occur only
   through the explicit `quillan set-review-state` command.
 
 Remaining requirements and review work:
@@ -611,7 +615,7 @@ Possible next issues after the initial documentation milestone:
 
 1. Add duplicate standards/comment validation.
 2. Implement assignment config loading and validation.
-3. Add `validate-assignment` CLI command.
+3. Add canonical `assignment validate <class_id> <assignment_id>` CLI action.
 4. Define basic requirements evaluation.
 5. Implement plain-text submission loading.
 6. Add paragraph and word counting.
@@ -647,6 +651,6 @@ These should not distract from the MVP.
 Quillan supports a focused teacher-facing setup path for students who wrote on
 plain paper when printable response pages were unavailable. The path creates
 the existing submission and review contracts without scans, OCR, placeholder
-files, fake evidence, bulk creation, or changes to QR/PDS1 printing. Subsequent
+files, fake evidence, bulk creation, or changes to superseded QR printing. Subsequent
 work remains in the active standards-based review and assignment-local export
 model.

--- a/docs/feedback_export_contract.md
+++ b/docs/feedback_export_contract.md
@@ -29,7 +29,7 @@ Which generic tags, generic comments, or generic rubric scores were attached to 
 The feedback export is not the canonical review record. The canonical teacher review record remains:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json
 ```
 
 A generated feedback export must not replace, rewrite, or become the source of truth for:
@@ -77,7 +77,7 @@ PDF is the primary student-facing feedback export format.
 The canonical PDF output path is:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
 ```
 
 Markdown may be retained as an optional plain-text companion artifact.
@@ -85,7 +85,7 @@ Markdown may be retained as an optional plain-text companion artifact.
 The optional Markdown output path is:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
 Rules:
@@ -105,7 +105,7 @@ A student feedback export is generated from the following records.
 Canonical path:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/assignment.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
 Required target schema:
@@ -143,7 +143,7 @@ as the default order for student-facing standards sections.
 Canonical path:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
 ```
 
 The export may use the submission manifest for:
@@ -174,7 +174,7 @@ Student-facing feedback must not include:
 Canonical path:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json
 ```
 
 Required target schema:
@@ -1099,7 +1099,7 @@ If Markdown is generated, it should use the same content model as the PDF.
 Recommended path:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
 Rules:

--- a/docs/prepared_review_workflow.md
+++ b/docs/prepared_review_workflow.md
@@ -204,8 +204,8 @@ Composition does not inspect evidence, generate language, or export feedback.
 Student feedback exports are derived artifacts:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
 Returned-work feedback can be exported when a review is returned without full
@@ -214,9 +214,9 @@ standards review.
 Assignment-local summaries are also derived artifacts:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/exports/student_performance_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/student_performance_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
 ```
 
 Student Performance Summary is the compact teacher-facing student-by-standard
@@ -237,14 +237,14 @@ results.
 ## Storage Map
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/assignment.json
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
-classes/<class_id>/assignments/<assignment_id>/exports/student_performance_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv
-classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/student_performance_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
 shared/focus_standard_comments/<comment_set_id>.json
 ```
 

--- a/docs/printable_response_template.md
+++ b/docs/printable_response_template.md
@@ -93,7 +93,7 @@ quillan printable-responses generate <class_id> <assignment_id> [--pages-per-stu
 Only the teacher menu may offer to open an installed PDF or its folder, and
 opening remains an explicit choice.
 
-PDS1 generation has been removed. PDS1 scan interpretation remains a separate,
-later migration boundary; this contract does not claim installed module-profile
-registration, a route handler, PDS2 scan dispatch, retained-source intake,
-evidence assembly, submission-schema migration, or plain-paper changes.
+PDS1 generation and interpretation have been removed. Generated pages use
+registered PDS2 locators backed by immutable issuance, page, and route records.
+Retained-source intake dispatches those locators through the installed module
+profile; submission assembly derives expected pages from issuance membership.

--- a/docs/review_record_contract.md
+++ b/docs/review_record_contract.md
@@ -6,7 +6,7 @@ The Quillan submission review record stores teacher-entered review data for
 one student submission. Its canonical workspace-relative path is:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json
 ```
 
 `review.json` is separate from the adjacent `submission.json` evidence
@@ -70,19 +70,19 @@ new standards-based review work.
 The canonical active review record path remains:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/review.json
+<PDS workspace root>/classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/review.json
 ```
 
 The adjacent evidence manifest remains:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+<PDS workspace root>/classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
 ```
 
 The associated assignment record normally remains:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+<PDS workspace root>/classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
 The review record must reference the submission manifest and assignment record
@@ -217,13 +217,13 @@ For a review record with identity `<class_id>`, `<assignment_id>`, and
 `<student_id>`, the canonical submission manifest reference is:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/submission.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/submission.json
 ```
 
 The canonical assignment reference is:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/assignment.json
+classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
 Review-local identifiers such as `requirement_check_id`, `unit_id`,
@@ -1422,8 +1422,8 @@ Student-facing feedback files are derived artifacts. In the v0.8.6 target
 model, expected derived feedback paths include:
 
 ```text
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
-classes/<class_id>/assignments/<assignment_id>/submissions/<student_id>/exports/feedback.md
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.pdf
+classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>/exports/feedback.md
 ```
 
 Assignment-level reports are also derived artifacts. They do not replace

--- a/docs/teacher_review_model.md
+++ b/docs/teacher_review_model.md
@@ -31,7 +31,7 @@ Source evidence:
 
 ```text
 submission.json
-routed evidence files under classes/<class_id>/assignments/<assignment_id>/scans/
+routed evidence files under classes/<class_id>/modules/quillan/work/<assignment_id>/scans/evidence/
 ```
 
 Teacher review artifact:

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -6,7 +6,7 @@ Quillan uses the shared Paper Data Suite workspace root. Class, assignment,
 and submission records are centered under:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/
+<PDS workspace root>/classes/<class_id>/modules/quillan/work/<assignment_id>/
 ```
 
 This is the active, local-first workspace for teacher-controlled instructional
@@ -52,24 +52,26 @@ The expected current and reserved layout is:
   classes/
     <class_id>/
       roster.csv
-      assignments/
-        <assignment_id>/
-          assignment.json
-          templates/
-            printable_response_pages.pdf
-          scans/
-          submissions/
-            <student_id>/
-              submission.json
-              review.json
+      modules/
+        quillan/
+          work/
+            <assignment_id>/
+              assignment.json
+              templates/
+                printable_response_pages.pdf
+              scans/
+              submissions/
+                <student_id>/
+                  submission.json
+                  review.json
+                  exports/
+                    feedback.pdf
+                    feedback.md
               exports/
-                feedback.pdf
-                feedback.md
-          exports/
-            student_performance_summary.csv
-            class_summary.csv
-            standards_summary.csv
-          debug/
+                student_performance_summary.csv
+                class_summary.csv
+                standards_summary.csv
+              debug/
 ```
 
 Reusable Focus Standard comments live outside individual assignments:
@@ -112,11 +114,11 @@ the teacher selects a class with an existing canonical roster. It uses the
 existing assignment validation contract and the shared assignment route:
 
 ```text
-<PDS workspace root>/classes/<class_id>/assignments/<assignment_id>/assignment.json
+<PDS workspace root>/classes/<class_id>/modules/quillan/work/<assignment_id>/assignment.json
 ```
 
-The menu can also load, validate, and summarize an explicit assignment JSON
-path without rewriting it. Existing configs require exact `OVERWRITE`
+The menu can also select, load, validate, and summarize a canonical assignment
+by class and assignment identity without rewriting it. Existing configs require exact `OVERWRITE`
 confirmation before replacement. This workflow does not edit or delete
 assignments and does not perform scoring, feedback, reporting, scan routing,
 OCR, AI, or printable packet
@@ -155,10 +157,12 @@ for teacher review.
 
 ### Assignment `scans/`
 
-The assignment-local directory for routed scan evidence. It is not the
-canonical retained source location. The direct `route-scan` workflow files a
-selected source here only when the caller supplies an already-decoded
-canonical PDS1 payload. The validation, naming, collision, provenance, and
+The assignment-local directory for immutable page observations and routed
+evidence. It is not the canonical retained source location. The direct
+`route-scan` workflow obtains a strict PDS2 locator from the retained physical
+page, dispatches through the current registered route, and persists successful
+Quillan results under the exact module-qualified work root. There is no caller
+payload mode or PDS1 fallback. Validation, naming, collision, provenance, and
 failure-review behavior is defined in
 [`scan_routing_design.md`](scan_routing_design.md). Quillan does not perform
 OCR or evaluate writing from scan contents.
@@ -173,12 +177,12 @@ submission-management state without containing private notes, Focus Standard
 ratings, feedback composition, or feedback exports.
 
 Loading, validation, canonical path computation, safe writing, and
-new-manifest assembly from caller-provided evidence metadata are implemented
-in modules distinct from the legacy text-oriented loader. The direct
-`assemble-submissions` command discovers already-routed evidence by filename
-and creates missing manifests; it does not merge into existing manifests or
-choose among ambiguous duplicates. `set-review-state` provides an explicit,
-metadata-only teacher-controlled state update.
+new-manifest assembly from immutable observation and issuance authority are
+implemented separately from the superseded text-oriented loader. The direct
+`assemble-submissions` command discovers validated observations, verifies
+routed evidence, and assembles issuance-authoritative manifests without
+caller-supplied expected-page identity. `set-review-state` provides an
+explicit, metadata-only teacher-controlled state update.
 
 ### `submissions/<student_id>/review.json`
 
@@ -302,15 +306,16 @@ evidence, teacher-review artifacts, Focus Standard ratings, feedback, and
 derived reports mean within Quillan's teacher-controlled review process.
 
 [`printable_response_template.md`](printable_response_template.md) defines the
-required structure, identity fields, PDS1 payload use, writing area, and
+required structure, immutable issuance/page/route identities, PDS2 locator,
+writing area, and
 implemented `templates/printable_response_pages.pdf` output for printable
 writing-response pages.
 
-[`scan_routing_design.md`](scan_routing_design.md) defines how decoded response
-payloads are validated and how Quillan routed evidence fits the shared
+[`scan_routing_design.md`](scan_routing_design.md) defines how detected PDS2
+locators are validated and how Quillan routed evidence fits the shared
 `pds-core` active scan contract. The direct `route-scan` command supports
-caller-supplied decoded payloads and QR-aware image, PDF, or non-recursive
-folder intake. Canonical retained sources belong in `scans/source/YYYY-MM-DD/`,
+QR-aware image, PDF, or non-recursive folder intake. Canonical retained sources
+belong in `scans/source/YYYY-MM-DD/`,
 canonical failure records belong in `scans/review/`, and assignment-level
 `scans/` contains routed evidence. OCR remains outside Quillan's scope.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ quillan = "quillan.pds_module:get_module_profile"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "menu_density_workflow(label): real recorder-backed menu-density acceptance workflow",
+    "menu_density_contract: collection and execution contract for density workflows",
+]
 
 [tool.ruff]
 line-length = 88

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -25,7 +25,6 @@ from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
 from quillan.assignments import (
     AssignmentConfigError,
-    load_assignment_config,
     validate_assignment_config,
 )
 from quillan.atomic_record_io import (
@@ -39,7 +38,6 @@ from quillan.record_context import (
     load_quillan_assignment_context,
 )
 from quillan.assignment_picker import prompt_assignment_choice
-from quillan.storage import assignment_config_path
 from quillan.work_paths import (
     QuillanWorkPathError,
     initialize_managed_work_layout,
@@ -228,6 +226,50 @@ def write_assignment_config(
     return write_assignment_configs(
         workspace_root, (class_id,), assignment, overwrite=overwrite
     )[0]
+
+
+@dataclass(frozen=True, slots=True)
+class AssignmentBatchDestination:
+    """Canonical preflight result for one assignment copy."""
+
+    class_id: str
+    path: Path
+    exists: bool
+
+
+def plan_assignment_config_destinations(
+    workspace_root: str | Path,
+    class_ids: Sequence[str],
+    assignment: Mapping[str, Any],
+) -> tuple[AssignmentBatchDestination, ...]:
+    """Return validated canonical destinations without writing or creating paths."""
+    assignment_data = dict(assignment)
+    validate_assignment_config(assignment_data)
+    selected = tuple(class_ids)
+    if not selected or len(set(selected)) != len(selected):
+        raise AssignmentConfigError("class_ids must be nonempty and unique.")
+    root = canonical_workspace_root(workspace_root)
+    assignment_id = str(assignment_data["assignment_id"])
+    destinations: list[AssignmentBatchDestination] = []
+    for class_id in selected:
+        if class_id not in assignment_data["class_ids"]:
+            raise AssignmentConfigError(
+                "Assignment class_ids must include every selected class_id."
+            )
+        paths = quillan_work_paths(root, class_id, assignment_id)
+        try:
+            preflight_managed_work_layout(paths)
+            preflight_work_file_destination(root, paths.work_ref, "assignment.json")
+        except QuillanWorkPathError as error:
+            raise AssignmentConfigError(str(error)) from error
+        destinations.append(
+            AssignmentBatchDestination(
+                class_id=class_id,
+                path=paths.assignment_path,
+                exists=os.path.lexists(paths.assignment_path),
+            )
+        )
+    return tuple(destinations)
 
 
 def write_assignment_configs(
@@ -481,13 +523,28 @@ def format_assignment_summary(
     workspace_root: str | Path | None = None,
 ) -> str:
     """Return a concise human-readable assignment summary."""
+    path = Path(assignment_path)
+    if path.is_absolute():
+        if workspace_root is None:
+            raise ValueError(
+                "An absolute assignment path requires the exact workspace root."
+            )
+        try:
+            path = path.relative_to(Path(workspace_root))
+        except ValueError as error:
+            raise ValueError(
+                "Assignment path is outside the exact workspace root."
+            ) from error
+    if not path.parts or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("Assignment path is not canonical workspace-relative text.")
+    path_text = path.as_posix()
     class_ids = ", ".join(str(value) for value in assignment["class_ids"])
     focus_standard_ids = [str(value) for value in assignment["focus_standard_ids"]]
     focus_text = ", ".join(focus_standard_ids)
     review_unit = assignment.get("review_unit", {})
     rating_scale = assignment.get("rating_scale", {})
     lines = [
-        f"Assignment path: {Path(assignment_path)}",
+        f"Assignment path: {path_text}",
         f"Schema version: {assignment['schema_version']}",
         f"Assignment ID: {assignment['assignment_id']}",
         f"Title: {assignment['title']}",
@@ -939,10 +996,14 @@ def prompt_create_assignment() -> int:
         print(f"Error: {error}")
         return 1
 
-    output_paths = [
-        assignment_config_path(workspace_root, class_id, assignment_id)
-        for class_id in class_ids
-    ]
+    try:
+        destinations = plan_assignment_config_destinations(
+            workspace_root, class_ids, assignment
+        )
+    except AssignmentConfigError as error:
+        print(f"Error: {error}")
+        return 1
+    output_paths = [destination.path for destination in destinations]
     _print_assignment_section_header(
         "Review Assignment Before Saving",
         class_ids=class_ids,
@@ -954,16 +1015,16 @@ def prompt_create_assignment() -> int:
     class_word = "class" if class_count == 1 else "classes"
     print(f"This assignment will be saved for {class_count} {class_word}:")
     for class_id, output_path in zip(class_ids, output_paths, strict=True):
-        print(f"- {class_id}: {output_path}")
+        print(f"- {class_id}: {output_path.relative_to(workspace_root).as_posix()}")
     if not _prompt_yes_no("Save this assignment? [Y/n]: ", default=True):
         print("Canceled: assignment was not saved.")
         return 0
 
     overwrite = False
     existing_paths = [
-        (class_id, output_path)
-        for class_id, output_path in zip(class_ids, output_paths, strict=True)
-        if output_path.exists()
+        (destination.class_id, destination.path)
+        for destination in destinations
+        if destination.exists
     ]
     if existing_paths:
         _print_assignment_section_header(
@@ -974,7 +1035,10 @@ def prompt_create_assignment() -> int:
         print("Assignment config already exists in one or more selected classes:")
         print()
         for class_id, output_path in existing_paths:
-            print(f"- {class_id}: {output_path}")
+            print(
+                f"- {class_id}: "
+                f"{output_path.relative_to(workspace_root).as_posix()}"
+            )
         print()
         confirmation = input(
             "Type OVERWRITE to replace existing assignment configs: "
@@ -996,12 +1060,22 @@ def prompt_create_assignment() -> int:
     except (AssignmentConfigError, OSError, FileExistsError) as error:
         print(f"Error: {error}")
         return 1
+    from quillan.menu import clear_screen, print_menu_header
+
+    clear_screen()
+    print_menu_header("Assignment Saved")
     if len(saved_paths) == 1:
-        print(f"Saved assignment: {saved_paths[0]}")
+        print(
+            "Saved assignment: "
+            f"{saved_paths[0].relative_to(workspace_root).as_posix()}"
+        )
     else:
         print(f"Saved assignment for {len(saved_paths)} classes:")
         for class_id, saved_path in zip(class_ids, saved_paths, strict=True):
-            print(f"- {class_id}: {saved_path}")
+            print(
+                f"- {class_id}: "
+                f"{saved_path.relative_to(workspace_root).as_posix()}"
+            )
     return 0
 
 
@@ -1119,7 +1193,8 @@ def _normalize_path_input(value: str) -> str:
 
 def prompt_view_validate_assignment() -> int:
     """Select, load, validate, and summarize a canonical assignment config."""
-    from quillan.menu import print_menu_header
+    from quillan.assignment_setup import load_canonical_assignment
+    from quillan.menu import clear_screen, print_menu_header
 
     print_menu_header("View/Validate Assignment")
     workspace_root = _workspace_root()
@@ -1129,12 +1204,16 @@ def prompt_view_validate_assignment() -> int:
     if choice is None:
         return 0
     try:
-        assignment = load_assignment_config(choice.path)
-    except (AssignmentConfigError, OSError) as error:
+        plan = load_canonical_assignment(
+            workspace_root, choice.class_id, choice.assignment_id
+        )
+    except (AssignmentConfigError, OSError, ValueError) as error:
         print(f"Error: {error}")
         return 1
+    clear_screen()
+    print_menu_header("Assignment Validation Result")
     print("Assignment config is valid.")
-    print(format_assignment_summary(assignment, choice.path, workspace_root))
+    print(format_assignment_summary(plan.assignment, plan.path, workspace_root))
     return 0
 
 
@@ -1161,7 +1240,7 @@ def launch_assignment_menu() -> int:
             navigation = parse_navigation_choice(choice)
             print()
 
-            if choice == "4" or navigation is NavigationChoice.BACK:
+            if navigation is NavigationChoice.BACK:
                 return 0
             workflows = {
                 "1": prompt_create_assignment,

--- a/quillan/cli_app/handlers/assignments.py
+++ b/quillan/cli_app/handlers/assignments.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -19,15 +20,17 @@ from quillan.assignment_workflows import (
 )
 
 
-def _relative(path: Path, root: Path) -> Path:
+def _relative(path: Path, root: Path) -> str:
     try:
-        return path.relative_to(root)
-    except ValueError:
-        return path
+        return path.relative_to(root).as_posix()
+    except ValueError as error:
+        raise ValueError(
+            "Canonical assignment path is outside the exact workspace root."
+        ) from error
 
 
 def _error(action: str, error: Exception) -> int:
-    print(f"Error: assignment {action}: {error}")
+    print(f"Error: assignment {action}: {error}", file=sys.stderr)
     return 1
 
 

--- a/quillan/cli_app/handlers/comments.py
+++ b/quillan/cli_app/handlers/comments.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import math
 import re
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -122,5 +123,5 @@ def _optional_trimmed(value: str | None, label: str) -> str | None:
 
 
 def _error(error: Exception) -> int:
-    print(f"Error: {error}")
+    print(f"Error: {error}", file=sys.stderr)
     return 1

--- a/quillan/cli_app/handlers/dashboard.py
+++ b/quillan/cli_app/handlers/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -32,7 +33,10 @@ def handle_review_dashboard(args: argparse.Namespace) -> int:
             else format_assignment_review_dashboard(dashboard)
         )
     except (WorkspaceRootError, ReviewDashboardError, OSError, TypeError) as error:
-        print(f"Error: could not build assignment review dashboard: {error}")
+        print(
+            f"Error: could not build assignment review dashboard: {error}",
+            file=sys.stderr,
+        )
         return 1
     print(output)
     return 0

--- a/quillan/cli_app/handlers/decoding.py
+++ b/quillan/cli_app/handlers/decoding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass
 from pathlib import Path
+import sys
 
 from pds_core.pds2 import parse_pds2_payload, serialize_pds2_payload
 from pds_core.routing_models import RouteLocator
@@ -171,7 +172,7 @@ def handle_decode_scan(args: argparse.Namespace) -> int:
             workspace_root=resolve_workspace_root(),
         )
     except Exception as error:
-        print(f"Decode failed: {error}")
+        print(f"Decode failed: {error}", file=sys.stderr)
         return 1
     success = True
     for page in pages:
@@ -180,8 +181,8 @@ def handle_decode_scan(args: argparse.Namespace) -> int:
         if page.locator is None:
             success = False
             print(f"Decode failed: {page.failure_category}")
-            print(f"Reason: {page.error}")
-            if page.raw_payload_text is not None and not args.hide_payload:
+            print(f"Reason: {_safe_decode_reason(page)}")
+            if page.raw_payload_text is not None and args.show_payload:
                 print(f"Raw payload: {page.raw_payload_text}")
             continue
         locator = page.locator
@@ -190,9 +191,28 @@ def handle_decode_scan(args: argparse.Namespace) -> int:
         print(f"Class: {locator.class_id}")
         print(f"Work: {locator.work_id}")
         print(f"Route: {locator.route_id}")
-        if not args.hide_payload:
+        if args.show_payload:
             print(f"Canonical payload: {serialize_pds2_payload(locator)}")
     return 0 if success and bool(pages) else 1
+
+
+def _safe_decode_reason(page: DecodedPds2Page) -> str:
+    """Explain a failure without echoing potentially sensitive QR text."""
+    reasons = {
+        "payload_schema_unsupported": (
+            "This QR uses an unsupported schema; only PDS2 is supported."
+        ),
+        "payload_missing": "No QR payload was detected on this physical page.",
+        "payload_unreadable": "The QR payload could not be read safely.",
+        "payload_too_large": "The QR payload exceeds the PDS2 size limit.",
+        "identifier_invalid": "A PDS2 identity field is invalid.",
+        "payload_invalid": "The QR payload is not a valid PDS2 locator.",
+        "source_unreadable": "The retained physical page could not be read.",
+    }
+    return reasons.get(
+        page.failure_category or "",
+        "The physical page could not be decoded as a PDS2 locator.",
+    )
 
 
 __all__ = [

--- a/quillan/cli_app/handlers/exports.py
+++ b/quillan/cli_app/handlers/exports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -66,7 +67,7 @@ def handle_export_feedback(args: argparse.Namespace) -> int:
             overwrite=args.overwrite,
         )
     except (WorkspaceRootError, FeedbackExportError) as error:
-        print(f"Error: could not export student feedback: {error}")
+        print(f"Error: could not export student feedback: {error}", file=sys.stderr)
         return 1
 
     print_exported_feedback(exported)
@@ -84,7 +85,10 @@ def handle_export_class_summary(args: argparse.Namespace) -> int:
             overwrite=args.overwrite,
         )
     except (WorkspaceRootError, ClassSummaryExportError) as error:
-        print(f"Error: could not export class review summary: {error}")
+        print(
+            f"Error: could not export class review summary: {error}",
+            file=sys.stderr,
+        )
         return 1
 
     print_exported_class_summary(exported)
@@ -99,7 +103,10 @@ def handle_export_student_performance_summary(args: argparse.Namespace) -> int:
             workspace_root, args.class_id, args.assignment_id, overwrite=args.overwrite
         )
     except (WorkspaceRootError, StudentPerformanceSummaryExportError) as error:
-        print(f"Error: could not export student performance summary: {error}")
+        print(
+            f"Error: could not export student performance summary: {error}",
+            file=sys.stderr,
+        )
         return 1
     print_exported_student_performance_summary(exported)
     return 0
@@ -116,7 +123,7 @@ def handle_export_standards_summary(args: argparse.Namespace) -> int:
             overwrite=args.overwrite,
         )
     except (WorkspaceRootError, StandardsSummaryExportError) as error:
-        print(f"Error: could not export standards summary: {error}")
+        print(f"Error: could not export standards summary: {error}", file=sys.stderr)
         return 1
 
     print_exported_standards_summary(exported)

--- a/quillan/cli_app/handlers/feedback.py
+++ b/quillan/cli_app/handlers/feedback.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -231,5 +232,5 @@ def _optional_bool(value: bool | None) -> str:
 
 
 def _error(error: Exception) -> int:
-    print(f"Error: {error}")
+    print(f"Error: {error}", file=sys.stderr)
     return 1

--- a/quillan/cli_app/handlers/observations.py
+++ b/quillan/cli_app/handlers/observations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -172,5 +173,5 @@ def _yes_no(value: bool) -> str:
 
 
 def _error(error: Exception) -> int:
-    print(f"Error: {error}")
+    print(f"Error: {error}", file=sys.stderr)
     return 1

--- a/quillan/cli_app/handlers/pages.py
+++ b/quillan/cli_app/handlers/pages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 from pathlib import Path
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -32,7 +33,7 @@ def handle_pages_list(args: argparse.Namespace) -> int:
             args.student_id,
         )
     except (WorkspaceRootError, SubmissionPageManagementError, OSError) as error:
-        print(f"Error: could not list submission pages: {error}")
+        print(f"Error: could not list submission pages: {error}", file=sys.stderr)
         return 1
     print_submission_page_context(context)
     return 0
@@ -67,7 +68,7 @@ def _mutate(args: argparse.Namespace, service: PageMutation) -> int:
             args.page,
         )
     except (WorkspaceRootError, SubmissionPageManagementError, OSError) as error:
-        print(f"Error: page change was not saved: {error}")
+        print(f"Error: page change was not saved: {error}", file=sys.stderr)
         return 1
     print_managed_submission_page(result, workspace_root)
     return 0

--- a/quillan/cli_app/handlers/printable_responses.py
+++ b/quillan/cli_app/handlers/printable_responses.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.rosters import RosterError
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
@@ -51,5 +52,5 @@ def handle_printable_responses_generate(args: argparse.Namespace) -> int:
 
 
 def _error(error: Exception) -> int:
-    print(f"Error: {error}")
+    print(f"Error: {error}", file=sys.stderr)
     return 1

--- a/quillan/cli_app/handlers/ratings.py
+++ b/quillan/cli_app/handlers/ratings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -194,5 +195,5 @@ def _yes_no(value: bool) -> str:
 
 
 def _error(error: Exception) -> int:
-    print(f"Error: {error}")
+    print(f"Error: {error}", file=sys.stderr)
     return 1

--- a/quillan/cli_app/handlers/requirements.py
+++ b/quillan/cli_app/handlers/requirements.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from typing import Any
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
@@ -139,5 +140,5 @@ def _yes_no(value: bool) -> str:
 
 
 def _error(error: Exception) -> int:
-    print(f"Error: {error}")
+    print(f"Error: {error}", file=sys.stderr)
     return 1

--- a/quillan/cli_app/handlers/review.py
+++ b/quillan/cli_app/handlers/review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -22,7 +23,7 @@ def handle_add_note(args: argparse.Namespace) -> int:
             args.text,
         )
     except (WorkspaceRootError, ReviewNoteError) as error:
-        print(f"Error: could not add teacher note: {error}")
+        print(f"Error: could not add teacher note: {error}", file=sys.stderr)
         return 1
 
     print_added_review_note(added)

--- a/quillan/cli_app/handlers/review_status.py
+++ b/quillan/cli_app/handlers/review_status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -27,7 +28,10 @@ def handle_review_status(args: argparse.Namespace) -> int:
             else format_student_review_status(status)
         )
     except (WorkspaceRootError, StudentReviewStatusError, OSError, TypeError) as error:
-        print(f"Error: could not build student review status: {error}")
+        print(
+            f"Error: could not build student review status: {error}",
+            file=sys.stderr,
+        )
         return 1
     print(output)
     return 0

--- a/quillan/cli_app/handlers/review_units.py
+++ b/quillan/cli_app/handlers/review_units.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -73,5 +74,5 @@ def handle_review_units_set(args: argparse.Namespace) -> int:
 
 
 def _error(error: Exception) -> int:
-    print(f"Error: {error}")
+    print(f"Error: {error}", file=sys.stderr)
     return 1

--- a/quillan/cli_app/handlers/review_workflow.py
+++ b/quillan/cli_app/handlers/review_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -24,7 +25,10 @@ def handle_review_workflow_set_state(args: argparse.Namespace) -> int:
             args.state,
         )
     except (WorkspaceRootError, ReviewWorkflowStateError) as error:
-        print(f"Error: could not update review workflow state: {error}")
+        print(
+            f"Error: could not update review workflow state: {error}",
+            file=sys.stderr,
+        )
         return 1
     print_updated_review_workflow_state(updated)
     return 0

--- a/quillan/cli_app/handlers/rosters.py
+++ b/quillan/cli_app/handlers/rosters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping
+import sys
 
 from pds_core.rosters import RosterError, RosterValidationError
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
@@ -21,10 +22,11 @@ from quillan.roster_management import (
     write_roster_mutation,
 )
 from quillan.roster_workflows import format_roster_for_display
+from quillan.cli_app.output import workspace_relative_display
 
 
 def _error(error: Exception) -> int:
-    print(f"Error: {error}")
+    print(f"Error: {error}", file=sys.stderr)
     if isinstance(error, RosterValidationError):
         for issue in error.issues:
             location: list[str] = []
@@ -33,7 +35,7 @@ def _error(error: Exception) -> int:
             if issue.column:
                 location.append(f"column {issue.column}")
             prefix = f"  {' / '.join(location)}: " if location else "  "
-            print(f"{prefix}[{issue.code}] {issue.message}")
+            print(f"{prefix}[{issue.code}] {issue.message}", file=sys.stderr)
     return 1
 
 
@@ -65,8 +67,14 @@ def _print_creation(plan: RosterCreationPlan, *, dry_run: bool) -> None:
         "Optional columns: "
         f"{_optional_columns_label(optional_roster_columns(plan.roster))}"
     )
-    print(f"Roster path: {plan.roster_path}")
-    print(f"Class metadata path: {plan.metadata_path}")
+    print(
+        "Roster path: "
+        f"{workspace_relative_display(plan.roster_path, plan.workspace_root)}"
+    )
+    print(
+        "Class metadata path: "
+        f"{workspace_relative_display(plan.metadata_path, plan.workspace_root)}"
+    )
     print(f"Existing target: {'yes' if plan.target_exists else 'no'}")
     if dry_run:
         print("No files were written.")
@@ -108,9 +116,11 @@ def handle_roster_show(args: argparse.Namespace) -> int:
         print(
             format_roster_for_display(
                 loaded.roster,
-                loaded.roster_path,
+                workspace_relative_display(loaded.roster_path, loaded.workspace_root),
                 metadata=loaded.metadata,
-                metadata_path=loaded.metadata_path,
+                metadata_path=workspace_relative_display(
+                    loaded.metadata_path, loaded.workspace_root
+                ),
                 metadata_error=loaded.metadata_error,
             )
         )
@@ -128,7 +138,10 @@ def handle_roster_validate(args: argparse.Namespace) -> int:
         print("Canonical roster is valid.")
         print(f"Class ID: {loaded.roster.class_id}")
         print(f"Student count: {len(loaded.roster.students)}")
-        print(f"Roster path: {loaded.roster_path}")
+        print(
+            "Roster path: "
+            f"{workspace_relative_display(loaded.roster_path, loaded.workspace_root)}"
+        )
         print(
             "School year: "
             f"{loaded.metadata.school_year if loaded.metadata is not None else 'not set'}"
@@ -151,7 +164,10 @@ def _print_mutation(plan: RosterMutationPlan, *, dry_run: bool) -> None:
     print(f"Period: {plan.student.period}")
     print(f"Optional fields: {_fields_label(plan.student.extra_fields)}")
     print(f"Resulting student count: {len(plan.roster.students)}")
-    print(f"Roster path: {plan.roster_path}")
+    print(
+        "Roster path: "
+        f"{workspace_relative_display(plan.roster_path, plan.workspace_root)}"
+    )
     if dry_run:
         print("No files were written.")
 

--- a/quillan/cli_app/handlers/routing.py
+++ b/quillan/cli_app/handlers/routing.py
@@ -3,22 +3,17 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
 from pathlib import Path
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root as _resolve_workspace_root
 
-from quillan.pds2_scan_intake import (
-    QuillanScanIntakeSummary,
-    process_quillan_scan_folder,
-    process_quillan_scan_source,
-)
 from quillan.intake_assembly import (
-    format_post_dispatch_persistence_result,
-    persist_and_assemble_quillan_scan_successes,
+    QuillanScanWorkflowResult,
+    format_scan_workflow_result,
+    process_quillan_scan_workflow,
 )
 from quillan.retained_scan_pages import SUPPORTED_SCAN_EXTENSIONS
-from quillan.scan_intake_summary import format_scan_intake_summary
 
 
 def resolve_workspace_root() -> Path:
@@ -27,47 +22,45 @@ def resolve_workspace_root() -> Path:
 
 def handle_route_scan(args: argparse.Namespace) -> int:
     """Dispatch QR locators extracted from retained physical source pages."""
-    return run_qr_scan_intake(args.source_file)
+    try:
+        result = run_scan_intake_workflow(args.source_file)
+    except WorkspaceRootError as error:
+        print(f"Error: could not resolve the PDS workspace: {error}", file=sys.stderr)
+        return 1
+    except Exception as error:
+        print(f"Error: scan intake could not start safely: {error}", file=sys.stderr)
+        return 1
+    print(format_scan_workflow_result(result))
+    return 0 if result.complete_success else 1
+
+
+def run_scan_intake_workflow(
+    source_path: Path,
+    workspace_root: Path | None = None,
+) -> QuillanScanWorkflowResult:
+    """Return the typed result shared by direct and menu interfaces."""
+    root = resolve_workspace_root() if workspace_root is None else workspace_root
+    return process_quillan_scan_workflow(root, source_path)
 
 
 def run_qr_scan_intake(
     source_path: Path,
     workspace_root: Path | None = None,
-    *,
-    on_summary: Callable[[QuillanScanIntakeSummary], None] | None = None,
 ) -> int:
-    """Delegate one file/folder operation to the reusable PDS2 service."""
+    """Render the shared typed workflow result for simple programmatic callers."""
     try:
-        root = resolve_workspace_root() if workspace_root is None else workspace_root
-        if source_path.exists() and source_path.is_dir():
-            summary = process_quillan_scan_folder(source_path, workspace_root=root)
-        else:
-            source = process_quillan_scan_source(source_path, workspace_root=root)
-            summary = QuillanScanIntakeSummary(
-                (source,), source.registry_module_ids
-            )
+        result = run_scan_intake_workflow(source_path, workspace_root)
     except WorkspaceRootError as error:
-        print(f"Error: could not resolve the PDS workspace: {error}")
+        print(f"Error: could not resolve the PDS workspace: {error}", file=sys.stderr)
         return 1
     except Exception as error:
-        print(f"Error: scan intake could not start safely: {error}")
+        print(f"Error: scan intake could not start safely: {error}", file=sys.stderr)
         return 1
-    print(format_scan_intake_summary(summary))
-    try:
-        post_dispatch = persist_and_assemble_quillan_scan_successes(root, summary)
-    except Exception as error:
-        print(f"Error: post-dispatch persistence could not start safely: {error}")
-        if on_summary is not None:
-            on_summary(summary)
-        return 1
-    print()
-    print(format_post_dispatch_persistence_result(post_dispatch))
-    if on_summary is not None:
-        on_summary(summary)
-    return 0 if post_dispatch.complete_success else 1
+    print(format_scan_workflow_result(result))
+    return 0 if result.complete_success else 1
 
 
 __all__ = [
     "SUPPORTED_SCAN_EXTENSIONS", "handle_route_scan", "resolve_workspace_root",
-    "run_qr_scan_intake",
+    "run_qr_scan_intake", "run_scan_intake_workflow",
 ]

--- a/quillan/cli_app/handlers/scan_review.py
+++ b/quillan/cli_app/handlers/scan_review.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
+import sys
 
+from pds_core.route_registrations import load_route_registration
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef, RouteLocator
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
+from quillan.post_dispatch_review_resolution import (
+    PostDispatchReviewResolutionError,
+    discover_post_dispatch_review_items,
+    resolve_post_dispatch_review_occurrence,
+)
 from quillan.scan_review_resolution import (
     ScanReviewResolutionError,
     discover_scan_review_items,
     resolve_scan_review_item,
 )
+from quillan.work_paths import quillan_work_ref
 
 
 def handle_list_scan_review(args: argparse.Namespace) -> int:
@@ -26,13 +36,13 @@ def handle_list_scan_review(args: argparse.Namespace) -> int:
             limit=args.limit,
         )
     except (WorkspaceRootError, ScanReviewResolutionError) as error:
-        print(f"Error: {error}")
+        print(f"Error: {error}", file=sys.stderr)
         return 1
 
-    print("Quillan scan review items")
+    print("Core routing review items")
     print()
     if not discovery.items:
-        print("No Quillan scan review items match this request.")
+        print("No Core routing review items match this request.")
     for index, item in enumerate(discovery.items, start=1):
         print(f"{index}. {item.failure_id}")
         print(f"   Status: {item.display_status}")
@@ -41,10 +51,6 @@ def handle_list_scan_review(args: argparse.Namespace) -> int:
         print(f"   Page: {_display(item.source_page_number)}")
         print(f"   Class: {_display(item.class_id)}")
         print(f"   Assignment: {_display(item.assignment_id)}")
-        print(f"   Student: {_display(item.student_id)}")
-        print(f"   Review record: {item.failure_metadata_relative_path}")
-        if item.retained_source_path is not None:
-            print(f"   Retained source: {item.retained_source_path}")
         print()
     if discovery.warnings:
         print(
@@ -58,15 +64,18 @@ def handle_resolve_scan_review(args: argparse.Namespace) -> int:
     """Resolve or defer one Quillan routing review record."""
     try:
         root = resolve_workspace_root()
+        locator, target = _selected_route(root, args)
         result = resolve_scan_review_item(
             root,
             args.failure_id,
             action=args.action,
             message=args.message,
             evidence_path=args.evidence_path,
+            route_locator=locator,
+            target=target,
         )
-    except (WorkspaceRootError, ScanReviewResolutionError) as error:
-        print(f"Error: {error}")
+    except (WorkspaceRootError, ScanReviewResolutionError, ValueError) as error:
+        print(f"Error: {error}", file=sys.stderr)
         return 1
 
     print(f"Scan review item {result.resolution_status}.")
@@ -74,6 +83,108 @@ def handle_resolve_scan_review(args: argparse.Namespace) -> int:
     print(f"Action: {result.resolution_action}")
     print(f"Resolution record: {result.resolution_metadata_relative_path}")
     return 0
+
+
+def handle_list_post_dispatch_review(args: argparse.Namespace) -> int:
+    """List one work root's active Quillan post-dispatch occurrences."""
+    try:
+        root = resolve_workspace_root()
+        discovery = discover_post_dispatch_review_items(
+            root,
+            quillan_work_ref(args.class_id, args.assignment_id),
+            include_resolved=args.include_resolved,
+            category=args.category,
+            limit=args.limit,
+        )
+    except (WorkspaceRootError, PostDispatchReviewResolutionError, ValueError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    print("Quillan post-dispatch review occurrences")
+    print(f"Class: {args.class_id}")
+    print(f"Assignment: {args.assignment_id}")
+    print()
+    if not discovery.items:
+        print("No post-dispatch occurrences match this request.")
+    for index, item in enumerate(discovery.items, start=1):
+        occurrence = item.occurrence.occurrence
+        print(f"{index}. {occurrence.failure_id}")
+        print(f"   Status: {item.display_status}")
+        print(f"   Category: {occurrence.category}")
+        print(f"   Stage: {occurrence.stage}")
+        print(f"   Student: {_display(occurrence.student_id)}")
+        print(f"   Occurrence: {item.occurrence.relative_path}")
+        print()
+    if discovery.warnings:
+        print(
+            f"Warning: skipped {len(discovery.warnings)} malformed or unreadable "
+            "post-dispatch record(s)."
+        )
+    return 0
+
+
+def handle_resolve_post_dispatch_review(args: argparse.Namespace) -> int:
+    """Append one Quillan-owned post-dispatch resolution."""
+    try:
+        root = resolve_workspace_root()
+        result = resolve_post_dispatch_review_occurrence(
+            root,
+            quillan_work_ref(args.class_id, args.assignment_id),
+            args.failure_id,
+            action=args.action,
+            message=args.message,
+        )
+    except (WorkspaceRootError, PostDispatchReviewResolutionError, ValueError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Post-dispatch review item {result.resolution.status}.")
+    print(f"Failure ID: {result.resolution.failure_id}")
+    print(f"Action: {result.resolution.action}")
+    print(f"Resolution record: {result.relative_path}")
+    return 0
+
+
+def _selected_route(
+    root: Path, args: argparse.Namespace
+) -> tuple[RouteLocator | None, ModuleRecordRef | None]:
+    route_action = args.action in {"route_selected", "route_corrected"}
+    route_values = (args.route_id, args.route_class_id, args.route_assignment_id)
+    if not route_action:
+        if any(value is not None for value in route_values):
+            raise ScanReviewResolutionError(
+                "Route identity arguments are valid only for route_selected or "
+                "route_corrected."
+            )
+        return None, None
+    if args.route_id is None:
+        raise ScanReviewResolutionError("A route action requires --route-id.")
+    discovery = discover_scan_review_items(root, include_resolved=True)
+    matches = [item for item in discovery.items if item.failure_id == args.failure_id]
+    if len(matches) != 1:
+        raise ScanReviewResolutionError(
+            "Route selection requires one valid Core routing-review failure."
+        )
+    item = matches[0]
+    class_id = args.route_class_id or item.class_id
+    assignment_id = args.route_assignment_id or item.assignment_id
+    if class_id is None or assignment_id is None:
+        raise ScanReviewResolutionError(
+            "An unscoped failure requires --route-class-id and "
+            "--route-assignment-id."
+        )
+    locator = RouteLocator(
+        "PDS2",
+        ModuleWorkRef("quillan", class_id, assignment_id),
+        args.route_id,
+    )
+    try:
+        registration = load_route_registration(root, locator)
+    except Exception as error:
+        raise ScanReviewResolutionError(
+            f"Could not load the exact registered route: {error}"
+        ) from error
+    return locator, registration.target
 
 
 def _display(value: object | None) -> str:

--- a/quillan/cli_app/handlers/submissions.py
+++ b/quillan/cli_app/handlers/submissions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
@@ -15,7 +16,6 @@ from quillan.cli_app.output import (
     print_opened_submission_review,
     print_updated_submission_review_state,
 )
-from quillan.evidence_opening import EvidenceOpeningError, open_workspace_evidence
 from quillan.plain_paper_submission import (
     create_plain_paper_submission,
     plan_plain_paper_submission,
@@ -34,7 +34,10 @@ from quillan.submission_status import list_assignment_submission_status
 def handle_create_plain_paper_submission(args: argparse.Namespace) -> int:
     """Validate or create one evidence-less plain-paper submission."""
     if not args.yes and not args.dry_run:
-        print("Error: creating a plain-paper submission requires --yes or --dry-run.")
+        print(
+            "Error: creating a plain-paper submission requires --yes or --dry-run.",
+            file=sys.stderr,
+        )
         return 1
 
     try:
@@ -49,7 +52,7 @@ def handle_create_plain_paper_submission(args: argparse.Namespace) -> int:
             )
     except Exception as error:
         action = "dry run failed" if args.dry_run else "was not created"
-        print(f"Error: plain-paper submission {action}: {error}")
+        print(f"Error: plain-paper submission {action}: {error}", file=sys.stderr)
         return 1
 
     if args.dry_run:
@@ -62,6 +65,7 @@ def handle_create_plain_paper_submission(args: argparse.Namespace) -> int:
             f"{plan.submission_manifest_relative_path}"
         )
         print(f"Would create review record: {plan.review_record_relative_path}")
+        print("No digital pages, scan records, QR records, or evidence will be created.")
         print("No files were written.")
     else:
         print("Created plain-paper submission:")
@@ -84,7 +88,10 @@ def handle_assemble_submissions(args: argparse.Namespace) -> int:
             args.assignment_id,
         )
     except Exception as error:
-        print(f"Error: could not assemble submission manifests: {error}")
+        print(
+            f"Error: could not assemble submission manifests: {error}",
+            file=sys.stderr,
+        )
         return 1
 
     print_assignment_submission_assembly(result, workspace_root)
@@ -99,10 +106,9 @@ def handle_list_submissions(args: argparse.Namespace) -> int:
             workspace_root,
             args.class_id,
             args.assignment_id,
-            expected_pages=args.expected_pages,
         )
     except Exception as error:
-        print(f"Error: could not list submission status: {error}")
+        print(f"Error: could not list submission status: {error}", file=sys.stderr)
         return 1
 
     print_assignment_submission_status(
@@ -113,33 +119,28 @@ def handle_list_submissions(args: argparse.Namespace) -> int:
     return 0
 
 
-def handle_open_evidence(args: argparse.Namespace) -> int:
-    """Open one workspace-relative evidence file with the system viewer."""
-    try:
-        workspace_root = resolve_workspace_root()
-        opened = open_workspace_evidence(workspace_root, args.evidence_path)
-    except (WorkspaceRootError, EvidenceOpeningError) as error:
-        print(f"Error: could not open evidence file: {error}")
-        return 1
-
-    print("Opened evidence file:")
-    print(opened.evidence_relative_path)
-    return 0
-
-
 def handle_open_submission(args: argparse.Namespace) -> int:
     """Open selected evidence for one canonical student submission."""
     try:
         workspace_root = resolve_workspace_root()
-        opened = open_student_submission_for_review(
+        identity = (
             workspace_root,
             args.class_id,
             args.assignment_id,
             args.student_id,
-            page_number=args.page,
         )
+        if args.evidence_id is None:
+            opened = open_student_submission_for_review(
+                *identity, page_number=args.page
+            )
+        else:
+            opened = open_student_submission_for_review(
+                *identity,
+                page_number=args.page,
+                evidence_id=args.evidence_id,
+            )
     except (WorkspaceRootError, SubmissionReviewOpeningError) as error:
-        print(f"Error: could not open student submission: {error}")
+        print(f"Error: could not open student submission: {error}", file=sys.stderr)
         return 1
 
     print_opened_submission_review(opened)
@@ -158,7 +159,10 @@ def handle_set_review_state(args: argparse.Namespace) -> int:
             args.state,
         )
     except (WorkspaceRootError, SubmissionReviewStateError) as error:
-        print(f"Error: could not update lightweight submission state: {error}")
+        print(
+            f"Error: could not update lightweight submission state: {error}",
+            file=sys.stderr,
+        )
         return 1
 
     print_updated_submission_review_state(updated)

--- a/quillan/cli_app/handlers/workspace.py
+++ b/quillan/cli_app/handlers/workspace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
 
 from pds_core.workspace import (
     WorkspaceRootError,
@@ -58,7 +59,7 @@ def show_workspace() -> int:
     try:
         status = inspect_workspace_root()
     except WorkspaceRootError as error:
-        print(f"Error: {error}")
+        print(f"Error: {error}", file=sys.stderr)
         return 1
 
     print_workspace_status(status)
@@ -71,7 +72,7 @@ def set_workspace(path: str | Path) -> int:
         workspace_root = ensure_workspace_root(path)
         saved_root = save_workspace_root(workspace_root)
     except WorkspaceRootError as error:
-        print(f"Error: {error}")
+        print(f"Error: {error}", file=sys.stderr)
         return 1
 
     print("Saved PDS workspace root:")
@@ -91,7 +92,7 @@ def validate_workspace() -> int:
         workspace_root = resolve_workspace_root()
         validated_root = ensure_workspace_root(workspace_root)
     except WorkspaceRootError as error:
-        print(f"Error: {error}")
+        print(f"Error: {error}", file=sys.stderr)
         return 1
 
     print("Workspace validated successfully:")
@@ -105,7 +106,7 @@ def reset_workspace() -> int:
         was_cleared = clear_saved_workspace_root()
         workspace_root = resolve_workspace_root()
     except WorkspaceRootError as error:
-        print(f"Error: {error}")
+        print(f"Error: {error}", file=sys.stderr)
         return 1
 
     if was_cleared:

--- a/quillan/cli_app/output.py
+++ b/quillan/cli_app/output.py
@@ -507,7 +507,7 @@ def print_exported_feedback(exported: ExportedFeedback) -> None:
     print(f"Assignment: {exported.assignment_id}")
     print(f"Student: {exported.student_id}")
     print(f"Included comments: {exported.included_comment_count}")
-    print(f"Scores: {exported.score_count}")
+    print(f"Overall Focus Standard ratings: {exported.score_count}")
     print(f"Overwrote existing: {format_bool(exported.overwrote_existing)}")
     print(f"Feedback file: {exported.feedback_relative_path}")
 
@@ -635,7 +635,7 @@ def print_assignment_submission_status(
     page_counts["missing"] += sum(
         len(status.missing_pages)
         for status in result.student_statuses
-        if status.manifest_path is None
+        if status.manifest_path is None and not status.pages
     )
     unselected_count = sum(
         len(status.unselected_present_pages)
@@ -673,11 +673,20 @@ def print_assignment_submission_status(
         for status in result.student_statuses:
             if status.manifest_path is None:
                 routed_details = "routed evidence exists; no manifest"
+                if status.issuance_ids:
+                    routed_details += "; issuance=" + ",".join(status.issuance_ids)
                 if status.missing_pages:
                     routed_details += (
                         "; missing="
                         f"{format_page_numbers(status.missing_pages)}"
                     )
+                if status.duplicate_pages:
+                    routed_details += (
+                        "; duplicate="
+                        f"{format_page_numbers(status.duplicate_pages)}"
+                    )
+                if status.conflicts:
+                    routed_details += "; conflict=" + ",".join(status.conflicts)
                 print(f"- {status.student_id}: {routed_details}")
                 continue
 
@@ -894,13 +903,10 @@ def format_page_numbers(page_numbers: tuple[int, ...]) -> str:
 
 
 def workspace_relative_display(path: Path, workspace_root: Path) -> str:
-    """Display a path relative to the workspace when possible."""
-    try:
-        return path.resolve(strict=False).relative_to(
-            workspace_root.resolve(strict=False)
-        ).as_posix()
-    except (OSError, ValueError):
-        return str(path)
+    """Return one canonical workspace-relative POSIX artifact path."""
+    return path.resolve(strict=False).relative_to(
+        workspace_root.resolve(strict=False)
+    ).as_posix()
 
 
 def _print_path_section(

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -71,17 +71,17 @@ from quillan.cli_app.handlers.rosters import (
 from quillan.cli_app.handlers.routing import handle_route_scan
 from quillan.cli_app.handlers.scan_review import (
     handle_list_scan_review,
+    handle_list_post_dispatch_review,
     handle_resolve_scan_review,
+    handle_resolve_post_dispatch_review,
 )
 from quillan.cli_app.handlers.submissions import (
     handle_assemble_submissions,
     handle_create_plain_paper_submission,
     handle_list_submissions,
-    handle_open_evidence,
     handle_open_submission,
     handle_set_review_state,
 )
-from quillan.cli_app.handlers.validation import handle_validate_assignment
 from quillan.cli_app.handlers.assignments import (
     handle_assignment_create,
     handle_assignment_show,
@@ -179,6 +179,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     assignment_parser = subparsers.add_parser(
         "assignment", help="Create, show, and validate canonical assignments."
+    )
+    assignment_parser.set_defaults(
+        handler=partial(_print_parser_help, assignment_parser)
     )
     assignment_subparsers = assignment_parser.add_subparsers(dest="assignment_command")
     assignment_create_parser = assignment_subparsers.add_parser(
@@ -685,17 +688,6 @@ def build_parser() -> argparse.ArgumentParser:
     _add_write_confirmation(roster_remove_parser)
     roster_remove_parser.set_defaults(handler=handle_roster_remove_student)
 
-    validate_assignment_parser = subparsers.add_parser(
-        "validate-assignment",
-        help="Validate an assignment config JSON file.",
-    )
-    validate_assignment_parser.add_argument(
-        "path",
-        type=Path,
-        help="Path to the assignment config JSON file.",
-    )
-    validate_assignment_parser.set_defaults(handler=handle_validate_assignment)
-
     route_scan_parser = subparsers.add_parser(
         "route-scan",
         help="Retain scans once and dispatch PDS2 QR locators through Core.",
@@ -752,13 +744,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--action",
         required=True,
         choices=(
+            "route_selected",
+            "route_corrected",
+            "evidence_filed",
             "rescan_needed",
             "cannot_route",
-            "mixed_assignment",
-            "evidence_filed",
             "dismissed_duplicate",
+            "deferred",
             "other",
+            # Explicitly documented teacher-facing aliases.
             "defer",
+            "mixed_assignment",
         ),
         help="Teacher-selected resolution action.",
     )
@@ -773,7 +769,88 @@ def build_parser() -> argparse.ArgumentParser:
             "it must be an existing ordinary non-link file in the affected work."
         ),
     )
+    resolve_scan_review_parser.add_argument(
+        "--route-id",
+        help="Exact registered PDS2 route ID for a route action.",
+    )
+    resolve_scan_review_parser.add_argument(
+        "--route-class-id",
+        help=(
+            "Canonical class ID for a route action; may default from a "
+            "work-scoped failure."
+        ),
+    )
+    resolve_scan_review_parser.add_argument(
+        "--route-assignment-id",
+        help=(
+            "Canonical assignment ID for a route action; may default from a "
+            "work-scoped failure."
+        ),
+    )
     resolve_scan_review_parser.set_defaults(handler=handle_resolve_scan_review)
+
+    list_post_dispatch_parser = subparsers.add_parser(
+        "list-post-dispatch-review",
+        help="List Quillan-owned post-dispatch review occurrences.",
+        description=(
+            "List immutable post-dispatch occurrences from one selected "
+            "module-qualified Quillan assignment. Resolved occurrences are "
+            "hidden unless --include-resolved is supplied; deferred occurrences "
+            "remain visible."
+        ),
+    )
+    _add_assignment_identity_arguments(list_post_dispatch_parser)
+    list_post_dispatch_parser.add_argument(
+        "--include-resolved",
+        action="store_true",
+        help="Include occurrences whose latest resolution is resolved.",
+    )
+    list_post_dispatch_parser.add_argument(
+        "--limit",
+        type=positive_integer,
+        help="Show at most this many matching occurrences.",
+    )
+    list_post_dispatch_parser.add_argument(
+        "--category",
+        help="Filter by exact Quillan post-dispatch category.",
+    )
+    list_post_dispatch_parser.set_defaults(handler=handle_list_post_dispatch_review)
+
+    resolve_post_dispatch_parser = subparsers.add_parser(
+        "resolve-post-dispatch-review",
+        help="Resolve or defer one Quillan post-dispatch occurrence.",
+        description=(
+            "Append one Quillan-owned resolution beneath the selected "
+            "module-qualified work root. The immutable occurrence and all "
+            "evidence, observations, scans, manifests, and reviews are retained."
+        ),
+    )
+    _add_assignment_identity_arguments(resolve_post_dispatch_parser)
+    resolve_post_dispatch_parser.add_argument("failure_id", help="Occurrence failure ID.")
+    resolve_post_dispatch_parser.add_argument(
+        "--action",
+        required=True,
+        choices=(
+            "rescan_needed",
+            "record_corrected",
+            "cannot_recover",
+            "dismissed_duplicate",
+            "deferred",
+            "other",
+        ),
+        help=(
+            "Explicit teacher-selected post-dispatch resolution action. "
+            "Successful retry resolution is available only from the interactive "
+            "workflow after a current shared-service retry succeeds."
+        ),
+    )
+    resolve_post_dispatch_parser.add_argument(
+        "--message",
+        help="Teacher message; required for action 'other'.",
+    )
+    resolve_post_dispatch_parser.set_defaults(
+        handler=handle_resolve_post_dispatch_review
+    )
 
     decode_scan_parser = subparsers.add_parser(
         "decode-scan",
@@ -790,9 +867,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a supported image or PDF scan file.",
     )
     decode_scan_parser.add_argument(
-        "--hide-payload",
+        "--show-payload",
         action="store_true",
-        help="Suppress raw QR payload text in diagnostic output.",
+        help="Explicitly include sensitive raw QR payload text in diagnostics.",
     )
     decode_scan_parser.set_defaults(handler=handle_decode_scan)
 
@@ -892,30 +969,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     status_parser.add_argument("class_id", help="Class identifier.")
     status_parser.add_argument("assignment_id", help="Assignment identifier.")
-    status_parser.add_argument(
-        "--expected-pages",
-        type=positive_integer,
-        help=(
-            "Expected page count used only to show missing pages for students "
-            "with routed evidence but no manifest."
-        ),
-    )
     status_parser.set_defaults(handler=handle_list_submissions)
-
-    open_evidence_parser = subparsers.add_parser(
-        "open-evidence",
-        help="Open a local evidence file from the active PDS workspace.",
-        description=(
-            "Open one workspace-relative local evidence file with the system "
-            "default application. The path must remain inside the active PDS "
-            "workspace."
-        ),
-    )
-    open_evidence_parser.add_argument(
-        "evidence_path",
-        help="Workspace-relative path to an existing local evidence file.",
-    )
-    open_evidence_parser.set_defaults(handler=handle_open_evidence)
 
     open_submission_parser = subparsers.add_parser(
         "open-submission",
@@ -931,6 +985,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--page",
         type=positive_integer,
         help="Open only one logical response page number.",
+    )
+    open_submission_parser.add_argument(
+        "--evidence-id",
+        help=(
+            "Open one explicit evidence candidate belonging to this canonical "
+            "submission and, when supplied, --page."
+        ),
     )
     open_submission_parser.set_defaults(handler=handle_open_submission)
 
@@ -976,8 +1037,7 @@ def build_parser() -> argparse.ArgumentParser:
         description=(
             "Generate student-facing feedback from the canonical review.json "
             "for one student submission. PDF export updates feedback export "
-            "metadata after a successful write; Markdown remains available for "
-            "compatibility."
+            "metadata after a successful write."
         ),
     )
     _add_submission_identity_arguments(export_feedback_parser)
@@ -985,7 +1045,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--format",
         choices=("markdown", "pdf", "both"),
         default="markdown",
-        help="Feedback export format. Defaults to markdown for compatibility.",
+        help="Feedback export format (default: markdown).",
     )
     export_feedback_parser.add_argument(
         "--overwrite",

--- a/quillan/intake_assembly.py
+++ b/quillan/intake_assembly.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 from pds_core.module_dispatch import RouteDispatchSuccess
 
 from quillan.pds2_scan_intake import QuillanScanIntakeSummary
+from quillan.pds2_scan_intake import (
+    process_quillan_scan_folder,
+    process_quillan_scan_source,
+)
 from quillan.pds_contract import QUILLAN_MODULE_ID
 from quillan.post_dispatch_review import (
     PersistedPostDispatchReviewOccurrence,
@@ -84,9 +89,28 @@ class QuillanPostDispatchPersistenceResult:
             self.intake_summary.complete_success
             and not self.observation_persistence.failures
             and not self.submission_assembly.failures
+            and not self.review_preservation.failures
             and len(self.observation_persistence.persisted)
             == self.intake_summary.quillan_success_count
         )
+
+    @property
+    def affected_targets(self) -> tuple[IntakeAssemblyTarget, ...]:
+        """Return deterministic Quillan work identities affected by this intake."""
+        return assembly_targets_from_intake_summary(self.intake_summary)
+
+    @property
+    def overall_status(
+        self,
+    ) -> Literal["complete_success", "partial_failure", "complete_failure"]:
+        if self.complete_success:
+            return "complete_success"
+        if self.intake_summary.dispatch_success_count:
+            return "partial_failure"
+        return "complete_failure"
+
+
+QuillanScanWorkflowResult = QuillanPostDispatchPersistenceResult
 
 
 def assembly_targets_from_intake_summary(
@@ -130,6 +154,78 @@ def persist_and_assemble_quillan_scan_successes(
         submission_assembly=assembly,
         review_preservation=preservation,
     )
+
+
+def process_quillan_scan_workflow(
+    workspace_root: Path,
+    source_path: Path,
+) -> QuillanScanWorkflowResult:
+    """Run retained intake, persistence, assembly, and preservation without output."""
+    if source_path.exists() and source_path.is_dir():
+        summary = process_quillan_scan_folder(
+            source_path, workspace_root=workspace_root
+        )
+    else:
+        source = process_quillan_scan_source(
+            source_path, workspace_root=workspace_root
+        )
+        summary = QuillanScanIntakeSummary((source,), source.registry_module_ids)
+    return persist_and_assemble_quillan_scan_successes(workspace_root, summary)
+
+
+def format_scan_workflow_result(result: QuillanScanWorkflowResult) -> str:
+    """Return compact deterministic direct-command output for the full workflow."""
+    summary = result.intake_summary
+    persistence = result.observation_persistence
+    assembly = result.submission_assembly
+    modules = ", ".join(
+        f"{module_id}={count}"
+        for module_id, count in summary.successful_pages_by_module.items()
+    ) or "none"
+    targets = ", ".join(
+        f"{target.class_id}/{target.assignment_id}"
+        for target in result.affected_targets
+    ) or "none"
+    lines = [
+        "Scan intake result",
+        f"Sources: {summary.source_count}",
+        f"Source failures: {summary.source_failure_count}",
+        f"Physical pages: {summary.total_source_pages}",
+        f"Dispatch successes by module: {modules}",
+        f"Core routing failures: {summary.core_dispatch_failure_count}",
+        f"Pre-dispatch failures: {summary.pre_dispatch_failure_count}",
+        f"Quillan integration failures: {summary.quillan_integration_failure_count}",
+        "Core review-record persistence failures: "
+        f"{summary.review_persistence_failure_count}",
+        f"Observations created: {persistence.observation_created_count}",
+        f"Observations unchanged: {persistence.observation_existing_count}",
+        "Observation persistence failures: "
+        f"{persistence.observation_persistence_failure_count}",
+        "Routed evidence created: "
+        f"{persistence.routed_evidence_created_count}",
+        "Routed evidence unchanged: "
+        f"{persistence.routed_evidence_existing_count}",
+        "Routed-evidence persistence failures: "
+        f"{persistence.routed_evidence_persistence_failure_count}",
+        f"Submissions created: {assembly.created_count}",
+        f"Submissions updated: {assembly.updated_count}",
+        f"Submissions unchanged: {assembly.unchanged_count}",
+        f"Submission assembly failures: {len(assembly.failures)}",
+        "Post-dispatch review occurrences created: "
+        f"{len(result.review_preservation.persisted)}",
+        "Post-dispatch preservation failures: "
+        f"{len(result.review_preservation.failures)}",
+        f"Affected work target count: {len(result.affected_targets)}",
+        f"Affected Quillan assignments: {targets}",
+        f"Batch status: {summary.batch_status}",
+        f"Overall status: {result.overall_status}",
+    ]
+    if not result.complete_success:
+        lines.append(
+            "Next step: review Core routing problems and Quillan post-dispatch "
+            "occurrences before retrying affected work."
+        )
+    return "\n".join(lines)
 
 
 def preserve_post_dispatch_review_occurrences(
@@ -256,16 +352,24 @@ def format_post_dispatch_persistence_result(
     lines = [
         "Quillan post-dispatch persistence summary",
         f"Quillan dispatch successes: {result.intake_summary.quillan_success_count}",
-        f"Observations created: {persistence.created_count}",
-        f"Observations already present: {persistence.existing_count}",
-        f"Observation persistence failures: {persistence.failure_count}",
-        f"Routed evidence created: {persistence.created_count}",
+        f"Observations created: {persistence.observation_created_count}",
+        "Observations already present: "
+        f"{persistence.observation_existing_count}",
+        "Observation persistence failures: "
+        f"{persistence.observation_persistence_failure_count}",
+        "Routed evidence created: "
+        f"{persistence.routed_evidence_created_count}",
+        "Routed evidence already present: "
+        f"{persistence.routed_evidence_existing_count}",
+        "Routed-evidence persistence failures: "
+        f"{persistence.routed_evidence_persistence_failure_count}",
         f"Submission manifests created: {assembly.created_count}",
         f"Submission manifests updated: {assembly.updated_count}",
         f"Submission manifests unchanged: {assembly.unchanged_count}",
         f"Submission assembly failures: {len(assembly.failures)}",
         f"Post-dispatch review occurrences: {len(result.review_preservation.persisted)}",
         f"Post-dispatch preservation failures: {len(result.review_preservation.failures)}",
+        f"Affected work target count: {len(result.affected_targets)}",
     ]
     for failure in persistence.failures:
         lines.append(
@@ -290,8 +394,11 @@ __all__ = [
     "IntakeAssemblyTarget",
     "PostDispatchReviewPreservationBatch",
     "QuillanPostDispatchPersistenceResult",
+    "QuillanScanWorkflowResult",
     "assembly_targets_from_intake_summary",
     "format_post_dispatch_persistence_result",
+    "format_scan_workflow_result",
     "persist_and_assemble_quillan_scan_successes",
+    "process_quillan_scan_workflow",
     "preserve_post_dispatch_review_occurrences",
 ]

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -14,7 +14,10 @@ from quillan.cli_app.output import (
     print_assignment_submission_assembly,
     print_assignment_submission_status,
 )
-from quillan.intake_assembly import IntakeAssemblyTarget
+from quillan.intake_assembly import (
+    IntakeAssemblyTarget,
+    QuillanPostDispatchPersistenceResult,
+)
 from quillan.menu_navigation import (
     NavigationChoice,
     QuitQuillan,
@@ -89,44 +92,30 @@ def print_menu_help() -> None:
     """Print concise teacher-facing purpose, safety, and CLI help."""
     print_menu_header("Help")
     print("Quillan is a local-first, teacher-controlled writing-evidence tool.")
-    print("It helps teachers organize and validate writing evidence.")
     print("Teacher judgment remains primary; Quillan is not automated grading software.")
-    print()
-    print("Quillan does not implement AI tagging, AI scoring, AI feedback, or OCR.")
-    print("Quillan supports guided scan intake and scan-review resolution.")
-    print("Student writing review remains teacher-controlled.")
-    print()
     print("Use synthetic data only in repository examples and tests.")
-    print("Do not commit or post real student data, rosters, scans, writing, grades,")
-    print("feedback, reports, screenshots, or workspace artifacts publicly.")
+    print("Do not commit or post real student data.")
     print()
-    print("Current direct CLI starting points:")
+    print("Assignment setup:")
+    print("  Create, show, or validate an assignment from Assignment Management.")
     print()
-    print("Diagnostics:")
-    print("  quillan review-dashboard <class_id> <assignment_id>")
-    print("  quillan review-status <class_id> <assignment_id> <student_id>")
+    print("Printable response pages:")
+    print("  Generate managed PDS2 response packets from Assignment Management.")
     print()
-    print("Setup and paper workflow:")
-    print("  quillan assignment --help")
-    print("  quillan roster --help")
-    print("  quillan printable-responses --help")
-    print("  quillan route-scan --help")
-    print("  quillan assemble-submissions --help")
+    print("Scan intake and review:")
+    print("  Route retained scans and resolve Core or Quillan review problems.")
     print()
-    print("Review workflow:")
-    print("  quillan requirements --help")
-    print("  quillan review-units --help")
-    print("  quillan observations --help")
-    print("  quillan ratings --help")
-    print("  quillan feedback --help")
-    print("  quillan review-workflow --help")
+    print("Student review:")
+    print("  Assemble submissions, inspect page evidence, and record teacher judgments.")
     print()
-    print("Other tools:")
-    print("  quillan comments --help")
-    print("  quillan pages --help")
-    print("  quillan workspace --help")
-    print("  quillan menu")
-    print("  quillan --help  (complete command surface)")
+    print("Feedback and reports:")
+    print("  Export teacher-authored feedback and assignment CSV reports.")
+    print()
+    print("Workspace settings:")
+    print("  Show, select, or validate the shared Paper Data Suite workspace.")
+    print()
+    print("Complete direct help:")
+    print("  quillan --help")
 
 
 def launch_assignment_menu() -> None:
@@ -383,23 +372,89 @@ def _handle_single_post_route_target(
 
 def handle_scan_post_route_menu(
     workspace_root: Path,
-    targets: Sequence[IntakeAssemblyTarget],
+    workflow: QuillanPostDispatchPersistenceResult | Sequence[IntakeAssemblyTarget],
 ) -> None:
     """Show status-aware follow-up actions after scan intake routes evidence."""
-    if not targets:
-        return
+    if isinstance(workflow, QuillanPostDispatchPersistenceResult):
+        result = workflow
+        targets = result.affected_targets
+    else:
+        result = None
+        targets = tuple(workflow)
 
-    should_clear_menu = False
     while True:
-        if should_clear_menu:
-            clear_screen()
-        print_menu_header("Scan Intake / Route Paper Responses")
+        clear_screen()
+        print_menu_header("Scan Intake Result")
+        if result is not None:
+            summary = result.intake_summary
+            print(f"Outcome: {result.overall_status.replace('_', ' ')}")
+            print(f"Sources: {summary.source_count}")
+            print(f"Physical pages: {summary.total_source_pages}")
+            print(f"Dispatch successes: {summary.dispatch_success_count}")
+            print(f"Core dispatch failures: {summary.core_dispatch_failure_count}")
+            print(f"Pre-dispatch failures: {summary.pre_dispatch_failure_count}")
+            print(
+                "Quillan integration failures: "
+                f"{summary.quillan_integration_failure_count}"
+            )
+            print(
+                "Observation persistence failures: "
+                f"{result.observation_persistence.observation_persistence_failure_count}"
+            )
+            print(
+                "Routed-evidence persistence failures: "
+                f"{result.observation_persistence.routed_evidence_persistence_failure_count}"
+            )
+            print(
+                "Submission assembly failures: "
+                f"{len(result.submission_assembly.failures)}"
+            )
+            print(
+                "Post-dispatch problems preserved: "
+                f"{len(result.review_preservation.persisted)}"
+            )
+            print(
+                "Review-preservation failures: "
+                f"{len(result.review_preservation.failures)}"
+            )
+            print(f"Affected work targets: {len(targets)}")
+            print()
+        if not targets:
+            print("No Quillan assignment work was affected.")
+            if result is not None and (
+                result.intake_summary.core_dispatch_failure_count
+                or result.intake_summary.pre_dispatch_failure_count
+                or result.intake_summary.quillan_integration_failure_count
+                or result.observation_persistence.failures
+                or result.submission_assembly.failures
+                or result.review_preservation.persisted
+                or result.review_preservation.failures
+            ):
+                print()
+                print("1. Review scan problems")
+                print_navigation_options()
+                print()
+                choice = input("Select an option: ").strip()
+                if choice == "1":
+                    from quillan.scan_review_menu import (
+                        launch_scan_review_resolution_menu,
+                    )
+
+                    launch_scan_review_resolution_menu(workspace_root)
+                    continue
+                if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+                    return
+                print(f"Invalid selection. {navigation_hint()}")
+                pause_for_user()
+                continue
+            print()
+            pause_for_user()
+            return
         statuses = [
             _post_route_target_status(workspace_root, target)
             for target in targets
         ]
-        print("Scan routed successfully.")
-        print("Routed evidence was filed for:")
+        print("Affected Quillan assignments:")
         for index, (target, status) in enumerate(
             zip(targets, statuses, strict=True),
             start=1,
@@ -421,7 +476,6 @@ def handle_scan_post_route_menu(
             )
             if not should_redraw:
                 return
-            should_clear_menu = True
             continue
 
         print("Select a target to view status-aware actions.")
@@ -437,7 +491,6 @@ def handle_scan_post_route_menu(
                 targets[index],
                 statuses[index],
             )
-            should_clear_menu = True
             continue
         print(f"Invalid selection. {navigation_hint()}")
 
@@ -445,7 +498,6 @@ def handle_scan_post_route_menu(
 def launch_scan_intake_workflow() -> None:
     """Route scans from the shared inbox, with a power-user path fallback."""
     from quillan.cli_app.handlers import routing
-    from quillan.pds2_scan_intake import QuillanScanIntakeSummary
 
     try:
         workspace_root = routing.resolve_workspace_root()
@@ -458,9 +510,6 @@ def launch_scan_intake_workflow() -> None:
         return
     inbox = scans_inbox_dir(workspace_root)
     inbox.mkdir(parents=True, exist_ok=True)
-
-    def post_route(summary: QuillanScanIntakeSummary) -> None:
-        _ = summary
 
     while True:
         clear_screen()
@@ -495,7 +544,6 @@ def launch_scan_intake_workflow() -> None:
             print()
             pause_for_user()
             return
-        selected_inbox_scan = False
         if selection.casefold() == "r":
             continue
         if selection.casefold() == "c":
@@ -508,7 +556,6 @@ def launch_scan_intake_workflow() -> None:
                 continue
         elif selection.isdigit() and 1 <= int(selection) <= len(scans):
             source_path = scans[int(selection) - 1]
-            selected_inbox_scan = True
         else:
             # Preserve pasted-path convenience for experienced users of earlier menus.
             source_path = _normalize_menu_path(selection)
@@ -516,14 +563,20 @@ def launch_scan_intake_workflow() -> None:
                 print(f"Invalid selection. {navigation_hint()}")
                 pause_for_user()
                 continue
+        clear_screen()
+        print_menu_header("Processing Scan Intake")
+        print(f"Source: {source_path}")
         print()
-        routing.run_qr_scan_intake(
-            source_path,
-            workspace_root,
-            on_summary=post_route if selected_inbox_scan else None,
-        )
-        print()
-        pause_for_user()
+        try:
+            result = routing.run_scan_intake_workflow(source_path, workspace_root)
+        except Exception as error:
+            clear_screen()
+            print_menu_header("Scan Intake Failed")
+            print(f"Could not process the selected source: {error}")
+            print()
+            pause_for_user()
+            continue
+        handle_scan_post_route_menu(workspace_root, result)
 
 
 def launch_review_student_work_menu() -> None:
@@ -585,7 +638,7 @@ def launch_workspace_menu(
             workspace_reset()
             print()
             pause_for_user()
-        elif choice == "5" or navigation is NavigationChoice.BACK:
+        elif navigation is NavigationChoice.BACK:
             return
         else:
             print(f"Invalid selection. {navigation_hint()}")
@@ -636,7 +689,7 @@ def launch_menu(
                 print_menu_help()
                 print()
                 pause_for_user()
-            elif choice == "6" or navigation is NavigationChoice.QUIT:
+            elif navigation is NavigationChoice.QUIT:
                 print("Goodbye.")
                 return 0
             else:

--- a/quillan/post_dispatch_review.py
+++ b/quillan/post_dispatch_review.py
@@ -118,7 +118,10 @@ class PostDispatchReviewOccurrence:
             raise PostDispatchReviewError(
                 "Occurrence failure_message must be nonempty text."
             )
-        _timestamp(self.created_at)
+        if _timestamp(self.created_at) != self.created_at:
+            raise PostDispatchReviewError(
+                "Occurrence created_at must be normalized UTC timestamp text."
+            )
         for field in (
             "issuance_ids",
             "page_ids",
@@ -139,6 +142,8 @@ class PostDispatchReviewOccurrence:
                 type(item) is not str or not item for item in values
             ):
                 raise PostDispatchReviewError(f"{field} contains invalid path text.")
+            for item in values:
+                _relative_posix(item)
             if values != tuple(sorted(set(values))):
                 raise PostDispatchReviewError(
                     f"{field} must be a deterministic unique text tuple."
@@ -190,10 +195,15 @@ class PersistedPostDispatchReviewOccurrence:
     occurrence: PostDispatchReviewOccurrence
     path: Path
     relative_path: str
+    original_bytes: bytes
 
     def __post_init__(self) -> None:
         if type(self.occurrence) is not PostDispatchReviewOccurrence:
             raise PostDispatchReviewError("Persisted occurrence has the wrong type.")
+        if type(self.original_bytes) is not bytes or not self.original_bytes:
+            raise PostDispatchReviewError(
+                "Persisted occurrence original_bytes must be exact nonempty bytes."
+            )
         if type(self.workspace_root) is not type(Path()):
             raise PostDispatchReviewError(
                 "Persisted occurrence workspace_root must be an exact Path."
@@ -245,6 +255,12 @@ class PersistedPostDispatchReviewOccurrence:
             )
         except QuillanWorkPathError as error:
             raise PostDispatchReviewError(str(error)) from error
+        if _occurrence_from_bytes(
+            self.original_bytes, self.workspace_root, self.work_ref
+        ) != self.occurrence:
+            raise PostDispatchReviewError(
+                "Persisted occurrence bytes disagree with the occurrence model."
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -454,6 +470,7 @@ def discover_post_dispatch_review_occurrences(
                     occurrence,
                     path,
                     path.relative_to(root).as_posix(),
+                    data,
                 )
             )
         except (
@@ -559,6 +576,7 @@ def _write_occurrence(
         occurrence,
         path,
         path.relative_to(root).as_posix(),
+        data,
     )
 
 
@@ -798,10 +816,10 @@ def _identifier(value: object, field: str) -> None:
 
 def _timestamp(value: datetime | str | None) -> str:
     candidate: datetime | str = datetime.now(timezone.utc) if value is None else value
-    if isinstance(candidate, datetime):
+    if type(candidate) is datetime:
         if candidate.tzinfo is None or candidate.utcoffset() is None:
             raise PostDispatchReviewError("created_at must be timezone-aware.")
-        return candidate.isoformat(timespec="microseconds")
+        return candidate.astimezone(timezone.utc).isoformat(timespec="microseconds")
     if type(candidate) is not str:
         raise PostDispatchReviewError("created_at must be a datetime or string.")
     try:
@@ -810,7 +828,7 @@ def _timestamp(value: datetime | str | None) -> str:
         raise PostDispatchReviewError("created_at must be ISO 8601 text.") from error
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         raise PostDispatchReviewError("created_at must be timezone-aware.")
-    return candidate
+    return parsed.astimezone(timezone.utc).isoformat(timespec="microseconds")
 
 
 def _freeze_json_mapping(value: Mapping[str, object]) -> Mapping[str, object]:

--- a/quillan/post_dispatch_review_resolution.py
+++ b/quillan/post_dispatch_review_resolution.py
@@ -1,0 +1,1713 @@
+"""Append-only resolutions for Quillan-owned post-dispatch occurrences."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Any, Final, Literal, cast
+from uuid import uuid4
+
+from pds_core.identifiers import validate_identifier
+from pds_core.local_open import LocalOpenError, open_local_path
+from pds_core.routing_models import ModuleWorkRef
+
+from quillan.atomic_record_io import (
+    AtomicRecordConcurrencyError,
+    AtomicRecordDurabilityError,
+    AtomicRecordError,
+    create_exclusive_record,
+)
+from quillan.assignment_submission_assembly import AssignmentSubmissionAssemblyResult
+from quillan.module_errors import QuillanObservationError
+from quillan.pds_contract import QUILLAN_MODULE_ID
+from quillan.post_dispatch_review import (
+    POST_DISPATCH_CATEGORIES,
+    PersistedPostDispatchReviewOccurrence,
+    PostDispatchReviewError,
+    PostDispatchReviewOccurrence,
+    discover_post_dispatch_review_occurrences,
+)
+from quillan.record_context import canonical_workspace_root
+from quillan.response_page_observations import (
+    load_contextual_response_page_observation,
+)
+from quillan.routed_evidence import verify_contextual_routed_page_evidence
+from quillan.submission_manifest import (
+    PDS2_SUBMISSION_ENTRY_METHOD,
+    SubmissionManifestError,
+    load_submission_manifest,
+)
+from quillan.submission_observation_assembly import AssembledQuillanSubmission
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    _is_link_like,
+    post_dispatch_review_path,
+    post_dispatch_resolution_dir,
+    post_dispatch_resolution_path,
+    preflight_work_directory_destination,
+    preflight_work_file_destination,
+    quillan_work_paths,
+    quillan_work_ref,
+    submission_manifest_path,
+)
+
+POST_DISPATCH_RESOLUTION_SCHEMA_VERSION: Final = "1"
+POST_DISPATCH_RESOLUTION_RECORD_TYPE: Final = "post_dispatch_review_resolution"
+POST_DISPATCH_RESOLUTION_ACTIONS: Final[tuple[str, ...]] = (
+    "resolved_after_retry",
+    "rescan_needed",
+    "record_corrected",
+    "cannot_recover",
+    "dismissed_duplicate",
+    "deferred",
+    "other",
+)
+POST_DISPATCH_GENERIC_RESOLUTION_ACTIONS: Final[tuple[str, ...]] = tuple(
+    action
+    for action in POST_DISPATCH_RESOLUTION_ACTIONS
+    if action != "resolved_after_retry"
+)
+POST_DISPATCH_RESOLUTION_STATUSES: Final[tuple[str, ...]] = (
+    "resolved",
+    "deferred",
+)
+
+_RESOLUTION_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "record_type",
+        "module_id",
+        "resolution_id",
+        "failure_id",
+        "occurrence_path",
+        "class_id",
+        "assignment_id",
+        "status",
+        "action",
+        "resolved_at",
+        "teacher_message",
+        "occurrence_identity_snapshot",
+        "module_details",
+        "retry_provenance",
+    }
+)
+
+_OCCURRENCE_SNAPSHOT_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "failure_id",
+        "category",
+        "stage",
+        "created_at",
+        "class_id",
+        "assignment_id",
+        "student_id",
+        "issuance_ids",
+        "page_ids",
+        "route_ids",
+        "observation_ids",
+        "source_scan_ids",
+        "source_page_numbers",
+        "occurrence_sha256",
+    }
+)
+
+_RETRY_OPERATIONS: Final[tuple[str, ...]] = ("submission_assembly",)
+_RETRY_PROVENANCE_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "operation",
+        "class_id",
+        "assignment_id",
+        "student_id",
+        "issuance_ids",
+        "assembled_status",
+        "manifest_path",
+        "assembly_revision",
+        "completed_at",
+    }
+)
+
+
+class PostDispatchReviewResolutionError(RuntimeError):
+    """Raised when a work-local resolution cannot be verified or persisted."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        possibly_durable_path: Path | None = None,
+        possible_lock_path: Path | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.possibly_durable_path = possibly_durable_path
+        self.possible_lock_path = possible_lock_path
+
+
+@dataclass(frozen=True, slots=True)
+class PostDispatchReviewResolution:
+    """One exact immutable resolution of a post-dispatch occurrence."""
+
+    resolution_id: str
+    failure_id: str
+    occurrence_path: str
+    class_id: str
+    assignment_id: str
+    status: Literal["resolved", "deferred"]
+    action: str
+    resolved_at: str
+    teacher_message: str | None
+    occurrence_identity_snapshot: Mapping[str, object]
+    module_details: Mapping[str, object]
+    retry_provenance: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        _identifier(self.resolution_id, "resolution_id")
+        _identifier(self.failure_id, "failure_id")
+        _identifier(self.class_id, "class_id")
+        _identifier(self.assignment_id, "assignment_id")
+        _relative_posix(self.occurrence_path, "occurrence_path")
+        expected_occurrence_path = post_dispatch_review_path(
+            Path(),
+            quillan_work_ref(self.class_id, self.assignment_id),
+            self.failure_id,
+        ).as_posix()
+        if self.occurrence_path != expected_occurrence_path:
+            raise PostDispatchReviewResolutionError(
+                "Resolution occurrence_path is not the exact canonical occurrence path."
+            )
+        if (
+            type(self.status) is not str
+            or self.status not in POST_DISPATCH_RESOLUTION_STATUSES
+        ):
+            raise PostDispatchReviewResolutionError("Resolution status is invalid.")
+        if (
+            type(self.action) is not str
+            or self.action not in POST_DISPATCH_RESOLUTION_ACTIONS
+        ):
+            raise PostDispatchReviewResolutionError("Resolution action is invalid.")
+        if (self.action == "deferred") != (self.status == "deferred"):
+            raise PostDispatchReviewResolutionError(
+                "Only deferred action may use deferred status."
+            )
+        if _timestamp(self.resolved_at, "resolved_at") != self.resolved_at:
+            raise PostDispatchReviewResolutionError(
+                "resolved_at must be normalized UTC timestamp text."
+            )
+        if self.teacher_message is not None and (
+            type(self.teacher_message) is not str
+            or not self.teacher_message
+            or self.teacher_message != self.teacher_message.strip()
+        ):
+            raise PostDispatchReviewResolutionError(
+                "teacher_message must be nonblank trimmed text or null."
+            )
+        if self.action == "other" and self.teacher_message is None:
+            raise PostDispatchReviewResolutionError(
+                "The other action requires a teacher message."
+            )
+        if (self.action == "resolved_after_retry") != (
+            self.retry_provenance is not None
+        ):
+            raise PostDispatchReviewResolutionError(
+                "resolved_after_retry requires exact current retry provenance, and "
+                "other actions must not carry retry provenance."
+            )
+        if self.retry_provenance is not None:
+            provenance = _validated_retry_provenance(self.retry_provenance)
+            object.__setattr__(self, "retry_provenance", provenance)
+            if (
+                provenance["class_id"] != self.class_id
+                or provenance["assignment_id"] != self.assignment_id
+            ):
+                raise PostDispatchReviewResolutionError(
+                    "Retry provenance disagrees with resolution work identity."
+                )
+            if datetime.fromisoformat(
+                cast(str, provenance["completed_at"])
+            ) > datetime.fromisoformat(self.resolved_at):
+                raise PostDispatchReviewResolutionError(
+                    "Resolution timestamp predates the successful retry."
+                )
+        snapshot = _frozen_mapping(
+            self.occurrence_identity_snapshot,
+            "occurrence_identity_snapshot",
+            max_keys=16,
+        )
+        details = _frozen_mapping(self.module_details, "module_details", max_keys=8)
+        object.__setattr__(self, "occurrence_identity_snapshot", snapshot)
+        object.__setattr__(self, "module_details", details)
+        _validate_occurrence_snapshot(self)
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedPostDispatchReviewResolution:
+    """A verified work-local resolution and canonical paths."""
+
+    workspace_root: Path
+    work_ref: ModuleWorkRef
+    resolution: PostDispatchReviewResolution
+    path: Path
+    relative_path: str
+
+    def __post_init__(self) -> None:
+        if type(self.workspace_root) is not type(Path()):
+            raise PostDispatchReviewResolutionError(
+                "Persisted resolution workspace_root must be an exact Path."
+            )
+        try:
+            canonical_root = canonical_workspace_root(self.workspace_root)
+        except (OSError, TypeError, ValueError) as error:
+            raise PostDispatchReviewResolutionError(str(error)) from error
+        if self.workspace_root != canonical_root:
+            raise PostDispatchReviewResolutionError(
+                "Persisted resolution workspace_root must be canonical."
+            )
+        if type(self.work_ref) is not ModuleWorkRef:
+            raise PostDispatchReviewResolutionError(
+                "Persisted resolution work_ref must be an exact ModuleWorkRef."
+            )
+        if type(self.resolution) is not PostDispatchReviewResolution:
+            raise PostDispatchReviewResolutionError(
+                "Persisted resolution has the wrong model type."
+            )
+        expected_ref = quillan_work_ref(
+            self.resolution.class_id, self.resolution.assignment_id
+        )
+        if self.work_ref != expected_ref:
+            raise PostDispatchReviewResolutionError(
+                "Persisted resolution work_ref disagrees with its identity."
+            )
+        if type(self.path) is not type(Path()) or not self.path.is_absolute():
+            raise PostDispatchReviewResolutionError(
+                "Persisted resolution path must be an exact absolute Path."
+            )
+        expected_path = post_dispatch_resolution_path(
+            self.workspace_root, self.work_ref, self.resolution.resolution_id
+        )
+        if self.path != expected_path:
+            raise PostDispatchReviewResolutionError(
+                "Persisted resolution path is not its exact canonical path."
+            )
+        _relative_posix(self.relative_path, "relative_path")
+        if self.relative_path != self.path.relative_to(self.workspace_root).as_posix():
+            raise PostDispatchReviewResolutionError(
+                "Persisted resolution relative path is not exact."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PostDispatchReviewItem:
+    """One occurrence paired with its deterministic latest resolution."""
+
+    occurrence: PersistedPostDispatchReviewOccurrence
+    latest_resolution: PersistedPostDispatchReviewResolution | None
+
+    def __post_init__(self) -> None:
+        if type(self.occurrence) is not PersistedPostDispatchReviewOccurrence:
+            raise PostDispatchReviewResolutionError(
+                "Review item occurrence has the wrong runtime type."
+            )
+        if self.latest_resolution is not None:
+            if type(self.latest_resolution) is not PersistedPostDispatchReviewResolution:
+                raise PostDispatchReviewResolutionError(
+                    "Review item resolution has the wrong runtime type."
+                )
+            _verify_resolution_link(
+                self.latest_resolution.resolution, self.occurrence
+            )
+
+    @property
+    def display_status(self) -> str:
+        return (
+            "unresolved"
+            if self.latest_resolution is None
+            else self.latest_resolution.resolution.status
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PostDispatchReviewResolutionDiscovery:
+    """Filtered post-dispatch items and conservative malformed-record warnings."""
+
+    items: tuple[PostDispatchReviewItem, ...]
+    warnings: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.items) is not tuple or any(
+            type(item) is not PostDispatchReviewItem for item in self.items
+        ):
+            raise PostDispatchReviewResolutionError(
+                "Discovery items must be an exact review-item tuple."
+            )
+        if type(self.warnings) is not tuple or any(
+            type(item) is not str or not item for item in self.warnings
+        ):
+            raise PostDispatchReviewResolutionError(
+                "Discovery warnings must be nonblank text."
+            )
+        failure_ids = tuple(
+            item.occurrence.occurrence.failure_id for item in self.items
+        )
+        if len(set(failure_ids)) != len(failure_ids):
+            raise PostDispatchReviewResolutionError(
+                "Discovery contains duplicate occurrence identities."
+            )
+        expected = tuple(
+            sorted(
+                self.items,
+                key=lambda item: (
+                    item.occurrence.occurrence.created_at,
+                    item.occurrence.occurrence.failure_id,
+                ),
+            )
+        )
+        if self.items != expected:
+            raise PostDispatchReviewResolutionError(
+                "Discovery items are not deterministically ordered."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class OpenedPostDispatchPossiblePath:
+    """One validated occurrence-owned contextual file opened read-only."""
+
+    workspace_root: Path
+    work_ref: ModuleWorkRef
+    failure_id: str
+    kind: Literal["evidence", "manifest"]
+    path: Path
+    relative_path: str
+
+    def __post_init__(self) -> None:
+        if type(self.workspace_root) is not type(Path()):
+            raise PostDispatchReviewResolutionError(
+                "Opened contextual workspace_root must be an exact Path."
+            )
+        try:
+            canonical_root = canonical_workspace_root(self.workspace_root)
+        except (OSError, TypeError, ValueError) as error:
+            raise PostDispatchReviewResolutionError(str(error)) from error
+        if self.workspace_root != canonical_root:
+            raise PostDispatchReviewResolutionError(
+                "Opened contextual workspace_root must be canonical."
+            )
+        if type(self.work_ref) is not ModuleWorkRef:
+            raise PostDispatchReviewResolutionError(
+                "Opened contextual work_ref must be an exact ModuleWorkRef."
+            )
+        canonical_ref = quillan_work_ref(
+            self.work_ref.class_id, self.work_ref.work_id
+        )
+        if self.work_ref != canonical_ref:
+            raise PostDispatchReviewResolutionError(
+                "Opened contextual work_ref must be an exact Quillan work reference."
+            )
+        _identifier(self.failure_id, "failure_id")
+        if type(self.kind) is not str or self.kind not in {"evidence", "manifest"}:
+            raise PostDispatchReviewResolutionError(
+                "Opened contextual path kind is invalid."
+            )
+        if type(self.path) is not type(Path()) or not self.path.is_absolute():
+            raise PostDispatchReviewResolutionError(
+                "Opened contextual path must be an exact absolute Path."
+            )
+        _relative_posix(self.relative_path, "relative_path")
+        if self.path != self.workspace_root.joinpath(
+            *PurePosixPath(self.relative_path).parts
+        ):
+            raise PostDispatchReviewResolutionError(
+                "Opened contextual path and relative_path disagree."
+            )
+        work_root = quillan_work_paths(
+            self.workspace_root, self.work_ref.class_id, self.work_ref.work_id
+        ).work_root
+        try:
+            self.path.relative_to(work_root)
+        except ValueError as error:
+            raise PostDispatchReviewResolutionError(
+                "Opened contextual path escapes its exact Quillan work root."
+            ) from error
+
+
+def discover_post_dispatch_review_items(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    *,
+    include_resolved: bool = False,
+    category: str | None = None,
+    limit: int | None = None,
+) -> PostDispatchReviewResolutionDiscovery:
+    """Discover occurrences and their latest valid append-only resolutions."""
+    root, canonical_ref = _context(workspace_root, work_ref)
+    if category is not None and category not in POST_DISPATCH_CATEGORIES:
+        raise PostDispatchReviewResolutionError(
+            f"Unknown post-dispatch category: {category}"
+        )
+    if limit is not None and (
+        isinstance(limit, bool) or not isinstance(limit, int) or limit < 1
+    ):
+        raise PostDispatchReviewResolutionError("limit must be a positive integer.")
+    try:
+        occurrences = discover_post_dispatch_review_occurrences(root, canonical_ref)
+    except PostDispatchReviewError as error:
+        raise PostDispatchReviewResolutionError(str(error)) from error
+    occurrence_by_id = {
+        item.occurrence.failure_id: item for item in occurrences.items
+    }
+    resolutions, resolution_warnings = _discover_resolutions(
+        root, canonical_ref, occurrence_by_id
+    )
+    latest: dict[str, PersistedPostDispatchReviewResolution] = {}
+    for persisted in resolutions:
+        failure_id = persisted.resolution.failure_id
+        current = latest.get(failure_id)
+        if current is None or _resolution_order(persisted) > _resolution_order(current):
+            latest[failure_id] = persisted
+
+    items: list[PostDispatchReviewItem] = []
+    for occurrence in occurrences.items:
+        if category is not None and occurrence.occurrence.category != category:
+            continue
+        resolution = latest.get(occurrence.occurrence.failure_id)
+        if (
+            resolution is not None
+            and resolution.resolution.status == "resolved"
+            and not include_resolved
+        ):
+            continue
+        items.append(PostDispatchReviewItem(occurrence, resolution))
+    if limit is not None:
+        items = items[:limit]
+    return PostDispatchReviewResolutionDiscovery(
+        tuple(items), (*occurrences.warnings, *resolution_warnings)
+    )
+
+
+def open_post_dispatch_possible_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    failure_id: str,
+    *,
+    kind: Literal["evidence", "manifest"],
+    relative_path: str,
+) -> OpenedPostDispatchPossiblePath:
+    """Validate and open one exact path stored by the selected occurrence."""
+    root, canonical_ref = _context(workspace_root, work_ref)
+    _identifier(failure_id, "failure_id")
+    if type(kind) is not str or kind not in {"evidence", "manifest"}:
+        raise PostDispatchReviewResolutionError(
+            "Contextual path kind must be evidence or manifest."
+        )
+    selected_relative = _relative_posix(relative_path, "relative_path")
+    discovery = discover_post_dispatch_review_items(
+        root, canonical_ref, include_resolved=True
+    )
+    matches = [
+        item
+        for item in discovery.items
+        if item.occurrence.occurrence.failure_id == failure_id
+    ]
+    if len(matches) != 1:
+        raise PostDispatchReviewResolutionError(
+            f"No unique valid post-dispatch occurrence has failure ID {failure_id}."
+        )
+    persisted = matches[0].occurrence
+    _read_occurrence_revision(root, canonical_ref, persisted)
+    occurrence = persisted.occurrence
+    allowed = (
+        occurrence.possible_evidence_paths
+        if kind == "evidence"
+        else occurrence.possible_manifest_paths
+    )
+    if selected_relative not in allowed:
+        raise PostDispatchReviewResolutionError(
+            "Selected path is not stored by this exact occurrence."
+        )
+    target = root.joinpath(*PurePosixPath(selected_relative).parts)
+    work_root = quillan_work_paths(
+        root, canonical_ref.class_id, canonical_ref.work_id
+    ).work_root
+    try:
+        work_relative = target.relative_to(work_root)
+    except ValueError as error:
+        raise PostDispatchReviewResolutionError(
+            "Selected path escapes the affected Quillan work root."
+        ) from error
+    try:
+        checked = preflight_work_file_destination(
+            root, canonical_ref, work_relative
+        )
+    except QuillanWorkPathError as error:
+        raise PostDispatchReviewResolutionError(str(error)) from error
+    if checked != target:
+        raise PostDispatchReviewResolutionError(
+            "Selected path preflight returned a different path."
+        )
+    if (
+        not os.path.lexists(target)
+        or _is_link_like(target)
+        or not target.is_file()
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Selected contextual path must be an ordinary non-link file."
+        )
+    if kind == "manifest":
+        _validate_possible_manifest(target, occurrence)
+    else:
+        _validate_possible_evidence(root, canonical_ref, selected_relative, occurrence)
+    try:
+        opened = open_local_path(target)
+    except LocalOpenError as error:
+        raise PostDispatchReviewResolutionError(
+            f"Could not open validated contextual path: {error}"
+        ) from error
+    return OpenedPostDispatchPossiblePath(
+        root,
+        canonical_ref,
+        failure_id,
+        kind,
+        opened,
+        selected_relative,
+    )
+
+
+def _matching_verified_retry_assembly(
+    persisted_occurrence: PersistedPostDispatchReviewOccurrence,
+    result: AssignmentSubmissionAssemblyResult,
+    *,
+    completed_at: datetime | str,
+) -> AssembledQuillanSubmission | None:
+    """Return the exact assembled target only when current durable state proves it."""
+    if type(persisted_occurrence) is not PersistedPostDispatchReviewOccurrence:
+        raise PostDispatchReviewResolutionError(
+            "Retry proof requires an exact persisted occurrence."
+        )
+    if type(result) is not AssignmentSubmissionAssemblyResult:
+        raise PostDispatchReviewResolutionError(
+            "Retry proof requires an exact assignment assembly result."
+        )
+    root, work_ref = _context(
+        persisted_occurrence.workspace_root, persisted_occurrence.work_ref
+    )
+    if root != persisted_occurrence.workspace_root:
+        raise PostDispatchReviewResolutionError(
+            "Retry occurrence workspace identity is not canonical."
+        )
+    occurrence = persisted_occurrence.occurrence
+    if (
+        result.class_id != occurrence.class_id
+        or result.assignment_id != occurrence.assignment_id
+        or work_ref.class_id != occurrence.class_id
+        or work_ref.work_id != occurrence.assignment_id
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Retry result disagrees with the selected occurrence work identity."
+        )
+    _read_occurrence_revision(root, work_ref, persisted_occurrence)
+    if occurrence.category not in {
+        "submission_assembly",
+        "mixed_issuance",
+        "manifest_conflict",
+    }:
+        return None
+
+    expected_issuances = set(occurrence.issuance_ids)
+    if occurrence.student_id is not None:
+        relevant_assembled = tuple(
+            assembled
+            for assembled in result.assembled
+            if assembled.student_id == occurrence.student_id
+        )
+        relevant_failures = tuple(
+            failure
+            for failure in result.failures
+            if failure.student_id == occurrence.student_id
+            or bool(expected_issuances.intersection(failure.issuance_ids))
+        )
+    elif occurrence.category == "mixed_issuance":
+        if not expected_issuances:
+            return None
+        relevant_assembled = tuple(
+            assembled
+            for assembled in result.assembled
+            if assembled.issuance_id in expected_issuances
+        )
+        relevant_failures = result.failures
+    elif occurrence.category == "manifest_conflict":
+        relevant_assembled = tuple(
+            assembled
+            for assembled in result.assembled
+            if not expected_issuances
+            or assembled.issuance_id in expected_issuances
+        )
+        relevant_failures = result.failures
+    else:
+        # An assignment-level assembly failure is proven repaired only by one
+        # concrete processed target and a wholly successful assignment retry.
+        relevant_assembled = result.assembled
+        relevant_failures = result.failures
+
+    if len(relevant_assembled) != 1 or relevant_failures:
+        return None
+    assembled = relevant_assembled[0]
+    if type(assembled) is not AssembledQuillanSubmission:
+        return None
+    if (
+        assembled.workspace_root != root
+        or assembled.class_id != occurrence.class_id
+        or assembled.assignment_id != occurrence.assignment_id
+    ):
+        return None
+    if expected_issuances:
+        if occurrence.category == "mixed_issuance":
+            if assembled.issuance_id not in expected_issuances:
+                return None
+        elif expected_issuances != {assembled.issuance_id}:
+            return None
+
+    canonical_manifest = submission_manifest_path(
+        root, work_ref, assembled.student_id
+    )
+    if assembled.manifest_path != canonical_manifest:
+        return None
+    expected_relative = canonical_manifest.relative_to(root).as_posix()
+    if assembled.manifest_relative_path != expected_relative:
+        return None
+    try:
+        checked_manifest = preflight_work_file_destination(
+            root,
+            work_ref,
+            Path("submissions") / assembled.student_id / "submission.json",
+        )
+        if checked_manifest != canonical_manifest:
+            return None
+        manifest = load_submission_manifest(checked_manifest)
+    except (OSError, QuillanWorkPathError, SubmissionManifestError):
+        return None
+    details = manifest.get("module_details")
+    if (
+        manifest.get("class_id") != occurrence.class_id
+        or manifest.get("assignment_id") != occurrence.assignment_id
+        or manifest.get("student_id") != assembled.student_id
+        or type(details) is not dict
+        or details.get("submission_entry_method") != PDS2_SUBMISSION_ENTRY_METHOD
+        or details.get("response_issuance_id") != assembled.issuance_id
+        or details.get("assembly_revision") != assembled.assembly_revision
+    ):
+        return None
+    timestamp = _timestamp(completed_at, "completed_at")
+    if datetime.fromisoformat(timestamp) < datetime.fromisoformat(
+        occurrence.created_at
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Retry completion timestamp predates the selected occurrence."
+        )
+    return assembled
+
+
+def post_dispatch_retry_proves_resolution(
+    persisted_occurrence: PersistedPostDispatchReviewOccurrence,
+    result: AssignmentSubmissionAssemblyResult,
+    *,
+    completed_at: datetime | str,
+) -> bool:
+    """Report whether a current typed retry proves the selected occurrence repaired."""
+    try:
+        return (
+            _matching_verified_retry_assembly(
+                persisted_occurrence,
+                result,
+                completed_at=completed_at,
+            )
+            is not None
+        )
+    except PostDispatchReviewResolutionError:
+        return False
+
+
+def _current_occurrence(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    failure_id: str,
+) -> tuple[PersistedPostDispatchReviewOccurrence, bytes]:
+    try:
+        discovery = discover_post_dispatch_review_occurrences(root, work_ref)
+    except PostDispatchReviewError as error:
+        raise PostDispatchReviewResolutionError(str(error)) from error
+    matches = [
+        item for item in discovery.items if item.occurrence.failure_id == failure_id
+    ]
+    if len(matches) != 1:
+        suffix = (
+            f" Warnings: {'; '.join(discovery.warnings)}"
+            if discovery.warnings
+            else ""
+        )
+        raise PostDispatchReviewResolutionError(
+            f"No unique valid post-dispatch occurrence has failure ID {failure_id}."
+            + suffix
+        )
+    occurrence = matches[0]
+    return occurrence, _read_occurrence_revision(root, work_ref, occurrence)
+
+
+def resolve_post_dispatch_review_occurrence(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    failure_id: str,
+    *,
+    action: str,
+    message: str | None = None,
+    resolved_at: datetime | str | None = None,
+    resolution_id: str | None = None,
+) -> PersistedPostDispatchReviewResolution:
+    """Append and verify one resolution without mutating its occurrence."""
+    root, canonical_ref = _context(workspace_root, work_ref)
+    _identifier(failure_id, "failure_id")
+    if action not in POST_DISPATCH_GENERIC_RESOLUTION_ACTIONS:
+        raise PostDispatchReviewResolutionError(
+            f"Unsupported post-dispatch resolution action: {action}"
+        )
+    teacher_message = _message(action, message)
+    status: Literal["resolved", "deferred"] = (
+        "deferred" if action == "deferred" else "resolved"
+    )
+    occurrence, occurrence_revision = _current_occurrence(
+        root, canonical_ref, failure_id
+    )
+    timestamp = _timestamp(resolved_at, "resolved_at")
+    allocated_id = resolution_id or f"resolution_{uuid4().hex}"
+    _identifier(allocated_id, "resolution_id")
+    resolution = PostDispatchReviewResolution(
+        resolution_id=allocated_id,
+        failure_id=failure_id,
+        occurrence_path=occurrence.relative_path,
+        class_id=canonical_ref.class_id,
+        assignment_id=canonical_ref.work_id,
+        status=status,
+        action=action,
+        resolved_at=timestamp,
+        teacher_message=teacher_message,
+        occurrence_identity_snapshot=_occurrence_snapshot(
+            occurrence, occurrence_revision
+        ),
+        module_details={
+            "resolved_by": "teacher",
+            "resolution_origin": "quillan_post_dispatch_review",
+            "occurrence_category": occurrence.occurrence.category,
+            "occurrence_stage": occurrence.occurrence.stage,
+        },
+        retry_provenance=None,
+    )
+    return _write_resolution(
+        root,
+        canonical_ref,
+        occurrence,
+        occurrence_revision,
+        resolution,
+    )
+
+
+def resolve_post_dispatch_after_successful_retry(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    failure_id: str,
+    *,
+    assembly_result: AssignmentSubmissionAssemblyResult,
+    completed_at: datetime | str,
+    message: str | None = None,
+    resolved_at: datetime | str | None = None,
+    resolution_id: str | None = None,
+) -> PersistedPostDispatchReviewResolution:
+    """Prove one current retry and atomically resolve only its exact occurrence."""
+    root, canonical_ref = _context(workspace_root, work_ref)
+    _identifier(failure_id, "failure_id")
+    occurrence, occurrence_revision = _current_occurrence(
+        root, canonical_ref, failure_id
+    )
+    assembled = _matching_verified_retry_assembly(
+        occurrence,
+        assembly_result,
+        completed_at=completed_at,
+    )
+    if assembled is None:
+        raise PostDispatchReviewResolutionError(
+            "The assembly result does not prove that this occurrence was resolved."
+        )
+    completion_timestamp = _timestamp(completed_at, "completed_at")
+    provenance: dict[str, object] = {
+        "operation": "submission_assembly",
+        "class_id": canonical_ref.class_id,
+        "assignment_id": canonical_ref.work_id,
+        "student_id": assembled.student_id,
+        "issuance_ids": (assembled.issuance_id,),
+        "assembled_status": assembled.status,
+        "manifest_path": assembled.manifest_relative_path,
+        "assembly_revision": assembled.assembly_revision,
+        "completed_at": completion_timestamp,
+    }
+    if _retry_provenance_was_used(root, canonical_ref, provenance):
+        raise PostDispatchReviewResolutionError(
+            "This successful retry has already authorized another resolution."
+        )
+    timestamp = _timestamp(resolved_at, "resolved_at")
+    allocated_id = resolution_id or f"resolution_{uuid4().hex}"
+    _identifier(allocated_id, "resolution_id")
+    resolution = PostDispatchReviewResolution(
+        resolution_id=allocated_id,
+        failure_id=failure_id,
+        occurrence_path=occurrence.relative_path,
+        class_id=canonical_ref.class_id,
+        assignment_id=canonical_ref.work_id,
+        status="resolved",
+        action="resolved_after_retry",
+        resolved_at=timestamp,
+        teacher_message=_message("resolved_after_retry", message),
+        occurrence_identity_snapshot=_occurrence_snapshot(
+            occurrence, occurrence_revision
+        ),
+        module_details={
+            "resolved_by": "teacher",
+            "resolution_origin": "quillan_post_dispatch_review",
+            "occurrence_category": occurrence.occurrence.category,
+            "occurrence_stage": occurrence.occurrence.stage,
+        },
+        retry_provenance=provenance,
+    )
+    return _write_resolution(
+        root,
+        canonical_ref,
+        occurrence,
+        occurrence_revision,
+        resolution,
+    )
+
+
+resolve_post_dispatch_review_item = resolve_post_dispatch_review_occurrence
+
+
+def _discover_resolutions(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    occurrences: Mapping[str, PersistedPostDispatchReviewOccurrence],
+) -> tuple[tuple[PersistedPostDispatchReviewResolution, ...], tuple[str, ...]]:
+    directory = post_dispatch_resolution_dir(root, work_ref)
+    if not os.path.lexists(directory):
+        try:
+            preflight_work_directory_destination(
+                root,
+                work_ref,
+                Path("scans") / "review" / "post_dispatch" / "resolutions",
+            )
+        except QuillanWorkPathError as error:
+            return (), (f"Unsafe resolution directory: {error}",)
+        return (), ()
+    try:
+        preflight_work_directory_destination(
+            root,
+            work_ref,
+            Path("scans") / "review" / "post_dispatch" / "resolutions",
+        )
+        children = tuple(sorted(directory.iterdir(), key=lambda item: item.name))
+    except (OSError, QuillanWorkPathError) as error:
+        return (), (f"Could not inspect post-dispatch resolutions: {error}",)
+    results: list[PersistedPostDispatchReviewResolution] = []
+    warnings: list[str] = []
+    seen: set[str] = set()
+    for path in children:
+        if path.suffix != ".json":
+            continue
+        try:
+            preflight_work_file_destination(
+                root,
+                work_ref,
+                Path("scans")
+                / "review"
+                / "post_dispatch"
+                / "resolutions"
+                / path.name,
+            )
+            resolution = _resolution_from_bytes(path.read_bytes())
+            if resolution.resolution_id in seen:
+                raise PostDispatchReviewResolutionError("duplicate resolution_id")
+            seen.add(resolution.resolution_id)
+            if path != post_dispatch_resolution_path(
+                root, work_ref, resolution.resolution_id
+            ):
+                raise PostDispatchReviewResolutionError(
+                    "filename and resolution_id disagree"
+                )
+            occurrence = occurrences.get(resolution.failure_id)
+            if occurrence is None:
+                raise PostDispatchReviewResolutionError(
+                    "resolution references no valid occurrence"
+                )
+            _verify_resolution_link(resolution, occurrence)
+            results.append(
+                PersistedPostDispatchReviewResolution(
+                    root,
+                    work_ref,
+                    resolution,
+                    path,
+                    path.relative_to(root).as_posix(),
+                )
+            )
+        except (
+            OSError,
+            UnicodeError,
+            ValueError,
+            QuillanWorkPathError,
+            PostDispatchReviewResolutionError,
+        ) as error:
+            warnings.append(f"Skipped malformed resolution {path.name}: {error}")
+    return tuple(results), tuple(warnings)
+
+
+def _retry_provenance_was_used(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    provenance: Mapping[str, object],
+) -> bool:
+    """Conservatively prevent one current retry proof authorizing two records."""
+    try:
+        occurrence_discovery = discover_post_dispatch_review_occurrences(
+            root, work_ref
+        )
+    except PostDispatchReviewError as error:
+        raise PostDispatchReviewResolutionError(str(error)) from error
+    occurrences = {
+        item.occurrence.failure_id: item for item in occurrence_discovery.items
+    }
+    resolutions, warnings = _discover_resolutions(root, work_ref, occurrences)
+    if warnings:
+        raise PostDispatchReviewResolutionError(
+            "Could not verify retry-proof uniqueness: " + "; ".join(warnings)
+        )
+    expected = dict(_validated_retry_provenance(provenance))
+    return any(
+        persisted.resolution.retry_provenance is not None
+        and dict(persisted.resolution.retry_provenance) == expected
+        for persisted in resolutions
+    )
+
+
+def _write_resolution(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    occurrence: PersistedPostDispatchReviewOccurrence,
+    expected_occurrence_bytes: bytes,
+    resolution: PostDispatchReviewResolution,
+) -> PersistedPostDispatchReviewResolution:
+    relative_directory = Path("scans") / "review" / "post_dispatch" / "resolutions"
+    if type(expected_occurrence_bytes) is not bytes:
+        raise PostDispatchReviewResolutionError(
+            "Expected occurrence revision must be exact bytes."
+        )
+    try:
+        directory = preflight_work_directory_destination(
+            root, work_ref, relative_directory
+        )
+        directory.mkdir(parents=True, exist_ok=True)
+        preflight_work_directory_destination(root, work_ref, relative_directory)
+    except (OSError, QuillanWorkPathError) as error:
+        raise PostDispatchReviewResolutionError(str(error)) from error
+    path = post_dispatch_resolution_path(root, work_ref, resolution.resolution_id)
+    data = _resolution_bytes(resolution)
+
+    def preflight() -> None:
+        if canonical_workspace_root(root) != root:
+            raise PostDispatchReviewResolutionError(
+                "Workspace root identity changed."
+            )
+        current_directory = preflight_work_directory_destination(
+            root, work_ref, relative_directory
+        )
+        if current_directory != directory:
+            raise PostDispatchReviewResolutionError(
+                "Resolution directory identity changed."
+            )
+        expected_occurrence_path = post_dispatch_review_path(
+            root, work_ref, occurrence.occurrence.failure_id
+        )
+        if occurrence.path != expected_occurrence_path:
+            raise PostDispatchReviewResolutionError(
+                "Occurrence path identity changed."
+            )
+        checked_occurrence_path = preflight_work_file_destination(
+            root,
+            work_ref,
+            Path("scans")
+            / "review"
+            / "post_dispatch"
+            / expected_occurrence_path.name,
+        )
+        if checked_occurrence_path != expected_occurrence_path:
+            raise PostDispatchReviewResolutionError(
+                "Occurrence path preflight returned a different path."
+            )
+        if (
+            not os.path.lexists(expected_occurrence_path)
+            or _is_link_like(expected_occurrence_path)
+            or not expected_occurrence_path.is_file()
+        ):
+            raise PostDispatchReviewResolutionError(
+                "Occurrence must remain an ordinary non-link file."
+            )
+        try:
+            current_occurrence_bytes = expected_occurrence_path.read_bytes()
+        except OSError as error:
+            raise PostDispatchReviewResolutionError(
+                f"Could not re-read immutable occurrence: {error}"
+            ) from error
+        if current_occurrence_bytes != expected_occurrence_bytes:
+            raise PostDispatchReviewResolutionError(
+                "Immutable occurrence changed after it was loaded."
+            )
+        checked_target = preflight_work_file_destination(
+            root, work_ref, relative_directory / path.name
+        )
+        if checked_target != path:
+            raise PostDispatchReviewResolutionError(
+                "Resolution target preflight returned a different path."
+            )
+
+    try:
+        create_exclusive_record(
+            path,
+            data,
+            preflight=preflight,
+            verify_bytes=lambda value: _verify_resolution_bytes(
+                value, resolution, occurrence
+            ),
+        )
+    except AtomicRecordConcurrencyError as error:
+        raise PostDispatchReviewResolutionError(
+            f"Resolution ID already exists: {resolution.resolution_id}"
+        ) from error
+    except AtomicRecordDurabilityError as error:
+        raise PostDispatchReviewResolutionError(
+            str(error),
+            possibly_durable_path=error.possibly_durable_path,
+            possible_lock_path=error.possible_lock_path,
+        ) from error
+    except (AtomicRecordError, OSError, QuillanWorkPathError) as error:
+        raise PostDispatchReviewResolutionError(
+            f"Could not persist post-dispatch resolution: {error}"
+        ) from error
+    return PersistedPostDispatchReviewResolution(
+        root,
+        work_ref,
+        resolution,
+        path,
+        path.relative_to(root).as_posix(),
+    )
+
+
+def _verify_resolution_bytes(
+    data: bytes,
+    expected: PostDispatchReviewResolution,
+    occurrence: PersistedPostDispatchReviewOccurrence,
+) -> None:
+    loaded = _resolution_from_bytes(data)
+    if loaded != expected:
+        raise PostDispatchReviewResolutionError(
+            "Persisted resolution bytes do not equal the requested resolution."
+        )
+    _verify_resolution_link(loaded, occurrence)
+
+
+def _verify_resolution_link(
+    resolution: PostDispatchReviewResolution,
+    occurrence: PersistedPostDispatchReviewOccurrence,
+) -> None:
+    occurrence_bytes = _read_occurrence_revision(
+        occurrence.workspace_root,
+        occurrence.work_ref,
+        occurrence,
+    )
+    if (
+        resolution.failure_id != occurrence.occurrence.failure_id
+        or resolution.occurrence_path != occurrence.relative_path
+        or resolution.class_id != occurrence.occurrence.class_id
+        or resolution.assignment_id != occurrence.occurrence.assignment_id
+        or dict(resolution.occurrence_identity_snapshot)
+        != _frozen_mapping(
+            _occurrence_snapshot(occurrence, occurrence_bytes),
+            "occurrence_identity_snapshot",
+            max_keys=16,
+        )
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Resolution does not match the immutable occurrence identity."
+        )
+    if datetime.fromisoformat(resolution.resolved_at) < datetime.fromisoformat(
+        occurrence.occurrence.created_at
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Resolution predates its immutable occurrence."
+        )
+
+
+def _occurrence_snapshot(
+    occurrence: PersistedPostDispatchReviewOccurrence,
+    occurrence_bytes: bytes,
+) -> dict[str, object]:
+    item = occurrence.occurrence
+    return {
+        "failure_id": item.failure_id,
+        "category": item.category,
+        "stage": item.stage,
+        "created_at": item.created_at,
+        "class_id": item.class_id,
+        "assignment_id": item.assignment_id,
+        "student_id": item.student_id,
+        "issuance_ids": list(item.issuance_ids),
+        "page_ids": list(item.page_ids),
+        "route_ids": list(item.route_ids),
+        "observation_ids": list(item.observation_ids),
+        "source_scan_ids": list(item.source_scan_ids),
+        "source_page_numbers": list(item.source_page_numbers),
+        "occurrence_sha256": hashlib.sha256(occurrence_bytes).hexdigest(),
+    }
+
+
+def _read_occurrence_revision(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    occurrence: PersistedPostDispatchReviewOccurrence,
+) -> bytes:
+    if type(occurrence) is not PersistedPostDispatchReviewOccurrence:
+        raise PostDispatchReviewResolutionError(
+            "Selected occurrence has the wrong runtime type."
+        )
+    expected_path = post_dispatch_review_path(
+        root, work_ref, occurrence.occurrence.failure_id
+    )
+    if occurrence.path != expected_path:
+        raise PostDispatchReviewResolutionError(
+            "Selected occurrence path is not its exact canonical path."
+        )
+    try:
+        checked_path = preflight_work_file_destination(
+            root,
+            work_ref,
+            Path("scans") / "review" / "post_dispatch" / expected_path.name,
+        )
+        if checked_path != expected_path:
+            raise PostDispatchReviewResolutionError(
+                "Occurrence preflight returned a different path."
+            )
+        if (
+            not os.path.lexists(expected_path)
+            or _is_link_like(expected_path)
+            or not expected_path.is_file()
+        ):
+            raise PostDispatchReviewResolutionError(
+                "Occurrence must be an ordinary non-link file."
+            )
+        current_bytes = expected_path.read_bytes()
+        if current_bytes != occurrence.original_bytes:
+            raise PostDispatchReviewResolutionError(
+                "Immutable occurrence changed after discovery."
+            )
+        return current_bytes
+    except (OSError, QuillanWorkPathError) as error:
+        raise PostDispatchReviewResolutionError(
+            f"Could not reload immutable occurrence: {error}"
+        ) from error
+
+
+def _resolution_bytes(resolution: PostDispatchReviewResolution) -> bytes:
+    value = {
+        "schema_version": POST_DISPATCH_RESOLUTION_SCHEMA_VERSION,
+        "record_type": POST_DISPATCH_RESOLUTION_RECORD_TYPE,
+        "module_id": QUILLAN_MODULE_ID,
+        "resolution_id": resolution.resolution_id,
+        "failure_id": resolution.failure_id,
+        "occurrence_path": resolution.occurrence_path,
+        "class_id": resolution.class_id,
+        "assignment_id": resolution.assignment_id,
+        "status": resolution.status,
+        "action": resolution.action,
+        "resolved_at": resolution.resolved_at,
+        "teacher_message": resolution.teacher_message,
+        "occurrence_identity_snapshot": _thaw(
+            resolution.occurrence_identity_snapshot
+        ),
+        "module_details": _thaw(resolution.module_details),
+        "retry_provenance": (
+            None
+            if resolution.retry_provenance is None
+            else _thaw(resolution.retry_provenance)
+        ),
+    }
+    return (
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")
+
+
+def _resolution_from_bytes(data: bytes) -> PostDispatchReviewResolution:
+    def pairs(items: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in items:
+            if key in result:
+                raise PostDispatchReviewResolutionError(
+                    f"Duplicate JSON key: {key}"
+                )
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                PostDispatchReviewResolutionError(
+                    f"Invalid JSON constant: {value}"
+                )
+            ),
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise PostDispatchReviewResolutionError(
+            f"Resolution is not strict JSON: {error}"
+        ) from error
+    if type(value) is not dict or set(value) != _RESOLUTION_FIELDS:
+        raise PostDispatchReviewResolutionError("Resolution fields are not exact.")
+    mapping = cast(dict[str, Any], value)
+    if (
+        mapping["schema_version"] != POST_DISPATCH_RESOLUTION_SCHEMA_VERSION
+        or mapping["record_type"] != POST_DISPATCH_RESOLUTION_RECORD_TYPE
+        or mapping["module_id"] != QUILLAN_MODULE_ID
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Resolution fixed identity is invalid."
+        )
+    return PostDispatchReviewResolution(
+        resolution_id=mapping["resolution_id"],
+        failure_id=mapping["failure_id"],
+        occurrence_path=mapping["occurrence_path"],
+        class_id=mapping["class_id"],
+        assignment_id=mapping["assignment_id"],
+        status=mapping["status"],
+        action=mapping["action"],
+        resolved_at=mapping["resolved_at"],
+        teacher_message=mapping["teacher_message"],
+        occurrence_identity_snapshot=mapping["occurrence_identity_snapshot"],
+        module_details=mapping["module_details"],
+        retry_provenance=_historical_retry_provenance_from_value(
+            mapping["retry_provenance"]
+        ),
+    )
+
+
+def _validate_possible_manifest(
+    path: Path,
+    occurrence: PostDispatchReviewOccurrence,
+) -> None:
+    try:
+        manifest = load_submission_manifest(path)
+    except (OSError, SubmissionManifestError) as error:
+        raise PostDispatchReviewResolutionError(
+            f"Possible manifest is not a valid submission manifest: {error}"
+        ) from error
+    if (
+        manifest.get("class_id") != occurrence.class_id
+        or manifest.get("assignment_id") != occurrence.assignment_id
+        or occurrence.student_id is None
+        or manifest.get("student_id") != occurrence.student_id
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Possible manifest identity disagrees with the occurrence."
+        )
+
+
+def _validate_possible_evidence(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    relative_path: str,
+    occurrence: PostDispatchReviewOccurrence,
+) -> None:
+    matching_observations = []
+    try:
+        for observation_id in occurrence.observation_ids:
+            observation = load_contextual_response_page_observation(
+                root, work_ref, observation_id
+            )
+            if observation.routed_evidence_path == relative_path:
+                matching_observations.append(observation)
+    except (OSError, QuillanObservationError) as error:
+        raise PostDispatchReviewResolutionError(
+            f"Could not validate possible evidence metadata: {error}"
+        ) from error
+    if len(matching_observations) != 1:
+        raise PostDispatchReviewResolutionError(
+            "Possible evidence has no unique immutable observation validator."
+        )
+    observation = matching_observations[0]
+    extension = PurePosixPath(relative_path).suffix
+    try:
+        verify_contextual_routed_page_evidence(
+            root,
+            work_ref,
+            issuance_id=observation.issuance_id,
+            student_id=observation.student_id,
+            logical_page=observation.logical_page,
+            observation_id=observation.observation_id,
+            extension=extension,
+            relative_path=relative_path,
+            expected_sha256=observation.routed_evidence_sha256,
+            expected_size_bytes=observation.routed_evidence_size_bytes,
+        )
+    except (OSError, QuillanObservationError) as error:
+        raise PostDispatchReviewResolutionError(
+            f"Possible evidence failed routed-evidence validation: {error}"
+        ) from error
+
+
+def _context(
+    workspace_root: str | Path, work_ref: ModuleWorkRef
+) -> tuple[Path, ModuleWorkRef]:
+    try:
+        root = canonical_workspace_root(workspace_root)
+        canonical_ref = quillan_work_ref(work_ref.class_id, work_ref.work_id)
+    except (AttributeError, OSError, TypeError, ValueError) as error:
+        raise PostDispatchReviewResolutionError(str(error)) from error
+    if type(work_ref) is not ModuleWorkRef or work_ref != canonical_ref:
+        raise PostDispatchReviewResolutionError(
+            "work_ref must be an exact Quillan work reference."
+        )
+    return root, canonical_ref
+
+
+def _message(action: str, value: str | None) -> str | None:
+    if value is None:
+        if action == "other":
+            raise PostDispatchReviewResolutionError(
+                "The other action requires a nonblank teacher message."
+            )
+        return None
+    if type(value) is not str or not value.strip():
+        raise PostDispatchReviewResolutionError(
+            "teacher message must be nonblank text when supplied."
+        )
+    return value.strip()
+
+
+def _resolution_order(
+    item: PersistedPostDispatchReviewResolution,
+) -> tuple[datetime, str]:
+    return datetime.fromisoformat(item.resolution.resolved_at), item.resolution.resolution_id
+
+
+def _timestamp(value: datetime | str | None, field: str) -> str:
+    selected: datetime | str = datetime.now(timezone.utc) if value is None else value
+    if type(selected) is datetime:
+        if selected.tzinfo is None or selected.utcoffset() is None:
+            raise PostDispatchReviewResolutionError(
+                f"{field} must be timezone-aware."
+            )
+        return selected.astimezone(timezone.utc).isoformat(timespec="microseconds")
+    if type(selected) is not str:
+        raise PostDispatchReviewResolutionError(f"{field} must be timestamp text.")
+    try:
+        parsed = datetime.fromisoformat(selected)
+    except ValueError as error:
+        raise PostDispatchReviewResolutionError(
+            f"{field} must be ISO 8601 text."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise PostDispatchReviewResolutionError(
+            f"{field} must be timezone-aware."
+        )
+    return parsed.astimezone(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _identifier(value: object, field: str) -> str:
+    if type(value) is not str:
+        raise PostDispatchReviewResolutionError(
+            f"{field} must be exact identifier text."
+        )
+    try:
+        return validate_identifier(value, field)
+    except ValueError as error:
+        raise PostDispatchReviewResolutionError(str(error)) from error
+
+
+def _identifier_tuple(value: object, field: str) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise PostDispatchReviewResolutionError(f"{field} must be an exact tuple.")
+    values = cast(tuple[object, ...], value)
+    for item in values:
+        _identifier(item, field.removesuffix("s"))
+    typed_values = cast(tuple[str, ...], values)
+    if typed_values != tuple(sorted(set(typed_values))):
+        raise PostDispatchReviewResolutionError(
+            f"{field} must be deterministic and unique."
+        )
+    return typed_values
+
+
+def _relative_posix(value: object, field: str) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or "\\" in value
+        or value.startswith("/")
+        or any(part in {"", ".", ".."} for part in value.split("/"))
+    ):
+        raise PostDispatchReviewResolutionError(
+            f"{field} must be canonical workspace-relative POSIX text."
+        )
+    return value
+
+
+def _frozen_mapping(
+    value: object, field: str, *, max_keys: int
+) -> Mapping[str, object]:
+    if type(value) is not dict and not isinstance(value, Mapping):
+        raise PostDispatchReviewResolutionError(f"{field} must be an object.")
+    mapping = dict(cast(Mapping[str, object], value))
+    if len(mapping) > max_keys or any(type(key) is not str for key in mapping):
+        raise PostDispatchReviewResolutionError(f"{field} is not bounded.")
+    try:
+        serialized = json.dumps(
+            _thaw(mapping), allow_nan=False, sort_keys=True
+        )
+    except (TypeError, ValueError) as error:
+        raise PostDispatchReviewResolutionError(
+            f"{field} must contain strict JSON."
+        ) from error
+    if len(serialized.encode("utf-8")) > 16_384:
+        raise PostDispatchReviewResolutionError(f"{field} is too large.")
+    return cast(Mapping[str, object], _freeze_json(mapping, field))
+
+
+def _freeze_json(value: object, field: str) -> object:
+    if isinstance(value, Mapping):
+        frozen: dict[str, object] = {}
+        for key, item in value.items():
+            if type(key) is not str or key in frozen:
+                raise PostDispatchReviewResolutionError(
+                    f"{field} contains an invalid object key."
+                )
+            frozen[key] = _freeze_json(item, field)
+        return MappingProxyType(frozen)
+    if type(value) in {list, tuple}:
+        values = cast(list[object] | tuple[object, ...], value)
+        return tuple(_freeze_json(item, field) for item in values)
+    if value is None or type(value) in {str, int, bool}:
+        return value
+    if type(value) is float:
+        if value != value or abs(value) == float("inf"):
+            raise PostDispatchReviewResolutionError(
+                f"{field} must contain strict JSON."
+            )
+        return value
+    raise PostDispatchReviewResolutionError(f"{field} must contain strict JSON.")
+
+
+def _validate_occurrence_snapshot(
+    resolution: PostDispatchReviewResolution,
+) -> None:
+    snapshot = resolution.occurrence_identity_snapshot
+    if set(snapshot) != _OCCURRENCE_SNAPSHOT_FIELDS:
+        raise PostDispatchReviewResolutionError(
+            "Occurrence identity snapshot fields are not exact."
+        )
+    if (
+        snapshot["failure_id"] != resolution.failure_id
+        or snapshot["class_id"] != resolution.class_id
+        or snapshot["assignment_id"] != resolution.assignment_id
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Occurrence snapshot disagrees with resolution identity."
+        )
+    _identifier(snapshot["failure_id"], "failure_id")
+    _identifier(snapshot["class_id"], "class_id")
+    _identifier(snapshot["assignment_id"], "assignment_id")
+    student_id = snapshot["student_id"]
+    if student_id is not None:
+        _identifier(student_id, "student_id")
+    for field in (
+        "issuance_ids",
+        "page_ids",
+        "route_ids",
+        "observation_ids",
+        "source_scan_ids",
+    ):
+        _identifier_tuple(snapshot[field], field)
+    page_numbers = snapshot["source_page_numbers"]
+    if type(page_numbers) is not tuple or any(
+        type(item) is not int or item < 1 for item in page_numbers
+    ):
+        raise PostDispatchReviewResolutionError(
+            "source_page_numbers must contain exact positive integers."
+        )
+    typed_page_numbers = cast(tuple[int, ...], page_numbers)
+    if typed_page_numbers != tuple(sorted(set(typed_page_numbers))):
+        raise PostDispatchReviewResolutionError(
+            "source_page_numbers must be deterministic and unique."
+        )
+    category = snapshot["category"]
+    if type(category) is not str or category not in POST_DISPATCH_CATEGORIES:
+        raise PostDispatchReviewResolutionError(
+            "Occurrence snapshot category is invalid."
+        )
+    for field in ("stage",):
+        value = snapshot[field]
+        if type(value) is not str or not value or value != value.strip():
+            raise PostDispatchReviewResolutionError(
+                f"Occurrence snapshot {field} is invalid."
+            )
+    created_at = snapshot["created_at"]
+    if type(created_at) is not str or _timestamp(created_at, "created_at") != created_at:
+        raise PostDispatchReviewResolutionError(
+            "Occurrence snapshot timestamp is not normalized UTC text."
+        )
+    digest = snapshot["occurrence_sha256"]
+    if (
+        type(digest) is not str
+        or len(digest) != 64
+        or any(character not in "0123456789abcdef" for character in digest)
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Occurrence snapshot SHA-256 is invalid."
+        )
+    if resolution.retry_provenance is not None:
+        provenance = resolution.retry_provenance
+        occurrence_issuances = cast(tuple[str, ...], snapshot["issuance_ids"])
+        if student_id is not None and provenance["student_id"] != student_id:
+            raise PostDispatchReviewResolutionError(
+                "Retry provenance disagrees with the occurrence identity snapshot."
+            )
+        provenance_issuances = cast(tuple[str, ...], provenance["issuance_ids"])
+        if occurrence_issuances and not set(provenance_issuances).issubset(
+            occurrence_issuances
+        ):
+            raise PostDispatchReviewResolutionError(
+                "Retry provenance disagrees with the occurrence identity snapshot."
+            )
+
+
+def _validated_retry_provenance(
+    value: Mapping[str, object],
+) -> Mapping[str, object]:
+    if set(value) != _RETRY_PROVENANCE_FIELDS:
+        raise PostDispatchReviewResolutionError(
+            "Retry provenance fields are not exact."
+        )
+    if value["operation"] != "submission_assembly":
+        raise PostDispatchReviewResolutionError("Retry operation is invalid.")
+    class_id = _identifier(value["class_id"], "class_id")
+    assignment_id = _identifier(value["assignment_id"], "assignment_id")
+    student_id = _identifier(value["student_id"], "student_id")
+    issuance_ids_value = value["issuance_ids"]
+    if type(issuance_ids_value) not in {list, tuple}:
+        raise PostDispatchReviewResolutionError(
+            "Retry provenance issuance_ids must be an array."
+        )
+    issuance_ids = tuple(cast(list[str] | tuple[str, ...], issuance_ids_value))
+    _identifier_tuple(issuance_ids, "issuance_ids")
+    if len(issuance_ids) != 1:
+        raise PostDispatchReviewResolutionError(
+            "Retry provenance requires one assembled issuance."
+        )
+    assembled_status = value["assembled_status"]
+    if assembled_status not in {"created", "updated", "unchanged"}:
+        raise PostDispatchReviewResolutionError("Assembled retry status is invalid.")
+    manifest_path = value["manifest_path"]
+    _relative_posix(manifest_path, "manifest_path")
+    expected_manifest_path = submission_manifest_path(
+        Path(),
+        quillan_work_ref(class_id, assignment_id),
+        student_id,
+    ).as_posix()
+    if manifest_path != expected_manifest_path:
+        raise PostDispatchReviewResolutionError(
+            "Retry manifest_path is not the canonical student manifest path."
+        )
+    assembly_revision = value["assembly_revision"]
+    if (
+        isinstance(assembly_revision, bool)
+        or not isinstance(assembly_revision, int)
+        or assembly_revision < 1
+    ):
+        raise PostDispatchReviewResolutionError(
+            "Retry assembly_revision must be a positive integer."
+        )
+    completed_at = value["completed_at"]
+    if type(completed_at) is not str:
+        raise PostDispatchReviewResolutionError(
+            "Retry completion timestamp must be normalized UTC text."
+        )
+    if _timestamp(completed_at, "completed_at") != completed_at:
+        raise PostDispatchReviewResolutionError(
+            "Retry completion timestamp must be normalized UTC text."
+        )
+    return MappingProxyType(
+        {
+            "operation": "submission_assembly",
+            "class_id": class_id,
+            "assignment_id": assignment_id,
+            "student_id": student_id,
+            "issuance_ids": issuance_ids,
+            "assembled_status": assembled_status,
+            "manifest_path": manifest_path,
+            "assembly_revision": assembly_revision,
+            "completed_at": completed_at,
+        }
+    )
+
+
+def _historical_retry_provenance_from_value(
+    value: object,
+) -> Mapping[str, object] | None:
+    if value is None:
+        return None
+    if type(value) is not dict or set(value) != _RETRY_PROVENANCE_FIELDS:
+        raise PostDispatchReviewResolutionError(
+            "Retry provenance fields are not exact."
+        )
+    mapping = cast(dict[str, object], value)
+    issuance_ids = mapping["issuance_ids"]
+    if type(issuance_ids) is not list:
+        raise PostDispatchReviewResolutionError(
+            "Retry provenance issuance_ids must be an array."
+        )
+    normalized = dict(mapping)
+    normalized["issuance_ids"] = tuple(cast(list[str], issuance_ids))
+    return _validated_retry_provenance(normalized)
+
+
+def _thaw(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+__all__ = [
+    "POST_DISPATCH_GENERIC_RESOLUTION_ACTIONS",
+    "POST_DISPATCH_RESOLUTION_ACTIONS",
+    "POST_DISPATCH_RESOLUTION_RECORD_TYPE",
+    "POST_DISPATCH_RESOLUTION_SCHEMA_VERSION",
+    "POST_DISPATCH_RESOLUTION_STATUSES",
+    "OpenedPostDispatchPossiblePath",
+    "PersistedPostDispatchReviewResolution",
+    "PostDispatchReviewItem",
+    "PostDispatchReviewResolution",
+    "PostDispatchReviewResolutionDiscovery",
+    "PostDispatchReviewResolutionError",
+    "discover_post_dispatch_review_items",
+    "open_post_dispatch_possible_path",
+    "post_dispatch_retry_proves_resolution",
+    "resolve_post_dispatch_after_successful_retry",
+    "resolve_post_dispatch_review_item",
+    "resolve_post_dispatch_review_occurrence",
+]

--- a/quillan/printable_response_workflows.py
+++ b/quillan/printable_response_workflows.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-import os
-import sys
 from typing import cast
 
 from pds_core.classes import ClassFolder, list_class_folders
@@ -22,25 +20,11 @@ from quillan.generated_output_opening import (
 from quillan.printable_response import PRINTABLE_RESPONSE_FILENAME
 from quillan.printable_response_generation import PrintableResponseGenerationError
 from quillan.storage import assignment_templates_dir
-
-
-def _print_menu_header(title: str) -> None:
-    print("\033[32mQuillan\033[0m")
-    print(title)
-    print()
-
-
-def _clear_screen() -> None:
-    try:
-        interactive = sys.stdin.isatty() and sys.stdout.isatty()
-    except (AttributeError, OSError):
-        interactive = False
-    if interactive:
-        os.system("cls" if os.name == "nt" else "clear")
-
-
-def _pause_for_user() -> None:
-    input("Press Enter to continue...")
+from quillan.menu import (
+    clear_screen as _clear_screen,
+    pause_for_user as _pause_for_user,
+    print_menu_header as _print_menu_header,
+)
 
 
 @dataclass(frozen=True)
@@ -119,23 +103,32 @@ def _workspace_root() -> Path | None:
 
 def _prompt_open_generated_packet(
     workspace_root: Path,
-    generated_path: Path,
+    generated: object,
 ) -> None:
+    from quillan.printable_response_generation import GeneratedPrintableResponsePacket
     from quillan.menu_navigation import (
         NavigationChoice,
         parse_navigation_choice,
     )
 
+    if not isinstance(generated, GeneratedPrintableResponsePacket):
+        raise TypeError("generated must be a GeneratedPrintableResponsePacket.")
+    generated_path = generated.output_path
+    _clear_screen()
+    _print_menu_header("Printable Response Result")
+    print("Packet replaced." if generated.replaced_existing else "Packet created.")
+    print(f"Students: {generated.student_count}")
+    print(f"Pages per student: {generated.pages_per_student}")
+    print(f"Total physical pages: {generated.physical_page_count}")
+    print(f"Packet: {generated.output_relative_path}")
     print()
-    print("What would you like to do next?")
-    print("1. Open generated packet")
+    print("1. Open packet")
     print("2. Open containing folder")
-    print("3. Return to Printable Response Pages")
+    print("B. Back")
     selection = input("Select an option: ").strip()
     navigation = parse_navigation_choice(selection)
     if (
         selection == ""
-        or selection == "3"
         or navigation is NavigationChoice.BACK
     ):
         return
@@ -144,24 +137,32 @@ def _prompt_open_generated_packet(
         try:
             opened = open_generated_output_file(workspace_root, generated_path)
         except GeneratedOutputOpeningError as error:
+            _clear_screen()
+            _print_menu_header("Open Printable Response Packet")
             print(f"Error: could not open generated packet: {error}")
             print("Generated packet remains saved at:")
-            print(generated_path)
+            print(generated.output_relative_path)
             return
+        _clear_screen()
+        _print_menu_header("Printable Response Packet Opened")
         print("Opened generated packet:")
-        print(opened.path)
+        print(opened.relative_path)
         return
 
     if selection == "2":
         try:
             opened = open_generated_output_folder(workspace_root, generated_path)
         except GeneratedOutputOpeningError as error:
+            _clear_screen()
+            _print_menu_header("Open Printable Response Folder")
             print(f"Error: could not open containing folder: {error}")
             print("Generated packet remains saved at:")
-            print(generated_path)
+            print(generated.output_relative_path)
             return
+        _clear_screen()
+        _print_menu_header("Printable Response Folder Opened")
         print("Opened containing folder:")
-        print(opened.path)
+        print(opened.relative_path)
         return
 
     print("Returning to Printable Response Pages.")
@@ -262,17 +263,27 @@ def prompt_generate_class_packet() -> int:
         plan_printable_response_packet,
     )
 
-    _print_menu_header("Generate Printable Response Class Packet")
+    _clear_screen()
+    _print_menu_header("Select Class for Printable Responses")
     workspace_root = _workspace_root()
     if workspace_root is None:
         return 1
     class_folder = _prompt_class_selection(workspace_root)
     if class_folder is None:
         return 1
+    _clear_screen()
+    _print_menu_header("Select Assignment for Printable Responses")
+    print(f"Class: {class_folder.class_id}")
+    print()
     assignment = _prompt_assignment_selection(workspace_root, class_folder.class_id)
     if assignment is None:
         return 1
 
+    _clear_screen()
+    _print_menu_header("Choose Pages per Student")
+    print(f"Class: {class_folder.class_id}")
+    print(f"Assignment: {assignment.assignment_id}")
+    print()
     try:
         pages_per_student = parse_pages_per_student(
             input("Pages per student [1]: ")
@@ -298,9 +309,18 @@ def prompt_generate_class_packet() -> int:
         print(f"Error: {error}")
         return 1
 
+    _clear_screen()
+    _print_menu_header("Printable Response Generation Plan")
+    print(f"Class: {plan.class_id}")
+    print(f"Assignment: {plan.assignment_id}")
+    print(f"Students: {plan.student_count}")
+    print(f"Pages per student: {plan.pages_per_student}")
+    print(f"Total physical pages: {plan.total_page_count}")
+    print(f"Packet: {plan.output_relative_path}")
+    print()
     overwrite = False
     if plan.target_exists:
-        print(f"Printable response packet already exists:\n{plan.output_path}")
+        print("A printable response packet already exists.")
         confirmation = input(
             "Type OVERWRITE to replace the existing printable response packet: "
         ).strip()
@@ -309,7 +329,6 @@ def prompt_generate_class_packet() -> int:
             return 1
         overwrite = True
 
-    print("Output mode: one class packet PDF")
     try:
         generated = generate_printable_response_packet(
             plan,
@@ -325,10 +344,10 @@ def prompt_generate_class_packet() -> int:
         print(f"Error: {error}")
         return 1
 
+    _clear_screen()
     print_generated_printable_response_packet(generated)
     if generated.installed:
-        print(f"Saved at: {generated.output_path}")
-        _prompt_open_generated_packet(workspace_root, generated.output_path)
+        _prompt_open_generated_packet(workspace_root, generated)
     return 0 if generated.success else 1
 
 
@@ -352,7 +371,7 @@ def launch_printable_response_menu() -> int:
             navigation = parse_navigation_choice(choice)
             print()
 
-            if choice == "2" or navigation is NavigationChoice.BACK:
+            if navigation is NavigationChoice.BACK:
                 return 0
             if choice == "1":
                 _clear_screen()

--- a/quillan/response_page_observation_persistence.py
+++ b/quillan/response_page_observation_persistence.py
@@ -219,6 +219,36 @@ class QuillanObservationPersistenceBatch:
     def failure_count(self) -> int:
         return len(self.failures)
 
+    @property
+    def observation_created_count(self) -> int:
+        """Count verified new observation records from the paired transaction."""
+        return sum(item.status == "created" for item in self.persisted)
+
+    @property
+    def observation_existing_count(self) -> int:
+        """Count verified existing observation records from the paired transaction."""
+        return sum(item.status == "existing" for item in self.persisted)
+
+    @property
+    def routed_evidence_created_count(self) -> int:
+        """Count verified new evidence files from the paired transaction."""
+        return sum(item.status == "created" for item in self.persisted)
+
+    @property
+    def routed_evidence_existing_count(self) -> int:
+        """Count verified existing evidence files from the paired transaction."""
+        return sum(item.status == "existing" for item in self.persisted)
+
+    @property
+    def observation_persistence_failure_count(self) -> int:
+        """Count paired operations that did not verify observation durability."""
+        return len(self.failures)
+
+    @property
+    def routed_evidence_persistence_failure_count(self) -> int:
+        """Count paired operations that did not verify evidence durability."""
+        return len(self.failures)
+
 
 def persist_quillan_page_observation(
     workspace_root: Path,

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -16,7 +16,6 @@ from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
 from quillan.assignment_picker import prompt_assignment_choice
 from quillan.assignment_submission_assembly import assemble_assignment_submissions
-from quillan.assignments import AssignmentConfigError, load_assignment_config
 from quillan.class_summary_export import (
     ClassSummaryExportError,
     export_class_review_summary,
@@ -44,8 +43,6 @@ from quillan.feedback_export import (
     FeedbackExportError,
     export_student_feedback,
     export_student_feedback_pdf,
-    feedback_export_path,
-    feedback_pdf_export_path,
 )
 from quillan.focus_standard_comments import (
     FocusStandardCommentError,
@@ -93,13 +90,6 @@ from quillan.review_feedback import (
     set_standard_feedback_options,
     summarize_standard_feedback,
 )
-from quillan.review_record import (
-    ReviewRecordError,
-    load_review_record,
-)
-from quillan.review_record_paths import (
-    review_record_path,
-)
 from quillan.review_workflow_state import (
     REVIEW_WORKFLOW_STATES,
     ReviewWorkflowStateError,
@@ -113,7 +103,6 @@ from quillan.review_dashboard import (
     format_assignment_review_dashboard,
 )
 from quillan.review_status_display import (
-    feedback_export_status,
     review_progress_status,
     review_status_label,
 )
@@ -124,19 +113,18 @@ from quillan.review_targets import (
     parse_paragraph_selection,
 )
 from quillan.review_requirements import ReviewRequirementError
-from quillan.storage import assignment_config_path
+from quillan.record_context import (
+    MissingSubmissionError,
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+)
 from quillan.submission_review_opening import (
     SubmissionReviewOpeningError,
+    list_submission_evidence_candidates,
     open_student_submission_for_review,
-    selected_submission_evidence_pages,
-)
-from quillan.submission_manifest import (
-    SubmissionManifestError,
-    load_submission_manifest,
-)
-from quillan.submission_manifest_paths import (
-    SubmissionManifestPathError,
-    submission_manifest_path,
 )
 from quillan.submission_page_management import (
     SubmissionPageManagementError,
@@ -146,10 +134,16 @@ from quillan.submission_page_management import (
 )
 from quillan.submission_status import (
     AssignmentSubmissionStatus,
+    PageStatusSummary,
     StudentSubmissionStatus,
     list_assignment_submission_status,
 )
 from quillan.student_display import student_display_lookup, student_review_label
+from quillan.student_review_status import (
+    StudentReviewStatusError,
+    build_student_review_status,
+    student_review_status_to_dict,
+)
 from quillan.menu_navigation import (
     NavigationChoice,
     navigation_hint,
@@ -159,8 +153,9 @@ from quillan.menu_navigation import (
 from quillan.plain_paper_submission import (
     PlainPaperSubmissionError,
     create_plain_paper_submission,
-    is_plain_paper_submission,
+    plan_plain_paper_submission,
 )
+from quillan.work_paths import quillan_work_ref
 
 _BACK = object()
 _CANCEL = object()
@@ -183,7 +178,7 @@ def launch_review_student_work_menu() -> int:
             navigation = parse_navigation_choice(choice)
             print()
 
-            if choice in {"", "3"} or navigation is NavigationChoice.BACK:
+            if choice == "" or navigation is NavigationChoice.BACK:
                 return 0
             if choice == "1":
                 clear_screen()
@@ -384,11 +379,8 @@ def _student_status_label(
         )
     if status.manifest_path is None:
         return "routed evidence exists; no manifest"
-    try:
-        if is_plain_paper_submission(load_submission_manifest(status.manifest_path)):
-            return "plain-paper manual submission; no digital evidence"
-    except (OSError, SubmissionManifestError):
-        pass
+    if status.plain_paper:
+        return "plain-paper manual submission; no digital evidence"
     evidence_count = sum(page.evidence_count for page in status.pages)
     return (
         f"{status.submission_state}; manifest exists; evidence files={evidence_count}"
@@ -418,25 +410,38 @@ def _launch_selected_student_review(
         if student_status is None:
             print("No digital submission evidence has been found for this student.")
             print()
-            print("1. Create plain-paper submission for this student")
-            print("2. View routed evidence status")
-            print("3. Refresh summary")
+            try:
+                plan_plain_paper_submission(
+                    workspace_root, class_id, assignment_id, student_id
+                )
+            except (PlainPaperSubmissionError, OSError, ValueError) as error:
+                plain_paper_available = False
+                print(f"Plain-paper creation is unavailable: {error}")
+            else:
+                plain_paper_available = True
+            if plain_paper_available:
+                print("1. Create plain-paper submission for this student")
+                print("2. View routed evidence status")
+                print("3. Refresh summary")
+            else:
+                print("1. View routed evidence status")
+                print("2. Refresh summary")
             print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
             navigation = parse_navigation_choice(choice)
             print()
-            if choice in {"", "4"} or navigation is NavigationChoice.BACK:
+            if choice == "" or navigation is NavigationChoice.BACK:
                 return 0
-            if choice == "1":
+            if choice == "1" and plain_paper_available:
                 _create_plain_paper_submission_menu(
                     workspace_root, class_id, assignment_id, student_id
                 )
                 input("Press Enter to continue...")
                 continue
-            if choice in {"2", "3"}:
+            if choice in ({"2", "3"} if plain_paper_available else {"1", "2"}):
                 continue
-            print("Invalid selection. Please enter a number from 1 to 4.")
+            print("Invalid selection. Please choose a listed action.")
             input("Press Enter to continue...")
             continue
         if student_status.manifest_path is None:
@@ -445,7 +450,7 @@ def _launch_selected_student_review(
                 "submission record has not been assembled yet."
             )
             print(
-                "Assemble submissions before reviewing, tagging, scoring, or exporting."
+                "Assemble submissions before reviewing, rating, or exporting."
             )
             print()
             print("1. Assemble this assignment now")
@@ -456,7 +461,7 @@ def _launch_selected_student_review(
             choice = input("Select an option: ").strip()
             navigation = parse_navigation_choice(choice)
             print()
-            if choice in {"", "4"} or navigation is NavigationChoice.BACK:
+            if choice == "" or navigation is NavigationChoice.BACK:
                 return 0
             if choice == "1":
                 _assemble_assignment(workspace_root, class_id, assignment_id)
@@ -485,7 +490,7 @@ def _launch_selected_student_review(
         navigation = parse_navigation_choice(choice)
         print()
 
-        if choice in {"", "12"} or navigation is NavigationChoice.BACK:
+        if choice == "" or navigation is NavigationChoice.BACK:
             return 0
         if choice == "1":
             _open_submission_evidence(
@@ -700,10 +705,11 @@ def _load_assignment_for_review(
     assignment_id: str,
 ) -> dict[str, Any] | None:
     try:
-        return load_assignment_config(
-            assignment_config_path(workspace_root, class_id, assignment_id)
+        context = load_quillan_assignment_context(
+            workspace_root, quillan_work_ref(class_id, assignment_id)
         )
-    except (AssignmentConfigError, OSError) as error:
+        return mutable_json_copy(context.assignment)
+    except (QuillanRecordContextError, OSError) as error:
         print(f"Error: could not load assignment config: {error}")
         return None
 
@@ -719,14 +725,9 @@ def _menu_update_review_workflow_state(
     )
     print("Use this to update the teacher-review workflow. This is not a grade.")
     print()
-    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
-    record = None
-    if path.exists():
-        try:
-            record = load_review_record(path)
-        except (OSError, ReviewRecordError) as error:
-            print(f"Error: could not load review record: {error}")
-            return
+    record = _current_review_record(
+        workspace_root, class_id, assignment_id, student_id
+    )
     current_state = "not_started" if record is None else str(record["review_state"])
     print(f"Current review workflow state: {current_state}")
     print()
@@ -844,12 +845,19 @@ def _current_review_record(
     assignment_id: str,
     student_id: str,
 ) -> dict[str, Any] | None:
-    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
-    if not path.exists():
-        return None
     try:
-        return load_review_record(path)
-    except (OSError, ReviewRecordError) as error:
+        context = load_quillan_student_review_context(
+            workspace_root,
+            quillan_work_ref(class_id, assignment_id),
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+        )
+        return (
+            None if context.review is None else mutable_json_copy(context.review)
+        )
+    except MissingSubmissionError:
+        return None
+    except (OSError, QuillanRecordContextError) as error:
         print(f"Error: could not load review record: {error}")
         return None
 
@@ -1060,51 +1068,40 @@ def _print_review_summary(
 ) -> None:
     print("Current review summary")
     print()
+    try:
+        status = build_student_review_status(
+            workspace_root, class_id, assignment_id, student_id
+        )
+    except StudentReviewStatusError as error:
+        print(f"Status unavailable: {error}")
+        return
+    data = student_review_status_to_dict(status)
+    student = cast(dict[str, Any], data["student"])
+    routed = cast(dict[str, Any], data["routed_evidence"])
+    submission = cast(dict[str, Any], data["submission"])
+    review = cast(dict[str, Any], data["review"])
+    progress = cast(dict[str, Any], review["progress"])
+    exports = cast(dict[str, Any], review["exports"])
+    export_summary = cast(dict[str, Any], exports["summary"])
     print(f"Class: {class_id}")
     print(f"Assignment: {assignment_id}")
-    print(f"Student: {student_review_label(workspace_root, class_id, student_id)}")
-
-    status = _load_submission_status(workspace_root, class_id, assignment_id)
-    student_status = None
-    if status is not None:
-        student_status = next(
-            (
-                candidate
-                for candidate in status.student_statuses
-                if candidate.student_id == student_id
-            ),
-            None,
-        )
-    if student_status is None:
-        print("Submission: not assembled")
-        print("Evidence files: 0")
-    elif student_status.manifest_path is None:
-        print("Submission: not assembled")
-        print("Evidence files: routed but not assembled")
-    else:
-        print("Submission: assembled")
-        print(
-            "Evidence files: "
-            f"{sum(page.evidence_count for page in student_status.pages)}"
-        )
-
-    path = review_record_path(workspace_root, class_id, assignment_id, student_id)
-    record = None
-    if path.exists():
-        try:
-            record = load_review_record(path)
-        except (OSError, ReviewRecordError):
-            pass
-    print(f"Review: {review_status_label(record)}")
-    _print_review_phase_statuses(record)
-    print(f"Feedback export: {feedback_export_status(workspace_root, record)}")
-
-    _print_review_record_summary(
-        workspace_root,
-        class_id,
-        assignment_id,
-        student_id,
+    print(f"Student: {student['display_name']}")
+    print(f"Submission: {submission['status']}")
+    print(f"Routed evidence files: {routed['file_count']}")
+    print(f"Needs assembly: {_format_yes_no(routed['needs_assembly'] is True)}")
+    print(f"Review: {review['state_label'] or 'not started'}")
+    print(
+        "Review progress: "
+        f"observations={'complete' if progress['observations_complete'] else 'incomplete'}; "
+        f"ratings={'complete' if progress['ratings_complete'] else 'incomplete'}; "
+        f"feedback={'composed' if progress['feedback_composed'] else 'not composed'}"
     )
+    print(
+        "Feedback exports: "
+        f"current={export_summary['current']}; stale={export_summary['stale']}; "
+        f"missing={export_summary['missing']}"
+    )
+    print(f"Warnings: {len(status.warnings)}")
 
 
 def _print_review_record_summary(
@@ -1113,13 +1110,10 @@ def _print_review_record_summary(
     assignment_id: str,
     student_id: str,
 ) -> None:
-    path = review_record_path(
-        workspace_root,
-        class_id,
-        assignment_id,
-        student_id,
+    record = _current_review_record(
+        workspace_root, class_id, assignment_id, student_id
     )
-    if not path.exists():
+    if record is None:
         print("Review record: not started")
         print("Review record file: missing")
         _print_requirement_check_summary(
@@ -1128,13 +1122,6 @@ def _print_review_record_summary(
             assignment_id,
             {},
         )
-        return
-
-    try:
-        record = load_review_record(path)
-    except ReviewRecordError as error:
-        print("Review record: invalid")
-        print(f"Review record error: {error}")
         return
 
     print("Review record: exists")
@@ -1246,10 +1233,11 @@ def _load_assignment_for_summary(
     assignment_id: str,
 ) -> dict[str, Any] | None:
     try:
-        return load_assignment_config(
-            assignment_config_path(workspace_root, class_id, assignment_id)
+        context = load_quillan_assignment_context(
+            workspace_root, quillan_work_ref(class_id, assignment_id)
         )
-    except (AssignmentConfigError, OSError):
+        return mutable_json_copy(context.assignment)
+    except (QuillanRecordContextError, OSError):
         return None
 
 
@@ -1259,47 +1247,108 @@ def _open_submission_evidence(
     assignment_id: str,
     student_id: str,
 ) -> None:
-    try:
-        manifest = load_submission_manifest(
-            submission_manifest_path(
-                workspace_root, class_id, assignment_id, student_id
-            )
-        )
-        if is_plain_paper_submission(manifest):
-            print(
-                "This is a plain-paper manual submission. "
-                "No digital evidence is attached."
-            )
-            print(
-                "Review the physical paper, then use Quillan's review actions "
-                "to record your judgment."
-            )
-            return
-    except (OSError, SubmissionManifestError, SubmissionManifestPathError):
-        pass
-    page_number = _choose_submission_evidence_page(
-        workspace_root,
-        class_id,
-        assignment_id,
-        student_id,
-    )
-    if page_number is _BACK:
-        print("Open submission evidence canceled.")
-        return
-    assert page_number is None or isinstance(page_number, int)
+    from quillan.menu import clear_screen, print_menu_header
 
     try:
-        opened = open_student_submission_for_review(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-            page_number=page_number,
+        inventory = list_submission_evidence_candidates(
+            workspace_root, class_id, assignment_id, student_id
         )
+    except SubmissionReviewOpeningError as error:
+        print(f"Error: could not inspect student submission: {error}")
+        return
+    if inventory.plain_paper:
+        clear_screen()
+        print_menu_header("Open Submission Evidence")
+        print("This plain-paper submission has no digital evidence.")
+        print("Review the physical paper and record teacher judgments in Quillan.")
+        return
+    clear_screen()
+    print_menu_header("Select Submission Page")
+    print(f"Class: {class_id}")
+    print(f"Assignment: {assignment_id}")
+    print(f"Student: {student_review_label(workspace_root, class_id, student_id)}")
+    print()
+    for index, page in enumerate(inventory.pages, start=1):
+        selected = "selected" if page.selected_evidence_id is not None else "unselected"
+        print(
+            f"{index}. Page {page.page_number}; {page.page_state}; {selected}; "
+            f"candidates={len(page.candidates)}"
+        )
+    print("A. Open all selected pages")
+    print("B. Back")
+    print()
+    choice = input("Select page: ").strip()
+    if choice.casefold() == "b" or choice == "":
+        return
+    evidence_id: str | None = None
+    page_number: int | None = None
+    if choice.casefold() != "a":
+        if not choice.isdigit() or not 1 <= int(choice) <= len(inventory.pages):
+            return
+        page = inventory.pages[int(choice) - 1]
+        clear_screen()
+        print_menu_header("Select Evidence Candidate")
+        print(f"Page: {page.page_number}")
+        print(f"Page state: {page.page_state}")
+        print()
+        if not page.candidates:
+            print("This page has no evidence candidates to open.")
+            return
+        for index, candidate in enumerate(page.candidates, start=1):
+            label = "selected" if candidate.selected else candidate.evidence_role
+            print(
+                f"{index}. {label}; state={candidate.evidence_state}; "
+                f"evidence={candidate.evidence_id}"
+            )
+        print("B. Back")
+        print()
+        candidate_choice = input("Select candidate: ").strip()
+        if (
+            not candidate_choice.isdigit()
+            or not 1 <= int(candidate_choice) <= len(page.candidates)
+        ):
+            return
+        candidate = page.candidates[int(candidate_choice) - 1]
+        clear_screen()
+        print_menu_header("Evidence Candidate Details")
+        print(f"Page: {page.page_number}")
+        print(f"Evidence ID: {candidate.evidence_id}")
+        print(f"Role: {candidate.evidence_role}")
+        print(f"State: {candidate.evidence_state}")
+        print(f"Path: {candidate.relative_path}")
+        print()
+        if input("Open this candidate? [y/N]: ").strip().casefold() not in {
+            "y",
+            "yes",
+        }:
+            return
+        page_number = page.page_number
+        evidence_id = candidate.evidence_id
+
+    try:
+        if evidence_id is None:
+            opened = open_student_submission_for_review(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                page_number=page_number,
+            )
+        else:
+            opened = open_student_submission_for_review(
+                workspace_root,
+                class_id,
+                assignment_id,
+                student_id,
+                page_number=page_number,
+                evidence_id=evidence_id,
+            )
     except SubmissionReviewOpeningError as error:
         print(f"Error: could not open student submission: {error}")
         return
 
+    clear_screen()
+    print_menu_header("Submission Evidence Opened")
     print_opened_submission_review(opened)
 
 
@@ -1312,8 +1361,8 @@ def _create_plain_paper_submission_menu(
     _print_review_action_header(
         "Create Plain-Paper Submission", class_id, assignment_id, student_id
     )
-    print("Use this only when the student completed the assignment on paper outside")
-    print("Quillan and you want to review the physical paper manually.")
+    print("This creates a review-ready record for physical paper.")
+    print("It does not attach or create digital evidence.")
     print()
     print("This will create:")
     print("- submission.json")
@@ -1329,7 +1378,7 @@ def _create_plain_paper_submission_menu(
         print("Plain-paper submission creation canceled.")
         return
     try:
-        create_plain_paper_submission(
+        created = create_plain_paper_submission(
             workspace_root, class_id, assignment_id, student_id
         )
     except Exception as error:
@@ -1338,67 +1387,15 @@ def _create_plain_paper_submission_menu(
         else:
             print(f"Error: plain-paper submission was not created: {error}")
         return
-    student_label = student_review_label(workspace_root, class_id, student_id)
-    print(f"Plain-paper submission created for {student_label}.")
-    print()
-    print(
-        "You can now review minimum requirements, review units, Focus Standard "
-        "observations, overall Focus Standard ratings, feedback, and private notes."
-    )
+    from quillan.menu import clear_screen, print_menu_header
 
-
-def _choose_submission_evidence_page(
-    workspace_root: Path,
-    class_id: str,
-    assignment_id: str,
-    student_id: str,
-) -> int | None | object:
-    try:
-        manifest_path = submission_manifest_path(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-        )
-        manifest = load_submission_manifest(manifest_path)
-        pages = selected_submission_evidence_pages(manifest)
-    except (
-        OSError,
-        RuntimeError,
-        SubmissionManifestError,
-        SubmissionManifestPathError,
-        SubmissionReviewOpeningError,
-    ) as error:
-        print(f"Error: could not load selected evidence pages: {error}")
-        return _BACK
-
-    if len(pages) == 1:
-        return pages[0].page_number
-
-    _print_review_action_header(
-        "Open Submission Evidence", class_id, assignment_id, student_id
-    )
-    print("Selected evidence pages:")
-    for index, page in enumerate(pages, start=1):
-        print(
-            f"{index}. Page {page.page_number} - {page.page_state} - {page.evidence_id}"
-        )
-    print_navigation_options(all_items=True)
-    print()
-
-    choice = input("Select page: ").strip()
-    navigation = parse_navigation_choice(choice, allow_all=True)
-    print()
-    if navigation is NavigationChoice.BACK or choice == "":
-        return _BACK
-    if navigation is NavigationChoice.ALL:
-        return None
-    if choice.isdecimal():
-        index = int(choice)
-        if 1 <= index <= len(pages):
-            return pages[index - 1].page_number
-    print(f"Invalid selection. {navigation_hint(all_items=True)}")
-    return _BACK
+    clear_screen()
+    print_menu_header("Plain-Paper Submission Created")
+    print(f"Class: {created.class_id}")
+    print(f"Assignment: {created.assignment_id}")
+    print(f"Student: {student_review_label(workspace_root, class_id, student_id)}")
+    print(f"Submission: {created.submission_manifest_relative_path}")
+    print(f"Review: {created.review_record_relative_path}")
 
 
 def _menu_review_unit_observations(
@@ -2779,6 +2776,7 @@ def _prompt_reusable_comment_purpose() -> str:
     print()
     print("Purpose is broad teacher-facing organization metadata.")
     print("It describes the feedback move, not the assignment genre.")
+    print("Ratings and feedback comments remain explicit teacher choices.")
     print("It is not used for automatic scoring or automatic comment selection.")
     print('Use "general" when none of the categories fit.')
     print()
@@ -3340,57 +3338,56 @@ def _menu_manage_submission_pages(
         return
 
     _print_manageable_pages(student_status.pages)
-    print()
-    print("Actions:")
-    print("1. Exclude page from review")
-    print("2. Restore excluded page")
-    print("3. Mark page as needs rescan")
     print_navigation_options()
     print()
-    choice = input("Select an option: ").strip()
-    if choice in {"", "4"}:
+    page_number = _prompt_page_number("Select page: ")
+    selected_page = next(
+        (page for page in student_status.pages if page.page_number == page_number),
+        None,
+    )
+    if selected_page is None:
         print("Manage submission pages canceled.")
         return
-    if choice == "1":
-        _menu_change_submission_page(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-            student_status.pages,
-            action="exclude",
-        )
-    elif choice == "2":
-        _menu_change_submission_page(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-            student_status.pages,
-            action="restore",
-        )
-    elif choice == "3":
-        _menu_change_submission_page(
-            workspace_root,
-            class_id,
-            assignment_id,
-            student_id,
-            student_status.pages,
-            action="needs_rescan",
-        )
-    else:
-        print("Invalid selection. Please enter a number from 1 to 4.")
+    _print_review_action_header(
+        "Submission Page Details", class_id, assignment_id, student_id
+    )
+    print(f"Page: {selected_page.page_number}")
+    print(f"State: {_teacher_page_state_label(selected_page.page_state)}")
+    print(f"Evidence records: {selected_page.evidence_count}")
+    print(f"Selected evidence: {selected_page.selected_evidence_id or 'none'}")
+    print(f"Evidence roles: {', '.join(selected_page.evidence_roles) or 'none'}")
+    print(f"Evidence states: {', '.join(selected_page.evidence_states) or 'none'}")
+    print()
+    actions: tuple[tuple[str, str], ...] = (
+        (("restore", "Restore page to active review"),)
+        if selected_page.page_state == "excluded"
+        else (("exclude", "Exclude page from active review"),)
+    )
+    if selected_page.page_state != "needs_rescan":
+        actions += (("needs_rescan", "Mark page as needing rescan"),)
+    for index, (_, label) in enumerate(actions, start=1):
+        print(f"{index}. {label}")
+    print_navigation_options()
+    print()
+    choice = input("Select an action: ").strip()
+    if not choice.isdigit() or not 1 <= int(choice) <= len(actions):
+        print("Page action canceled.")
+        return
+    _menu_change_submission_page(
+        workspace_root,
+        class_id,
+        assignment_id,
+        student_id,
+        selected_page,
+        action=actions[int(choice) - 1][0],
+    )
 
 
-def _print_manageable_pages(pages: tuple[Any, ...]) -> None:
+def _print_manageable_pages(pages: tuple[PageStatusSummary, ...]) -> None:
     print("Pages:")
     for page in pages:
         state = _teacher_page_state_label(page.page_state)
-        selected = page.selected_evidence_id or "no selected evidence"
-        print(
-            f"{page.page_number}. Page {page.page_number} - {state} - "
-            f"selected evidence: {selected}"
-        )
+        print(f"{page.page_number}. Page {page.page_number} — {state}")
 
 
 def _teacher_page_state_label(page_state: str) -> str:
@@ -3406,7 +3403,7 @@ def _menu_change_submission_page(
     class_id: str,
     assignment_id: str,
     student_id: str,
-    pages: tuple[Any, ...],
+    page: PageStatusSummary,
     *,
     action: str,
 ) -> None:
@@ -3420,35 +3417,28 @@ def _menu_change_submission_page(
         print("This keeps the evidence file but removes the page from active review.")
         print(
             "Use this for blank pages, wrong pages, accidental scans, or pages "
-            "that should not be scored."
+            "that should not be part of the active evidence review."
         )
     elif action == "restore":
         print("This returns an excluded page to active review.")
-        print("It does not change scores, tags, comments, or feedback.")
+        print("It does not change teacher observations, ratings, or feedback.")
     else:
         print(
             "Use this when a page is missing, damaged, unreadable, incomplete, "
             "or the wrong page."
         )
-    print()
-    _print_manageable_pages(pages)
-    print("B. Back")
-    print()
-    page_number = _prompt_page_number("Select page: ")
-    if page_number is None:
-        print("Page action canceled.")
-        return
-    if page_number not in {page.page_number for page in pages}:
-        print("Page action canceled. Please choose a listed page.")
-        return
+    page_number = page.page_number
 
     confirm_labels = {
         "exclude": f"Exclude page {page_number} from active review?",
         "restore": f"Restore page {page_number} to active review?",
         "needs_rescan": f"Mark page {page_number} as needing rescan?",
     }
-    print()
+    _print_review_action_header(
+        "Confirm Page Change", class_id, assignment_id, student_id
+    )
     print(confirm_labels[action])
+    print("The evidence record and underlying file will be preserved.")
     print()
     print("1. Save page change")
     print("2. Back")
@@ -3474,11 +3464,14 @@ def _menu_change_submission_page(
         print(f"Error: page change was not saved: {error}")
         return
 
+    _print_review_action_header(
+        "Page Change Result", class_id, assignment_id, student_id
+    )
     print("Page change saved.")
     print(f"Page: {result.page_number}")
     print(f"State: {_teacher_page_state_label(result.page_state)}")
     print(f"Evidence records preserved: {result.evidence_count}")
-    print("Review notes, tags, comments, scores, and feedback were not changed.")
+    print("Teacher observations, ratings, notes, and feedback were not changed.")
 
 
 def _prompt_page_number(prompt: str) -> int | None:
@@ -3594,12 +3587,9 @@ def _menu_export_student_feedback(
     print("This creates a student feedback export from the current review record.")
     print("It does not rescore work or generate AI feedback.")
     print()
-    try:
-        record = load_review_record(
-            review_record_path(workspace_root, class_id, assignment_id, student_id)
-        )
-    except (ReviewRecordError, OSError):
-        record = None
+    record = _current_review_record(
+        workspace_root, class_id, assignment_id, student_id
+    )
     if record is not None:
         status = review_progress_status(record)
         print(f"Current review state: {status.review_state}")
@@ -3621,32 +3611,42 @@ def _menu_export_student_feedback(
         print("Export canceled.")
         return
 
-    pdf_path = feedback_pdf_export_path(
-        workspace_root, class_id, assignment_id, student_id
-    )
-    markdown_path = feedback_export_path(
-        workspace_root, class_id, assignment_id, student_id
-    )
-    selected_paths = {
-        "1": [pdf_path],
-        "2": [markdown_path],
-        "3": [pdf_path, markdown_path],
+    try:
+        status_document = student_review_status_to_dict(
+            build_student_review_status(
+                workspace_root, class_id, assignment_id, student_id
+            )
+        )
+    except (StudentReviewStatusError, OSError) as error:
+        print(f"Error: could not load feedback export status: {error}")
+        return
+    review_section = cast(dict[str, Any], status_document["review"])
+    export_section = cast(dict[str, Any], review_section["exports"])
+    export_keys = {
+        "1": ("feedback_pdf",),
+        "2": ("feedback_markdown",),
+        "3": ("feedback_pdf", "feedback_markdown"),
     }[export_choice]
+    selected_exports = [
+        cast(dict[str, Any], export_section[key]) for key in export_keys
+    ]
     _print_review_action_header(
         "Export Student Feedback", class_id, assignment_id, student_id
     )
     print(f"Export type: {_student_feedback_export_choice_label(export_choice)}")
     print("Output files:")
-    for path in selected_paths:
-        print(f"- {path}")
+    for export in selected_exports:
+        print(f"- {export['path']}")
     overwrite: bool
-    existing_paths = [path for path in selected_paths if path.exists()]
-    if existing_paths:
+    existing_exports = [
+        export for export in selected_exports if export["file_present"] is True
+    ]
+    if existing_exports:
         print()
         print("A feedback export already exists.")
         print("Existing output files:")
-        for path in existing_paths:
-            print(f"- {path}")
+        for export in existing_exports:
+            print(f"- {export['path']}")
         print()
         print("1. Keep existing export and cancel")
         print("2. Overwrite existing export")
@@ -3789,18 +3789,15 @@ def _launch_assignment_review_actions(
             input("Press Enter to continue...")
             return 1
 
-        print(
-            format_assignment_review_dashboard(
-                dashboard, show_unused_duplicate_files=False
-            )
-        )
+        _print_compact_assignment_dashboard(dashboard)
         print()
 
         print("1. Select student/submission")
-        print("2. Assemble routed submissions")
-        print("3. Export assignment-local class summary — Comprehensive Class Summary")
-        print("4. Export assignment-local Focus Standard summary — Standards Summary")
-        print("5. Export Student Performance Summary")
+        print("2. View submission status")
+        print("3. Review scan problems")
+        print("4. Export reports")
+        print("5. View full diagnostic dashboard")
+        print("6. Refresh")
         print_navigation_options()
         print()
 
@@ -3808,7 +3805,7 @@ def _launch_assignment_review_actions(
         navigation = parse_navigation_choice(choice)
         print()
 
-        if choice in {"", "6"} or navigation is NavigationChoice.BACK:
+        if choice == "" or navigation is NavigationChoice.BACK:
             return 0
         elif choice == "1":
             student_id = _prompt_student_id(
@@ -3822,19 +3819,114 @@ def _launch_assignment_review_actions(
                     student_id,
                 )
         elif choice == "2":
-            _assemble_assignment(workspace_root, class_id, assignment_id)
+            clear_screen()
+            print_menu_header("Assignment Submission Status")
+            status = _load_submission_status(
+                workspace_root, class_id, assignment_id
+            )
+            if status is not None:
+                from quillan.cli_app.output import print_assignment_submission_status
+
+                print_assignment_submission_status(status, workspace_root)
             input("Press Enter to continue...")
         elif choice == "3":
-            _menu_export_class_summary(workspace_root, class_id, assignment_id)
-            input("Press Enter to continue...")
+            from quillan.scan_review_menu import launch_scan_review_resolution_menu
+
+            launch_scan_review_resolution_menu(
+                workspace_root, class_id, assignment_id
+            )
         elif choice == "4":
-            _menu_export_standards_summary(workspace_root, class_id, assignment_id)
-            input("Press Enter to continue...")
+            _menu_export_assignment_reports(
+                workspace_root, class_id, assignment_id
+            )
         elif choice == "5":
+            clear_screen()
+            print_menu_header("Full Assignment Diagnostic Dashboard")
+            print(
+                format_assignment_review_dashboard(
+                    dashboard, show_unused_duplicate_files=False
+                )
+            )
+            input("Press Enter to continue...")
+        elif choice == "6":
+            continue
+        else:
+            print("Invalid selection. Please choose a listed action.")
+            input("Press Enter to continue...")
+
+
+def _print_compact_assignment_dashboard(
+    dashboard: AssignmentReviewDashboard,
+) -> None:
+    submissions = dict(dashboard.submission_counts)
+    routed = dict(dashboard.routed_counts)
+    pages = dict(dashboard.page_counts)
+    reviews = dict(dashboard.review_counts)
+    scan_review = dict(dashboard.scan_review_counts)
+    page_problem_count = sum(
+        pages.get(state, 0)
+        for state in ("missing", "duplicate", "needs_rescan", "present_unselected")
+    )
+    print(f"Class: {dashboard.class_id}")
+    print(f"Assignment: {dashboard.assignment_title} ({dashboard.assignment_id})")
+    print(f"Students: {len(dashboard.students)}")
+    print(
+        "Submissions: "
+        f"valid={submissions['valid']}; missing={submissions['missing']}; "
+        f"invalid={submissions['invalid']}"
+    )
+    print(f"Assembly needed: {routed['students_needing_assembly']}")
+    print(f"Page problems: {page_problem_count}")
+    print(
+        "Reviews: "
+        f"valid={reviews['valid']}; missing={reviews['missing']}; "
+        f"invalid={reviews['invalid']}"
+    )
+    print(
+        "Feedback PDFs: "
+        + "; ".join(
+            f"{state}={count}" for state, count in dashboard.feedback_pdf_counts
+        )
+    )
+    print(f"Active Core scan-review items: {scan_review['attention_items']}")
+    print(f"Warnings: {len(dashboard.warnings)}")
+
+
+def _menu_export_assignment_reports(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> None:
+    from quillan.menu import clear_screen, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    while True:
+        clear_screen()
+        print_menu_header("Assignment Reports")
+        print(f"Class: {class_id}")
+        print(f"Assignment: {assignment_id}")
+        print()
+        print("1. Comprehensive Class Summary")
+        print("2. Focus Standard Summary")
+        print("3. Student Performance Summary")
+        print("B. Back")
+        print()
+        choice = input("Select report: ").strip()
+        if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+            return
+        clear_screen()
+        if choice == "1":
+            print_menu_header("Export Comprehensive Class Summary")
+            _menu_export_class_summary(workspace_root, class_id, assignment_id)
+        elif choice == "2":
+            print_menu_header("Export Focus Standard Summary")
+            _menu_export_standards_summary(workspace_root, class_id, assignment_id)
+        elif choice == "3":
+            print_menu_header("Export Student Performance Summary")
             _menu_export_student_performance_summary(
                 workspace_root, class_id, assignment_id
             )
-            input("Press Enter to continue...")
         else:
-            print("Invalid selection. Please enter a number from 1 to 6.")
-            input("Press Enter to continue...")
+            continue
+        print()
+        input("Press Enter to return to reports...")

--- a/quillan/roster_workflows.py
+++ b/quillan/roster_workflows.py
@@ -513,9 +513,9 @@ def prompt_view_roster() -> int:
     print(
         format_roster_for_display(
             roster,
-            folder.roster_path,
+            folder.roster_path.relative_to(workspace_root).as_posix(),
             metadata=metadata,
-            metadata_path=folder.metadata_path,
+            metadata_path=folder.metadata_path.relative_to(workspace_root).as_posix(),
             metadata_error=metadata_error,
         )
     )
@@ -607,9 +607,11 @@ def prompt_edit_class_roster() -> int:
                 print(
                     format_roster_for_display(
                         staged_roster,
-                        folder.roster_path,
+                        folder.roster_path.relative_to(workspace_root).as_posix(),
                         metadata=metadata,
-                        metadata_path=folder.metadata_path,
+                        metadata_path=(
+                            folder.metadata_path.relative_to(workspace_root).as_posix()
+                        ),
                         metadata_error=metadata_error,
                     )
                 )
@@ -789,7 +791,7 @@ def launch_roster_menu() -> int:
             navigation = parse_navigation_choice(choice)
             print()
 
-            if choice == "5" or navigation is NavigationChoice.BACK:
+            if navigation is NavigationChoice.BACK:
                 return 0
             workflows = {
                 "1": prompt_create_roster,

--- a/quillan/scan_review_menu.py
+++ b/quillan/scan_review_menu.py
@@ -2,29 +2,249 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
+from pds_core.classes import list_class_folders
+from pds_core.routing_models import ModuleWorkRef
+
+from quillan.assignment_discovery import discover_quillan_assignments
+from quillan.assignment_submission_assembly import assemble_assignment_submissions
+from quillan.cli_app.output import (
+    print_assignment_submission_assembly,
+    print_assignment_submission_status,
+)
+from quillan.post_dispatch_review_resolution import (
+    POST_DISPATCH_GENERIC_RESOLUTION_ACTIONS,
+    PostDispatchReviewItem,
+    PostDispatchReviewResolutionError,
+    discover_post_dispatch_review_items,
+    open_post_dispatch_possible_path,
+    post_dispatch_retry_proves_resolution,
+    resolve_post_dispatch_after_successful_retry,
+    resolve_post_dispatch_review_occurrence,
+)
 from quillan.scan_review_resolution import (
     DEFAULT_RESOLUTION_MESSAGES,
     QuillanReviewItem,
+    QuillanRouteOption,
     ScanReviewResolutionError,
+    discover_scan_review_route_options,
     discover_scan_review_items,
     resolve_scan_review_item,
 )
+from quillan.student_display import student_display_lookup
+from quillan.submission_status import list_assignment_submission_status
+from quillan.work_paths import quillan_work_ref
 
 _ACTIONS: tuple[tuple[str, str], ...] = (
+    ("route_selected", "Use selected registered route"),
+    ("route_corrected", "Correct to selected registered route"),
     ("rescan_needed", "Rescan needed"),
     ("cannot_route", "Cannot route safely"),
-    ("mixed_assignment", "Mixed assignment"),
     ("evidence_filed", "Evidence filed elsewhere"),
     ("dismissed_duplicate", "Dismiss duplicate"),
-    ("defer", "Defer for later"),
+    ("deferred", "Defer for later"),
     ("other", "Other"),
 )
 
+_POST_ACTION_LABELS = {
+    "resolved_after_retry": "Resolved after an explicit successful retry",
+    "rescan_needed": "Rescan needed",
+    "record_corrected": "Record corrected",
+    "cannot_recover": "Cannot recover safely",
+    "dismissed_duplicate": "Dismiss duplicate",
+    "deferred": "Defer for later",
+    "other": "Other",
+}
 
-def launch_scan_review_resolution_menu(workspace_root: Path) -> int:
-    """List active review items and write teacher-selected resolutions."""
+
+def launch_scan_review_resolution_menu(
+    workspace_root: Path,
+    class_id: str | None = None,
+    assignment_id: str | None = None,
+) -> int:
+    """Open the coherent Core/post-dispatch Scan Review workflow."""
+    if (class_id is None) != (assignment_id is None):
+        raise ValueError("class_id and assignment_id must be supplied together.")
+    try:
+        core = discover_scan_review_items(
+            workspace_root,
+            class_id=class_id,
+            assignment_id=assignment_id,
+        )
+        if class_id is None or assignment_id is None:
+            work_refs = set(_active_scan_review_work_refs(workspace_root))
+            for item in core.items:
+                if item.class_id is None or item.assignment_id is None:
+                    continue
+                try:
+                    work_refs.add(
+                        quillan_work_ref(item.class_id, item.assignment_id)
+                    )
+                except (TypeError, ValueError):
+                    continue
+            if not work_refs and not core.items:
+                return _launch_core_review_menu(workspace_root)
+            return _launch_global_scan_review_menu(
+                workspace_root,
+                tuple(
+                    sorted(
+                        work_refs,
+                        key=lambda item: (item.class_id, item.work_id),
+                    )
+                ),
+                has_unscoped=any(
+                    item.class_id is None or item.assignment_id is None
+                    for item in core.items
+                ),
+                has_core=bool(core.items),
+            )
+        post = discover_post_dispatch_review_items(
+            workspace_root, quillan_work_ref(class_id, assignment_id)
+        )
+    except (ScanReviewResolutionError, PostDispatchReviewResolutionError) as error:
+        from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+        clear_screen()
+        print_menu_header("Scan Review")
+        print(f"Error: {error}")
+        print()
+        pause_for_user()
+        return 1
+    if not post.items:
+        return _launch_core_review_menu(workspace_root, class_id, assignment_id)
+    if not core.items:
+        return _launch_post_dispatch_review_menu(
+            workspace_root, class_id, assignment_id
+        )
+    return _launch_review_source_menu(workspace_root, class_id, assignment_id)
+
+
+def _launch_global_scan_review_menu(
+    workspace_root: Path,
+    work_refs: tuple[ModuleWorkRef, ...],
+    *,
+    has_unscoped: bool,
+    has_core: bool,
+) -> int:
+    """Keep scoped, unscoped, and global Core review paths reachable."""
+    from quillan.menu import clear_screen, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    while True:
+        clear_screen()
+        print_menu_header("Scan Review")
+        if work_refs:
+            print("1. Select assignment-scoped problems")
+        if has_unscoped:
+            print("2. Unscoped Core routing problems")
+        if has_core:
+            print("3. All Core routing problems")
+        print("B. Back")
+        print()
+        choice = input("Select scan review scope: ").strip()
+        if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+            return 0
+        if choice == "1" and work_refs:
+            selected = _prompt_scan_review_work(work_refs)
+            if selected is not None:
+                launch_scan_review_resolution_menu(
+                    workspace_root, selected.class_id, selected.work_id
+                )
+        elif choice == "2" and has_unscoped:
+            _launch_core_review_menu(workspace_root, unscoped_only=True)
+        elif choice == "3" and has_core:
+            _launch_core_review_menu(workspace_root)
+
+
+def _active_scan_review_work_refs(
+    workspace_root: Path,
+) -> tuple[ModuleWorkRef, ...]:
+    """Return deterministic work refs with active Quillan post-dispatch items."""
+    refs: set[ModuleWorkRef] = set()
+    for folder in list_class_folders(workspace_root):
+        for assignment in discover_quillan_assignments(
+            workspace_root, folder.class_id
+        ):
+            try:
+                work_ref = quillan_work_ref(folder.class_id, assignment.assignment_id)
+                discovery = discover_post_dispatch_review_items(
+                    workspace_root, work_ref
+                )
+            except PostDispatchReviewResolutionError:
+                continue
+            if discovery.items:
+                refs.add(work_ref)
+    return tuple(sorted(refs, key=lambda item: (item.class_id, item.work_id)))
+
+
+def _prompt_scan_review_work(
+    work_refs: tuple[ModuleWorkRef, ...],
+) -> ModuleWorkRef | None:
+    from quillan.menu import clear_screen, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    if type(work_refs) is not tuple or any(
+        type(item) is not ModuleWorkRef for item in work_refs
+    ):
+        raise ValueError("work_refs must contain exact ModuleWorkRef values.")
+    clear_screen()
+    print_menu_header("Select Scan Review Assignment")
+    for index, work_ref in enumerate(work_refs, start=1):
+        print(
+            f"{index}. Class: {work_ref.class_id}; "
+            f"Assignment: {work_ref.work_id}"
+        )
+    print("B. Back")
+    print()
+    choice = input("Select assignment work: ").strip()
+    if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+        return None
+    if choice.isdigit() and 1 <= int(choice) <= len(work_refs):
+        return work_refs[int(choice) - 1]
+    return None
+
+
+def _launch_review_source_menu(
+    workspace_root: Path, class_id: str, assignment_id: str
+) -> int:
+    from quillan.menu import clear_screen, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    while True:
+        clear_screen()
+        print_menu_header("Scan Review")
+        print(f"Class: {class_id}")
+        print(f"Assignment: {assignment_id}")
+        print()
+        print("1. Core routing problems")
+        print("2. Quillan post-dispatch problems")
+        print("3. All active problems")
+        print("B. Back")
+        print()
+        choice = input("Select problem source: ").strip()
+        if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+            return 0
+        if choice == "1":
+            _launch_core_review_menu(workspace_root, class_id, assignment_id)
+        elif choice == "2":
+            _launch_post_dispatch_review_menu(
+                workspace_root, class_id, assignment_id
+            )
+        elif choice == "3":
+            _launch_combined_review_menu(workspace_root, class_id, assignment_id)
+
+
+def _launch_core_review_menu(
+    workspace_root: Path,
+    class_id: str | None = None,
+    assignment_id: str | None = None,
+    *,
+    unscoped_only: bool = False,
+) -> int:
+    """List Core-owned items and write Core-owned resolutions."""
     from quillan.menu import clear_screen, pause_for_user, print_menu_header
     from quillan.menu_navigation import (
         NavigationChoice,
@@ -37,7 +257,20 @@ def launch_scan_review_resolution_menu(workspace_root: Path) -> int:
         clear_screen()
         print_menu_header("Resolve Scan Review Items")
         try:
-            discovery = discover_scan_review_items(workspace_root)
+            discovery = discover_scan_review_items(
+                workspace_root,
+                class_id=class_id,
+                assignment_id=assignment_id,
+            )
+            if unscoped_only:
+                discovery = type(discovery)(
+                    items=tuple(
+                        item
+                        for item in discovery.items
+                        if item.class_id is None or item.assignment_id is None
+                    ),
+                    warnings=discovery.warnings,
+                )
         except ScanReviewResolutionError as error:
             print(f"Error: {error}")
             print()
@@ -78,31 +311,48 @@ def launch_scan_review_resolution_menu(workspace_root: Path) -> int:
             continue
 
         item = discovery.items[int(choice) - 1]
-        action = _prompt_action(item)
-        if action is None:
-            continue
-        message = _prompt_message(action)
-        if message is None:
-            continue
-        evidence_path = _prompt_evidence_path() if action == "evidence_filed" else None
+        _resolve_core_item(workspace_root, item)
 
-        clear_screen()
-        print_menu_header("Scan Review Result")
-        try:
-            result = resolve_scan_review_item(
-                workspace_root,
-                item.failure_id,
-                action=action,
-                message=message,
-                evidence_path=evidence_path,
-            )
-        except ScanReviewResolutionError as error:
-            print(f"Could not save the scan review decision: {error}")
-        else:
-            print(f"Scan review item {result.resolution_status}.")
-            print(f"Resolution record: {result.resolution_metadata_relative_path}")
-        print()
-        pause_for_user()
+
+def _resolve_core_item(workspace_root: Path, item: QuillanReviewItem) -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    action = _prompt_action(item)
+    if action is None:
+        return
+    route = (
+        _prompt_route_option(workspace_root, item)
+        if action in {"route_selected", "route_corrected"}
+        else None
+    )
+    if action in {"route_selected", "route_corrected"} and route is None:
+        return
+    message = _prompt_message(action)
+    if message is None:
+        return
+    evidence_path = _prompt_evidence_path() if action == "evidence_filed" else None
+    if not _confirm_core_resolution(item, action, route):
+        return
+    clear_screen()
+    print_menu_header("Core Routing Review Result")
+    try:
+        result = resolve_scan_review_item(
+            workspace_root,
+            item.failure_id,
+            action=action,
+            message=message,
+            evidence_path=evidence_path,
+            route_locator=None if route is None else route.locator,
+            target=None if route is None else route.target,
+        )
+    except ScanReviewResolutionError as error:
+        print(f"Could not save the Core routing-review decision: {error}")
+    else:
+        print(f"Core routing-review item {result.resolution_status}.")
+        print(f"Failure ID: {result.failure_id}")
+        print(f"Resolution record: {result.resolution_metadata_relative_path}")
+    print()
+    pause_for_user()
 
 
 def _prompt_action(item: QuillanReviewItem) -> str | None:
@@ -138,6 +388,467 @@ def _prompt_action(item: QuillanReviewItem) -> str | None:
     if choice.isdigit() and 1 <= int(choice) <= len(_ACTIONS):
         return _ACTIONS[int(choice) - 1][0]
     return None
+
+
+def _prompt_route_option(
+    workspace_root: Path, item: QuillanReviewItem
+) -> QuillanRouteOption | None:
+    from quillan.assignment_picker import prompt_assignment_choice
+    from quillan.menu import clear_screen, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    class_id, assignment_id = item.class_id, item.assignment_id
+    if class_id is None or assignment_id is None:
+        clear_screen()
+        print_menu_header("Select Route Work")
+        chosen_assignment = prompt_assignment_choice(workspace_root)
+        if chosen_assignment is None:
+            return None
+        class_id = chosen_assignment.class_id
+        assignment_id = chosen_assignment.assignment_id
+    try:
+        discovery = discover_scan_review_route_options(
+            workspace_root, class_id, assignment_id
+        )
+    except ScanReviewResolutionError as error:
+        clear_screen()
+        print_menu_header("Select Registered Route")
+        print(f"Could not load route choices: {error}")
+        input("Press Enter to return...")
+        return None
+    clear_screen()
+    print_menu_header("Select Registered Route")
+    print(f"Class: {class_id}")
+    print(f"Assignment: {assignment_id}")
+    print()
+    labels = student_display_lookup(workspace_root, class_id)
+    for index, route in enumerate(discovery.routes, start=1):
+        student = labels.get(route.student_id, route.student_id)
+        print(
+            f"{index}. {student}; page {route.logical_page}/{route.total_pages}; "
+            f"route {route.locator.route_id}"
+        )
+    if discovery.warnings:
+        print(f"Skipped invalid routes: {len(discovery.warnings)}")
+    if not discovery.routes:
+        print("No valid current Quillan routes are available for this assignment.")
+        input("Press Enter to return...")
+        return None
+    print("B. Back")
+    print()
+    choice = input("Select route: ").strip()
+    if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+        return None
+    if choice.isdigit() and 1 <= int(choice) <= len(discovery.routes):
+        selected_route = discovery.routes[int(choice) - 1]
+    else:
+        return None
+    clear_screen()
+    print_menu_header("Registered Route Details")
+    print(
+        f"Student: {labels.get(selected_route.student_id, selected_route.student_id)}"
+    )
+    print(
+        f"Logical page: {selected_route.logical_page} of {selected_route.total_pages}"
+    )
+    print(f"Route ID: {selected_route.locator.route_id}")
+    print(f"Page record ID: {selected_route.target.record_id}")
+    print()
+    confirmation = input("Use this registered route? [y/N]: ").strip().casefold()
+    return selected_route if confirmation in {"y", "yes"} else None
+
+
+def _confirm_core_resolution(
+    item: QuillanReviewItem,
+    action: str,
+    route: QuillanRouteOption | None,
+) -> bool:
+    from quillan.menu import clear_screen, print_menu_header
+
+    clear_screen()
+    print_menu_header("Confirm Core Routing Review Decision")
+    print(f"Failure ID: {item.failure_id}")
+    print(f"Action: {action}")
+    if route is not None:
+        print(f"Selected route: {route.locator.route_id}")
+        print(f"Selected page record: {route.target.record_id}")
+    print("This appends an immutable Core resolution record.")
+    print()
+    return input("Save this decision? [y/N]: ").strip().casefold() in {"y", "yes"}
+
+
+def _launch_post_dispatch_review_menu(
+    workspace_root: Path, class_id: str, assignment_id: str
+) -> int:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    while True:
+        clear_screen()
+        print_menu_header("Quillan Post-Dispatch Problems")
+        try:
+            discovery = discover_post_dispatch_review_items(
+                workspace_root, quillan_work_ref(class_id, assignment_id)
+            )
+        except PostDispatchReviewResolutionError as error:
+            print(f"Error: {error}")
+            print()
+            pause_for_user()
+            return 1
+        if not discovery.items:
+            print("There are no unresolved or deferred post-dispatch problems.")
+            print()
+            pause_for_user()
+            return 0
+        for index, item in enumerate(discovery.items, start=1):
+            occurrence = item.occurrence.occurrence
+            student = occurrence.student_id or "assignment-level"
+            print(
+                f"{index}. {occurrence.category}; {student}; "
+                f"{item.display_status}"
+            )
+        if discovery.warnings:
+            print(f"Skipped malformed records: {len(discovery.warnings)}")
+        print("B. Back")
+        print()
+        choice = input("Select a post-dispatch problem: ").strip()
+        if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+            return 0
+        if choice.isdigit() and 1 <= int(choice) <= len(discovery.items):
+            _resolve_post_dispatch_item(
+                workspace_root, discovery.items[int(choice) - 1]
+            )
+
+
+def _resolve_post_dispatch_item(
+    workspace_root: Path, item: PostDispatchReviewItem
+) -> None:
+    from quillan.menu import clear_screen, print_menu_header
+
+    occurrence = item.occurrence.occurrence
+    clear_screen()
+    print_menu_header("Post-Dispatch Problem Details")
+    print(f"Category: {occurrence.category}")
+    print(f"Stage: {occurrence.stage}")
+    print(f"What failed: {occurrence.failure_message}")
+    print(f"Class: {occurrence.class_id}")
+    print(f"Assignment: {occurrence.assignment_id}")
+    print(f"Student: {occurrence.student_id or 'assignment-level'}")
+    print(f"Issuances: {len(occurrence.issuance_ids)}")
+    print(f"Pages: {len(occurrence.page_ids)}")
+    print(f"Observations: {len(occurrence.observation_ids)}")
+    if occurrence.issuance_ids:
+        print(f"Issuance IDs: {', '.join(occurrence.issuance_ids)}")
+    if occurrence.page_ids:
+        print(f"Page IDs: {', '.join(occurrence.page_ids)}")
+    if occurrence.route_ids:
+        print(f"Route IDs: {', '.join(occurrence.route_ids)}")
+    if occurrence.observation_ids:
+        print(f"Observation IDs: {', '.join(occurrence.observation_ids)}")
+    if occurrence.source_scan_ids:
+        print(f"Source scan IDs: {', '.join(occurrence.source_scan_ids)}")
+    for path in (
+        *occurrence.possible_evidence_paths,
+        *occurrence.possible_manifest_paths,
+    ):
+        print(f"Possible durable path: {path}")
+    print(f"Occurrence: {item.occurrence.relative_path}")
+    print()
+    input("Press Enter to choose an action...")
+    _launch_post_dispatch_context_actions(workspace_root, item)
+
+
+def _launch_post_dispatch_context_actions(
+    workspace_root: Path,
+    item: PostDispatchReviewItem,
+) -> None:
+    from quillan.menu import clear_screen, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    occurrence = item.occurrence.occurrence
+    retry_supported = occurrence.category in {
+        "submission_assembly",
+        "mixed_issuance",
+        "manifest_conflict",
+    }
+    actions: list[tuple[str, str]] = []
+    if retry_supported:
+        actions.append(("retry", "Retry submission assembly"))
+    actions.append(("status", "View current submission status"))
+    if occurrence.possible_evidence_paths:
+        actions.append(("evidence", "Open validated possible evidence"))
+    if occurrence.possible_manifest_paths:
+        actions.append(("manifest", "Open validated possible manifest"))
+    actions.append(("resolve", "Record another resolution"))
+
+    clear_screen()
+    print_menu_header("Choose Post-Dispatch Action")
+    print(f"Class: {occurrence.class_id}")
+    print(f"Assignment: {occurrence.assignment_id}")
+    print(f"Failure ID: {occurrence.failure_id}")
+    print()
+    for index, (_, label) in enumerate(actions, start=1):
+        print(f"{index}. {label}")
+    print("B. Back")
+    print()
+    choice = input("Select an action: ").strip()
+    if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+        return
+    if not choice.isdigit() or not 1 <= int(choice) <= len(actions):
+        return
+    action = actions[int(choice) - 1][0]
+    if action == "retry":
+        _retry_post_dispatch_assembly(workspace_root, item)
+    elif action == "status":
+        _view_post_dispatch_status(workspace_root, item)
+    elif action == "evidence":
+        _open_post_dispatch_context_path(workspace_root, item, "evidence")
+    elif action == "manifest":
+        _open_post_dispatch_context_path(workspace_root, item, "manifest")
+    else:
+        _record_post_dispatch_resolution(workspace_root, item)
+
+
+def _record_post_dispatch_resolution(
+    workspace_root: Path,
+    item: PostDispatchReviewItem,
+) -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    occurrence = item.occurrence.occurrence
+    actions = tuple(POST_DISPATCH_GENERIC_RESOLUTION_ACTIONS)
+    clear_screen()
+    print_menu_header("Record Post-Dispatch Resolution")
+    for index, action in enumerate(actions, start=1):
+        print(f"{index}. {_POST_ACTION_LABELS[action]}")
+    print("B. Back")
+    print()
+    choice = input("Select a resolution: ").strip()
+    if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+        return
+    if not choice.isdigit() or not 1 <= int(choice) <= len(actions):
+        return
+    action = actions[int(choice) - 1]
+    clear_screen()
+    print_menu_header("Post-Dispatch Review Note")
+    prompt = "Teacher message (required): " if action == "other" else "Teacher message (optional): "
+    message = input(prompt).strip() or None
+    if action == "other" and message is None:
+        return
+    clear_screen()
+    print_menu_header("Confirm Post-Dispatch Decision")
+    print(f"Failure ID: {occurrence.failure_id}")
+    print(f"Action: {action}")
+    print("The occurrence and all durable work records remain unchanged.")
+    print()
+    if input("Save this decision? [y/N]: ").strip().casefold() not in {"y", "yes"}:
+        return
+    clear_screen()
+    print_menu_header("Post-Dispatch Review Result")
+    try:
+        result = resolve_post_dispatch_review_occurrence(
+            workspace_root,
+            item.occurrence.work_ref,
+            occurrence.failure_id,
+            action=action,
+            message=message,
+        )
+    except PostDispatchReviewResolutionError as error:
+        print(f"Could not save the post-dispatch decision: {error}")
+    else:
+        print(f"Post-dispatch occurrence {result.resolution.status}.")
+        print(f"Failure ID: {result.resolution.failure_id}")
+        print(f"Resolution record: {result.relative_path}")
+    print()
+    pause_for_user()
+
+
+def _retry_post_dispatch_assembly(
+    workspace_root: Path,
+    item: PostDispatchReviewItem,
+) -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    occurrence = item.occurrence.occurrence
+    clear_screen()
+    print_menu_header("Retry Submission Assembly")
+    print(f"Class: {occurrence.class_id}")
+    print(f"Assignment: {occurrence.assignment_id}")
+    print()
+    try:
+        result = assemble_assignment_submissions(
+            workspace_root,
+            occurrence.class_id,
+            occurrence.assignment_id,
+        )
+    except Exception as error:
+        clear_screen()
+        print_menu_header("Submission Assembly Retry Result")
+        print(f"Submission assembly retry failed: {error}")
+        print("The occurrence remains active; no resolution was recorded.")
+        print()
+        pause_for_user()
+        return
+    clear_screen()
+    print_menu_header("Submission Assembly Retry Result")
+    print_assignment_submission_assembly(result, workspace_root)
+    completed_at = datetime.now(timezone.utc).isoformat(timespec="microseconds")
+    if not post_dispatch_retry_proves_resolution(
+        item.occurrence,
+        result,
+        completed_at=completed_at,
+    ):
+        print()
+        print(
+            "The retry completed without an operational failure, but it did not "
+            "prove that this occurrence was resolved."
+        )
+        print("The occurrence remains active; no resolution was recorded.")
+        print()
+        pause_for_user()
+        return
+    print()
+    print("The retry completed successfully.")
+    confirm = input(
+        "Record this occurrence as resolved after retry? [y/N]: "
+    ).strip().casefold()
+    if confirm not in {"y", "yes"}:
+        print("No resolution was recorded.")
+        print()
+        pause_for_user()
+        return
+    try:
+        resolution = resolve_post_dispatch_after_successful_retry(
+            workspace_root,
+            item.occurrence.work_ref,
+            occurrence.failure_id,
+            assembly_result=result,
+            completed_at=completed_at,
+        )
+    except PostDispatchReviewResolutionError as error:
+        clear_screen()
+        print_menu_header("Retry Resolution Result")
+        print(f"Could not record the successful retry: {error}")
+    else:
+        clear_screen()
+        print_menu_header("Retry Resolution Result")
+        print(f"Resolution record: {resolution.relative_path}")
+    print()
+    pause_for_user()
+
+
+def _view_post_dispatch_status(
+    workspace_root: Path,
+    item: PostDispatchReviewItem,
+) -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    occurrence = item.occurrence.occurrence
+    clear_screen()
+    print_menu_header("Current Submission Status")
+    print(f"Class: {occurrence.class_id}")
+    print(f"Assignment: {occurrence.assignment_id}")
+    print()
+    try:
+        status = list_assignment_submission_status(
+            workspace_root, occurrence.class_id, occurrence.assignment_id
+        )
+    except Exception as error:
+        print(f"Could not load current submission status: {error}")
+    else:
+        print_assignment_submission_status(status, workspace_root)
+    print()
+    pause_for_user()
+
+
+def _open_post_dispatch_context_path(
+    workspace_root: Path,
+    item: PostDispatchReviewItem,
+    kind: Literal["evidence", "manifest"],
+) -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    occurrence = item.occurrence.occurrence
+    paths = (
+        occurrence.possible_evidence_paths
+        if kind == "evidence"
+        else occurrence.possible_manifest_paths
+    )
+    clear_screen()
+    print_menu_header(f"Open Validated Possible {kind.title()}")
+    for index, path in enumerate(paths, start=1):
+        print(f"{index}. {path}")
+    print("B. Back")
+    print()
+    choice = input(f"Select possible {kind}: ").strip()
+    if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+        return
+    if not choice.isdigit() or not 1 <= int(choice) <= len(paths):
+        return
+    selected = paths[int(choice) - 1]
+    clear_screen()
+    print_menu_header(f"Open Possible {kind.title()} Result")
+    try:
+        opened = open_post_dispatch_possible_path(
+            workspace_root,
+            item.occurrence.work_ref,
+            occurrence.failure_id,
+            kind=kind,
+            relative_path=selected,
+        )
+    except PostDispatchReviewResolutionError as error:
+        print(f"Could not open the possible {kind}: {error}")
+    else:
+        print(f"Opened validated {kind}: {opened.relative_path}")
+        print("The occurrence remains active; no resolution was recorded.")
+    print()
+    pause_for_user()
+
+
+def _launch_combined_review_menu(
+    workspace_root: Path, class_id: str, assignment_id: str
+) -> int:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+    from quillan.menu_navigation import NavigationChoice, parse_navigation_choice
+
+    while True:
+        core = discover_scan_review_items(
+            workspace_root, class_id=class_id, assignment_id=assignment_id
+        )
+        post = discover_post_dispatch_review_items(
+            workspace_root, quillan_work_ref(class_id, assignment_id)
+        )
+        combined: tuple[tuple[str, QuillanReviewItem | PostDispatchReviewItem], ...] = (
+            *(("Core", item) for item in core.items),
+            *(("Post-dispatch", item) for item in post.items),
+        )
+        clear_screen()
+        print_menu_header("All Active Scan Problems")
+        if not combined:
+            print("There are no active scan problems for this assignment.")
+            print()
+            pause_for_user()
+            return 0
+        for index, (source, item) in enumerate(combined, start=1):
+            if isinstance(item, QuillanReviewItem):
+                label = f"{item.source_filename}; {item.failure_category}"
+            else:
+                occurrence = item.occurrence.occurrence
+                label = f"{occurrence.category}; {occurrence.student_id or 'assignment-level'}"
+            print(f"{index}. {source}: {label}")
+        print("B. Back")
+        print()
+        choice = input("Select a problem: ").strip()
+        if choice == "" or parse_navigation_choice(choice) is NavigationChoice.BACK:
+            return 0
+        if choice.isdigit() and 1 <= int(choice) <= len(combined):
+            _, selected = combined[int(choice) - 1]
+            if isinstance(selected, QuillanReviewItem):
+                _resolve_core_item(workspace_root, selected)
+            else:
+                _resolve_post_dispatch_item(workspace_root, selected)
 
 
 def _prompt_message(action: str) -> str | None:

--- a/quillan/scan_review_resolution.py
+++ b/quillan/scan_review_resolution.py
@@ -10,9 +10,18 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Final
 
-from pds_core.identifiers import validate_identifier
-from pds_core.route_registrations import load_route_registration
-from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef, RouteLocator
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.route_registrations import (
+    RouteRegistrationPersistenceError,
+    load_route_registration,
+)
+from pds_core.routes import module_routes_dir
+from pds_core.routing_models import (
+    ModuleRecordRef,
+    ModuleWorkRef,
+    RouteLocator,
+    RoutingModelError,
+)
 from pds_core.scan_failure_metadata import (
     ROUTING_FAILURE_SCHEMA_VERSION,
     RoutingFailureMetadata,
@@ -41,8 +50,12 @@ from quillan.pds_contract import (
 from quillan.printable_response_persistence import (
     PrintableResponsePersistenceError,
     load_printable_response_page,
+    load_printable_response_page_context,
 )
-from quillan.work_paths import quillan_work_paths
+from quillan.printable_response_records import response_page_target
+from quillan.printable_response_routes import validate_route_id
+from quillan.printable_response_routes import PrintableResponseRouteError
+from quillan.work_paths import QuillanWorkPathError, quillan_work_paths
 from quillan.work_paths import (
     _preflight_arbitrary_file_destination,
     _preflight_path_chain,
@@ -132,6 +145,85 @@ class QuillanReviewDiscovery:
 
     items: tuple[QuillanReviewItem, ...]
     warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanRouteOption:
+    """One current registered Quillan response-page route for teacher selection."""
+
+    locator: RouteLocator
+    target: ModuleRecordRef
+    student_id: str
+    logical_page: int
+    total_pages: int
+
+
+@dataclass(frozen=True, slots=True)
+class QuillanRouteDiscovery:
+    """Valid route choices and conservative malformed-registration warnings."""
+
+    routes: tuple[QuillanRouteOption, ...]
+    warnings: tuple[str, ...]
+
+
+def discover_scan_review_route_options(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> QuillanRouteDiscovery:
+    """List valid current response-page routes within one exact Quillan work."""
+    root = _workspace_root(workspace_root)
+    work_ref = ModuleWorkRef(QUILLAN_MODULE_ID, class_id, assignment_id)
+    directory = module_routes_dir(root, work_ref)
+    if not os.path.lexists(directory):
+        return QuillanRouteDiscovery((), ())
+    try:
+        _preflight_path_chain(root=root, target=directory, expect_file=False)
+        children = tuple(sorted(directory.iterdir(), key=lambda path: path.name))
+    except (OSError, RuntimeError, ValueError) as error:
+        return QuillanRouteDiscovery((), (f"Could not inspect route directory: {error}",))
+    routes: list[QuillanRouteOption] = []
+    warnings: list[str] = []
+    for path in children:
+        if path.suffix != ".json":
+            continue
+        try:
+            _preflight_arbitrary_file_destination(path)
+            route_id = validate_route_id(path.stem)
+            locator = RouteLocator("PDS2", work_ref, route_id)
+            registration = load_route_registration(root, locator)
+            if registration.status != "active":
+                continue
+            context = load_printable_response_page_context(
+                root, work_ref, registration.target.record_id
+            )
+            if registration.target != response_page_target(context.page):
+                raise ScanReviewResolutionError(
+                    "registration target contradicts its immutable response page"
+                )
+            routes.append(
+                QuillanRouteOption(
+                    locator,
+                    registration.target,
+                    context.student_id,
+                    context.logical_page,
+                    context.total_pages,
+                )
+            )
+        except (
+            IdentifierValidationError,
+            OSError,
+            PrintableResponsePersistenceError,
+            PrintableResponseRouteError,
+            QuillanWorkPathError,
+            RouteRegistrationPersistenceError,
+            RoutingModelError,
+        ) as error:
+            warnings.append(f"Skipped invalid route {path.name}: {error}")
+    routes.sort(
+        key=lambda item: (item.student_id, item.logical_page, item.locator.route_id)
+    )
+    return QuillanRouteDiscovery(tuple(routes), tuple(warnings))
 
 
 def discover_scan_review_items(
@@ -786,10 +878,13 @@ __all__ = [
     "DEFAULT_RESOLUTION_MESSAGES",
     "QUILLAN_RESOLUTION_ACTIONS",
     "QuillanResolutionResult",
+    "QuillanRouteDiscovery",
+    "QuillanRouteOption",
     "QuillanReviewDiscovery",
     "QuillanReviewItem",
     "ScanReviewResolutionError",
     "discover_scan_review_items",
+    "discover_scan_review_route_options",
     "list_scan_review_items",
     "resolve_scan_review_item",
 ]

--- a/quillan/submission_review_opening.py
+++ b/quillan/submission_review_opening.py
@@ -15,6 +15,7 @@ from quillan.record_context import (
     mutable_json_copy,
 )
 from quillan.submission_guidance import missing_submission_guidance
+from quillan.plain_paper_submission import is_plain_paper_submission
 from quillan.work_paths import quillan_work_ref
 
 
@@ -76,6 +77,87 @@ class OpenedSubmissionReview:
         return self.opened_pages[0].page_state
 
 
+@dataclass(frozen=True, slots=True)
+class SubmissionEvidenceCandidate:
+    """Compact candidate metadata for identity-based menu selection."""
+
+    evidence_id: str
+    evidence_role: str
+    evidence_state: str
+    selected: bool
+    relative_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionEvidencePageOptions:
+    """Compact page state and candidates for one canonical manifest page."""
+
+    page_number: int
+    page_state: str
+    selected_evidence_id: str | None
+    candidates: tuple[SubmissionEvidenceCandidate, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionEvidenceInventory:
+    """Read-only identity-based evidence choices for one canonical submission."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    manifest_relative_path: str
+    plain_paper: bool
+    pages: tuple[SubmissionEvidencePageOptions, ...]
+
+
+def list_submission_evidence_candidates(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> SubmissionEvidenceInventory:
+    """Return canonical page/candidate choices without opening or mutation."""
+    try:
+        context = load_quillan_student_review_context(
+            workspace_root,
+            quillan_work_ref(class_id, assignment_id),
+            student_id,
+            review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+        )
+    except MissingSubmissionError as error:
+        raise SubmissionReviewOpeningError(missing_submission_guidance()) from error
+    except (OSError, RuntimeError, QuillanRecordContextError) as error:
+        raise SubmissionReviewOpeningError(str(error)) from error
+    manifest = mutable_json_copy(context.submission)
+    pages = tuple(
+        SubmissionEvidencePageOptions(
+            page_number=page["page_number"],
+            page_state=page["page_state"],
+            selected_evidence_id=page["selected_evidence_id"],
+            candidates=tuple(
+                SubmissionEvidenceCandidate(
+                    evidence_id=evidence["evidence_id"],
+                    evidence_role=evidence["evidence_role"],
+                    evidence_state=evidence["evidence_state"],
+                    selected=evidence["evidence_id"]
+                    == page["selected_evidence_id"],
+                    relative_path=evidence["routed_evidence_path"],
+                )
+                for evidence in page["evidence"]
+            ),
+        )
+        for page in manifest["pages"]
+    )
+    return SubmissionEvidenceInventory(
+        class_id,
+        assignment_id,
+        student_id,
+        context.paths.submission_relative_path,
+        is_plain_paper_submission(manifest),
+        pages,
+    )
+
+
 def open_student_submission_for_review(
     workspace_root: str | Path,
     class_id: str,
@@ -83,6 +165,7 @@ def open_student_submission_for_review(
     student_id: str,
     *,
     page_number: int | None = None,
+    evidence_id: str | None = None,
 ) -> OpenedSubmissionReview:
     """Open selected routed evidence files for one submission."""
     try:
@@ -102,6 +185,7 @@ def open_student_submission_for_review(
     selected_pages = selected_submission_evidence_pages(
         manifest,
         page_number=page_number,
+        evidence_id=evidence_id,
     )
 
     try:
@@ -149,9 +233,49 @@ def selected_submission_evidence_pages(
     manifest: dict[str, Any],
     *,
     page_number: int | None = None,
+    evidence_id: str | None = None,
 ) -> tuple[SelectedSubmissionEvidencePage, ...]:
     """Return selected evidence pages in ascending logical page order."""
     pages = manifest["pages"]
+    if evidence_id is not None:
+        if not isinstance(evidence_id, str) or not evidence_id.strip():
+            raise SubmissionReviewOpeningError(
+                "evidence_id must be nonblank exact text."
+            )
+        candidates = (
+            pages
+            if page_number is None
+            else tuple(page for page in pages if page["page_number"] == page_number)
+        )
+        if page_number is not None and not candidates:
+            raise SubmissionReviewOpeningError(
+                f"Submission page {page_number} does not exist."
+            )
+        matches = [
+            (page, evidence)
+            for page in candidates
+            for evidence in page["evidence"]
+            if evidence["evidence_id"] == evidence_id
+        ]
+        if len(matches) != 1:
+            scope = (
+                "this submission"
+                if page_number is None
+                else f"submission page {page_number}"
+            )
+            raise SubmissionReviewOpeningError(
+                f"Evidence ID '{evidence_id}' does not identify exactly one "
+                f"candidate in {scope}."
+            )
+        page, evidence = matches[0]
+        return (
+            SelectedSubmissionEvidencePage(
+                page_number=page["page_number"],
+                evidence_id=evidence["evidence_id"],
+                evidence_relative_path=evidence["routed_evidence_path"],
+                page_state=page["page_state"],
+            ),
+        )
     if page_number is not None:
         matching_page = next(
             (page for page in pages if page["page_number"] == page_number),
@@ -227,3 +351,17 @@ def _validate_manifest_identity(
             raise SubmissionReviewOpeningError(
                 f"Submission manifest {field} is {actual!r}, expected {expected!r}."
             )
+
+
+__all__ = [
+    "OpenedSubmissionEvidencePage",
+    "OpenedSubmissionReview",
+    "SelectedSubmissionEvidencePage",
+    "SubmissionEvidenceCandidate",
+    "SubmissionEvidenceInventory",
+    "SubmissionEvidencePageOptions",
+    "SubmissionReviewOpeningError",
+    "list_submission_evidence_candidates",
+    "open_student_submission_for_review",
+    "selected_submission_evidence_pages",
+]

--- a/quillan/submission_status.py
+++ b/quillan/submission_status.py
@@ -20,6 +20,11 @@ from quillan.record_context import (
     mutable_json_copy,
     student_record_paths,
 )
+from quillan.printable_response_persistence import (
+    PrintableResponsePersistenceError,
+    load_printable_response_record_set,
+)
+from quillan.plain_paper_submission import is_plain_paper_submission
 from quillan.response_page_observations import QuillanResponsePageObservation
 from quillan.work_paths import _is_link_like, quillan_work_ref
 
@@ -49,6 +54,9 @@ class StudentSubmissionStatus:
     needs_rescan_pages: tuple[int, ...]
     excluded_pages: tuple[int, ...]
     unselected_present_pages: tuple[int, ...]
+    issuance_ids: tuple[str, ...] = ()
+    conflicts: tuple[str, ...] = ()
+    plain_paper: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,14 +78,10 @@ def list_assignment_submission_status(
     workspace_root: str | Path,
     class_id: str,
     assignment_id: str,
-    *,
-    expected_pages: int | None = None,
 ) -> AssignmentSubmissionStatus:
     """Return read-only submission/evidence status for one assignment."""
     validate_identifier(class_id, "class_id")
     validate_identifier(assignment_id, "assignment_id")
-    _validate_expected_pages(expected_pages)
-
     work_ref = quillan_work_ref(class_id, assignment_id)
     assignment_context = load_quillan_assignment_context(workspace_root, work_ref)
     root = assignment_context.paths.workspace_root
@@ -122,9 +126,10 @@ def list_assignment_submission_status(
     ]
     statuses.extend(
         _summarize_routed_only_student(
+            root,
+            work_ref,
             student_id,
             discovery.evidence_by_student[student_id],
-            expected_pages,
         )
         for student_id in students_without_manifests
     )
@@ -233,34 +238,122 @@ def _summarize_manifest(
         manifest_path=manifest_path,
         submission_state=manifest["submission_state"],
         pages=pages,
+        plain_paper=is_plain_paper_submission(manifest),
     )
 
 
 def _summarize_routed_only_student(
+    root: Path,
+    work_ref: object,
     student_id: str,
     evidence_items: tuple[QuillanResponsePageObservation, ...],
-    expected_pages: int | None,
 ) -> StudentSubmissionStatus:
-    routed_page_numbers = {item.logical_page for item in evidence_items}
-    missing_pages = (
-        tuple(
-            page_number
-            for page_number in range(1, expected_pages + 1)
-            if page_number not in routed_page_numbers
+    issuance_ids = tuple(sorted({item.issuance_id for item in evidence_items}))
+    if len(issuance_ids) != 1:
+        return StudentSubmissionStatus(
+            student_id=student_id,
+            manifest_path=None,
+            submission_state=None,
+            pages=(),
+            missing_pages=(),
+            duplicate_pages=(),
+            needs_rescan_pages=(),
+            excluded_pages=(),
+            unselected_present_pages=(),
+            issuance_ids=issuance_ids,
+            conflicts=("mixed_issuance",),
         )
-        if expected_pages is not None
-        else ()
+    try:
+        record_set = load_printable_response_record_set(
+            root, work_ref, issuance_ids[0]
+        )
+    except PrintableResponsePersistenceError:
+        return StudentSubmissionStatus(
+            student_id=student_id,
+            manifest_path=None,
+            submission_state=None,
+            pages=(),
+            missing_pages=(),
+            duplicate_pages=(),
+            needs_rescan_pages=(),
+            excluded_pages=(),
+            unselected_present_pages=(),
+            issuance_ids=issuance_ids,
+            conflicts=("issuance_invalid",),
+        )
+    if record_set.issuance.student_id != student_id:
+        return StudentSubmissionStatus(
+            student_id=student_id,
+            manifest_path=None,
+            submission_state=None,
+            pages=(),
+            missing_pages=(),
+            duplicate_pages=(),
+            needs_rescan_pages=(),
+            excluded_pages=(),
+            unselected_present_pages=(),
+            issuance_ids=issuance_ids,
+            conflicts=("issuance_student_conflict",),
+        )
+    expected_by_id = {page.page_id: page for page in record_set.pages}
+    unexpected = tuple(
+        item.observation_id
+        for item in evidence_items
+        if item.page_id not in expected_by_id
+        or expected_by_id[item.page_id].logical_page != item.logical_page
+    )
+    if unexpected:
+        return StudentSubmissionStatus(
+            student_id=student_id,
+            manifest_path=None,
+            submission_state=None,
+            pages=(),
+            missing_pages=(),
+            duplicate_pages=(),
+            needs_rescan_pages=(),
+            excluded_pages=(),
+            unselected_present_pages=(),
+            issuance_ids=issuance_ids,
+            conflicts=("unexpected_page",),
+        )
+    pages = tuple(
+        _routed_only_page(page.logical_page, page.page_id, evidence_items)
+        for page in record_set.pages
+    )
+    missing_pages = tuple(
+        page.page_number for page in pages if page.page_state == "missing"
+    )
+    duplicate_pages = tuple(
+        page.page_number for page in pages if page.page_state == "duplicate"
     )
     return StudentSubmissionStatus(
         student_id=student_id,
         manifest_path=None,
         submission_state=None,
-        pages=(),
+        pages=pages,
         missing_pages=missing_pages,
-        duplicate_pages=(),
+        duplicate_pages=duplicate_pages,
         needs_rescan_pages=(),
         excluded_pages=(),
         unselected_present_pages=(),
+        issuance_ids=issuance_ids,
+    )
+
+
+def _routed_only_page(
+    logical_page: int,
+    page_id: str,
+    evidence_items: tuple[QuillanResponsePageObservation, ...],
+) -> PageStatusSummary:
+    matches = tuple(item for item in evidence_items if item.page_id == page_id)
+    state = "missing" if not matches else "duplicate" if len(matches) > 1 else "present"
+    return PageStatusSummary(
+        page_number=logical_page,
+        page_state=state,
+        selected_evidence_id=None,
+        evidence_count=len(matches),
+        evidence_roles=tuple("candidate" for _ in matches),
+        evidence_states=tuple("active" for _ in matches),
     )
 
 
@@ -270,6 +363,7 @@ def _student_status(
     manifest_path: Path,
     submission_state: str,
     pages: tuple[PageStatusSummary, ...],
+    plain_paper: bool = False,
 ) -> StudentSubmissionStatus:
     def pages_with_state(state: str) -> tuple[int, ...]:
         return tuple(
@@ -291,19 +385,8 @@ def _student_status(
             if page.page_state == "present"
             and page.selected_evidence_id is None
         ),
+        plain_paper=plain_paper,
     )
-
-
-def _validate_expected_pages(expected_pages: int | None) -> None:
-    if (
-        expected_pages is not None
-        and (
-            isinstance(expected_pages, bool)
-            or not isinstance(expected_pages, int)
-            or expected_pages < 1
-        )
-    ):
-        raise ValueError("expected_pages must be a positive integer.")
 
 
 def _resolved_evidence_path(root: Path, value: str | Path) -> Path:

--- a/quillan/work_paths.py
+++ b/quillan/work_paths.py
@@ -370,6 +370,30 @@ def post_dispatch_review_path(
     return post_dispatch_review_dir(workspace_root, work_ref) / f"{validated_id}.json"
 
 
+def post_dispatch_resolution_dir(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> Path:
+    """Return the Quillan-owned post-dispatch resolution directory."""
+    return safe_module_work_descendant(
+        workspace_root,
+        _require_quillan_work_ref(work_ref),
+        Path("scans") / "review" / "post_dispatch" / "resolutions",
+    )
+
+
+def post_dispatch_resolution_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    resolution_id: str,
+) -> Path:
+    """Return one canonical immutable post-dispatch resolution path."""
+    validated_id = validate_identifier(resolution_id, "resolution_id")
+    return post_dispatch_resolution_dir(
+        workspace_root, work_ref
+    ) / f"{validated_id}.json"
+
+
 def relative_assignment_path(class_id: str, assignment_id: str) -> str:
     """Return the canonical workspace-relative assignment record path."""
     return quillan_work_paths(Path(), class_id, assignment_id).assignment_path.as_posix()
@@ -621,6 +645,8 @@ __all__ = [
     "preflight_work_directory_destination",
     "post_dispatch_review_dir",
     "post_dispatch_review_path",
+    "post_dispatch_resolution_dir",
+    "post_dispatch_resolution_path",
     "quillan_work_collection_dir",
     "quillan_work_paths",
     "quillan_work_ref",

--- a/tests/menu_screen_recorder.py
+++ b/tests/menu_screen_recorder.py
@@ -1,0 +1,163 @@
+"""Scripted recorder for clear-delimited interactive menu acceptance tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Final
+
+import pytest
+
+import quillan.menu as menu
+
+
+_CLEAR_PREFIX: Final = "<<<QUILLAN-CLEAR:"
+_RECORDER_EVENTS: dict[str, set[str]] = {}
+
+
+def _record_event(event: str) -> None:
+    current = os.environ.get("PYTEST_CURRENT_TEST", "")
+    node_id, separator, _phase = current.rpartition(" (")
+    if separator and node_id:
+        _RECORDER_EVENTS.setdefault(node_id, set()).add(event)
+
+
+def recorder_events(node_id: str) -> frozenset[str]:
+    """Return recorder lifecycle events observed for one pytest item."""
+    return frozenset(_RECORDER_EVENTS.get(node_id, ()))
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedPrompt:
+    prompt: str
+    choice: str
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedScreen:
+    clear_number: int
+    output: str
+
+
+class MenuScreenRecorder:
+    """Capture clear events, output segments, prompts, pauses, and choices."""
+
+    def __init__(self, responses: list[str]) -> None:
+        _record_event("instantiated")
+        self._responses = iter(responses)
+        self.clear_count = 0
+        self.prompts: list[RecordedPrompt] = []
+
+    def install(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        clear_aliases: tuple[str, ...] = (),
+    ) -> None:
+        _record_event("installed")
+        monkeypatch.setattr(menu, "clear_screen", self._clear)
+        for alias in clear_aliases:
+            monkeypatch.setattr(alias, self._clear)
+        monkeypatch.setattr("builtins.input", self._input)
+
+    def _clear(self) -> None:
+        self.clear_count += 1
+        print(f"{_CLEAR_PREFIX}{self.clear_count}>>>")
+
+    def _input(self, prompt: str = "") -> str:
+        try:
+            choice = next(self._responses)
+        except StopIteration as error:
+            raise AssertionError(
+                f"Menu requested an unexpected input after prompt {prompt!r}."
+            ) from error
+        self.prompts.append(RecordedPrompt(prompt, choice))
+        return choice
+
+    def screens(self, output: str) -> tuple[RecordedScreen, ...]:
+        _record_event("screens")
+        screens: list[RecordedScreen] = []
+        for chunk in output.split(_CLEAR_PREFIX)[1:]:
+            number_text, separator, body = chunk.partition(">>>")
+            if not separator or not number_text.isdigit():
+                raise AssertionError("Malformed clear marker in recorded output.")
+            screens.append(RecordedScreen(int(number_text), body.strip()))
+        if len(screens) != self.clear_count:
+            raise AssertionError("Captured screen count disagrees with clear events.")
+        return tuple(screens)
+
+    def print_transcript(
+        self, screens: tuple[RecordedScreen, ...], *, label: str
+    ) -> None:
+        """Print an artifact-friendly transcript after assertions succeed."""
+        print(f"=== {label} ===")
+        for screen in screens:
+            print(f"--- CLEAR EVENT {screen.clear_number} ---")
+            print(screen.output)
+        print("--- PROMPTS AND CHOICES ---")
+        for prompt in self.prompts:
+            print(f"{prompt.prompt}{prompt.choice}")
+
+
+def assert_focused_child_screen(
+    screens: tuple[RecordedScreen, ...],
+    *,
+    heading: str,
+    required_text: str | tuple[str, ...],
+    forbidden_parent_text: str | tuple[str, ...],
+    parent_heading: str,
+    result_heading: str,
+    unrelated_previous_text: str | tuple[str, ...] = (),
+) -> None:
+    """Assert one complete parent/child/result/redraw clear-screen lifecycle."""
+    _record_event("asserted")
+    required = (required_text,) if isinstance(required_text, str) else required_text
+    forbidden = (
+        (forbidden_parent_text,)
+        if isinstance(forbidden_parent_text, str)
+        else forbidden_parent_text
+    )
+    unrelated = (
+        (unrelated_previous_text,)
+        if isinstance(unrelated_previous_text, str)
+        else unrelated_previous_text
+    )
+    child_indexes = [
+        index
+        for index, screen in enumerate(screens)
+        if heading in screen.output
+        and all(text in screen.output for text in required)
+        and all(text not in screen.output for text in (*forbidden, *unrelated))
+    ]
+    assert child_indexes, f"No clear-delimited screen has heading {heading!r}."
+    child_index = child_indexes[0]
+    assert child_index > 0, "Focused child was not cleared after a parent screen."
+    child = screens[child_index]
+    prior_indexes = [
+        index
+        for index, screen in enumerate(screens[:child_index])
+        if parent_heading in screen.output
+    ]
+    assert prior_indexes, "Focused child has no prior parent screen."
+    parent_index = prior_indexes[-1]
+    assert child.clear_number > screens[parent_index].clear_number
+    for text in required:
+        assert text in child.output
+    for text in (*forbidden, *unrelated):
+        assert text not in child.output
+
+    result_indexes = [
+        index
+        for index, screen in enumerate(screens[child_index:], child_index)
+        if result_heading in screen.output
+    ]
+    assert result_indexes, f"No later cleared result screen has {result_heading!r}."
+    result_index = result_indexes[0]
+    assert screens[result_index].clear_number >= child.clear_number
+    redraw_indexes = [
+        index
+        for index, screen in enumerate(screens[result_index + 1 :], result_index + 1)
+        if parent_heading in screen.output
+    ]
+    assert redraw_indexes, "Parent screen was not redrawn after returning."
+    assert screens[redraw_indexes[0]].clear_number > screens[result_index].clear_number

--- a/tests/test_assignment_workflows.py
+++ b/tests/test_assignment_workflows.py
@@ -18,6 +18,8 @@ from pds_core.standards import (
 )
 import pytest
 
+from tests.menu_screen_recorder import MenuScreenRecorder, assert_focused_child_screen
+
 import quillan.assignment_workflows as workflows
 from quillan.assignments import (
     AssignmentConfigError,
@@ -1243,7 +1245,7 @@ def test_assignment_menu_displays_options_and_dispatches(
         "prompt_view_validate_assignment",
         lambda: record("view"),
     )
-    _inputs(monkeypatch, ["1", "", "2", "", "4"])
+    _inputs(monkeypatch, ["1", "", "2", "", "b"])
 
     assert workflows.launch_assignment_menu() == 0
     output = capsys.readouterr().out
@@ -1258,7 +1260,7 @@ def test_assignment_menu_invalid_selection_and_keyboard_interrupt(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    _inputs(monkeypatch, ["bad", "", "4"])
+    _inputs(monkeypatch, ["bad", "", "b"])
     assert workflows.launch_assignment_menu() == 0
     assert "Invalid selection" in capsys.readouterr().out
 
@@ -1268,3 +1270,79 @@ def test_assignment_menu_invalid_selection_and_keyboard_interrupt(
     monkeypatch.setattr("builtins.input", interrupt)
     assert workflows.launch_assignment_menu() == 0
     assert "Exiting assignment menu." in capsys.readouterr().out
+
+
+@pytest.mark.menu_density_workflow("assignment creation")
+def test_assignment_creation_density_uses_real_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_standards_library(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    recorder = MenuScreenRecorder(
+        [
+            "1",
+            "1",
+            "1",
+            "Literary Analysis Essay",
+            "",
+            "literary analysis",
+            "Analyze how the author develops a central idea.",
+            "1",
+            "1,2",
+            "",
+            "",
+            "4",
+            "6",
+            "500",
+            "900",
+            "claim, textual evidence",
+            "",
+            "",
+            "",
+            "b",
+        ]
+    )
+    recorder.install(monkeypatch)
+
+    assert workflows.launch_assignment_menu() == 0
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="Create Writing Assignment",
+        required_text="Assignment creation requires an existing PDS Core standards profile.",
+        forbidden_parent_text="3. Printable Response Pages",
+        parent_heading="Assignment Management",
+        result_heading="Assignment Saved",
+        unrelated_previous_text="View/validate assignment",
+    )
+
+
+@pytest.mark.menu_density_workflow("assignment validation")
+def test_assignment_validation_density_uses_real_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    workflows.write_assignment_config(tmp_path, "english_12_p3", _assignment())
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    recorder = MenuScreenRecorder(["2", "1", "1", "", "b"])
+    recorder.install(monkeypatch)
+
+    assert workflows.launch_assignment_menu() == 0
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="View/Validate Assignment",
+        required_text="english_12_p3",
+        forbidden_parent_text="3. Printable Response Pages",
+        parent_heading="Assignment Management",
+        result_heading="Assignment Validation Result",
+        unrelated_previous_text="Create writing assignment",
+    )
+    recorder.print_transcript(screens, label="ASSIGNMENT VALIDATION")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-import json
 from pathlib import Path
 
 from pds_core.workspace import WorkspaceRootError, WorkspaceStatus
@@ -62,11 +61,11 @@ def test_cli_without_command_displays_menu_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["6"])
+    _menu_input(monkeypatch, ["q"])
 
     assert main([]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Quillan" in output
     assert "\033[32mQuillan\033[0m" in output
     assert "1. Assignment Management" in output
@@ -89,7 +88,7 @@ def test_nested_menu_main_and_quit_shortcuts_unwind_globally(
     _menu_input(monkeypatch, ["1", "m", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert output.count("1. Assignment Management") == 2
     assert "Goodbye." in output
 
@@ -101,84 +100,31 @@ def test_nested_menu_quit_shortcut_exits_cleanly(
     _menu_input(monkeypatch, ["1", "q"])
 
     assert main(["menu"]) == 0
-    assert "Goodbye." in capsys.readouterr().out
+    assert "Goodbye." in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
-def test_cli_validates_assignment_config(
-    tmp_path: Path,
+def test_cli_retires_raw_path_assignment_validation(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_data = {
-        "schema_version": "2",
-        "module": "quillan",
-        "record_type": "assignment",
-        "assignment_id": "villainy_final_essay_synthetic",
-        "title": "Villainy Final Essay",
-        "class_ids": ["english12_period3_synthetic"],
-        "writing_type": "literary argument essay",
-        "student_prompt": "Rank villains using evidence from the texts.",
-        "standards_profile_id": "english_12_njsls_synthetic",
-        "focus_standard_ids": [
-            "njsls-ela:W.AW.11-12.1",
-            "njsls-ela:W.WP.11-12.4",
-        ],
-        "review_unit": {
-            "type": "paragraph",
-            "singular_label": "paragraph",
-            "plural_label": "paragraphs",
-        },
-        "rating_scale": {
-            "scale_id": "standards_2_level",
-            "levels": [
-                {
-                    "value": 1,
-                    "label": "Developing",
-                    "description": "Limited evidence.",
-                }
-            ],
-        },
-        "basic_requirements": {
-            "paragraphs_min": 4,
-            "paragraphs_max": 6,
-            "word_count_min": 500,
-            "required_elements": [
-                "thesis",
-                "textual evidence",
-                "comparative reasoning",
-            ],
-        },
-        "minimum_requirement_policy": {
-            "allow_return_without_full_review": True,
-        },
-        "created_at": "2026-07-13T00:00:00+00:00",
-        "updated_at": "2026-07-13T00:00:00+00:00",
-        "module_details": {},
-    }
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    main(["validate-assignment", str(assignment_path)])
-
-    captured = capsys.readouterr()
-
-    assert "Valid assignment config: villainy_final_essay_synthetic" in captured.out
-
-    for field in ("created_at", "updated_at", "module_details"):
-        assignment_data.pop(field)
-    assignment_path.write_text(json.dumps(assignment_data), encoding="utf-8")
-
-    with pytest.raises(SystemExit, match="created_at"):
-        main(["validate-assignment", str(assignment_path)])
-
-
-def test_cli_reports_invalid_assignment_config(tmp_path: Path) -> None:
-    assignment_path = tmp_path / "assignment.json"
-    assignment_path.write_text("{bad json", encoding="utf-8")
-
     with pytest.raises(SystemExit) as error:
-        main(["validate-assignment", str(assignment_path)])
+        main(["validate-assignment", "assignment.json"])
 
-    assert "Invalid assignment config" in str(error.value)
+    assert error.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "invalid choice: 'validate-assignment'" in captured.err
+
+
+def test_assignment_namespace_requires_a_canonical_action(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["assignment", "assignment.json"])
+
+    assert error.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "invalid choice" in captured.err
 
 
 def test_workspace_show_uses_pds_core_status(
@@ -238,7 +184,7 @@ def test_workspace_show_reports_status_fields(
     )
 
     assert main(["workspace", "show"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert "Exists:\nno" in output
     assert "Directory:\nno" in output
@@ -271,7 +217,7 @@ def test_workspace_show_reports_workspace_error(
     )
 
     assert main(["workspace", "show"]) != 0
-    assert "Error: bad workspace" in capsys.readouterr().out
+    assert "Error: bad workspace" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_workspace_set_validates_and_saves_shared_root(
@@ -297,7 +243,7 @@ def test_workspace_set_validates_and_saves_shared_root(
     monkeypatch.setattr(cli_workspace, "save_workspace_root", save)
 
     assert main(["workspace", "set", str(requested_root)]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert calls == [("ensure", requested_root), ("save", requested_root)]
     assert requested_root.is_dir()
@@ -330,7 +276,7 @@ def test_workspace_validate_uses_current_resolved_root(
     monkeypatch.setattr(cli_workspace, "ensure_workspace_root", ensure)
 
     assert main(["workspace", "validate"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert calls == [resolved_root]
     assert resolved_root.is_dir()
@@ -370,7 +316,7 @@ def test_workspace_reset_clears_only_saved_preference(
     )
 
     assert main(["workspace", "reset"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert calls == 1
     assert existing_file.read_text(encoding="utf-8") == "keep me"
@@ -401,17 +347,17 @@ def test_workspace_commands_report_workspace_errors(
     monkeypatch.setattr(cli_workspace, patched_name, fail)
 
     assert main(command) != 0
-    assert "Error: bad workspace" in capsys.readouterr().out
+    assert "Error: bad workspace" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_menu_dispatch_displays_options_and_exits(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["6"])
+    _menu_input(monkeypatch, ["q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert "Quillan" in output
     assert "\033[32mQuillan\033[0m" in output
@@ -432,10 +378,10 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["5", "", "6"])
+    _menu_input(monkeypatch, ["5", "", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert "local-first, teacher-controlled" in output
     assert "Teacher judgment remains primary" in output
@@ -443,17 +389,17 @@ def test_menu_help_explains_teacher_control_and_safe_data(
     assert "synthetic data only" in output
     assert "Do not commit or post real student data" in output
     assert "quillan validate-standards" not in output
-    assert "quillan menu" in output
+    assert "quillan --help" in output
 
 
 def test_assignment_management_opens_printable_response_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["1", "3", "2", "", "4", "6"])
+    _menu_input(monkeypatch, ["1", "3", "b", "", "b", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Printable Response Pages" in output
     assert "Generate class packet" in output
     assert "Back" in output
@@ -464,10 +410,10 @@ def test_main_menu_opens_assignment_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["1", "4", "6"])
+    _menu_input(monkeypatch, ["1", "b", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Assignment Management" in output
     assert "\033[32mQuillan\033[0m" in output
     assert "Create writing assignment" in output
@@ -481,10 +427,10 @@ def test_main_menu_opens_roster_management_submenu(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["3", "5", "6"])
+    _menu_input(monkeypatch, ["3", "b", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Roster Management" in output
     assert "Create class roster" in output
     assert "View class roster" in output
@@ -507,10 +453,10 @@ def test_workspace_menu_reuses_workspace_show_handler(
         return 0
 
     monkeypatch.setattr(cli_workspace, "show_workspace", handle_workspace_show)
-    _menu_input(monkeypatch, ["4", "1", "", "5", "6"])
+    _menu_input(monkeypatch, ["4", "1", "", "b", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert calls == 1
     assert "Workspace Settings" in output
@@ -538,10 +484,10 @@ def test_workspace_menu_sets_workspace_folder(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["4", "2", str(workspace_root), "", "5", "6"])
+    _menu_input(monkeypatch, ["4", "2", str(workspace_root), "", "b", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert calls == [str(workspace_root)]
     assert str(workspace_root) in output
@@ -562,10 +508,10 @@ def test_workspace_menu_blank_set_cancels_without_change(
         return 0
 
     monkeypatch.setattr(cli_workspace, "set_workspace", handle_workspace_set)
-    _menu_input(monkeypatch, ["4", "2", "  ", "", "5", "6"])
+    _menu_input(monkeypatch, ["4", "2", "  ", "", "b", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert calls == 0
     assert "canceled" in output
@@ -589,11 +535,11 @@ def test_workspace_menu_validates_current_workspace(
         "validate_workspace",
         handle_workspace_validate,
     )
-    _menu_input(monkeypatch, ["4", "3", "", "5", "6"])
+    _menu_input(monkeypatch, ["4", "3", "", "b", "q"])
 
     assert main(["menu"]) == 0
     assert calls == 1
-    assert "Workspace validated successfully" in capsys.readouterr().out
+    assert "Workspace validated successfully" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_workspace_menu_resets_saved_preference(
@@ -616,10 +562,10 @@ def test_workspace_menu_resets_saved_preference(
         "reset_workspace",
         handle_workspace_reset,
     )
-    _menu_input(monkeypatch, ["4", "4", "", "5", "6"])
+    _menu_input(monkeypatch, ["4", "4", "", "b", "q"])
 
     assert main(["menu"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert calls == 1
     assert "No workspace files were deleted" in output
@@ -637,4 +583,4 @@ def test_menu_handles_keyboard_interrupt(
     monkeypatch.setattr("builtins.input", interrupt)
 
     assert main(["menu"]) == 0
-    assert "Exiting Quillan." in capsys.readouterr().out
+    assert "Exiting Quillan." in (lambda captured: captured.out + captured.err)(capsys.readouterr())

--- a/tests/test_cli_assignments.py
+++ b/tests/test_cli_assignments.py
@@ -97,7 +97,7 @@ def test_assignment_help_surface(capsys: pytest.CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit) as error:
             main(argv)
         assert error.value.code == 0
-        assert expected in capsys.readouterr().out
+        assert expected in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_create_show_validate_and_overwrite_safety(
@@ -122,7 +122,7 @@ def test_create_show_validate_and_overwrite_safety(
     assert path.read_bytes() == original
     assert main(["assignment", "show", "english10_p2", "literary_analysis"]) == 0
     assert main(["assignment", "validate", "english10_p2", "literary_analysis"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Assignment config is valid." in output
     assert "Valid canonical assignment:" in output
 
@@ -141,7 +141,7 @@ def test_dry_run_and_prompt_file_preserve_content(
     assert main(argv) == 0
     assignment = json.loads((target / "assignment.json").read_text(encoding="utf-8"))
     assert assignment["student_prompt"] == "Line one.\nLine two.\n"
-    assert "No files were written." in capsys.readouterr().out
+    assert "No files were written." in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_invalid_standards_and_path_identity_fail_cleanly(
@@ -150,14 +150,14 @@ def test_invalid_standards_and_path_identity_fail_cleanly(
     bad = _args("--dry-run")
     bad[bad.index(STANDARD_ID)] = OTHER_STANDARD_ID
     assert main(bad) == 1
-    assert "assignment was not created" in capsys.readouterr().out
+    assert "assignment was not created" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert main(_args("--yes")) == 0
     path = workspace / "classes/english10_p2/modules/quillan/work/literary_analysis/assignment.json"
     data = json.loads(path.read_text(encoding="utf-8"))
     data["assignment_id"] = "different_id"
     path.write_text(json.dumps(data), encoding="utf-8")
     assert main(["assignment", "validate", "english10_p2", "literary_analysis"]) == 1
-    assert "Path assignment_id" in capsys.readouterr().out
+    assert "Path assignment_id" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_canonical_validate_rejects_assignment_missing_contract_metadata(
@@ -171,4 +171,4 @@ def test_canonical_validate_rejects_assignment_missing_contract_metadata(
     path.write_text(json.dumps(assignment), encoding="utf-8")
 
     assert main(["assignment", "validate", "english10_p2", "literary_analysis"]) == 1
-    assert "Missing required field 'created_at'" in capsys.readouterr().out
+    assert "Missing required field 'created_at'" in (lambda captured: captured.out + captured.err)(capsys.readouterr())

--- a/tests/test_cli_class_summary_export.py
+++ b/tests/test_cli_class_summary_export.py
@@ -30,7 +30,7 @@ def test_cli_exports_ready_and_non_ready_rows_and_prints_summary(
 
     assert main(["export-class-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Exported assignment-local class summary:" in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
@@ -68,7 +68,7 @@ def test_cli_missing_submissions_directory_returns_one(
 ) -> None:
     monkeypatch.setattr(cli_exports, "resolve_workspace_root", lambda: tmp_path)
     assert main(["export-class-summary", CLASS_ID, ASSIGNMENT_ID]) == 1
-    assert "assignment config" in capsys.readouterr().out
+    assert "assignment config" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_cli_overwrite_flag_controls_replacement(
@@ -94,7 +94,7 @@ def test_cli_overwrite_flag_controls_replacement(
     assert output_path.read_text(encoding="utf-8") == "manual edit"
     assert main([*command, "--overwrite"]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Use --overwrite" in output
     assert "Overwrote existing: yes" in output
     assert "review_valid" in output_path.read_text(encoding="utf-8")

--- a/tests/test_cli_comments.py
+++ b/tests/test_cli_comments.py
@@ -63,7 +63,7 @@ def test_comments_help_and_bare_namespace_do_not_resolve_workspace(
     monkeypatch.setattr(cli_comments, "resolve_workspace_root", fail_if_called)
 
     assert main(["comments"]) == 0
-    namespace_help = capsys.readouterr().out
+    namespace_help = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert all(command in namespace_help for command in ("list", "show", "create"))
     for arguments in (
         ["--help"],
@@ -84,7 +84,7 @@ def test_empty_list_is_successful_and_does_not_create_directory(
 
     assert main(["comments", "list"]) == 0
 
-    assert "No reusable Focus Standard comments matched." in capsys.readouterr().out
+    assert "No reusable Focus Standard comments matched." in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not directory.exists()
 
 
@@ -92,7 +92,7 @@ def test_show_missing_set_fails_without_creating_files(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     assert main(["comments", "show", "missing_set"]) == 1
-    assert "Error:" in capsys.readouterr().out
+    assert "Error:" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not (workspace / "shared").exists()
 
 
@@ -122,7 +122,7 @@ def test_create_new_set_preserves_text_and_normalizes_metadata(
         ]
     ) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Comment set: created" in output
     assert "Comment ID: explain_evidence" in output
     assert "Rating values: -1, 0, 2.5" in output
@@ -177,7 +177,7 @@ def test_create_appends_collision_safe_id_and_preserves_existing_data(
         ]
     ) == 0
 
-    assert "Comment ID: explain_evidence_2" in capsys.readouterr().out
+    assert "Comment ID: explain_evidence_2" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     after = load_comment_set(path)
     assert after["comments"][0] == before["comments"][0]
     assert after["created_at"] == before["created_at"]
@@ -220,7 +220,7 @@ def test_incompatible_append_is_byte_for_byte_unchanged(
 
     assert main(arguments) == 1
 
-    assert message in capsys.readouterr().out
+    assert message in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert path.read_bytes() == before
 
 
@@ -269,7 +269,7 @@ def test_list_filters_visibility_order_and_reports_invalid_files(
         ]
     ) == 1
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert output.index("Comment set ID: a_set") < output.index("Comment set ID: z_set")
     assert "A first text." in output
     assert "A second text." not in output
@@ -296,7 +296,7 @@ def test_show_includes_inactive_teacher_only_and_is_read_only(
 
     assert main(["comments", "show", "argument_comments"]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Description:" in output
     assert "Comment count: 1" in output
     assert "Student-facing: no" in output
@@ -336,7 +336,7 @@ def test_create_rejects_invalid_rating_lists_without_writing(
     )
 
     assert result == 1
-    assert "Error:" in capsys.readouterr().out
+    assert "Error:" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not (workspace / "shared").exists()
 
 

--- a/tests/test_cli_contract_docs.py
+++ b/tests/test_cli_contract_docs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import re
 
 from quillan.cli_app.parser import build_parser
 
@@ -31,8 +32,96 @@ def test_cli_contract_lists_every_registered_top_level_command_and_alias() -> No
 
 def test_cli_contract_surface_excludes_removed_legacy_commands() -> None:
     surface = _current_command_surface()
-    for removed in ("add-tag", "add-comment", "set-score"):
+    for removed in (
+        "add-tag",
+        "add-comment",
+        "set-score",
+        "validate-assignment",
+        "open-evidence",
+    ):
         assert f"quillan {removed}" not in surface
+    for removed_option in ("--expected-pages", "--hide-payload"):
+        assert removed_option not in surface
+
+
+def test_parser_inventory_rejects_retired_raw_path_commands() -> None:
+    parser = build_parser()
+    subparsers = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    assert "validate-assignment" not in subparsers.choices
+    assert "open-evidence" not in subparsers.choices
+
+
+def test_contract_records_the_hard_menu_design_rule() -> None:
+    contract = (ROOT / "docs" / "cli_contract.md").read_text(encoding="utf-8")
+    assert (
+        "The menu should look and feel like a modern application menu, not a dump of\n"
+        "CLI commands or a legacy operator console."
+    ) in contract
+    assert (
+        "Screen clearing and redrawing after a teacher selects an option is the\n"
+        "default. Information remains visible only when it is essential or directly\n"
+        "useful for the teacher's current action."
+    ) in contract
+    for requirement in (
+        "parent menus are compact",
+        "selection lists are compact",
+        "detail appears only after selection",
+        "action screens are focused",
+        "confirmation screens are concise",
+        "result workflows clear before rendering the result",
+        "result screens are concise, then pause",
+        "returning redraws the parent screen",
+        "direct non-interactive CLI commands are exempt",
+        "context is retained intentionally only when it is needed",
+    ):
+        assert requirement in contract
+
+
+def test_active_teacher_documentation_has_only_reviewed_legacy_matches() -> None:
+    documents = (
+        "README.md",
+        "docs/cli_contract.md",
+        "docs/development_plan.md",
+        "docs/workspace_lifecycle.md",
+        "docs/assignment_reporting_contract.md",
+        "docs/prepared_review_workflow.md",
+        "docs/printable_response_template.md",
+        "docs/pds2_scan_intake.md",
+        "docs/scan_routing_design.md",
+    )
+    pattern = re.compile(
+        r"PDS1|--payload|validate-assignment|open-evidence|"
+        r"explicit assignment JSON|classes/.*/assignments|"
+        r"classes/<class_id>/assignments|expected pages?",
+        re.IGNORECASE,
+    )
+    allowlist = {
+        ("docs/cli_contract.md", "identity and path, lightweight submission state, expected page count, manifest"),
+        ("docs/cli_contract.md", "or leaves unchanged each canonical student `submission.json`. Expected pages"),
+        ("docs/cli_contract.md", "`validate-assignment <path>` and `open-evidence <path>` are not public"),
+        ("docs/development_plan.md", "Historically, Quillan interpreted its `PDS1` response payloads and owned the"),
+        ("docs/development_plan.md", '`quillan route-scan <source-file> --payload "<PDS1|...>"` form accepted an'),
+        ("docs/workspace_lifecycle.md", "payload mode or PDS1 fallback. Validation, naming, collision, provenance, and"),
+        ("docs/assignment_reporting_contract.md", "classes/<class_id>/assignments/<assignment_id>/exports/student_performance_summary.csv"),
+        ("docs/assignment_reporting_contract.md", "classes/<class_id>/assignments/<assignment_id>/exports/class_summary.csv"),
+        ("docs/assignment_reporting_contract.md", "classes/<class_id>/assignments/<assignment_id>/exports/standards_summary.csv"),
+        ("docs/printable_response_template.md", "PDS1 generation and interpretation have been removed. Generated pages use"),
+        ("docs/printable_response_template.md", "profile; submission assembly derives expected pages from issuance membership."),
+        ("docs/pds2_scan_intake.md", "payload identity becomes a locator and there is no PDS1 fallback."),
+        ("docs/scan_routing_design.md", "the locator. There is no caller payload mode, PDS1 parser, PDS1 route planner,"),
+        ("docs/scan_routing_design.md", "groups by exact issuance ID. It loads all expected pages in issuance order,"),
+    }
+    matches: set[tuple[str, str]] = set()
+    for relative in documents:
+        for line in (ROOT / relative).read_text(encoding="utf-8").splitlines():
+            if pattern.search(line):
+                matches.add((relative, line.strip()))
+    assert matches - allowlist == set()
+    assert allowlist - matches == set()
 
 
 def test_readme_treats_command_list_as_representative_and_links_contract() -> None:

--- a/tests/test_cli_decode_scan.py
+++ b/tests/test_cli_decode_scan.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 from pathlib import Path
 
 import pytest
@@ -10,7 +11,39 @@ from quillan.qr_decode import QrPayloadDetectionResult
 def test_decode_scan_accepts_image_or_pdf_source_path() -> None:
     args = build_parser().parse_args(["decode-scan", "scan.pdf"])
     assert args.source_file.name == "scan.pdf"
-    assert args.hide_payload is False
+    assert args.show_payload is False
+
+
+def test_decode_scan_reports_pds1_as_unsupported_without_echoing_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    raw = "PDS1|student=private_student|assignment=old"
+    page = decoding.DecodedPds2Page(
+        source_page_number=1,
+        raw_payload_text=raw,
+        locator=None,
+        decode_method="synthetic",
+        failure_category="payload_schema_unsupported",
+        error=ValueError(f"could not parse {raw}"),
+    )
+    monkeypatch.setattr(decoding, "resolve_workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        decoding,
+        "decode_retained_pds2_scan",
+        lambda *_args, **_kwargs: (page,),
+    )
+
+    assert decoding.handle_decode_scan(
+        Namespace(source_file=tmp_path / "scan.png", show_payload=False)
+    ) == 1
+    output = capsys.readouterr().out
+    assert "unsupported schema" in output
+    assert "only PDS2 is supported" in output
+    assert "private_student" not in output
+    assert "Schema:" not in output
+    assert "Module:" not in output
 
 
 def test_decode_only_contains_unexpected_qr_error_and_continues(

--- a/tests/test_cli_feedback.py
+++ b/tests/test_cli_feedback.py
@@ -60,7 +60,7 @@ def test_bare_feedback_prints_help_without_resolving_workspace(
         handlers, "resolve_workspace_root", lambda: pytest.fail("resolved workspace")
     )
     assert main(["feedback"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "{show,set-options,add-comment,use-reusable-comment,mark-composed}" in output
 
 
@@ -71,7 +71,7 @@ def test_show_without_review_is_ordered_read_only(
     submission = assignment.parent / "submissions" / STUDENT_ID / "submission.json"
     before = assignment.read_bytes(), submission.read_bytes()
     assert main(["feedback", "show", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Review state: not_started" in output
     assert "Configured feedback records: 0" in output
     assert "Missing feedback records: 2" in output
@@ -92,13 +92,13 @@ def test_set_options_replaces_selection_and_rejects_excluded_observation(
         "--include-overall-rationale", "false",
     ]
     assert main([*base, "--observation-ids", "observation_0001"]) == 0
-    assert "Action: created" in capsys.readouterr().out
+    assert "Action: created" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert main(base) == 0
     review = json.loads(path.read_text(encoding="utf-8"))
     assert review["feedback"]["standard_feedback"][0]["included_observation_ids"] == []
     before = path.read_bytes()
     assert main([*base, "--observation-ids", "observation_0003"]) == 1
-    assert "excluded from feedback eligibility" in capsys.readouterr().out
+    assert "excluded from feedback eligibility" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert path.read_bytes() == before
 
 
@@ -117,7 +117,7 @@ def test_add_comment_preserves_exact_inner_text_and_requires_reuse_scope(
     assert review["feedback"]["standard_feedback"][0]["comments"][0]["text"] == "Keep\nTHIS punctuation!"
     before = path.read_bytes()
     assert main([*args, "--purpose", "general"]) == 1
-    assert "require --save-for-reuse" in capsys.readouterr().out
+    assert "require --save-for-reuse" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert path.read_bytes() == before
 
 
@@ -137,7 +137,7 @@ def test_reusable_selection_is_snapshot_and_increments_usage(
         "--comment-id", "claim_next_step", "--include-in-feedback", "true",
     ]
     assert main(args) == 0
-    assert "feedback_comment_0001" in capsys.readouterr().out
+    assert "feedback_comment_0001" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     review = json.loads(review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(encoding="utf-8"))
     assert review["feedback"]["standard_feedback"][0]["comments"][0]["text"] == "Explain why this evidence supports your claim."
     comment_set = json.loads((workspace / "shared" / "focus_standard_comments" / "synthetic_argument_focus_comments.json").read_text(encoding="utf-8"))
@@ -152,7 +152,7 @@ def test_mark_composed_requires_yes_without_argparse_prompt(
     before = path.read_bytes()
     base = ["feedback", "mark-composed", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
     assert main(base) == 1
-    assert "--yes is required" in capsys.readouterr().out
+    assert "--yes is required" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert path.read_bytes() == before
     assert main([*base, "--yes"]) == 0
     assert json.loads(path.read_text(encoding="utf-8"))["review_state"] == "feedback_composed"

--- a/tests/test_cli_feedback_export.py
+++ b/tests/test_cli_feedback_export.py
@@ -74,13 +74,13 @@ def test_cli_exports_feedback_and_prints_summary(
         ["export-feedback", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
     ) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Exported student feedback:" in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
     assert f"Student: {STUDENT_ID}" in output
     assert "Included comments: 1" in output
-    assert "Scores: 1" in output
+    assert "Overall Focus Standard ratings: 1" in output
     assert "Overwrote existing: no" in output
     relative = (
         f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/submissions/"
@@ -108,7 +108,7 @@ def test_cli_missing_review_returns_one(
     assert main(
         ["export-feedback", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
     ) == 1
-    assert "Review record does not exist" in capsys.readouterr().out
+    assert "Review record does not exist" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_cli_exports_pdf_feedback_and_prints_pdf_summary(
@@ -131,7 +131,7 @@ def test_cli_exports_pdf_feedback_and_prints_pdf_summary(
         ]
     ) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Exported student feedback PDF:" in output
     assert "Focus Standard ratings:" in output
     assert "PDF file:" in output
@@ -160,7 +160,7 @@ def test_cli_overwrite_flag_controls_replacement(
     assert output_path.read_text(encoding="utf-8") == "manual edit"
     assert main([*command, "--overwrite"]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Use --overwrite" in output
     assert "Overwrote existing: yes" in output
     assert output_path.read_text(encoding="utf-8").startswith("# Feedback")

--- a/tests/test_cli_observations.py
+++ b/tests/test_cli_observations.py
@@ -149,7 +149,7 @@ def test_bare_namespace_prints_help_without_resolving_workspace(
         lambda: pytest.fail("bare namespace resolved the workspace"),
     )
     assert main(["observations"]) == 0
-    assert "{list,set,mark-complete}" in capsys.readouterr().out
+    assert "{list,set,mark-complete}" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_mark_complete_requires_yes_before_resolving_workspace(
@@ -176,7 +176,7 @@ def test_list_without_review_is_read_only_and_reports_setup_guidance(
 
     assert main(["observations", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert f"Student: {STUDENT_ID}" in output
     assert "Review state: not_started" in output
     assert "Review record exists: no" in output
@@ -204,7 +204,7 @@ def test_list_orders_units_and_standards_and_reports_matrix_totals(
 
     assert main(["observations", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert output.index("1. Opening") < output.index("3. Conclusion")
     first_unit = output[output.index("1. Opening") : output.index("3. Conclusion")]
     assert first_unit.index("Focus Standard: W.1") < first_unit.index("Focus Standard: L.2")
@@ -243,7 +243,7 @@ def test_set_applicable_supports_optional_assignment_scale_rating_and_replacemen
             "false",
         )
     ) == 0
-    first_output = capsys.readouterr().out
+    first_output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Unit-level rating: 7 (Secure)" in first_output
     assert "Rationale: present" in first_output
 
@@ -261,7 +261,7 @@ def test_set_applicable_supports_optional_assignment_scale_rating_and_replacemen
     assert observation["include_in_feedback"] is True
     assert review["overall_standard_ratings"] == []
     assert review["feedback"]["standard_feedback"] == []
-    assert "Action: updated" in capsys.readouterr().out
+    assert "Action: updated" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_set_not_applicable_stores_nulls_and_allows_feedback_override(
@@ -329,7 +329,7 @@ def test_invalid_combinations_do_not_change_review(
     record_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     before = record_path.read_bytes()
     assert main(_set_args(*extra)) == 1
-    assert message in capsys.readouterr().out
+    assert message in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert record_path.read_bytes() == before
 
 
@@ -364,13 +364,13 @@ def test_returned_review_can_be_listed_but_not_changed(
     before = record_path.read_bytes()
 
     assert main(["observations", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
-    assert "Review state: returned_without_full_review" in capsys.readouterr().out
+    assert "Review state: returned_without_full_review" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert main(_set_args("--applicable", "true", "--evidence-present", "true")) == 1
-    assert "Change the minimum-requirements outcome" in capsys.readouterr().out
+    assert "Change the minimum-requirements outcome" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert record_path.read_bytes() == before
 
     assert main(_complete_args("--yes")) == 1
-    assert "Change the minimum-requirements outcome" in capsys.readouterr().out
+    assert "Change the minimum-requirements outcome" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert record_path.read_bytes() == before
 
 
@@ -405,7 +405,7 @@ def test_mark_complete_reuses_service_result_and_warns_without_prompting(
 
     assert main(_complete_args("--yes")) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert calls == [(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)]
     assert "Unobserved unit-standard pairs: 3" in output
     assert (
@@ -434,7 +434,7 @@ def test_mark_complete_allows_zero_observations_and_preserves_review_content(
     assert main(_complete_args("--yes")) == 0
 
     after = json.loads(record_path.read_text(encoding="utf-8"))
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert after["review_state"] == "observations_complete"
     assert after["updated_at"] != before["updated_at"]
     assert after["review_units"][0]["standard_observations"] == []
@@ -466,7 +466,7 @@ def test_mark_complete_with_partial_coverage_reports_service_count(
 
     assert main(_complete_args("--yes")) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     review = json.loads(
         review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).read_text(
             encoding="utf-8"
@@ -514,7 +514,7 @@ def test_mark_complete_with_full_coverage_has_no_warning(
 
     assert main(_complete_args("--yes")) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Unobserved unit-standard pairs: 0" in output
     assert "Warning:" not in output
 
@@ -527,7 +527,7 @@ def test_mark_complete_requires_existing_review_and_units_without_writing(
     manifest_before = manifest_path.read_bytes()
 
     assert main(_complete_args("--yes")) == 1
-    assert "Review units must be defined before recording observations" in capsys.readouterr().out
+    assert "Review units must be defined before recording observations" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not record_path.exists()
     assert manifest_path.read_bytes() == manifest_before
 
@@ -545,5 +545,5 @@ def test_mark_complete_requires_existing_review_and_units_without_writing(
     before = record_path.read_bytes()
 
     assert main(_complete_args("--yes")) == 1
-    assert "Define review units before marking observations complete" in capsys.readouterr().out
+    assert "Define review units before marking observations complete" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert record_path.read_bytes() == before

--- a/tests/test_cli_open_evidence.py
+++ b/tests/test_cli_open_evidence.py
@@ -1,4 +1,4 @@
-"""CLI tests for local evidence opening."""
+"""CLI contract tests for identity-based evidence opening."""
 
 from __future__ import annotations
 
@@ -8,63 +8,77 @@ import pytest
 
 from quillan.cli import main
 import quillan.cli_app.handlers.submissions as cli_submissions
-from quillan.evidence_opening import EvidenceOpeningError, OpenedEvidence
+from quillan.submission_review_opening import (
+    OpenedSubmissionEvidencePage,
+    OpenedSubmissionReview,
+)
 
 
-def test_open_evidence_uses_active_workspace_and_prints_relative_path(
+def test_raw_path_open_evidence_command_is_retired(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        main(["open-evidence", "classes/class_1/scans/evidence.pdf"])
+
+    assert error.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "invalid choice: 'open-evidence'" in captured.err
+
+
+def test_open_submission_passes_explicit_evidence_identity(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    relative_path = "classes/class_1/scans/evidence.pdf"
-    calls: list[tuple[Path, str | Path]] = []
+    calls: list[tuple[int | None, str | None]] = []
+    opened = OpenedSubmissionReview(
+        class_id="class_1",
+        assignment_id="assignment_1",
+        student_id="student_1",
+        manifest_path=tmp_path / "submission.json",
+        manifest_relative_path=(
+            "classes/class_1/modules/quillan/work/assignment_1/"
+            "submissions/student_1/submission.json"
+        ),
+        submission_state="unreviewed",
+        opened_pages=(
+            OpenedSubmissionEvidencePage(
+                page_number=2,
+                evidence_id="evidence_2",
+                evidence_path=tmp_path / "evidence.pdf",
+                evidence_relative_path="classes/class_1/scans/evidence.pdf",
+                page_state="present",
+            ),
+        ),
+    )
+    monkeypatch.setattr(cli_submissions, "resolve_workspace_root", lambda: tmp_path)
+
+    def open_submission(
+        *_args: object,
+        page_number: int | None = None,
+        evidence_id: str | None = None,
+    ) -> OpenedSubmissionReview:
+        calls.append((page_number, evidence_id))
+        return opened
 
     monkeypatch.setattr(
-        cli_submissions, "resolve_workspace_root", lambda: tmp_path
+        cli_submissions, "open_student_submission_for_review", open_submission
     )
 
-    def open_evidence(
-        workspace_root: str | Path,
-        evidence_path: str | Path,
-    ) -> OpenedEvidence:
-        calls.append((Path(workspace_root), evidence_path))
-        return OpenedEvidence(
-            evidence_path=tmp_path / relative_path,
-            evidence_relative_path=relative_path,
-        )
-
-    monkeypatch.setattr(
-        cli_submissions, "open_workspace_evidence", open_evidence
-    )
-
-    assert main(["open-evidence", relative_path]) == 0
-    assert calls == [(tmp_path, relative_path)]
-    assert capsys.readouterr().out == (
-        "Opened evidence file:\n"
-        "classes/class_1/scans/evidence.pdf\n"
-    )
-
-
-@pytest.mark.parametrize("evidence_path", ["missing.pdf", "../outside.pdf"])
-def test_open_evidence_reports_validation_failure(
-    tmp_path: Path,
-    evidence_path: str,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        cli_submissions, "resolve_workspace_root", lambda: tmp_path
-    )
-
-    def fail_to_open(
-        _workspace_root: str | Path,
-        _evidence_path: str | Path,
-    ) -> OpenedEvidence:
-        raise EvidenceOpeningError("unsafe or missing evidence")
-
-    monkeypatch.setattr(
-        cli_submissions, "open_workspace_evidence", fail_to_open
-    )
-
-    assert main(["open-evidence", evidence_path]) == 1
-    assert "Error: could not open evidence file" in capsys.readouterr().out
+    assert main(
+        [
+            "open-submission",
+            "class_1",
+            "assignment_1",
+            "student_1",
+            "--page",
+            "2",
+            "--evidence-id",
+            "evidence_2",
+        ]
+    ) == 0
+    assert calls == [(2, "evidence_2")]
+    output = capsys.readouterr().out
+    assert "Evidence: evidence_2" in output
+    assert str(tmp_path) not in output

--- a/tests/test_cli_pages.py
+++ b/tests/test_cli_pages.py
@@ -105,10 +105,10 @@ def test_help_lists_pages_namespace_and_all_subcommands(capsys: pytest.CaptureFi
     with pytest.raises(SystemExit) as top_help:
         main(["--help"])
     assert top_help.value.code == 0
-    assert "pages" in capsys.readouterr().out
+    assert "pages" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     assert main(["pages"]) == 0
-    namespace_help = capsys.readouterr().out
+    namespace_help = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "list" in namespace_help
     assert "exclude" in namespace_help
     assert "restore" in namespace_help
@@ -143,7 +143,7 @@ def test_list_is_read_only_and_orders_pages(
 
     assert main(["pages", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert output.index("Page 1:") < output.index("Page 2:") < output.index("Page 3:")
     assert "Selected evidence: none" in output
     assert "Present pages: 1" in output
@@ -164,7 +164,7 @@ def test_plain_paper_lists_zero_pages_and_mutations_fail_without_writing(
     _configure_workspace(monkeypatch, tmp_path)
 
     assert main(["pages", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Plain-paper submission: yes" in output
     assert "zero digital pages" in output
     assert "Digital pages: none" in output
@@ -182,7 +182,7 @@ def test_plain_paper_lists_zero_pages_and_mutations_fail_without_writing(
                 "--yes",
             ]
         ) == 1
-        assert "Page 1 is not in this submission record" in capsys.readouterr().out
+        assert "Page 1 is not in this submission record" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
         assert path.read_bytes() == before
 
 
@@ -195,7 +195,7 @@ def test_missing_manifest_reports_assembly_guidance_without_creating_files(
     path = submission_manifest_path(tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
 
     assert main(["pages", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 1
-    assert "Assemble submissions" in capsys.readouterr().out
+    assert "Assemble submissions" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not path.exists()
     assert not path.parent.exists()
 
@@ -257,13 +257,13 @@ def test_cli_mutations_report_transition_and_preserve_submission_state(
     args = [CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--page", "1", "--yes"]
 
     assert main(["pages", "exclude", *args]) == 0
-    excluded_output = capsys.readouterr().out
+    excluded_output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Action: excluded" in excluded_output
     assert "Previous state: present" in excluded_output
     assert "Resulting state: excluded from active review" in excluded_output
 
     assert main(["pages", "restore", *args]) == 0
-    restored_output = capsys.readouterr().out
+    restored_output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Action: restored" in restored_output
     assert "Restore source: preserved pre-exclusion metadata" in restored_output
 

--- a/tests/test_cli_printable_responses.py
+++ b/tests/test_cli_printable_responses.py
@@ -53,7 +53,7 @@ def test_direct_dry_run_is_nonmutating_and_aggregate_only(
     assert handlers.handle_printable_responses_generate(
         args(dry_run=True, pages_per_student=2)
     ) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Planned issuances: 2" in output
     assert "Planned routes: 4" in output
     assert "No files were written." in output
@@ -77,7 +77,7 @@ def test_direct_generation_never_opens_and_reports_verified_routes(
     assert handlers.handle_printable_responses_generate(args(yes=True)) == 0
     packet = assignment_path.parent / "templates" / "printable_response_pages.pdf"
     assert len(PdfReader(str(packet)).pages) == 2
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Created routes: 2" in output
     assert "Verified routes: 2" in output
     assert "Installed: yes" in output
@@ -115,7 +115,7 @@ def test_direct_governed_packet_error_is_clean_and_never_opens(
         ),
     )
     assert handlers.handle_printable_responses_generate(args(yes=True)) == 1
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Error: synthetic governed planning failure" in output
     assert "Traceback" not in output
     assert not list(tmp_path.rglob("*.pdf"))

--- a/tests/test_cli_ratings.py
+++ b/tests/test_cli_ratings.py
@@ -152,7 +152,7 @@ def test_bare_namespace_prints_help_without_resolving_workspace(
         lambda: pytest.fail("bare ratings namespace resolved workspace"),
     )
     assert main(["ratings"]) == 0
-    assert "{list,set,mark-complete}" in capsys.readouterr().out
+    assert "{list,set,mark-complete}" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_list_without_review_is_ordered_and_strictly_read_only(
@@ -164,7 +164,7 @@ def test_list_without_review_is_ordered_and_strictly_read_only(
 
     assert main(["ratings", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert f"Student: {STUDENT_ID}" in output
     assert "Review state: not_started" in output
     assert "Review record exists: no" in output
@@ -190,7 +190,7 @@ def test_set_creates_then_replaces_without_inference_or_duplicate(
     monkeypatch.setattr("builtins.input", lambda *_args: pytest.fail("CLI prompted"))
 
     assert main(_set_args("--rationale", "  Teacher judgment.  ")) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Rating: 7 - Secure" in output
     assert "Rationale: present" in output
     assert "Include in feedback: no" in output
@@ -203,7 +203,7 @@ def test_set_creates_then_replaces_without_inference_or_duplicate(
     assert review["overall_standard_ratings"][0]["rationale"] is None
     assert review["review_units"] == []
     assert review["feedback"]["standard_feedback"] == []
-    assert "Action: updated" in capsys.readouterr().out
+    assert "Action: updated" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert (assignment_path.read_bytes(), manifest_path.read_bytes()) == immutable
 
 
@@ -211,11 +211,11 @@ def test_write_commands_require_an_existing_review(
     workspace: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     assert main(_set_args()) == 1
-    assert "review record must exist" in capsys.readouterr().out
+    assert "review record must exist" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert main(
         ["ratings", "mark-complete", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--yes"]
     ) == 1
-    assert "review record must exist" in capsys.readouterr().out
+    assert "review record must exist" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
 
 
@@ -237,12 +237,12 @@ def test_invalid_standard_and_rating_fail_without_writing(
     argv = _set_args()
     argv[argv.index("W.1")] = "CORE.BUT.NOT.CONFIGURED"
     assert main(argv) == 1
-    assert "Valid Focus Standard IDs: W.1, L.2" in capsys.readouterr().out
+    assert "Valid Focus Standard IDs: W.1, L.2" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert path.read_bytes() == before
     argv = _set_args()
     argv[argv.index("7")] = "5"
     assert main(argv) == 1
-    assert "Allowed values: -2, 0, 7" in capsys.readouterr().out
+    assert "Allowed values: -2, 0, 7" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert path.read_bytes() == before
 
 
@@ -262,7 +262,7 @@ def test_mark_complete_requires_yes_and_allows_zero_ratings(
     review = json.loads(path.read_text(encoding="utf-8"))
     assert review["review_state"] == "ratings_complete"
     assert review["overall_standard_ratings"] == []
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Ratings recorded: 0" in output
     assert "Missing ratings: 2" in output
     assert "none were created" in output
@@ -284,9 +284,9 @@ def test_returned_review_is_listable_but_byte_stable_for_failed_writes(
     before = path.read_bytes()
 
     assert main(["ratings", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
-    assert "overall ratings not applicable" in capsys.readouterr().out
+    assert "overall ratings not applicable" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert main(_set_args()) == 1
-    assert "returned without full standards review" in capsys.readouterr().out
+    assert "returned without full standards review" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert main(
         ["ratings", "mark-complete", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, "--yes"]
     ) == 1
@@ -312,7 +312,7 @@ def test_list_reports_stale_rating_without_counting_it(
     before = copy.deepcopy(path.read_bytes())
 
     assert main(["ratings", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Ratings recorded: 0" in output
     assert "Ratings missing: 2" in output
     assert "Unrecognized or stale stored ratings" in output

--- a/tests/test_cli_requirements.py
+++ b/tests/test_cli_requirements.py
@@ -124,7 +124,7 @@ def test_bare_requirements_prints_help_without_resolving_workspace(
         lambda: pytest.fail("bare namespace resolved the workspace"),
     )
     assert main(["requirements"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "{list,set-check,set-outcome}" in output
 
 
@@ -142,7 +142,7 @@ def test_list_is_read_only_and_preserves_requirement_order(
 
     assert main(["requirements", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     keys = [
         "paragraphs_min",
         "paragraphs_max",
@@ -180,7 +180,7 @@ def test_set_check_uses_assignment_values_and_clears_omitted_note(
     assert check["met"] is True
     assert "teacher_note" not in check
     assert len(review["minimum_requirement_checks"]) == 1
-    assert "Action: updated" in capsys.readouterr().out
+    assert "Action: updated" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_unknown_key_and_missing_manifest_fail_without_writing(
@@ -191,12 +191,12 @@ def test_unknown_key_and_missing_manifest_fail_without_writing(
         "--requirement-key", "arbitrary", "--met", "true",
     ]
     assert main(command) == 1
-    assert "Valid keys:" in capsys.readouterr().out
+    assert "Valid keys:" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
 
     submission_manifest_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).unlink()
     assert main(command) == 1
-    assert "assemble" in capsys.readouterr().out.lower()
+    assert "assemble" in (lambda captured: captured.out + captured.err)(capsys.readouterr()).lower()
     assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()
 
 
@@ -221,7 +221,7 @@ def test_outcome_eligibility_and_return_safeguards(
         "teacher_note": "Revise and resubmit.",
         "updated_at": review["minimum_requirement_outcome"]["updated_at"],
     }
-    assert "Full standards review was not completed." in capsys.readouterr().out
+    assert "Full standards review was not completed." in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_met_succeeds_only_after_every_configured_check_is_met(workspace: Path) -> None:
@@ -304,7 +304,7 @@ def test_no_configured_requirements_list_succeeds_but_set_fails(
     assignment["basic_requirements"] = {}
     path.write_text(json.dumps(assignment), encoding="utf-8")
     assert main(["requirements", "list", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
-    assert "Minimum requirements: none configured" in capsys.readouterr().out
+    assert "Minimum requirements: none configured" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert main(
         ["requirements", "set-check", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID,
          "--requirement-key", "paragraphs_min", "--met", "true"]

--- a/tests/test_cli_review_dashboard.py
+++ b/tests/test_cli_review_dashboard.py
@@ -24,9 +24,9 @@ def test_cli_review_dashboard_text_and_json_are_read_only(
     monkeypatch.setattr(cli_dashboard, "resolve_workspace_root", lambda: tmp_path)
 
     assert main(["review-dashboard", CLASS_ID, ASSIGNMENT_ID]) == 0
-    assert "Assignment Review Dashboard" in capsys.readouterr().out
+    assert "Assignment Review Dashboard" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert main(["review-dashboard", CLASS_ID, ASSIGNMENT_ID, "--format", "json"]) == 0
-    document = json.loads(capsys.readouterr().out)
+    document = json.loads((lambda captured: captured.out + captured.err)(capsys.readouterr()))
 
     assert document["schema_version"] == "1"
     assert document["assignment"]["path"].startswith("classes/")
@@ -42,8 +42,8 @@ def test_cli_review_dashboard_help_and_expected_failure(
     with pytest.raises(SystemExit) as help_exit:
         main(["review-dashboard", "--help"])
     assert help_exit.value.code == 0
-    assert "--format" in capsys.readouterr().out
+    assert "--format" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     monkeypatch.setattr(cli_dashboard, "resolve_workspace_root", lambda: tmp_path)
     assert main(["review-dashboard", CLASS_ID, ASSIGNMENT_ID]) == 1
-    assert "Error: could not build" in capsys.readouterr().out
+    assert "Error: could not build" in (lambda captured: captured.out + captured.err)(capsys.readouterr())

--- a/tests/test_cli_review_units.py
+++ b/tests/test_cli_review_units.py
@@ -107,7 +107,7 @@ def test_bare_namespace_prints_help_without_resolving_workspace(
         lambda: pytest.fail("bare namespace resolved the workspace"),
     )
     assert main(["review-units"]) == 0
-    assert "{show,set}" in capsys.readouterr().out
+    assert "{show,set}" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_show_without_review_is_read_only(
@@ -119,7 +119,7 @@ def test_show_without_review_is_read_only(
 
     assert main(["review-units", "show", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert f"Student: {STUDENT_ID}" in output
     assert "Review-unit type: paragraph" in output
     assert "Review record exists: no" in output
@@ -150,7 +150,7 @@ def test_count_creates_menu_equivalent_canonical_units(
     ]
     assert all("page_number" not in unit and "evidence_id" not in unit for unit in review["review_units"])
     assert (assignment_path.read_bytes(), manifest_path.read_bytes()) == before
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Resulting unit count: 2" in output
     assert "Newly empty units added: 2" in output
     assert "Review state: observations_in_progress" in output
@@ -196,7 +196,7 @@ def test_invalid_json_input_does_not_create_review(
     units_path.write_text(json.dumps(value), encoding="utf-8")
     args = ["review-units", "set", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]
     assert main(args + ["--units", str(units_path)]) == 1
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Error: " in output
     assert error_text in output
     assert not review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID).exists()

--- a/tests/test_cli_rosters.py
+++ b/tests/test_cli_rosters.py
@@ -65,7 +65,7 @@ def test_roster_help_and_bare_namespace_do_not_resolve_workspace(
 
     monkeypatch.setattr(handlers, "resolve_workspace_root", fail_workspace)
     assert main(["roster"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     for command in (
         "create",
         "show",
@@ -78,7 +78,7 @@ def test_roster_help_and_bare_namespace_do_not_resolve_workspace(
     with pytest.raises(SystemExit) as help_exit:
         main(["roster", "update-student", "--help"])
     assert help_exit.value.code == 0
-    assert "cannot be changed" in capsys.readouterr().out
+    assert "cannot be changed" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 @pytest.mark.parametrize(
@@ -150,7 +150,7 @@ def test_create_uses_active_year_and_dry_run_writes_nothing(
             "--dry-run",
         ]
     ) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "School year: 2027-2028" in output
     assert "No files were written." in output
     assert not (workspace / "classes").exists()
@@ -236,12 +236,12 @@ def test_show_and_validate_are_read_only_and_report_metadata(
     _use_workspace(monkeypatch, workspace)
 
     assert main(["roster", "show", "english_10_p2"]) == 0
-    shown = capsys.readouterr().out
+    shown = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "0007" in shown
     assert "preferred_name" in shown
     assert "School year: not set" in shown
     assert main(["roster", "validate", "english_10_p2"]) == 0
-    assert "Canonical roster is valid." in capsys.readouterr().out
+    assert "Canonical roster is valid." in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert roster_path.read_bytes() == before
     assert not (roster_path.parent / "class.json").exists()
 
@@ -255,7 +255,7 @@ def test_validate_rejects_invalid_existing_metadata(
     _use_workspace(monkeypatch, workspace)
 
     assert main(["roster", "validate", "english_10_p2"]) == 1
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert output.startswith("Error:")
     assert "Traceback" not in output
 
@@ -274,7 +274,7 @@ def test_validate_prints_structured_roster_diagnostics(
     _use_workspace(monkeypatch, workspace)
 
     assert main(["roster", "validate", "english_10_p2"]) == 1
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "[blank_required_value]" in output
     assert "row 2" in output
     assert "column first_name" in output
@@ -397,7 +397,7 @@ def test_remove_changes_only_roster_and_preserves_evidence_and_metadata(
     ] == ["0042"]
     assert metadata_path.read_bytes() == metadata_before
     assert evidence.read_text(encoding="utf-8") == "retain"
-    assert "does not delete" in capsys.readouterr().out
+    assert "does not delete" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_mutation_dry_run_and_missing_confirmation_do_not_write(

--- a/tests/test_cli_scan_review_resolution.py
+++ b/tests/test_cli_scan_review_resolution.py
@@ -9,6 +9,7 @@ import pytest
 
 from quillan.cli import main
 import quillan.cli_app.handlers.scan_review as cli_scan_review
+from quillan.cli_app.parser import build_parser
 from tests.test_scan_review_resolution import FAILURE_ID, _write_failure
 
 
@@ -16,6 +17,26 @@ from tests.test_scan_review_resolution import FAILURE_ID, _write_failure
 def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(cli_scan_review, "resolve_workspace_root", lambda: tmp_path)
     return tmp_path
+
+
+def test_route_resolution_parser_accepts_exact_registered_route_identity() -> None:
+    args = build_parser().parse_args(
+        [
+            "resolve-scan-review",
+            FAILURE_ID,
+            "--action",
+            "route_selected",
+            "--route-id",
+            "rt_0123456789abcdef0123456789abcdef",
+            "--route-class-id",
+            "english12_p3",
+            "--route-assignment-id",
+            "essay_01",
+        ]
+    )
+    assert args.route_id == "rt_0123456789abcdef0123456789abcdef"
+    assert args.route_class_id == "english12_p3"
+    assert args.route_assignment_id == "essay_01"
 
 
 def test_list_and_resolve_scan_review_commands(
@@ -28,7 +49,7 @@ def test_list_and_resolve_scan_review_commands(
     listed = capsys.readouterr().out
     assert FAILURE_ID in listed
     assert "Status: unresolved" in listed
-    assert "Retained source:" in listed
+    assert "Source: teacher_scan.pdf" in listed
 
     assert main(
         [
@@ -46,7 +67,7 @@ def test_list_and_resolve_scan_review_commands(
     assert failure_path.read_bytes() == before
 
     assert main(["list-scan-review"]) == 0
-    assert "No Quillan scan review items" in capsys.readouterr().out
+    assert "No Core routing review items" in capsys.readouterr().out
     assert main(["list-scan-review", "--include-resolved"]) == 0
     assert "Status: resolved" in capsys.readouterr().out
 
@@ -73,7 +94,9 @@ def test_cli_reports_malformed_and_invalid_requests(
     assert main(
         ["resolve-scan-review", "failure_missing", "--action", "other", "--message", "x"]
     ) == 1
-    assert "Error:" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Error:" in captured.err
 
 
 def test_cli_writes_only_json_resolution_metadata(

--- a/tests/test_cli_standards_summary_export.py
+++ b/tests/test_cli_standards_summary_export.py
@@ -35,7 +35,7 @@ def test_cli_exports_standards_rows_and_prints_summary(
 
     assert main(["export-standards-summary", CLASS_ID, ASSIGNMENT_ID]) == 0
 
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Exported assignment-local Focus Standard summary:" in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
@@ -71,7 +71,7 @@ def test_cli_handles_missing_directory_and_overwrite(
     monkeypatch.setattr(cli_exports, "resolve_workspace_root", lambda: tmp_path)
     command = ["export-standards-summary", CLASS_ID, ASSIGNMENT_ID]
     assert main(command) == 1
-    assert "assignment config" in capsys.readouterr().out
+    assert "assignment config" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     _write_assignment(tmp_path)
     _write_review(
@@ -88,7 +88,7 @@ def test_cli_handles_missing_directory_and_overwrite(
     assert main(command) == 1
     assert output_path.read_text(encoding="utf-8") == "manual edit"
     assert main([*command, "--overwrite"]) == 0
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Use --overwrite" in output
     assert "Overwrote existing: yes" in output
 

--- a/tests/test_menu_density_matrix.py
+++ b/tests/test_menu_density_matrix.py
@@ -1,0 +1,34 @@
+"""Authoritative registry for the real menu-density acceptance workflows."""
+
+from __future__ import annotations
+
+
+MENU_DENSITY_ACCEPTANCE_MATRIX = {
+    "assignment creation": "tests/test_assignment_workflows.py::test_assignment_creation_density_uses_real_workflow",
+    "assignment validation": "tests/test_assignment_workflows.py::test_assignment_validation_density_uses_real_workflow",
+    "printable-response generation": "tests/test_printable_response_workflows.py::test_printable_response_density_uses_real_workflow",
+    "complete scan intake": "tests/test_menu_scan_intake.py::test_complete_scan_intake_density_uses_real_workflow",
+    "partial scan intake": "tests/test_menu_scan_intake.py::test_partial_scan_intake_density_uses_real_workflow",
+    "Core scan review": "tests/test_menu_scan_review_resolution.py::test_menu_resolves_one_scan_review_item",
+    "route selection/correction": "tests/test_menu_scan_review_resolution.py::test_route_correction_density_uses_real_workflow",
+    "post-dispatch review": "tests/test_menu_scan_review_resolution.py::test_post_dispatch_density_recorder_captures_focused_segments_and_redraw",
+    "successful retry": "tests/test_menu_scan_review_resolution.py::test_successful_retry_density_uses_real_workflow",
+    "assignment dashboard": "tests/test_menu_export_actions.py::test_assignment_review_actions_menu_includes_export_choices",
+    "full diagnostic dashboard": "tests/test_menu_export_actions.py::test_assignment_review_dashboard_hides_unused_duplicate_files",
+    "student selection": "tests/test_menu_review_student_work.py::test_review_workflow_selects_context_and_shows_read_only_summary",
+    "plain-paper creation": "tests/test_menu_review_student_work.py::test_review_menu_creates_plain_paper_submission_and_shows_review_actions",
+    "evidence opening": "tests/test_menu_review_student_work.py::test_review_menu_open_submission_uses_existing_safe_opening",
+    "page selection and page management": "tests/test_menu_review_student_work.py::test_review_menu_excludes_submission_page_without_touching_review_record",
+    "minimum requirements": "tests/test_menu_review_entry_actions.py::test_review_menu_records_minimum_requirement_check",
+    "review units": "tests/test_menu_review_student_work.py::test_review_menu_defines_review_units",
+    "observations": "tests/test_menu_review_student_work.py::test_review_menu_records_applicable_focus_standard_observation",
+    "ratings": "tests/test_menu_review_student_work.py::test_review_menu_records_and_completes_overall_focus_standard_rating",
+    "feedback composition": "tests/test_menu_review_student_work.py::test_review_menu_adds_custom_focus_standard_feedback_comment",
+    "teacher notes": "tests/test_menu_review_student_work.py::test_review_menu_adds_teacher_note_to_review_record",
+    "workflow-state changes": "tests/test_menu_review_student_work.py::test_review_menu_updates_review_workflow_state",
+    "feedback export": "tests/test_menu_export_actions.py::test_menu_export_student_feedback_creates_feedback_file",
+    "assignment-report export": "tests/test_menu_export_actions.py::test_menu_export_class_summary_creates_summary_file",
+    "help": "tests/test_menu_help.py::test_help_density_recorder_captures_focus_and_parent_redraw",
+}
+
+REQUIRED_MENU_DENSITY_WORKFLOWS = frozenset(MENU_DENSITY_ACCEPTANCE_MATRIX)

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+from tests.menu_screen_recorder import MenuScreenRecorder, assert_focused_child_screen
+
 from quillan.cli import main
 import quillan.review_menu as review_menu
 from quillan.review_record import build_empty_review_record
@@ -45,11 +47,15 @@ def _enter_assignment_review_actions() -> list[str]:
 
 
 def _exit_assignment_review_actions_to_main() -> list[str]:
-    return ["6", "", "3", "6"]
+    return ["b", "", "b", "q"]
 
 
 def _exit_after_assignment_action_to_main() -> list[str]:
-    return ["", "6", "", "3", "6"]
+    return ["", "b", "", "b", "q"]
+
+
+def _exit_after_report_action_to_main() -> list[str]:
+    return ["", "b", "b", "", "b", "q"]
 
 
 def _enter_selected_student(student_choice: str = "1") -> list[str]:
@@ -57,11 +63,11 @@ def _enter_selected_student(student_choice: str = "1") -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["12"] + _exit_assignment_review_actions_to_main()
+    return ["b"] + _exit_assignment_review_actions_to_main()
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "12"] + _exit_assignment_review_actions_to_main()
+    return ["", "b"] + _exit_assignment_review_actions_to_main()
 
 
 def _write_workspace(root: Path) -> None:
@@ -291,25 +297,41 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
+@pytest.mark.menu_density_workflow("assignment dashboard")
 def test_assignment_review_actions_menu_includes_export_choices(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         _enter_assignment_review_actions()
         + _exit_assignment_review_actions_to_main(),
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Assignment Review Actions",
+        required_text=(
+            f"Class: {CLASS_ID}",
+            f"Assignment: Synthetic Essay ({ASSIGNMENT_ID})",
+        ),
+        forbidden_parent_text="2. Scan Intake / Route Paper Responses",
+        parent_heading="Review Student Work",
+        result_heading="Assembly needed:",
+        unrelated_previous_text="R. Resolve Scan Review Items",
+    )
     assert "Assignment Review Actions" in output
-    assert "2. Assemble routed submissions" in output
-    assert "3. Export assignment-local class summary" in output
-    assert "4. Export assignment-local Focus Standard summary" in output
+    assert "2. View submission status" in output
+    assert "3. Review scan problems" in output
+    assert "4. Export reports" in output
+    assert "5. View full diagnostic dashboard" in output
 
 
+@pytest.mark.menu_density_workflow("full diagnostic dashboard")
 def test_assignment_review_dashboard_hides_unused_duplicate_files(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -327,7 +349,8 @@ def test_assignment_review_dashboard_hides_unused_duplicate_files(
         / "response_stu_0001_pg_001__dup_001.pdf"
     )
     duplicate.write_bytes(b"duplicate synthetic evidence")
-    _menu_input(monkeypatch, ["6"])
+    recorder = MenuScreenRecorder(["5", "", "b"])
+    recorder.install(monkeypatch)
 
     assert (
         review_menu._launch_assignment_review_actions(
@@ -337,7 +360,20 @@ def test_assignment_review_dashboard_hides_unused_duplicate_files(
     )
 
     output = capsys.readouterr().out
-    assert "Unassembled routed files: 0" in output
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Full Assignment Diagnostic Dashboard",
+        required_text=(
+            f"Class: {CLASS_ID}",
+            f"Assignment: Synthetic Essay ({ASSIGNMENT_ID})",
+        ),
+        forbidden_parent_text="4. Export reports",
+        parent_heading="Assignment Review Actions",
+        result_heading="Full Assignment Diagnostic Dashboard",
+        unrelated_previous_text="1. Select student/submission",
+    )
+    assert "Assembly needed: 0" in output
     assert "Duplicate routed files not used" not in output
     assert duplicate.name not in output
 
@@ -376,6 +412,7 @@ def test_selected_student_review_menu_includes_feedback_export(
     assert "10. Export student feedback" in output
 
 
+@pytest.mark.menu_density_workflow("feedback export")
 def test_menu_export_student_feedback_creates_feedback_file(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -412,15 +449,26 @@ def test_menu_export_student_feedback_creates_feedback_file(
     )
     review_before = review_path.read_bytes()
 
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         _enter_selected_student()
         + ["10", "2"]
         + _exit_after_selected_student_action_to_main(),
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Export Student Feedback",
+        required_text=(f"Student: Avery Rivera ({STUDENT_ID})", "Exported student feedback:"),
+        forbidden_parent_text="11. Refresh summary",
+        parent_heading="Selected Student Review",
+        result_heading="Exported student feedback:",
+        unrelated_previous_text="Current review summary",
+    )
+    recorder.print_transcript(screens, label="FEEDBACK EXPORT")
     assert "Exported student feedback:" in output
     assert "Overwrote existing: no" in output
     assert feedback_path.is_file()
@@ -478,6 +526,7 @@ def test_menu_export_student_feedback_pdf_creates_pdf_and_updates_metadata(
     )
 
 
+@pytest.mark.menu_density_workflow("assignment-report export")
 def test_menu_export_class_summary_creates_summary_file(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -497,15 +546,25 @@ def test_menu_export_class_summary_creates_summary_file(
     )
     assert not summary_path.exists()
 
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         _enter_assignment_review_actions()
-        + ["3", ""]
-        + _exit_after_assignment_action_to_main(),
+        + ["4", "1", ""]
+        + _exit_after_report_action_to_main(),
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Export Comprehensive Class Summary",
+        required_text=(f"Class: {CLASS_ID}", "Exported assignment-local class summary:"),
+        forbidden_parent_text="2. Export Focus Standard summary",
+        parent_heading="Assignment Reports",
+        result_heading="Exported assignment-local class summary:",
+        unrelated_previous_text="4. Back",
+    )
     assert "Exported assignment-local class summary:" in output
     assert "Overwrote existing: no" in output
     assert summary_path.is_file()
@@ -533,8 +592,8 @@ def test_menu_export_standards_summary_creates_summary_file(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["4", ""]
-        + _exit_after_assignment_action_to_main(),
+        + ["4", "2", ""]
+        + _exit_after_report_action_to_main(),
     )
 
     assert main(["menu"]) == 0
@@ -709,8 +768,8 @@ def test_menu_export_class_summary_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["3", ""]
-        + _exit_after_assignment_action_to_main(),
+        + ["4", "1", ""]
+        + _exit_after_report_action_to_main(),
     )
 
     assert main(["menu"]) == 0
@@ -743,8 +802,8 @@ def test_menu_export_class_summary_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["3", "y"]
-        + _exit_after_assignment_action_to_main(),
+        + ["4", "1", "y"]
+        + _exit_after_report_action_to_main(),
     )
 
     assert main(["menu"]) == 0
@@ -775,8 +834,8 @@ def test_menu_export_class_summary_invalid_overwrite_cancels_without_writing(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["3", "maybe"]
-        + _exit_after_assignment_action_to_main(),
+        + ["4", "1", "maybe"]
+        + _exit_after_report_action_to_main(),
     )
 
     assert main(["menu"]) == 0
@@ -807,8 +866,8 @@ def test_menu_export_standards_summary_overwrites_existing_export(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["4", "y"]
-        + _exit_after_assignment_action_to_main(),
+        + ["4", "2", "y"]
+        + _exit_after_report_action_to_main(),
     )
 
     assert main(["menu"]) == 0
@@ -841,8 +900,8 @@ def test_menu_export_standards_summary_requires_overwrite_when_existing(
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["4", ""]
-        + _exit_after_assignment_action_to_main(),
+        + ["4", "2", ""]
+        + _exit_after_report_action_to_main(),
     )
 
     assert main(["menu"]) == 0
@@ -873,8 +932,8 @@ def test_menu_export_standards_summary_invalid_overwrite_cancels_without_writing
     _menu_input(
         monkeypatch,
         _enter_assignment_review_actions()
-        + ["4", "maybe"]
-        + _exit_after_assignment_action_to_main(),
+        + ["4", "2", "maybe"]
+        + _exit_after_report_action_to_main(),
     )
 
     assert main(["menu"]) == 0

--- a/tests/test_menu_help.py
+++ b/tests/test_menu_help.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from quillan.menu import print_menu_help
+from quillan.menu import launch_menu, print_menu_help
+from tests.menu_screen_recorder import MenuScreenRecorder, assert_focused_child_screen
 
 
 def test_menu_help_is_current_concise_and_side_effect_free(
@@ -24,24 +25,50 @@ def test_menu_help_is_current_concise_and_side_effect_free(
     print_menu_help()
     output = capsys.readouterr().out
 
-    for entry_point in (
-        "review-dashboard",
-        "review-status",
-        "assignment --help",
-        "roster --help",
-        "printable-responses --help",
-        "requirements --help",
-        "review-units --help",
-        "observations --help",
-        "ratings --help",
-        "feedback --help",
-        "review-workflow --help",
-        "workspace --help",
+    for category in (
+        "Assignment setup:",
+        "Printable response pages:",
+        "Scan intake and review:",
+        "Student review:",
+        "Feedback and reports:",
+        "Workspace settings:",
     ):
-        assert entry_point in output
+        assert category in output
     assert "quillan --help" in output
-    assert "complete command surface" in output
+    assert "Complete direct help" in output
     assert "local-first" in output
     assert "teacher-controlled" in output
     assert "synthetic data" in output
+    assert "Do not commit or post real student data" in output
     assert tuple(tmp_path.rglob("*")) == before
+
+
+@pytest.mark.menu_density_workflow("help")
+def test_help_density_recorder_captures_focus_and_parent_redraw(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    recorder = MenuScreenRecorder(["5", "", "5", "", "q"])
+    recorder.install(monkeypatch)
+
+    def no_op() -> int:
+        return 0
+
+    def set_no_op(_path: str) -> int:
+        return 0
+
+    assert launch_menu(no_op, set_no_op, no_op, no_op) == 0
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="Quillan\x1b[0m\nHelp",
+        required_text="Assignment setup:",
+        forbidden_parent_text="1. Assignment Management",
+        parent_heading="1. Assignment Management",
+        result_heading="Quillan\x1b[0m\nHelp",
+        unrelated_previous_text="4. Workspace Settings",
+    )
+    for screen in screens:
+        print(f"--- CLEAR EVENT {screen.clear_number} ---")
+        print(screen.output)

--- a/tests/test_menu_review_entry_actions.py
+++ b/tests/test_menu_review_entry_actions.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.menu_screen_recorder import MenuScreenRecorder, assert_focused_child_screen
+
 from quillan.cli import main
 import quillan.review_menu as review_menu
 from quillan.review_record_paths import review_record_path
@@ -165,11 +167,11 @@ def _enter_selected_student() -> list[str]:
 
 
 def _exit_selected_student_to_main() -> list[str]:
-    return ["12", "6", "", "3", "6"]
+    return ["b", "b", "", "b", "q"]
 
 
 def _exit_after_selected_student_action_to_main() -> list[str]:
-    return ["", "12", "6", "", "3", "6"]
+    return ["", "b", "b", "", "b", "q"]
 
 
 @pytest.fixture
@@ -212,6 +214,7 @@ def test_review_menu_selected_student_excludes_legacy_review_entry_actions(
     ).exists()
 
 
+@pytest.mark.menu_density_workflow("minimum requirements")
 def test_review_menu_records_minimum_requirement_check(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -222,15 +225,25 @@ def test_review_menu_records_minimum_requirement_check(
     )
     manifest_before = manifest_path.read_bytes()
 
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         _enter_selected_student()
         + ["3", "1", "1", "1", "", "4"]
         + _exit_selected_student_to_main(),
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Record Requirement Check",
+        required_text=(f"Student: Avery Rivera ({STUDENT_ID})", "Recorded requirement check:"),
+        forbidden_parent_text="3. Export returned-work feedback",
+        parent_heading="Review Minimum Requirements",
+        result_heading="Recorded requirement check:",
+        unrelated_previous_text="Minimum paragraphs: not checked",
+    )
     assert "Requirement Checks" in output
     assert "Record Requirement Check" in output
     assert "Review Minimum Requirements" in output

--- a/tests/test_menu_review_student_work.py
+++ b/tests/test_menu_review_student_work.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+from tests.menu_screen_recorder import MenuScreenRecorder, assert_focused_child_screen
+
 from quillan.cli import main
 from quillan.focus_standard_comments import focus_standard_comment_set_path
 import quillan.review_menu as review_menu
@@ -296,7 +298,7 @@ def test_main_menu_shows_and_opens_review_student_work(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(monkeypatch, ["2", "3", "6"])
+    _menu_input(monkeypatch, ["2", "b", "q"])
 
     assert main(["menu"]) == 0
 
@@ -312,6 +314,7 @@ def test_main_menu_shows_and_opens_review_student_work(
     assert "Goodbye." in output
 
 
+@pytest.mark.menu_density_workflow("student selection")
 def test_review_workflow_selects_context_and_shows_read_only_summary(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -329,14 +332,28 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
         for path in workspace.rglob("*")
         if path.is_file()
     )
-    _menu_input(monkeypatch, ["2", "1", "1", "1", "1", "1", "12", "6", "", "3", "6"])
+    recorder = MenuScreenRecorder(
+        ["2", "1", "1", "1", "1", "1", "b", "b", "", "b", "q"]
+    )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Select Student/Submission",
+        required_text=f"Avery Rivera ({STUDENT_ID})",
+        forbidden_parent_text="5. View full diagnostic dashboard",
+        parent_heading="Assignment Review Actions",
+        result_heading="Selected Student Review",
+        unrelated_previous_text="Assembly needed:",
+    )
+    recorder.print_transcript(screens, label="SELECTED STUDENT REVIEW")
     assert f"1. {CLASS_ID}" in output
     assert f"1. {ASSIGNMENT_ID} - Synthetic Essay" in output
-    assert f"Submission status for assignment {ASSIGNMENT_ID}" in output
+    assert "Select Student/Submission" in output
     assert (
         f"1. Avery Rivera ({STUDENT_ID}): "
         "unreviewed; manifest exists; evidence files=1"
@@ -349,10 +366,10 @@ def test_review_workflow_selects_context_and_shows_read_only_summary(
     assert "Current review summary" in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
-    assert f"Student: Avery Rivera ({STUDENT_ID})" in output
-    assert "Submission: assembled" in output
-    assert "Evidence files: 1" in output
-    assert "Review record: not started" in output
+    assert "Student: Avery Rivera" in output
+    assert "Submission: valid" in output
+    assert "Routed evidence files: 0" in output
+    assert "Review: no review record" in output
     assert manifest_path.read_bytes() == manifest_before
     assert files_before == sorted(
         path.relative_to(workspace)
@@ -382,26 +399,24 @@ def test_review_summary_includes_existing_review_record_counts(
     review_before = review_path.read_bytes()
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "12", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "b", "b", "", "b", "q"],
     )
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "Review record: exists" in output
     assert "Review: feedback composed" in output
-    assert "Private notes: 1" in output
-    assert "Review-unit observations: 0" in output
+    assert "Review progress:" in output
     assert review_path.read_bytes() == review_before
 
 
+@pytest.mark.menu_density_workflow("review units")
 def test_review_menu_defines_review_units(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         [
             "2",
             "1",
@@ -415,16 +430,23 @@ def test_review_menu_defines_review_units(
             "1",
             "",
             "4",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Review Units and Focus Standard Observations",
+        required_text=(f"Student: Avery Rivera ({STUDENT_ID})", "Updated review units:"),
+        forbidden_parent_text="11. Refresh summary",
+        parent_heading="Selected Student Review",
+        result_heading="Updated review units:",
+        unrelated_previous_text="Current review summary",
+    )
     assert "Review Units and Focus Standard Observations" in output
     assert "Updated review units:" in output
     review = json.loads(
@@ -443,13 +465,13 @@ def test_review_menu_defines_review_units(
     assert review["review_state"] == "observations_in_progress"
 
 
+@pytest.mark.menu_density_workflow("observations")
 def test_review_menu_records_applicable_focus_standard_observation(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         [
             "2",
             "1",
@@ -473,16 +495,23 @@ def test_review_menu_records_applicable_focus_standard_observation(
             "",
             "B",
             "4",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Record Focus Standard Observation",
+        required_text=(f"Student: Avery Rivera ({STUDENT_ID})", "Updated Focus Standard observation:"),
+        forbidden_parent_text="4. Back",
+        parent_heading="Review Units and Focus Standard Observations",
+        result_heading="Updated Focus Standard observation:",
+        unrelated_previous_text="Review units:",
+    )
     assert "Record Focus Standard Observation" in output
     assert "Step: Applicability" in output
     assert "Step: Save confirmation" in output
@@ -618,11 +647,7 @@ def test_review_menu_marks_observations_complete(
             "1",
             "",
             "4",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
 
@@ -634,6 +659,7 @@ def test_review_menu_marks_observations_complete(
     assert review["overall_standard_ratings"] == []
 
 
+@pytest.mark.menu_density_workflow("ratings")
 def test_review_menu_records_and_completes_overall_focus_standard_rating(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -666,8 +692,7 @@ def test_review_menu_records_and_completes_overall_focus_standard_rating(
     review_path = review_record_path(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)
     review_path.write_text(json.dumps(review), encoding="utf-8")
 
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         [
             "2",
             "1",
@@ -688,16 +713,23 @@ def test_review_menu_records_and_completes_overall_focus_standard_rating(
             "1",
             "",
             "4",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Record Overall Focus Standard Rating",
+        required_text=(f"Student: Avery Rivera ({STUDENT_ID})", "Updated overall Focus Standard rating:"),
+        forbidden_parent_text="4. Back",
+        parent_heading="Overall Focus Standard Ratings",
+        result_heading="Updated overall Focus Standard rating:",
+        unrelated_previous_text="3. Mark ratings complete",
+    )
     assert "Overall Focus Standard Ratings" in output
     assert "Record Overall Focus Standard Rating" in output
     assert "Step: Rating" in output
@@ -892,11 +924,7 @@ def test_review_menu_blocks_observations_for_returned_without_full_review(
             "1",
             "",
             "4",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
 
@@ -972,7 +1000,7 @@ def test_review_menu_views_current_review_details_read_only(
 
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "2", "", "12", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "2", "", "b", "b", "", "b", "q"],
     )
 
     assert main(["menu"]) == 0
@@ -989,6 +1017,7 @@ def test_review_menu_views_current_review_details_read_only(
     assert review_path.read_bytes() == review_before
 
 
+@pytest.mark.menu_density_workflow("evidence opening")
 def test_review_menu_open_submission_uses_existing_safe_opening(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1003,9 +1032,11 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
         student_id: str,
         *,
         page_number: int | None = None,
+        evidence_id: str | None = None,
     ) -> OpenedSubmissionReview:
         calls.append((Path(workspace_root), class_id, assignment_id, student_id))
         assert page_number == 1
+        assert evidence_id == "evidence_001"
         return OpenedSubmissionReview(
             class_id=class_id,
             assignment_id=assignment_id,
@@ -1029,14 +1060,24 @@ def test_review_menu_open_submission_uses_existing_safe_opening(
         "open_student_submission_for_review",
         open_submission,
     )
-    _menu_input(
-        monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "", "12", "6", "", "3", "6"],
+    recorder = MenuScreenRecorder(
+        ["2", "1", "1", "1", "1", "1", "1", "1", "1", "y", "", "b", "b", "", "b", "q"],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Select Submission Page",
+        required_text=f"Student: Avery Rivera ({STUDENT_ID})",
+        forbidden_parent_text="11. Refresh summary",
+        parent_heading="Selected Student Review",
+        result_heading="Submission Evidence Opened",
+        unrelated_previous_text="Current review summary",
+    )
     assert calls == [(workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID)]
     assert "Opened submission evidence for review:" in output
     assert (
@@ -1060,8 +1101,10 @@ def test_review_menu_multi_page_open_submission_selects_one_page(
         student_id: str,
         *,
         page_number: int | None = None,
+        evidence_id: str | None = None,
     ) -> OpenedSubmissionReview:
         calls.append(page_number)
+        assert evidence_id == "evidence_002"
         return OpenedSubmissionReview(
             class_id=class_id,
             assignment_id=assignment_id,
@@ -1087,17 +1130,17 @@ def test_review_menu_multi_page_open_submission_selects_one_page(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "2", "", "12", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "2", "1", "y", "", "b", "b", "", "b", "q"],
     )
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
     assert calls == [2]
-    assert "Open Submission Evidence" in output
-    assert "1. Page 1 - present - evidence_001" in output
-    assert "2. Page 2 - present - evidence_002" in output
-    assert "A. All" in output
+    assert "Select Submission Page" in output
+    assert "1. Page 1; present; selected; candidates=1" in output
+    assert "2. Page 2; present; selected; candidates=1" in output
+    assert "A. Open all selected pages" in output
 
 
 def test_review_menu_multi_page_open_submission_opens_all_pages(
@@ -1149,7 +1192,7 @@ def test_review_menu_multi_page_open_submission_opens_all_pages(
     )
     _menu_input(
         monkeypatch,
-        ["2", "1", "1", "1", "1", "1", "1", "A", "", "12", "6", "", "3", "6"],
+        ["2", "1", "1", "1", "1", "1", "1", "A", "", "b", "b", "", "b", "q"],
     )
 
     assert main(["menu"]) == 0
@@ -1172,8 +1215,8 @@ def test_review_menu_reports_missing_openable_evidence(
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert f"Student: Mina Patel ({SECOND_STUDENT_ID})" in output
-    assert "Submission: not assembled" in output
+    assert "Student: Mina Patel" in output
+    assert "Submission: missing" in output
     assert "No digital submission evidence has been found" in output
     assert "1. Create plain-paper submission for this student" in output
     assert "Plain-paper submission creation canceled." in output
@@ -1181,20 +1224,31 @@ def test_review_menu_reports_missing_openable_evidence(
     assert not list(workspace.rglob("review.json"))
 
 
+@pytest.mark.menu_density_workflow("plain-paper creation")
 def test_review_menu_creates_plain_paper_submission_and_shows_review_actions(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(
-        monkeypatch,
-        ["2", "1", "1", "1", "1", "2", "1", "yes", "", "12", "6", "b", "q"],
+    recorder = MenuScreenRecorder(
+        ["2", "1", "1", "1", "1", "2", "1", "yes", "", "b", "b", "", "b", "q"],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
-    assert "Plain-paper submission created for Mina Patel" in output
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Create Plain-Paper Submission",
+        required_text=f"Student: Mina Patel ({SECOND_STUDENT_ID})",
+        forbidden_parent_text="3. Refresh summary",
+        parent_heading="Selected Student Review",
+        result_heading="Plain-Paper Submission Created",
+        unrelated_previous_text="No digital submission evidence",
+    )
+    assert "Plain-Paper Submission Created" in output
     assert "1. Open submission evidence" in output
     assert "5. Overall Focus Standard ratings" in output
     student_dir = (
@@ -1215,13 +1269,13 @@ def test_review_menu_creates_plain_paper_submission_and_shows_review_actions(
 
 
 
+@pytest.mark.menu_density_workflow("teacher notes")
 def test_review_menu_adds_teacher_note_to_review_record(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         [
             "2",
             "1",
@@ -1232,15 +1286,22 @@ def test_review_menu_adds_teacher_note_to_review_record(
             "8",
             "This is a test note.",
             "",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="Add Teacher Note",
+        required_text=(f"Student: Avery Rivera ({STUDENT_ID})", "Added teacher note:"),
+        forbidden_parent_text="11. Refresh summary",
+        parent_heading="Selected Student Review",
+        result_heading="Added teacher note:",
+        unrelated_previous_text="Current review summary",
+    )
 
     review_path = (
         workspace
@@ -1260,13 +1321,13 @@ def test_review_menu_adds_teacher_note_to_review_record(
     assert review["review_state"] == "not_started"
 
 
+@pytest.mark.menu_density_workflow("workflow-state changes")
 def test_review_menu_updates_review_workflow_state(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         [
             "2",
             "1",
@@ -1278,15 +1339,22 @@ def test_review_menu_updates_review_workflow_state(
             "4",
             "1",
             "",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="Update Review Workflow State",
+        required_text=(f"Student: Avery Rivera ({STUDENT_ID})", "Updated review workflow state:"),
+        forbidden_parent_text="11. Refresh summary",
+        parent_heading="Selected Student Review",
+        result_heading="Updated review workflow state:",
+        unrelated_previous_text="Current review summary",
+    )
 
     manifest_path = submission_manifest_path(
         workspace,
@@ -1304,6 +1372,7 @@ def test_review_menu_updates_review_workflow_state(
     assert review["review_state"] == "observations_in_progress"
 
 
+@pytest.mark.menu_density_workflow("feedback composition")
 def test_review_menu_adds_custom_focus_standard_feedback_comment(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1314,8 +1383,7 @@ def test_review_menu_adds_custom_focus_standard_feedback_comment(
     review["feedback"]["standard_feedback"] = []
     review_path.write_text(json.dumps(review), encoding="utf-8")
 
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         [
             "2",
             "1",
@@ -1332,16 +1400,23 @@ def test_review_menu_adds_custom_focus_standard_feedback_comment(
             "1",
             "",
             "5",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Add Focus Standard Feedback Comment",
+        required_text=(f"Student: {STUDENT_ID}", "Added Focus Standard feedback comment:"),
+        forbidden_parent_text="5. Back",
+        parent_heading="Compose Focus Standard Feedback",
+        result_heading="Added Focus Standard feedback comment:",
+        unrelated_previous_text="2. Add custom feedback comment",
+    )
     assert "Compose Focus Standard Feedback" in output
     assert "Add Focus Standard Feedback Comment" in output
     assert "Current rating: not recorded" in output
@@ -1373,7 +1448,7 @@ def test_review_menu_saves_default_custom_comment_text_for_reuse(
             "1", "",  # Reject invalid default-yes input, then accept its default.
             "1", "y",  # Reject invalid default-no input, then choose yes.
             "General feedback", "1", "", "", "1",
-            "", "5", "12", "6", "", "3", "6",
+            "", "5", "b", "b", "", "b", "q",
         ],
     )
 
@@ -1418,7 +1493,7 @@ def test_review_menu_keeps_revised_reusable_text_separate(
             "Avery, revise paragraph 2.", "", "y", "General revision", "2",
             "Revise the relevant paragraph.", "",
             "Character, Scene Development, dialogue", "1",
-            "", "5", "12", "6", "", "3", "6",
+            "", "5", "b", "b", "", "b", "q",
         ],
     )
 
@@ -1463,7 +1538,7 @@ def test_review_menu_back_while_saving_reusable_comment_writes_nothing(
         [
             "2", "1", "1", "1", "1", "1", "6", "2", "1",
             *reusable_steps,
-            "", "5", "12", "6", "", "3", "6",
+            "", "5", "b", "b", "", "b", "q",
         ],
     )
 
@@ -1539,11 +1614,7 @@ def test_review_menu_selects_reusable_focus_standard_feedback_comment(
             "1",
             "",
             "5",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
 
@@ -1561,6 +1632,7 @@ def test_review_menu_selects_reusable_focus_standard_feedback_comment(
     assert comment["include_in_feedback"] is True
 
 
+@pytest.mark.menu_density_workflow("page selection and page management")
 def test_review_menu_excludes_submission_page_without_touching_review_record(
     workspace: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1582,8 +1654,7 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
     review_before = review_path.read_bytes()
     evidence_path = workspace / EVIDENCE_RELATIVE_PATH
     evidence_before = evidence_path.read_bytes()
-    _menu_input(
-        monkeypatch,
+    recorder = MenuScreenRecorder(
         [
             "2",
             "1",
@@ -1596,17 +1667,24 @@ def test_review_menu_excludes_submission_page_without_touching_review_record(
             "1",
             "1",
             "",
-            "12",
-            "6",
-            "",
-            "3",
-            "6",
+            "b", "b", "", "b", "q",
         ],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Page Change Result",
+        required_text=(f"Student: Avery Rivera ({STUDENT_ID})", "Page change saved."),
+        forbidden_parent_text="11. Refresh summary",
+        parent_heading="Selected Student Review",
+        result_heading="Page Change Result",
+        unrelated_previous_text="Current review summary",
+    )
     assert "Manage Submission Pages" in output
     assert "Excluding a page does not delete the file." in output
     assert "Page change saved." in output
@@ -1632,7 +1710,7 @@ def test_review_menu_no_classes_and_invalid_selection_back_out_safely(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
-    _menu_input(monkeypatch, ["2", "9", "", "1", "", "3", "6"])
+    _menu_input(monkeypatch, ["2", "9", "", "1", "", "b", "q"])
 
     assert main(["menu"]) == 0
 

--- a/tests/test_menu_scan_intake.py
+++ b/tests/test_menu_scan_intake.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 import quillan.cli_app.handlers.routing as routing
 import quillan.menu as menu
+from quillan.intake_assembly import PostDispatchReviewPreservationBatch
+from tests.menu_screen_recorder import MenuScreenRecorder, assert_focused_child_screen
+from tests.test_observation_result_models import _models
 
 
 def _inputs(monkeypatch: pytest.MonkeyPatch, values: list[str]) -> None:
@@ -22,24 +26,30 @@ def test_menu_selects_real_inbox_scan_through_shared_service(
     inbox.mkdir()
     scan = inbox / "teacher.png"
     scan.write_bytes(b"scan")
-    calls: list[tuple[Path, Path, bool]] = []
+    result = object()
+    calls: list[tuple[Path, Path]] = []
+    routed_results: list[object] = []
 
     def run(
         source_path: Path,
         workspace_root: Path,
-        *,
-        on_summary: object = None,
-    ) -> int:
-        calls.append((source_path, workspace_root, on_summary is not None))
-        return 1
+    ) -> object:
+        calls.append((source_path, workspace_root))
+        return result
 
     monkeypatch.setattr(routing, "resolve_workspace_root", lambda: tmp_path)
-    monkeypatch.setattr(routing, "run_qr_scan_intake", run)
+    monkeypatch.setattr(routing, "run_scan_intake_workflow", run)
+    monkeypatch.setattr(
+        menu,
+        "handle_scan_post_route_menu",
+        lambda _root, value: routed_results.append(value),
+    )
     monkeypatch.setattr(menu, "clear_screen", lambda: None)
     monkeypatch.setattr(menu, "pause_for_user", lambda: None)
     _inputs(monkeypatch, ["1", "b"])
     menu.launch_scan_intake_workflow()
-    assert calls == [(scan, tmp_path, True)]
+    assert calls == [(scan, tmp_path)]
+    assert routed_results == [result]
 
 
 def test_menu_custom_path_uses_same_service_without_post_route_callback(
@@ -48,21 +58,91 @@ def test_menu_custom_path_uses_same_service_without_post_route_callback(
 ) -> None:
     custom = tmp_path / "custom.pdf"
     custom.write_bytes(b"scan")
-    calls: list[tuple[Path, bool]] = []
+    result = object()
+    calls: list[Path] = []
+    routed_results: list[object] = []
 
     def run(
         source_path: Path,
         _workspace_root: Path,
-        *,
-        on_summary: object = None,
-    ) -> int:
-        calls.append((source_path, on_summary is not None))
-        return 1
+    ) -> object:
+        calls.append(source_path)
+        return result
 
     monkeypatch.setattr(routing, "resolve_workspace_root", lambda: tmp_path)
-    monkeypatch.setattr(routing, "run_qr_scan_intake", run)
+    monkeypatch.setattr(routing, "run_scan_intake_workflow", run)
+    monkeypatch.setattr(
+        menu,
+        "handle_scan_post_route_menu",
+        lambda _root, value: routed_results.append(value),
+    )
     monkeypatch.setattr(menu, "clear_screen", lambda: None)
     monkeypatch.setattr(menu, "pause_for_user", lambda: None)
     _inputs(monkeypatch, ["c", f'"{custom}"', "b"])
     menu.launch_scan_intake_workflow()
-    assert calls == [(custom, False)]
+    assert calls == [custom]
+    assert routed_results == [result]
+
+
+@pytest.mark.menu_density_workflow("complete scan intake")
+def test_complete_scan_intake_density_uses_real_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    inbox = tmp_path / "scans_inbox"
+    inbox.mkdir()
+    scan = inbox / "teacher.png"
+    scan.write_bytes(b"scan")
+    post = _models(tmp_path)[-1]
+    monkeypatch.setattr(routing, "resolve_workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(routing, "run_scan_intake_workflow", lambda *_args: post)
+    recorder = MenuScreenRecorder(["1", "b", "b"])
+    recorder.install(monkeypatch)
+
+    menu.launch_scan_intake_workflow()
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="Processing Scan Intake",
+        required_text="Source:",
+        forbidden_parent_text="C. Choose custom file/folder path",
+        parent_heading="Scan Intake / Route Paper Responses",
+        result_heading="Scan Intake Result",
+        unrelated_previous_text="Available scans:",
+    )
+
+
+@pytest.mark.menu_density_workflow("partial scan intake")
+def test_partial_scan_intake_density_uses_real_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    custom = tmp_path / "partial.pdf"
+    custom.write_bytes(b"scan")
+    post = _models(tmp_path)[-1]
+    partial = replace(
+        post,
+        review_preservation=PostDispatchReviewPreservationBatch(
+            failures=("preservation failed",)
+        ),
+    )
+    monkeypatch.setattr(routing, "resolve_workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(routing, "run_scan_intake_workflow", lambda *_args: partial)
+    recorder = MenuScreenRecorder(["c", str(custom), "b", "b"])
+    recorder.install(monkeypatch)
+
+    menu.launch_scan_intake_workflow()
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="Processing Scan Intake",
+        required_text=str(custom),
+        forbidden_parent_text="C. Choose custom file/folder path",
+        parent_heading="Scan Intake / Route Paper Responses",
+        result_heading="Outcome: partial failure",
+        unrelated_previous_text="No supported scans found",
+    )

--- a/tests/test_menu_scan_review_resolution.py
+++ b/tests/test_menu_scan_review_resolution.py
@@ -3,27 +3,48 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
+from pds_core.route_registrations import write_route_registration
+from pds_core.routing_models import RouteLocator
 
 from quillan.cli import main
+from quillan.assignment_submission_assembly import AssignmentSubmissionAssemblyResult
 import quillan.review_menu as review_menu
-from tests.test_scan_review_resolution import _write_failure
+import quillan.scan_review_menu as scan_review_menu
+from quillan.post_dispatch_review import (
+    PersistedPostDispatchReviewOccurrence,
+    create_post_dispatch_review_occurrence,
+)
+from quillan.post_dispatch_review_resolution import (
+    discover_post_dispatch_review_items,
+)
+from quillan.work_paths import quillan_work_ref
+from quillan.work_paths import quillan_work_paths
+from quillan.submission_manifest_paths import submission_manifest_path
+from tests.test_scan_review_resolution import _write_failure, _write_routed_failure
+from tests.test_post_dispatch_review_resolution import _retry_case
+from tests.menu_screen_recorder import MenuScreenRecorder, assert_focused_child_screen
 
 
-def _inputs(monkeypatch: pytest.MonkeyPatch, values: list[str]) -> None:
+def _inputs(monkeypatch: pytest.MonkeyPatch, values: list[str]) -> list[str]:
     responses: Iterator[str] = iter(values)
+    prompts: list[str] = []
 
     def fake_input(_prompt: str = "") -> str:
+        prompts.append(_prompt)
         try:
             return next(responses)
         except StopIteration as error:
             raise AssertionError("Menu requested unexpected input.") from error
 
     monkeypatch.setattr("builtins.input", fake_input)
+    return prompts
 
 
+@pytest.mark.menu_density_workflow("Core scan review")
 def test_menu_resolves_one_scan_review_item(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -32,17 +53,28 @@ def test_menu_resolves_one_scan_review_item(
     failure_path = _write_failure(tmp_path)
     before = failure_path.read_bytes()
     monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(
-        monkeypatch,
-        ["2", "r", "1", "", "1", "", "", "", "3", "6"],
+    recorder = MenuScreenRecorder(
+        ["2", "r", "1", "1", "1", "", "3", "", "y", "", "", "b", "b", "q"],
     )
+    recorder.install(monkeypatch)
 
     assert main(["menu"]) == 0
 
     output = capsys.readouterr().out
+    screens = recorder.screens(output)
+    assert_focused_child_screen(
+        screens,
+        heading="Scan Review Details",
+        required_text="No QR payload was found.",
+        forbidden_parent_text="Select a review item:",
+        parent_heading="Resolve Scan Review Items",
+        result_heading="Core Routing Review Result",
+        unrelated_previous_text="teacher_scan.pdf, page 2",
+    )
     assert "Resolve Scan Review Items" in output
+    assert "Select Scan Review Assignment" in output
     assert "No QR payload was found." in output
-    assert "Scan review item resolved." in output
+    assert "Core routing-review item resolved." in output
     assert "scans/review/resolutions/" in output
     assert failure_path.read_bytes() == before
     assert "archive" not in output.casefold()
@@ -54,7 +86,7 @@ def test_menu_scan_review_empty_state(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(monkeypatch, ["2", "r", "", "3", "6"])
+    _inputs(monkeypatch, ["2", "r", "", "b", "q"])
 
     assert main(["menu"]) == 0
 
@@ -62,3 +94,529 @@ def test_menu_scan_review_empty_state(
     assert "There are no unresolved or deferred scan review items." in output
     assert not (tmp_path / "scans").exists()
     assert "archive" not in output.casefold()
+
+
+def _post_dispatch_occurrence(
+    root: Path,
+) -> PersistedPostDispatchReviewOccurrence:
+    return create_post_dispatch_review_occurrence(
+        root,
+        quillan_work_ref("english12_p3", "essay_01"),
+        category="submission_assembly",
+        stage="submission_assembly",
+        failure_message="Synthetic assembly failure.",
+        student_id="student_01",
+    )
+
+
+def test_global_scan_review_reaches_post_dispatch_only_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _post_dispatch_occurrence(tmp_path)
+    monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["2", "r", "1", "1", "b", "b", "b", "q"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Select Scan Review Assignment" in output
+    assert "Class: english12_p3; Assignment: essay_01" in output
+    assert "Quillan Post-Dispatch Problems" in output
+    assert "submission_assembly" in output
+    assert "\nResolve Scan Review Items\n" not in output
+
+
+def test_global_scan_review_combined_source_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_failure(tmp_path)
+    _post_dispatch_occurrence(tmp_path)
+    monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
+    _inputs(monkeypatch, ["2", "r", "1", "1", "b", "b", "b", "q"])
+
+    assert main(["menu"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Select Scan Review Assignment" in output
+    assert "1. Core routing problems" in output
+    assert "2. Quillan post-dispatch problems" in output
+    assert "3. All active problems" in output
+
+
+def _unscoped_core_failure(root: Path, *, suffix: str = "c1d2e3f4a5b6") -> Path:
+    return _write_failure(
+        root,
+        failure_id=f"failure_20260711T130000000000Z_{suffix}",
+        scoped=False,
+    )
+
+
+def test_global_scan_review_unscoped_core_only_remains_reachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _unscoped_core_failure(tmp_path)
+    recorder = MenuScreenRecorder(["b"])
+    recorder.install(monkeypatch)
+
+    scan_review_menu.launch_scan_review_resolution_menu(tmp_path)
+
+    screen = recorder.screens(capsys.readouterr().out)[0].output
+    assert "Scan Review" in screen
+    assert "2. Unscoped Core routing problems" in screen
+    assert "3. All Core routing problems" in screen
+    assert "Select assignment-scoped problems" not in screen
+
+
+def test_global_scan_review_scoped_and_unscoped_core_show_all_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_failure(tmp_path)
+    _unscoped_core_failure(tmp_path)
+    recorder = MenuScreenRecorder(["b"])
+    recorder.install(monkeypatch)
+
+    scan_review_menu.launch_scan_review_resolution_menu(tmp_path)
+
+    screen = recorder.screens(capsys.readouterr().out)[0].output
+    assert "1. Select assignment-scoped problems" in screen
+    assert "2. Unscoped Core routing problems" in screen
+    assert "3. All Core routing problems" in screen
+
+
+def test_global_scan_review_post_dispatch_and_unscoped_core_show_all_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _post_dispatch_occurrence(tmp_path)
+    _unscoped_core_failure(tmp_path)
+    recorder = MenuScreenRecorder(["b"])
+    recorder.install(monkeypatch)
+
+    scan_review_menu.launch_scan_review_resolution_menu(tmp_path)
+
+    screen = recorder.screens(capsys.readouterr().out)[0].output
+    assert "1. Select assignment-scoped problems" in screen
+    assert "2. Unscoped Core routing problems" in screen
+    assert "3. All Core routing problems" in screen
+
+
+def test_global_scan_review_all_problem_sources_remain_reachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_failure(tmp_path)
+    _post_dispatch_occurrence(tmp_path)
+    _unscoped_core_failure(tmp_path)
+    recorder = MenuScreenRecorder(["1", "b", "2", "b", "3", "b", "b"])
+    recorder.install(monkeypatch)
+
+    scan_review_menu.launch_scan_review_resolution_menu(tmp_path)
+
+    screens = recorder.screens(capsys.readouterr().out)
+    outputs = tuple(screen.output for screen in screens)
+    assert any("Select Scan Review Assignment" in output for output in outputs)
+    core_screens = [
+        output for output in outputs if "Resolve Scan Review Items" in output
+    ]
+    assert len(core_screens) == 2
+    assert core_screens[0].count("payload_missing") == 1
+    assert core_screens[1].count("payload_missing") == 2
+
+
+def test_selecting_unscoped_core_does_not_fabricate_work_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_failure(tmp_path)
+    _unscoped_core_failure(tmp_path)
+    recorder = MenuScreenRecorder(["2", "1", "", "b", "b", "b"])
+    recorder.install(monkeypatch)
+
+    scan_review_menu.launch_scan_review_resolution_menu(tmp_path)
+
+    screens = recorder.screens(capsys.readouterr().out)
+    detail = next(
+        screen.output for screen in screens if "Scan Review Details" in screen.output
+    )
+    assert "Class:" in detail
+    assert "Assignment:" in detail
+    assert "english12_p3" not in detail
+    assert "essay_01" not in detail
+    assert screens[-1].output.startswith("\x1b[32mQuillan\x1b[0m\nScan Review")
+
+
+def test_post_dispatch_list_is_compact_and_detail_discloses_multi_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence = create_post_dispatch_review_occurrence(
+        tmp_path,
+        quillan_work_ref("english12_p3", "essay_01"),
+        category="submission_assembly",
+        stage="submission_assembly",
+        failure_message="Synthetic assembly failure.",
+        student_id="student_01",
+        issuance_ids=("iss_" + "a" * 32, "iss_" + "b" * 32),
+        page_ids=("pg_" + "a" * 32, "pg_" + "b" * 32),
+        observation_ids=("obs_" + "a" * 32, "obs_" + "b" * 32),
+    )
+    _inputs(monkeypatch, ["1", "", "b", "b"])
+
+    scan_review_menu._launch_post_dispatch_review_menu(
+        tmp_path, "english12_p3", "essay_01"
+    )
+
+    output = capsys.readouterr().out
+    compact, detail = output.split("Post-Dispatch Problem Details", maxsplit=1)
+    assert occurrence.occurrence.issuance_ids[0] not in compact
+    assert "Issuance IDs: " in detail
+    assert occurrence.occurrence.issuance_ids[0] in detail
+    assert occurrence.occurrence.issuance_ids[1] in detail
+
+
+@pytest.mark.menu_density_workflow("post-dispatch review")
+def test_post_dispatch_density_recorder_captures_focused_segments_and_redraw(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence = _post_dispatch_occurrence(tmp_path)
+    recorder = MenuScreenRecorder(["1", "", "b", "b"])
+    recorder.install(monkeypatch)
+
+    scan_review_menu._launch_post_dispatch_review_menu(
+        tmp_path, "english12_p3", "essay_01"
+    )
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert [screen.clear_number for screen in screens] == [1, 2, 3, 4]
+    listing, detail, actions, redrawn_listing = screens
+    assert "Quillan Post-Dispatch Problems" in listing.output
+    assert occurrence.occurrence.failure_message not in listing.output
+    assert "Post-Dispatch Problem Details" in detail.output
+    assert occurrence.occurrence.failure_message in detail.output
+    assert "Quillan Post-Dispatch Problems" not in detail.output
+    assert "Choose Post-Dispatch Action" in actions.output
+    assert occurrence.occurrence.failure_id in actions.output
+    assert occurrence.occurrence.failure_message not in actions.output
+    assert "Quillan Post-Dispatch Problems" in redrawn_listing.output
+    assert [prompt.prompt for prompt in recorder.prompts] == [
+        "Select a post-dispatch problem: ",
+        "Press Enter to choose an action...",
+        "Select an action: ",
+        "Select a post-dispatch problem: ",
+    ]
+    assert_focused_child_screen(
+        screens,
+        heading="Post-Dispatch Problem Details",
+        required_text=occurrence.occurrence.failure_id,
+        forbidden_parent_text="Select a post-dispatch problem:",
+        parent_heading="Quillan Post-Dispatch Problems",
+        result_heading="Choose Post-Dispatch Action",
+        unrelated_previous_text="1. submission_assembly",
+    )
+    for screen in screens:
+        print(f"--- CLEAR EVENT {screen.clear_number} ---")
+        print(screen.output)
+    print("--- PROMPTS AND CHOICES ---")
+    for prompt in recorder.prompts:
+        print(f"{prompt.prompt}{prompt.choice}")
+
+
+@pytest.mark.menu_density_workflow("route selection/correction")
+def test_route_correction_density_uses_real_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    locator, target, registration = _write_routed_failure(tmp_path)
+    corrected = replace(
+        registration,
+        locator=RouteLocator(
+            "PDS2", locator.work, "rt_ffffffffffffffffffffffffffffffff"
+        ),
+        target=target,
+    )
+    write_route_registration(tmp_path, corrected)
+    recorder = MenuScreenRecorder(
+        ["1", "", "2", "2", "y", "", "y", "", "b"]
+    )
+    recorder.install(monkeypatch)
+
+    assert (
+        scan_review_menu._launch_core_review_menu(tmp_path)
+        == 0
+    )
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert any(
+        "Select Registered Route" in screen.output
+        and "Class: english10_p2" in screen.output
+        and "Assignment: literary_analysis" in screen.output
+        and "2. " in screen.output
+        for screen in screens
+    ), "\n---\n".join(screen.output for screen in screens)
+    assert_focused_child_screen(
+        screens,
+        heading="Scan Review Details",
+        required_text="Teacher routing decision required.",
+        forbidden_parent_text="Select a review item:",
+        parent_heading="Resolve Scan Review Items",
+        result_heading="Core Routing Review Result",
+        unrelated_previous_text="route_mismatch (unresolved)",
+    )
+
+
+def _successful_assembly_result() -> AssignmentSubmissionAssemblyResult:
+    return AssignmentSubmissionAssemblyResult(
+        class_id="english12_p3",
+        assignment_id="essay_01",
+        written_manifests=(),
+        skipped_existing_manifests=(),
+        skipped_files=(),
+        students_with_evidence=(),
+        student_summaries=(),
+        assembled=(),
+        failures=(),
+    )
+
+
+def test_empty_retry_does_not_offer_resolution_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence = _post_dispatch_occurrence(tmp_path)
+    item = discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref
+    ).items[0]
+    monkeypatch.setattr(
+        scan_review_menu,
+        "assemble_assignment_submissions",
+        lambda *_args, **_kwargs: _successful_assembly_result(),
+    )
+    prompts = _inputs(monkeypatch, [""])
+
+    scan_review_menu._retry_post_dispatch_assembly(tmp_path, item)
+
+    output = capsys.readouterr().out
+    assert (
+        "The retry completed without an operational failure, but it did not prove "
+        "that this occurrence was resolved." in output
+    )
+    assert "Record this occurrence as resolved after retry? [y/N]: " not in prompts
+    assert discover_post_dispatch_review_items(tmp_path, occurrence.work_ref).items
+
+
+def test_successful_retry_requires_confirmation_and_does_not_auto_resolve(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence, assembly = _retry_case(tmp_path)
+    item = discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref
+    ).items[0]
+    monkeypatch.setattr(
+        scan_review_menu,
+        "assemble_assignment_submissions",
+        lambda *_args, **_kwargs: assembly,
+    )
+    prompts = _inputs(monkeypatch, ["n", ""])
+
+    scan_review_menu._retry_post_dispatch_assembly(tmp_path, item)
+
+    output = capsys.readouterr().out
+    assert "The retry completed successfully." in output
+    assert "Record this occurrence as resolved after retry? [y/N]: " in prompts
+    assert discover_post_dispatch_review_items(tmp_path, occurrence.work_ref).items
+
+
+def test_successful_retry_records_typed_provenance_only_after_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence, assembly = _retry_case(tmp_path)
+    item = discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref
+    ).items[0]
+    monkeypatch.setattr(
+        scan_review_menu,
+        "assemble_assignment_submissions",
+        lambda *_args, **_kwargs: assembly,
+    )
+    _inputs(monkeypatch, ["y", ""])
+
+    scan_review_menu._retry_post_dispatch_assembly(tmp_path, item)
+
+    output = capsys.readouterr().out
+    assert "The retry completed successfully." in output
+    assert "Resolution record:" in output
+    included = discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref, include_resolved=True
+    )
+    assert included.items[0].latest_resolution is not None
+    provenance = included.items[0].latest_resolution.resolution.retry_provenance
+    assert provenance is not None
+    assert provenance["operation"] == "submission_assembly"
+    assert provenance["assembled_status"] == "created"
+    assert provenance["manifest_path"] == assembly.assembled[0].manifest_relative_path
+
+
+@pytest.mark.menu_density_workflow("successful retry")
+def test_successful_retry_density_uses_real_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence, assembly = _retry_case(tmp_path)
+    monkeypatch.setattr(
+        scan_review_menu,
+        "assemble_assignment_submissions",
+        lambda *_args, **_kwargs: assembly,
+    )
+    recorder = MenuScreenRecorder(["1", "", "1", "y", "", "b"])
+    recorder.install(monkeypatch)
+
+    scan_review_menu._launch_post_dispatch_review_menu(
+        tmp_path, occurrence.work_ref.class_id, occurrence.work_ref.work_id
+    )
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="Post-Dispatch Problem Details",
+        required_text=occurrence.occurrence.failure_id,
+        forbidden_parent_text="1. submission_assembly",
+        parent_heading="Quillan Post-Dispatch Problems",
+        result_heading="Retry Resolution Result",
+        unrelated_previous_text="Select a post-dispatch problem:",
+    )
+
+
+def test_failed_retry_keeps_occurrence_active(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence = _post_dispatch_occurrence(tmp_path)
+    item = discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref
+    ).items[0]
+    monkeypatch.setattr(
+        scan_review_menu,
+        "assemble_assignment_submissions",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("retry failed")),
+    )
+    _inputs(monkeypatch, [""])
+
+    scan_review_menu._retry_post_dispatch_assembly(tmp_path, item)
+
+    output = capsys.readouterr().out
+    assert "retry failed" in output
+    assert "no resolution was recorded" in output.lower()
+    assert discover_post_dispatch_review_items(tmp_path, occurrence.work_ref).items
+
+
+def test_contextual_status_view_uses_shared_typed_service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence = _post_dispatch_occurrence(tmp_path)
+    item = discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref
+    ).items[0]
+    typed_status = object()
+    calls: list[object] = []
+    monkeypatch.setattr(
+        scan_review_menu,
+        "list_assignment_submission_status",
+        lambda *_args, **_kwargs: typed_status,
+    )
+    monkeypatch.setattr(
+        scan_review_menu,
+        "print_assignment_submission_status",
+        lambda value, root: calls.extend((value, root)),
+    )
+    _inputs(monkeypatch, [""])
+
+    scan_review_menu._view_post_dispatch_status(tmp_path, item)
+
+    assert calls == [typed_status, tmp_path]
+    assert "Current Submission Status" in capsys.readouterr().out
+    assert discover_post_dispatch_review_items(tmp_path, occurrence.work_ref).items
+
+
+@pytest.mark.parametrize("kind", ["evidence", "manifest"])
+def test_contextual_open_menu_uses_only_selected_occurrence_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    kind: str,
+) -> None:
+    work_ref = quillan_work_ref("english12_p3", "essay_01")
+    evidence = (
+        quillan_work_paths(tmp_path, "english12_p3", "essay_01").work_root
+        / "scans"
+        / "evidence"
+        / "response_student_01_page_1.png"
+    )
+    manifest = submission_manifest_path(
+        tmp_path, "english12_p3", "essay_01", "student_01"
+    )
+    selected = evidence if kind == "evidence" else manifest
+    selected.parent.mkdir(parents=True, exist_ok=True)
+    selected.write_bytes(b"fixture")
+    occurrence = create_post_dispatch_review_occurrence(
+        tmp_path,
+        work_ref,
+        category="submission_assembly",
+        stage="submission_assembly",
+        failure_message="Synthetic assembly failure.",
+        student_id="student_01",
+        possible_evidence_path=evidence if kind == "evidence" else None,
+        possible_manifest_path=manifest if kind == "manifest" else None,
+    )
+    item = discover_post_dispatch_review_items(tmp_path, work_ref).items[0]
+    opened: list[tuple[str, str]] = []
+
+    def open_selected(
+        _root: Path,
+        _work_ref: object,
+        _failure_id: str,
+        *,
+        kind: str,
+        relative_path: str,
+    ) -> object:
+        opened.append((kind, relative_path))
+        return type("Opened", (), {"relative_path": relative_path})()
+
+    monkeypatch.setattr(
+        scan_review_menu, "open_post_dispatch_possible_path", open_selected
+    )
+    _inputs(monkeypatch, ["1", ""])
+
+    scan_review_menu._open_post_dispatch_context_path(
+        tmp_path, item, kind  # type: ignore[arg-type]
+    )
+
+    relative = selected.relative_to(tmp_path).as_posix()
+    assert opened == [(kind, relative)]
+    assert f"Opened validated {kind}: {relative}" in capsys.readouterr().out
+    assert discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref
+    ).items

--- a/tests/test_plain_paper_submission.py
+++ b/tests/test_plain_paper_submission.py
@@ -379,8 +379,8 @@ def test_status_and_evidence_opening_are_teacher_friendly(
     review_menu._open_submission_evidence(
         workspace, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
     )
-    output = capsys.readouterr().out
-    assert "No digital evidence is attached" in output
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
+    assert "plain-paper submission has no digital evidence" in output
     assert "Review the physical paper" in output
 
 
@@ -389,11 +389,11 @@ def test_cli_help_lists_plain_paper_command_and_arguments(
 ) -> None:
     with pytest.raises(SystemExit, match="0"):
         main(["--help"])
-    assert "create-plain-paper-submission" in capsys.readouterr().out
+    assert "create-plain-paper-submission" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
     with pytest.raises(SystemExit, match="0"):
         main(["create-plain-paper-submission", "--help"])
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "class_id" in output
     assert "assignment_id" in output
     assert "student_id" in output
@@ -447,7 +447,7 @@ def test_cli_creates_plain_paper_submission(
         "submission.json",
         "review.json",
     }
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Created plain-paper submission:" in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
@@ -471,7 +471,7 @@ def test_cli_dry_run_validates_without_writing(
 
     assert result == 0
     assert not (cli_workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "submissions").exists()
-    output = capsys.readouterr().out
+    output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Plain-paper submission dry run:" in output
     assert "Would create submission manifest: classes/" in output
     assert "Would create review record: classes/" in output
@@ -486,7 +486,7 @@ def test_cli_requires_confirmation_without_writing(
     )
 
     assert result == 1
-    assert "requires --yes or --dry-run" in capsys.readouterr().out
+    assert "requires --yes or --dry-run" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not (cli_workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "submissions").exists()
 
 
@@ -523,7 +523,7 @@ def test_cli_rejects_invalid_student(
     )
 
     assert result == 1
-    assert "not in the roster" in capsys.readouterr().out
+    assert "not in the roster" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not (cli_workspace / "classes" / CLASS_ID / "modules" / "quillan" / "work" / ASSIGNMENT_ID / "submissions").exists()
 
 
@@ -545,7 +545,7 @@ def test_cli_refuses_existing_manifest_without_changing_it(
         ]
     ) == 1
     assert created.submission_manifest_path.read_bytes() == original
-    assert "already exists" in capsys.readouterr().out
+    assert "already exists" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_cli_refuses_orphan_review_without_changing_it(
@@ -567,7 +567,7 @@ def test_cli_refuses_orphan_review_without_changing_it(
     ) == 1
     assert review_path.read_bytes() == b"existing review"
     assert not (student_dir / "submission.json").exists()
-    assert "without a submission manifest" in capsys.readouterr().out
+    assert "without a submission manifest" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
 
 
 def test_cli_workspace_error_is_reported_without_traceback(
@@ -588,7 +588,7 @@ def test_cli_workspace_error_is_reported_without_traceback(
     )
 
     assert result == 1
-    assert capsys.readouterr().out == (
+    assert (lambda captured: captured.out + captured.err)(capsys.readouterr()) == (
         "Error: plain-paper submission was not created: workspace unavailable\n"
     )
 
@@ -621,7 +621,7 @@ def test_cli_rejects_class_not_in_assignment(
     )
 
     assert result == 1
-    assert "is not included in assignment" in capsys.readouterr().out
+    assert "is not included in assignment" in (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert not (
         cli_workspace
         / "classes"

--- a/tests/test_post_dispatch_review.py
+++ b/tests/test_post_dispatch_review.py
@@ -233,6 +233,7 @@ def test_persisted_occurrence_rejects_nonexact_relative_paths(
             created.occurrence,
             created.path,
             relative_path,
+            created.original_bytes,
         )
 
 
@@ -276,6 +277,7 @@ def test_persisted_occurrence_rejects_alternative_absolute_destinations(
             created.occurrence,
             alternative,
             alternative.relative_to(tmp_path).as_posix(),
+            created.original_bytes,
         )
 
 

--- a/tests/test_post_dispatch_review_resolution.py
+++ b/tests/test_post_dispatch_review_resolution.py
@@ -1,0 +1,1004 @@
+"""Tests for append-only Quillan post-dispatch resolutions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import replace
+from datetime import datetime, timezone
+import json
+import inspect
+import os
+from pathlib import Path
+import subprocess
+from typing import cast
+from types import SimpleNamespace
+
+import pytest
+
+from quillan.cli import main
+from quillan.assignment_submission_assembly import (
+    AssignmentSubmissionAssemblyResult,
+    assemble_assignment_submissions,
+)
+from quillan.atomic_record_io import (
+    AtomicRecordDurabilityError,
+    AtomicRecordResult,
+    create_exclusive_record,
+)
+import quillan.cli_app.handlers.scan_review as cli_scan_review
+import quillan.post_dispatch_review as post_dispatch_review
+import quillan.post_dispatch_review_resolution as resolution_service
+import quillan.work_paths as work_paths
+from quillan.post_dispatch_review import (
+    PersistedPostDispatchReviewOccurrence,
+    create_post_dispatch_review_occurrence,
+)
+from quillan.post_dispatch_review_resolution import (
+    POST_DISPATCH_GENERIC_RESOLUTION_ACTIONS,
+    PostDispatchReviewResolutionError,
+    discover_post_dispatch_review_items,
+    open_post_dispatch_possible_path,
+    resolve_post_dispatch_after_successful_retry,
+    resolve_post_dispatch_review_occurrence,
+)
+from quillan.response_page_observation_persistence import (
+    persist_quillan_page_observation,
+)
+from quillan.submission_observation_assembly import QuillanSubmissionAssemblyFailure
+from quillan.submission_manifest_paths import (
+    submission_manifest_path,
+    write_submission_manifest,
+)
+from quillan.submission_manifest import load_submission_manifest
+from quillan.work_paths import quillan_work_ref
+from tests.observation_test_support import successful_image_page, successful_pdf_pages
+
+CLASS_ID = "english12_p3"
+ASSIGNMENT_ID = "essay_01"
+
+
+def _occurrence(
+    root: Path, *, assignment_id: str = ASSIGNMENT_ID
+) -> PersistedPostDispatchReviewOccurrence:
+    return create_post_dispatch_review_occurrence(
+        root,
+        quillan_work_ref(CLASS_ID, assignment_id),
+        category="submission_assembly",
+        stage="submission_assembly",
+        failure_message="Synthetic manifest conflict.",
+        student_id="student_01",
+        issuance_id="iss_" + "a" * 32,
+        page_id="pg_" + "b" * 32,
+        observation_id="obs_" + "c" * 32,
+        source_scan_id="scan_01",
+        source_page_number=1,
+        created_at="2026-07-21T12:00:00+00:00",
+    )
+
+
+def _manifest_occurrence(
+    root: Path,
+) -> tuple[PersistedPostDispatchReviewOccurrence, Path]:
+    manifest_path = submission_manifest_path(
+        root, CLASS_ID, ASSIGNMENT_ID, "student_01"
+    )
+    write_submission_manifest(
+        manifest_path,
+        {
+            "schema_version": "1",
+            "module": "quillan",
+            "record_type": "submission_manifest",
+            "class_id": CLASS_ID,
+            "assignment_id": ASSIGNMENT_ID,
+            "student_id": "student_01",
+            "expected_pages": 1,
+            "submission_state": "unreviewed",
+            "pages": [],
+            "created_at": "2026-07-21T12:00:00+00:00",
+            "updated_at": "2026-07-21T12:00:00+00:00",
+            "module_details": {},
+        },
+    )
+    occurrence = create_post_dispatch_review_occurrence(
+        root,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        category="manifest_conflict",
+        stage="submission_assembly",
+        failure_message="Synthetic manifest conflict.",
+        student_id="student_01",
+        possible_manifest_path=manifest_path,
+        created_at="2026-07-21T12:00:01+00:00",
+    )
+    return occurrence, manifest_path
+
+
+@pytest.mark.parametrize("action", POST_DISPATCH_GENERIC_RESOLUTION_ACTIONS)
+def test_each_action_appends_quillan_owned_resolution(
+    tmp_path: Path, action: str
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    before = occurrence.path.read_bytes()
+
+    result = resolve_post_dispatch_review_occurrence(
+        tmp_path,
+        occurrence.work_ref,
+        occurrence.occurrence.failure_id,
+        action=action,
+        message="Teacher decision." if action == "other" else None,
+        resolved_at=datetime(2026, 7, 21, 13, 0, tzinfo=timezone.utc),
+        resolution_id=f"resolution_{action}",
+    )
+
+    data = json.loads(result.path.read_text(encoding="utf-8"))
+    assert data["schema_version"] == "1"
+    assert data["record_type"] == "post_dispatch_review_resolution"
+    assert data["module_id"] == "quillan"
+    assert data["failure_id"] == occurrence.occurrence.failure_id
+    assert data["occurrence_path"] == occurrence.relative_path
+    assert data["status"] == ("deferred" if action == "deferred" else "resolved")
+    assert occurrence.path.read_bytes() == before
+    assert not (tmp_path / "scans" / "resolutions").exists()
+
+
+def _retry_case(
+    root: Path,
+    *,
+    status: str = "created",
+) -> tuple[PersistedPostDispatchReviewOccurrence, AssignmentSubmissionAssemblyResult]:
+    if status == "updated":
+        first_outcome, second_outcome = successful_pdf_pages(root)
+        persisted = persist_quillan_page_observation(root, first_outcome)
+    else:
+        second_outcome = None
+        persisted = persist_quillan_page_observation(
+            root, successful_image_page(root)
+        )
+    observation = persisted.observation
+    occurrence = create_post_dispatch_review_occurrence(
+        root,
+        quillan_work_ref(observation.class_id, observation.assignment_id),
+        category="submission_assembly",
+        stage="submission_assembly",
+        failure_message="Synthetic retry target.",
+        student_id=observation.student_id,
+        issuance_id=observation.issuance_id,
+        created_at="2026-07-21T12:00:00+00:00",
+    )
+    result = assemble_assignment_submissions(
+        root, observation.class_id, observation.assignment_id
+    )
+    if status == "unchanged":
+        result = assemble_assignment_submissions(
+            root, observation.class_id, observation.assignment_id
+        )
+    elif status == "updated":
+        assert second_outcome is not None
+        persist_quillan_page_observation(root, second_outcome)
+        result = assemble_assignment_submissions(
+            root, observation.class_id, observation.assignment_id
+        )
+    assert result.assembled[0].status == status
+    return occurrence, result
+
+
+def test_generic_resolution_api_cannot_write_resolved_after_retry(
+    tmp_path: Path,
+) -> None:
+    occurrence, _assembly = _retry_case(tmp_path)
+    assert "retry_provenance" not in inspect.signature(
+        resolve_post_dispatch_review_occurrence
+    ).parameters
+    with pytest.raises(PostDispatchReviewResolutionError, match="Unsupported"):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="resolved_after_retry",
+        )
+    with pytest.raises(TypeError):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="resolved_after_retry",
+            retry_provenance={"result_status": "success"},  # type: ignore[call-arg]
+        )
+
+    assert not hasattr(resolution_service, "_PostDispatchRetryProvenance")
+    assert "PostDispatchRetryProvenance" not in resolution_service.__all__
+    assert not hasattr(resolution_service, "_create")
+
+
+def _assembly_failure(
+    assembly: AssignmentSubmissionAssemblyResult,
+    *,
+    student_id: str,
+    issuance_id: str,
+) -> QuillanSubmissionAssemblyFailure:
+    return QuillanSubmissionAssemblyFailure(
+        category="unexpected_error",
+        class_id=assembly.class_id,
+        assignment_id=assembly.assignment_id,
+        student_id=student_id,
+        issuance_ids=(issuance_id,),
+        observation_ids=(),
+        page_ids=(),
+        logical_pages=(),
+        source_scan_ids=(),
+        source_page_numbers=(),
+        reason="Synthetic relevant failure.",
+    )
+
+
+def test_empty_retry_result_does_not_prove_resolution(tmp_path: Path) -> None:
+    occurrence, assembly = _retry_case(tmp_path)
+    empty = replace(
+        assembly,
+        written_manifests=(),
+        student_summaries=(),
+        assembled=(),
+    )
+    with pytest.raises(PostDispatchReviewResolutionError, match="does not prove"):
+        resolve_post_dispatch_after_successful_retry(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            assembly_result=empty,
+            completed_at="2026-07-21T13:00:00.000000+00:00",
+        )
+
+
+def test_unrelated_student_or_issuance_does_not_prove_resolution(
+    tmp_path: Path,
+) -> None:
+    _occurrence_value, assembly = _retry_case(tmp_path)
+    assembled = assembly.assembled[0]
+    for student_id, issuance_id in (
+        ("other_student", assembled.issuance_id),
+        (assembled.student_id, "iss_" + "f" * 32),
+    ):
+        occurrence = create_post_dispatch_review_occurrence(
+            tmp_path,
+            quillan_work_ref(assembled.class_id, assembled.assignment_id),
+            category="submission_assembly",
+            stage="submission_assembly",
+            failure_message="Unrelated retry target.",
+            student_id=student_id,
+            issuance_id=issuance_id,
+        )
+        with pytest.raises(PostDispatchReviewResolutionError, match="does not prove"):
+            resolve_post_dispatch_after_successful_retry(
+                tmp_path,
+                occurrence.work_ref,
+                occurrence.occurrence.failure_id,
+                assembly_result=assembly,
+                completed_at="2026-07-21T13:00:00.000000+00:00",
+            )
+
+
+def test_matching_student_or_issuance_failure_blocks_retry_proof(
+    tmp_path: Path,
+) -> None:
+    occurrence, assembly = _retry_case(tmp_path)
+    assembled = assembly.assembled[0]
+    failures = (
+        _assembly_failure(
+            assembly,
+            student_id=assembled.student_id,
+            issuance_id="iss_" + "e" * 32,
+        ),
+        _assembly_failure(
+            assembly,
+            student_id="other_student",
+            issuance_id=assembled.issuance_id,
+        ),
+    )
+    for failure in failures:
+        contradictory = replace(assembly, failures=(failure,))
+        with pytest.raises(PostDispatchReviewResolutionError, match="does not prove"):
+            resolve_post_dispatch_after_successful_retry(
+                tmp_path,
+                occurrence.work_ref,
+                occurrence.occurrence.failure_id,
+                assembly_result=contradictory,
+                completed_at="2026-07-21T13:00:00.000000+00:00",
+            )
+
+
+def test_missing_or_contradictory_manifest_blocks_retry_proof(tmp_path: Path) -> None:
+    occurrence, assembly = _retry_case(tmp_path)
+    manifest_path = assembly.assembled[0].manifest_path
+    original = manifest_path.read_bytes()
+    manifest_path.unlink()
+    with pytest.raises(PostDispatchReviewResolutionError, match="does not prove"):
+        resolve_post_dispatch_after_successful_retry(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            assembly_result=assembly,
+            completed_at="2026-07-21T13:00:00.000000+00:00",
+        )
+    manifest_path.write_bytes(original)
+    manifest = load_submission_manifest(manifest_path)
+    manifest["module_details"]["assembly_revision"] += 1
+    write_submission_manifest(manifest_path, manifest, overwrite=True)
+    with pytest.raises(PostDispatchReviewResolutionError, match="does not prove"):
+        resolve_post_dispatch_after_successful_retry(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            assembly_result=assembly,
+            completed_at="2026-07-21T13:00:00.000000+00:00",
+        )
+
+
+@pytest.mark.parametrize("status", ["created", "updated", "unchanged"])
+def test_exact_retry_create_update_and_unchanged_are_proven(
+    tmp_path: Path, status: str
+) -> None:
+    occurrence, assembly = _retry_case(tmp_path, status=status)
+    assembled = assembly.assembled[0]
+    result = resolve_post_dispatch_after_successful_retry(
+        tmp_path,
+        occurrence.work_ref,
+        occurrence.occurrence.failure_id,
+        assembly_result=assembly,
+        completed_at="2026-07-21T13:00:00.000000+00:00",
+        resolved_at="2026-07-21T13:00:01.000000+00:00",
+    )
+    provenance = result.resolution.retry_provenance
+    assert provenance is not None
+    assert provenance["assembled_status"] == status
+    assert provenance["manifest_path"] == assembled.manifest_relative_path
+    assert provenance["assembly_revision"] == assembled.assembly_revision
+
+
+def test_successful_retry_and_loaded_history_cannot_be_reused(
+    tmp_path: Path,
+) -> None:
+    first, assembly = _retry_case(tmp_path)
+    assembled = assembly.assembled[0]
+    second = create_post_dispatch_review_occurrence(
+        tmp_path,
+        first.work_ref,
+        category="submission_assembly",
+        stage="submission_assembly",
+        failure_message="Second occurrence for the same retry target.",
+        student_id=assembled.student_id,
+        issuance_id=assembled.issuance_id,
+        created_at="2026-07-21T12:00:01+00:00",
+    )
+    resolve_post_dispatch_after_successful_retry(
+        tmp_path,
+        first.work_ref,
+        first.occurrence.failure_id,
+        assembly_result=assembly,
+        completed_at="2026-07-21T13:00:00.000000+00:00",
+        resolved_at="2026-07-21T13:00:01.000000+00:00",
+    )
+    loaded = discover_post_dispatch_review_items(
+        tmp_path, first.work_ref, include_resolved=True
+    )
+    historical = next(
+        item.latest_resolution.resolution.retry_provenance
+        for item in loaded.items
+        if item.occurrence.occurrence.failure_id == first.occurrence.failure_id
+        and item.latest_resolution is not None
+    )
+    assert historical is not None
+    with pytest.raises(TypeError):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            second.work_ref,
+            second.occurrence.failure_id,
+            action="resolved_after_retry",
+            retry_provenance=historical,  # type: ignore[call-arg]
+        )
+    with pytest.raises(PostDispatchReviewResolutionError, match="already authorized"):
+        resolve_post_dispatch_after_successful_retry(
+            tmp_path,
+            second.work_ref,
+            second.occurrence.failure_id,
+            assembly_result=assembly,
+            completed_at="2026-07-21T13:00:00.000000+00:00",
+            resolved_at="2026-07-21T13:00:02.000000+00:00",
+        )
+
+
+def test_resolved_hidden_deferred_visible_and_latest_is_deterministic(
+    tmp_path: Path,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    resolve_post_dispatch_review_occurrence(
+        tmp_path,
+        occurrence.work_ref,
+        occurrence.occurrence.failure_id,
+        action="deferred",
+        resolved_at="2026-07-21T13:00:00+00:00",
+        resolution_id="resolution_deferred",
+    )
+    deferred = discover_post_dispatch_review_items(tmp_path, occurrence.work_ref)
+    assert deferred.items[0].display_status == "deferred"
+
+    resolve_post_dispatch_review_occurrence(
+        tmp_path,
+        occurrence.work_ref,
+        occurrence.occurrence.failure_id,
+        action="rescan_needed",
+        resolved_at="2026-07-21T14:00:00+00:00",
+        resolution_id="resolution_resolved",
+    )
+    assert discover_post_dispatch_review_items(tmp_path, occurrence.work_ref).items == ()
+    included = discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref, include_resolved=True
+    )
+    assert included.items[0].latest_resolution is not None
+    assert included.items[0].latest_resolution.resolution.action == "rescan_needed"
+
+
+def test_resolution_rejects_cross_work_and_duplicate_id(tmp_path: Path) -> None:
+    occurrence = _occurrence(tmp_path)
+    with pytest.raises(PostDispatchReviewResolutionError, match="No unique"):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            quillan_work_ref(CLASS_ID, "other_assignment"),
+            occurrence.occurrence.failure_id,
+            action="cannot_recover",
+        )
+    resolve_post_dispatch_review_occurrence(
+        tmp_path,
+        occurrence.work_ref,
+        occurrence.occurrence.failure_id,
+        action="cannot_recover",
+        resolution_id="resolution_fixed",
+    )
+    with pytest.raises(PostDispatchReviewResolutionError, match="already exists"):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="rescan_needed",
+            resolution_id="resolution_fixed",
+        )
+
+
+def test_other_requires_message_and_malformed_resolution_warns(tmp_path: Path) -> None:
+    occurrence = _occurrence(tmp_path)
+    with pytest.raises(PostDispatchReviewResolutionError, match="requires"):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="other",
+        )
+    directory = occurrence.path.parent / "resolutions"
+    directory.mkdir()
+    (directory / "malformed.json").write_text("{bad", encoding="utf-8")
+    discovery = discover_post_dispatch_review_items(tmp_path, occurrence.work_ref)
+    assert len(discovery.items) == 1
+    assert len(discovery.warnings) == 1
+
+
+def test_resolution_with_unknown_field_is_reported_as_malformed(
+    tmp_path: Path,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    persisted = resolve_post_dispatch_review_occurrence(
+        tmp_path,
+        occurrence.work_ref,
+        occurrence.occurrence.failure_id,
+        action="record_corrected",
+    )
+    value = json.loads(persisted.path.read_text(encoding="utf-8"))
+    value["unknown_field"] = True
+    persisted.path.write_text(json.dumps(value), encoding="utf-8")
+
+    discovery = discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref, include_resolved=True
+    )
+
+    assert discovery.items[0].latest_resolution is None
+    assert len(discovery.warnings) == 1
+    assert "fields are not exact" in discovery.warnings[0]
+
+
+def test_direct_commands_list_and_resolve_exact_work_occurrence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    before = occurrence.path.read_bytes()
+    monkeypatch.setattr(cli_scan_review, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(
+        ["list-post-dispatch-review", CLASS_ID, ASSIGNMENT_ID]
+    ) == 0
+    listed = capsys.readouterr().out
+    assert occurrence.occurrence.failure_id in listed
+    assert "submission_assembly" in listed
+
+    assert main(
+        [
+            "resolve-post-dispatch-review",
+            CLASS_ID,
+            ASSIGNMENT_ID,
+            occurrence.occurrence.failure_id,
+            "--action",
+            "record_corrected",
+        ]
+    ) == 0
+    resolved = capsys.readouterr().out
+    assert "Post-dispatch review item resolved." in resolved
+    assert "/scans/review/post_dispatch/resolutions/" in resolved
+    assert occurrence.path.read_bytes() == before
+
+
+def test_generic_direct_cli_rejects_resolved_after_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    monkeypatch.setattr(cli_scan_review, "resolve_workspace_root", lambda: tmp_path)
+    with pytest.raises(SystemExit) as captured:
+        main(
+            [
+                "resolve-post-dispatch-review",
+                CLASS_ID,
+                ASSIGNMENT_ID,
+                occurrence.occurrence.failure_id,
+                "--action",
+                "resolved_after_retry",
+            ]
+        )
+    assert captured.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
+    assert not occurrence.path.parent.joinpath("resolutions").exists()
+
+
+def test_resolution_models_are_deeply_immutable_and_reject_corruption(
+    tmp_path: Path,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    persisted = resolve_post_dispatch_review_occurrence(
+        tmp_path,
+        occurrence.work_ref,
+        occurrence.occurrence.failure_id,
+        action="record_corrected",
+        resolved_at="2026-07-21T13:00:00.000000+00:00",
+    )
+    nested = replace(
+        persisted.resolution,
+        module_details={"nested": {"items": ["one", {"two": [2]}]}},
+    )
+    nested_mapping = cast(Mapping[str, object], nested.module_details["nested"])
+    nested_items = cast(tuple[object, ...], nested_mapping["items"])
+    assert nested_items[0] == "one"
+    assert cast(Mapping[str, object], nested_items[1])["two"] == (2,)
+    with pytest.raises(TypeError):
+        nested_mapping["new"] = "value"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        nested.occurrence_identity_snapshot["issuance_ids"] = ()  # type: ignore[index]
+    with pytest.raises(PostDispatchReviewResolutionError):
+        replace(persisted.resolution, status="deferred")
+    with pytest.raises(PostDispatchReviewResolutionError, match="canonical occurrence"):
+        replace(persisted.resolution, occurrence_path="wrong/occurrence.json")
+    with pytest.raises(PostDispatchReviewResolutionError, match="category"):
+        replace(
+            persisted.resolution,
+            occurrence_identity_snapshot={
+                **dict(persisted.resolution.occurrence_identity_snapshot),
+                "category": "invented_category",
+            },
+        )
+    with pytest.raises(PostDispatchReviewResolutionError):
+        replace(persisted, relative_path="wrong/path.json")
+
+
+@pytest.mark.parametrize("replacement", ["directory", "deleted", "changed"])
+def test_occurrence_is_repreflighted_after_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: str,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    discovery = post_dispatch_review.discover_post_dispatch_review_occurrences(
+        tmp_path, occurrence.work_ref
+    )
+    if replacement == "directory":
+        occurrence.path.unlink()
+        occurrence.path.mkdir()
+    elif replacement == "deleted":
+        occurrence.path.unlink()
+    else:
+        occurrence.path.write_bytes(b"changed after discovery")
+    monkeypatch.setattr(
+        resolution_service,
+        "discover_post_dispatch_review_occurrences",
+        lambda *_args, **_kwargs: discovery,
+    )
+    called = False
+
+    def forbidden_writer(*_args: object, **_kwargs: object) -> None:
+        nonlocal called
+        called = True
+        pytest.fail("resolution writer must not run after occurrence preflight fails")
+
+    monkeypatch.setattr(
+        "quillan.post_dispatch_review_resolution.create_exclusive_record",
+        forbidden_writer,
+    )
+    with pytest.raises(PostDispatchReviewResolutionError):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="record_corrected",
+        )
+    assert called is False
+
+
+def test_occurrence_replaced_by_symlink_is_rejected_before_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    discovery = post_dispatch_review.discover_post_dispatch_review_occurrences(
+        tmp_path, occurrence.work_ref
+    )
+    monkeypatch.setattr(
+        resolution_service,
+        "discover_post_dispatch_review_occurrences",
+        lambda *_args, **_kwargs: discovery,
+    )
+    monkeypatch.setattr(
+        "quillan.post_dispatch_review_resolution._is_link_like",
+        lambda path: path == occurrence.path,
+    )
+    with pytest.raises(PostDispatchReviewResolutionError, match="symlink|non-link"):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="record_corrected",
+        )
+
+
+def test_no_occurrence_read_when_link_preflight_rejects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    discovery = post_dispatch_review.discover_post_dispatch_review_occurrences(
+        tmp_path, occurrence.work_ref
+    )
+    monkeypatch.setattr(
+        resolution_service,
+        "discover_post_dispatch_review_occurrences",
+        lambda *_args, **_kwargs: discovery,
+    )
+    monkeypatch.setattr(
+        resolution_service,
+        "_is_link_like",
+        lambda path: path == occurrence.path,
+    )
+    original_read_bytes = Path.read_bytes
+
+    def guarded_read_bytes(path: Path) -> bytes:
+        if path == occurrence.path:
+            pytest.fail("occurrence bytes were read after link preflight rejected it")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
+    with pytest.raises(PostDispatchReviewResolutionError, match="non-link"):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="record_corrected",
+        )
+
+
+@pytest.mark.parametrize("replacement", ["file", "link_like"])
+def test_resolution_directory_wrong_type_or_link_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: str,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    directory = occurrence.path.parent / "resolutions"
+    if replacement == "file":
+        directory.write_text("wrong type", encoding="utf-8")
+    else:
+        directory.mkdir()
+        original_link_check = getattr(work_paths, "_is_link_like")
+        monkeypatch.setattr(
+            work_paths,
+            "_is_link_like",
+            lambda path: path == directory or original_link_check(path),
+        )
+    with pytest.raises(PostDispatchReviewResolutionError):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="record_corrected",
+        )
+
+
+def _create_windows_junction(link: Path, target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    completed = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/J", str(link), str(target)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        pytest.fail(
+            "Could not create the required Windows junction fixture: "
+            f"{completed.stderr or completed.stdout}"
+        )
+
+
+def test_occurrence_parent_windows_junction_is_rejected(
+    tmp_path: Path,
+) -> None:
+    if os.name != "nt":
+        return
+    occurrence = _occurrence(tmp_path)
+    directory = occurrence.path.parent
+    junction_target = tmp_path / "junction-target-occurrences"
+    directory.rename(junction_target)
+    _create_windows_junction(directory, junction_target)
+    try:
+        with pytest.raises(PostDispatchReviewResolutionError, match="junction"):
+            resolve_post_dispatch_review_occurrence(
+                tmp_path,
+                occurrence.work_ref,
+                occurrence.occurrence.failure_id,
+                action="record_corrected",
+            )
+    finally:
+        os.rmdir(directory)
+        junction_target.rename(directory)
+
+
+def test_resolution_directory_windows_junction_is_rejected(
+    tmp_path: Path,
+) -> None:
+    if os.name != "nt":
+        return
+    occurrence = _occurrence(tmp_path)
+    directory = occurrence.path.parent / "resolutions"
+    junction_target = tmp_path / "junction-target-resolutions"
+    _create_windows_junction(directory, junction_target)
+    try:
+        with pytest.raises(PostDispatchReviewResolutionError, match="junction"):
+            resolve_post_dispatch_review_occurrence(
+                tmp_path,
+                occurrence.work_ref,
+                occurrence.occurrence.failure_id,
+                action="record_corrected",
+            )
+    finally:
+        os.rmdir(directory)
+
+
+def test_link_like_resolution_child_is_rejected_before_atomic_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    resolution_id = "resolution_link_like"
+    target = occurrence.path.parent / "resolutions" / f"{resolution_id}.json"
+    original_link_check = getattr(work_paths, "_is_link_like")
+    monkeypatch.setattr(
+        work_paths,
+        "_is_link_like",
+        lambda path: path == target or original_link_check(path),
+    )
+    with pytest.raises(PostDispatchReviewResolutionError, match="symlink|junction"):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="record_corrected",
+            resolution_id=resolution_id,
+        )
+
+
+def test_occurrence_revision_race_immediately_before_atomic_installation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    real_writer = create_exclusive_record
+
+    def racing_writer(
+        path: Path,
+        replacement_bytes: bytes,
+        *,
+        preflight: Callable[[], None],
+        verify_bytes: Callable[[bytes], None],
+    ) -> AtomicRecordResult:
+        occurrence.path.write_bytes(b"raced")
+        return real_writer(
+            path,
+            replacement_bytes,
+            preflight=preflight,
+            verify_bytes=verify_bytes,
+        )
+
+    monkeypatch.setattr(
+        "quillan.post_dispatch_review_resolution.create_exclusive_record",
+        racing_writer,
+    )
+    with pytest.raises(PostDispatchReviewResolutionError, match="changed"):
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="record_corrected",
+        )
+    assert not tuple(occurrence.path.parent.joinpath("resolutions").glob("*.json"))
+
+
+def test_resolution_durability_and_lock_paths_are_propagated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    occurrence = _occurrence(tmp_path)
+    durable_path = occurrence.path.parent / "resolutions" / "possibly.json"
+    lock_path = occurrence.path.parent / "resolutions" / ".possibly.lock"
+
+    def durability_failure(*_args: object, **_kwargs: object) -> None:
+        raise AtomicRecordDurabilityError(
+            "durability uncertain",
+            possibly_durable_path=durable_path,
+            possible_lock_path=lock_path,
+        )
+
+    monkeypatch.setattr(resolution_service, "create_exclusive_record", durability_failure)
+    with pytest.raises(PostDispatchReviewResolutionError) as captured:
+        resolve_post_dispatch_review_occurrence(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            action="record_corrected",
+        )
+    assert captured.value.possibly_durable_path == durable_path
+    assert captured.value.possible_lock_path == lock_path
+
+
+def test_contextual_manifest_opening_is_occurrence_and_work_scoped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    occurrence, manifest_path = _manifest_occurrence(tmp_path)
+    monkeypatch.setattr(resolution_service, "open_local_path", lambda path: path)
+    relative = manifest_path.relative_to(tmp_path).as_posix()
+
+    opened = open_post_dispatch_possible_path(
+        tmp_path,
+        occurrence.work_ref,
+        occurrence.occurrence.failure_id,
+        kind="manifest",
+        relative_path=relative,
+    )
+    assert opened.path == manifest_path
+    assert opened.relative_path == relative
+    assert discover_post_dispatch_review_items(
+        tmp_path, occurrence.work_ref
+    ).items
+
+    for substitution in (
+        relative.replace(ASSIGNMENT_ID, "other_assignment", 1),
+        relative.replace("/modules/quillan/", "/modules/scoreform/", 1),
+        f"classes/{CLASS_ID}/assignments/{ASSIGNMENT_ID}/submissions/student_01/submission.json",
+    ):
+        with pytest.raises(PostDispatchReviewResolutionError, match="not stored"):
+            open_post_dispatch_possible_path(
+                tmp_path,
+                occurrence.work_ref,
+                occurrence.occurrence.failure_id,
+                kind="manifest",
+                relative_path=substitution,
+            )
+
+
+def test_contextual_manifest_opening_rejects_stale_and_symlink_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    occurrence, manifest_path = _manifest_occurrence(tmp_path)
+    relative = manifest_path.relative_to(tmp_path).as_posix()
+    manifest_bytes = manifest_path.read_bytes()
+    manifest_path.unlink()
+    with pytest.raises(PostDispatchReviewResolutionError, match="ordinary non-link"):
+        open_post_dispatch_possible_path(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            kind="manifest",
+            relative_path=relative,
+        )
+
+    manifest_path.write_bytes(manifest_bytes)
+    monkeypatch.setattr(
+        resolution_service,
+        "_is_link_like",
+        lambda path: path == manifest_path,
+    )
+    monkeypatch.setattr(resolution_service, "open_local_path", lambda path: path)
+    with pytest.raises(PostDispatchReviewResolutionError, match="symlink|non-link"):
+        open_post_dispatch_possible_path(
+            tmp_path,
+            occurrence.work_ref,
+            occurrence.occurrence.failure_id,
+            kind="manifest",
+            relative_path=relative,
+        )
+
+
+def test_contextual_evidence_opening_uses_occurrence_observation_validator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    work_ref = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    observation_id = "obs_" + "d" * 32
+    evidence_path = (
+        work_paths.quillan_work_paths(tmp_path, CLASS_ID, ASSIGNMENT_ID).work_root
+        / "scans"
+        / "evidence"
+        / "response_student_01_page_1.png"
+    )
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_bytes(b"validated evidence")
+    relative = evidence_path.relative_to(tmp_path).as_posix()
+    occurrence = create_post_dispatch_review_occurrence(
+        tmp_path,
+        work_ref,
+        category="routed_evidence_persistence",
+        stage="routed_evidence_persistence",
+        failure_message="Evidence installation was uncertain.",
+        student_id="student_01",
+        observation_id=observation_id,
+        possible_evidence_path=evidence_path,
+        created_at="2026-07-21T12:00:00+00:00",
+    )
+    observation = SimpleNamespace(
+        routed_evidence_path=relative,
+        issuance_id="iss_" + "e" * 32,
+        student_id="student_01",
+        logical_page=1,
+        observation_id=observation_id,
+        routed_evidence_sha256="a" * 64,
+        routed_evidence_size_bytes=len(b"validated evidence"),
+    )
+    monkeypatch.setattr(
+        resolution_service,
+        "load_contextual_response_page_observation",
+        lambda *_args, **_kwargs: observation,
+    )
+    validated: list[str] = []
+    monkeypatch.setattr(
+        resolution_service,
+        "verify_contextual_routed_page_evidence",
+        lambda *_args, **kwargs: validated.append(cast(str, kwargs["relative_path"])),
+    )
+    monkeypatch.setattr(resolution_service, "open_local_path", lambda path: path)
+
+    opened = open_post_dispatch_possible_path(
+        tmp_path,
+        work_ref,
+        occurrence.occurrence.failure_id,
+        kind="evidence",
+        relative_path=relative,
+    )
+
+    assert opened.path == evidence_path
+    assert opened.failure_id == occurrence.occurrence.failure_id
+    assert validated == [relative]
+    assert discover_post_dispatch_review_items(tmp_path, work_ref).items

--- a/tests/test_printable_response_workflows.py
+++ b/tests/test_printable_response_workflows.py
@@ -11,6 +11,8 @@ from pds_core.rosters import create_roster
 from pypdf import PdfReader
 import pytest
 
+from tests.menu_screen_recorder import MenuScreenRecorder, assert_focused_child_screen
+
 from quillan.generated_output_opening import (
     GeneratedOutputOpeningError,
     OpenedGeneratedOutput,
@@ -249,7 +251,7 @@ def test_generate_class_packet_happy_path(
     roster_bytes = roster_path.read_bytes()
     assignment_bytes = assignment_path.read_bytes()
     monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
-    _inputs(monkeypatch, ["1", "1", "2", "3"])
+    _inputs(monkeypatch, ["1", "1", "2", "b"])
 
     assert workflows.prompt_generate_class_packet() == 0
 
@@ -271,13 +273,12 @@ def test_generate_class_packet_happy_path(
     assert assignment_path.read_bytes() == assignment_bytes
 
     output = capsys.readouterr().out
-    assert "Output mode: one class packet PDF" in output
     assert "Generated printable response packet:" in output
-    assert str(output_path) in output
+    assert output_path.relative_to(tmp_path).as_posix() in output
     assert f"Class: {CLASS_ID}" in output
     assert f"Assignment: {ASSIGNMENT_ID}" in output
     assert "Pages per student: 2" in output
-    assert "What would you like to do next?" in output
+    assert "Printable Response Result" in output
 
 
 def test_generate_class_packet_accepts_exact_ids_and_blank_page_default(
@@ -327,7 +328,7 @@ def test_generate_class_packet_can_open_generated_packet(
     assert calls == [(tmp_path, output_path)]
     output = capsys.readouterr().out
     assert "Opened generated packet:" in output
-    assert str(output_path) in output
+    assert "synthetic.pdf" in output
 
 
 def test_generate_class_packet_can_open_containing_folder(
@@ -359,10 +360,10 @@ def test_generate_class_packet_can_open_containing_folder(
     assert calls == [(tmp_path, output_path)]
     output = capsys.readouterr().out
     assert "Opened containing folder:" in output
-    assert str(output_path.parent) in output
+    assert "templates" in output
 
 
-@pytest.mark.parametrize("selection", ["3", ""])
+@pytest.mark.parametrize("selection", ["b", ""])
 def test_generate_class_packet_declines_opening(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -420,7 +421,7 @@ def test_generate_class_packet_opening_failure_preserves_success(
     output = capsys.readouterr().out
     assert "Error: could not open generated packet: viewer failed" in output
     assert "Generated packet remains saved at:" in output
-    assert str(output_path) in output
+    assert output_path.relative_to(tmp_path).as_posix() in output
     assert "Traceback" not in output
 
 
@@ -594,7 +595,7 @@ def test_printable_response_menu_displays_options_and_dispatches(
         return 0
 
     monkeypatch.setattr(workflows, "prompt_generate_class_packet", generate)
-    _inputs(monkeypatch, ["1", "", "2"])
+    _inputs(monkeypatch, ["1", "", "b"])
 
     assert workflows.launch_printable_response_menu() == 0
     output = capsys.readouterr().out
@@ -607,7 +608,7 @@ def test_printable_response_menu_invalid_selection_and_keyboard_interrupt(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    _inputs(monkeypatch, ["bad", "", "2"])
+    _inputs(monkeypatch, ["bad", "", "b"])
     assert workflows.launch_printable_response_menu() == 0
     assert "Invalid selection" in capsys.readouterr().out
 
@@ -617,3 +618,33 @@ def test_printable_response_menu_invalid_selection_and_keyboard_interrupt(
     monkeypatch.setattr("builtins.input", interrupt)
     assert workflows.launch_printable_response_menu() == 0
     assert "Exiting printable response menu." in capsys.readouterr().out
+
+
+@pytest.mark.menu_density_workflow("printable-response generation")
+def test_printable_response_density_uses_real_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_roster(tmp_path)
+    _write_assignment(tmp_path)
+    monkeypatch.setattr(workflows, "resolve_workspace_root", lambda: tmp_path)
+    recorder = MenuScreenRecorder(["1", "1", "1", "2", "b", "", "b"])
+    recorder.install(
+        monkeypatch,
+        clear_aliases=("quillan.printable_response_workflows._clear_screen",),
+    )
+
+    assert workflows.launch_printable_response_menu() == 0
+
+    screens = recorder.screens(capsys.readouterr().out)
+    assert_focused_child_screen(
+        screens,
+        heading="Select Class for Printable Responses",
+        required_text=f"1. {CLASS_ID}",
+        forbidden_parent_text="1. Generate class packet",
+        parent_heading="Printable Response Pages",
+        result_heading="Printable Response Result",
+        unrelated_previous_text="Back to Assignment Management",
+    )
+    recorder.print_transcript(screens, label="PRINTABLE RESPONSE GENERATION")

--- a/tests/test_roster_workflows.py
+++ b/tests/test_roster_workflows.py
@@ -765,7 +765,7 @@ def test_roster_menu_displays_options_and_dispatches(
         "prompt_validate_roster",
         lambda: record("validate"),
     )
-    _inputs(monkeypatch, ["1", "", "2", "", "3", "", "4", "", "5"])
+    _inputs(monkeypatch, ["1", "", "2", "", "3", "", "4", "", "b"])
 
     assert workflows.launch_roster_menu() == 0
     output = capsys.readouterr().out
@@ -781,7 +781,7 @@ def test_roster_menu_invalid_selection_and_keyboard_interrupt(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    _inputs(monkeypatch, ["bad", "", "5"])
+    _inputs(monkeypatch, ["bad", "", "b"])
     assert workflows.launch_roster_menu() == 0
     assert "Invalid selection" in capsys.readouterr().out
 

--- a/tests/test_scan_review_resolution.py
+++ b/tests/test_scan_review_resolution.py
@@ -22,12 +22,42 @@ from pds_core.scan_resolution_metadata import (
 
 from quillan.scan_review_resolution import (
     ScanReviewResolutionError,
+    discover_scan_review_route_options,
     discover_scan_review_items,
     resolve_scan_review_item,
 )
+import quillan.scan_review_resolution as scan_review_resolution
 from tests.test_route_handler import route_context
 
 FAILURE_ID = "failure_20260711T120000000000Z_a1b2c3d4e5f6"
+
+
+def test_route_option_discovery_propagates_unexpected_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "routes"
+    directory.mkdir()
+    (directory / "route_0123456789abcdef.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        scan_review_resolution,
+        "module_routes_dir",
+        lambda *_args, **_kwargs: directory,
+    )
+    monkeypatch.setattr(
+        scan_review_resolution,
+        "validate_route_id",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("unexpected programming failure")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected programming failure"):
+        discover_scan_review_route_options(
+            tmp_path, "english12_p3", "essay_01"
+        )
 
 
 def _write_failure(
@@ -36,6 +66,7 @@ def _write_failure(
     failure_id: str = FAILURE_ID,
     stage: str = "quillan_route_review",
     module_id: str = "quillan",
+    scoped: bool = True,
 ) -> Path:
     return write_routing_failure_metadata(
         root,
@@ -43,18 +74,29 @@ def _write_failure(
             schema_version="2",
             failure_id=failure_id,
             scope="page",
-            stage=stage,
+            stage=stage if scoped else "qr_detection",
             created_at="2026-07-11T12:00:00+00:00",
             failure_category="payload_missing",
             failure_message="No QR payload was found.",
             source_filename="teacher_scan.pdf",
-            route_locator=RouteLocator(
-                "PDS2",
-                ModuleWorkRef(module_id, "english12_p3", "essay_01"),
-                "route_a1b2c3d4e5f6",
+            route_locator=(
+                RouteLocator(
+                    "PDS2",
+                    ModuleWorkRef(module_id, "english12_p3", "essay_01"),
+                    "route_a1b2c3d4e5f6",
+                )
+                if scoped
+                else None
             ),
             target=None,
-            module_details={"failure_origin": "qr_decode"},
+            module_details=(
+                {"failure_origin": "qr_decode"}
+                if scoped
+                else {
+                    "failure_owner": "quillan",
+                    "failure_origin": "qr_detection",
+                }
+            ),
             source_scan_id="scan_001",
             source_sha256="a" * 64,
             retained_source_path="scans/source/2026-07-11/teacher_scan.pdf",

--- a/tests/test_submission_review_opening.py
+++ b/tests/test_submission_review_opening.py
@@ -552,7 +552,9 @@ def test_cli_failure_returns_one(
     assert (
         main(["open-submission", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 1
     )
-    assert capsys.readouterr().out == (
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
         "Error: could not open student submission: manifest is unavailable\n"
     )
 
@@ -569,4 +571,6 @@ def test_cli_missing_manifest_returns_one(
     assert (
         main(["open-submission", CLASS_ID, ASSIGNMENT_ID, STUDENT_ID]) == 1
     )
-    assert "This submission is not review-ready yet" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "This submission is not review-ready yet" in captured.err

--- a/tests/test_submission_review_state.py
+++ b/tests/test_submission_review_state.py
@@ -397,7 +397,7 @@ def test_cli_success_prints_teacher_context(
         )
         == 0
     )
-    assert capsys.readouterr().out == (
+    assert (lambda captured: captured.out + captured.err)(capsys.readouterr()) == (
         "Updated lightweight submission state:\n"
         f"Class: {CLASS_ID}\n"
         f"Assignment: {ASSIGNMENT_ID}\n"
@@ -436,7 +436,7 @@ def test_cli_failure_returns_one(
         )
         == 1
     )
-    assert capsys.readouterr().out == (
+    assert (lambda captured: captured.out + captured.err)(capsys.readouterr()) == (
         "Error: could not update lightweight submission state: "
         "manifest is unavailable\n"
     )

--- a/tests/test_v080_end_to_end_smoke.py
+++ b/tests/test_v080_end_to_end_smoke.py
@@ -180,7 +180,7 @@ def test_v080_scan_review_export_end_to_end_smoke(
     assert assignment_path.is_file()
 
 
-    assert main(["validate-assignment", str(assignment_path)]) == 0
+    assert main(["assignment", "validate", CLASS_ID, ASSIGNMENT_ID]) == 0
 
     assert main(
         [

--- a/tests/test_zz_menu_density_contract.py
+++ b/tests/test_zz_menu_density_contract.py
@@ -1,0 +1,55 @@
+"""Collection and execution contract for all real density acceptance tests."""
+
+from __future__ import annotations
+
+from collections import Counter
+import inspect
+
+import pytest
+
+from tests.menu_screen_recorder import recorder_events
+from tests.test_menu_density_matrix import (
+    MENU_DENSITY_ACCEPTANCE_MATRIX,
+    REQUIRED_MENU_DENSITY_WORKFLOWS,
+)
+
+
+@pytest.mark.menu_density_contract
+def test_menu_density_matrix_collected_and_executed_exactly_once(
+    request: pytest.FixtureRequest,
+) -> None:
+    registered = set(MENU_DENSITY_ACCEPTANCE_MATRIX.values())
+    collected = {item.nodeid: item for item in request.session.items}
+    marked_items: dict[str, list[pytest.Item]] = {}
+    for item in request.session.items:
+        marker = item.get_closest_marker("menu_density_workflow")
+        if marker is None:
+            continue
+        assert len(marker.args) == 1 and not marker.kwargs
+        label = marker.args[0]
+        assert isinstance(label, str)
+        marked_items.setdefault(label, []).append(item)
+
+    assert set(marked_items) == REQUIRED_MENU_DENSITY_WORKFLOWS
+    assert Counter(
+        label for label, items in marked_items.items() for _item in items
+    ) == Counter({label: 1 for label in REQUIRED_MENU_DENSITY_WORKFLOWS})
+    assert registered == {
+        items[0].nodeid for items in marked_items.values()
+    }
+    assert registered <= collected.keys()
+
+    expected_events = frozenset(
+        {"instantiated", "installed", "screens", "asserted"}
+    )
+    for label, node_id in MENU_DENSITY_ACCEPTANCE_MATRIX.items():
+        item = collected[node_id]
+        marker = item.get_closest_marker("menu_density_workflow")
+        assert marker is not None and marker.args == (label,)
+        assert recorder_events(node_id) == expected_events
+        source = inspect.getsource(getattr(item, "obj"))
+        assert "MenuScreenRecorder" in source
+        assert ".install(" in source
+        assert ".screens(" in source
+        assert "assert_focused_child_screen(" in source
+        assert "RecordedScreen(" not in source


### PR DESCRIPTION
## Summary

Migrates Quillan’s direct CLI, interactive menu, dashboard, status, scan-review, feedback, and report workflows to the PDS2 and module-qualified service architecture.

Closes #341.

Related to #329.

## Interface Hard Cutover

Quillan’s teacher-facing interfaces now use canonical identity-based records beneath:

```text
classes/<class_id>/modules/quillan/work/<assignment_id>/
```

The public interface no longer exposes:

* `validate-assignment <path>`;
* `open-evidence <path>`;
* caller-supplied `--expected-pages`;
* `--hide-payload`;
* PDS1 packet or routing workflows;
* arbitrary assignment-record paths;
* arbitrary evidence paths;
* legacy assignment-tree compatibility;
* or hidden compatibility flags.

Assignment validation now uses:

```text
quillan assignment validate <class_id> <assignment_id>
```

Evidence opening now uses canonical class, assignment, student, page, and evidence identity.

## Direct CLI

Direct commands remain noninteractive and deterministic.

Expected operational failures:

* write concise messages to stderr;
* return exit status `1`;
* do not display tracebacks.

Argparse usage errors retain exit status `2`.

Successful artifact output uses canonical workspace-relative POSIX paths.

The migration covers:

* assignments;
* printable responses;
* scan intake;
* scan review;
* submission assembly and status;
* plain-paper submissions;
* evidence opening;
* page management;
* review requirements;
* review units and observations;
* ratings;
* feedback;
* review workflow state;
* notes;
* feedback export;
* assignment reports;
* roster paths;
* dashboard and status output.

## Menu Information Density

The established low-information-density interaction model is now an explicit mandatory contract.

Menu workflows use:

```text
compact parent
    -> compact selection
    -> focused details/action
    -> concise confirmation
    -> cleared concise result
    -> parent redraw
```

Previous dashboard, list, routing, or action output remains visible only when necessary for the teacher’s current decision.

A real clear-delimited recorder verifies 25 workflow families:

* assignment creation;
* assignment validation;
* printable-response generation;
* complete and partial scan intake;
* Core scan review;
* route selection and correction;
* post-dispatch review;
* successful retry;
* assignment dashboards;
* student selection;
* plain-paper creation;
* evidence opening;
* page management;
* requirements;
* review units;
* observations;
* ratings;
* feedback composition;
* notes;
* workflow state;
* feedback export;
* assignment-report export;
* help.

The collection contract requires every label exactly once and verifies that every registered test instantiated and installed the recorder, segmented real screen output, and asserted the lifecycle.

## PDS2 Scan Intake

Direct and menu scan intake now consume the same typed full-workflow result.

Results distinguish:

* Core dispatch failures;
* pre-dispatch failures;
* Quillan integration failures;
* observation-persistence failures;
* routed-evidence failures;
* submission-assembly failures;
* post-dispatch review-preservation failures;
* and affected assignment targets.

Post-route actions are derived from the actual result rather than unconditional success text.

## Core Scan Review

Core schema-version-2 routing-review workflows now support:

* route selection;
* route correction;
* evidence filed;
* rescan needed;
* cannot route;
* duplicate dismissal;
* deferral;
* and other teacher-directed resolution.

Route actions use exact registered PDS2 route identity rather than raw JSON, filenames, student identity, or payload text.

The global Scan Review workflow preserves access to:

* assignment-scoped Core problems;
* Quillan post-dispatch problems;
* unscoped Core problems;
* and all Core problems.

No class or assignment identity is invented for unscoped failures.

## Quillan Post-Dispatch Review

Adds teacher-facing list and resolution workflows for immutable Quillan post-dispatch occurrences.

Post-dispatch resolutions are append-only and do not modify:

* occurrence records;
* Core failures or resolutions;
* retained scans;
* page observations;
* routed evidence;
* submission manifests;
* or teacher review records.

Contextual actions can:

* inspect current submission status;
* open occurrence-owned possible evidence or manifests;
* retry supported submission assembly;
* defer;
* or record another explicit resolution.

Possible files are opened only after exact occurrence ownership, work containment, canonical path, and filesystem-safety validation.

## Successful-Retry Resolution

The generic resolver cannot write `resolved_after_retry` and accepts no retry-provenance argument.

A dedicated successful-retry operation:

1. reloads the exact immutable occurrence;
2. verifies its current revision;
3. validates the real typed assembly result;
4. proves that the affected student and issuance were processed;
5. validates the canonical post-retry manifest;
6. constructs provenance internally;
7. prevents reuse of the same retry proof;
8. atomically persists and verifies the resolution.

Empty, unrelated, failed, missing-manifest, and contradictory retry results remain unresolved.

The menu offers `resolved_after_retry` only after the current retry succeeds and the teacher explicitly confirms the resolution.

## Submission Workflows

Submission status is issuance-authoritative.

It reports:

* complete submissions;
* missing expected pages;
* duplicates and rescans;
* mixed issuances;
* unexpected pages;
* manifest conflicts;
* plain-paper submissions;
* and assembly failures.

Expected membership is never supplied by the caller or inferred from filenames.

Identity-based opening supports:

* all selected page evidence;
* one logical page;
* or one explicit evidence candidate.

Opening does not alter evidence selection or review state.

## Review Workflows

Menu and direct commands use the same shared review services.

Teacher judgment remains explicit for:

* minimum requirements;
* page exclusion and restoration;
* rescan decisions;
* review units;
* observations;
* overall Focus Standard ratings;
* feedback inclusion;
* reusable and custom comments;
* notes;
* and workflow-state changes.

No rating, feedback, route correction, or evidence selection is inferred automatically.

## Dashboard and Status

The migration preserves:

```text
review-dashboard schema_version = 1
review-status schema_version = 1
```

Their structured contracts retain existing keys, types, null semantics, deterministic ordering, and privacy boundaries.

Paths remain canonical workspace-relative POSIX text.

## Feedback and Reports

Student feedback and assignment reports now use module-qualified canonical destinations.

The migration preserves existing:

* report filenames;
* CSV headers;
* column ordering;
* row ordering;
* warning vocabulary;
* roster ordering;
* overwrite behavior;
* and privacy exclusions.

## Documentation

Active teacher-facing documentation now describes only the PDS2 and module-qualified workflow.

PDS1 references remain only in clearly labeled historical or unsupported-schema context.

A failing documentation allowlist prevents accidental reintroduction of active PDS1, raw-path, expected-page, or legacy-storage instructions.

## Validation

Passing validation includes:

* focused retry tests: 57 passed;
* menu-density acceptance: 26 passed;
* full pytest: 1,869 passed;
* repository wrapper: 1,869 passed;
* full Ruff;
* full mypy across 230 source files;
* direct CLI help and side-effect probes;
* structured dashboard/status checks;
* path-output checks;
* documentation hard-cutover checks;
* Core and post-dispatch review tests;
* real menu clear/redraw lifecycle tests;
* Windows-junction tests;
* import and dependency checks;
* and `git diff --check`.

The 17 skipped tests are existing Windows privilege-dependent symlink cases reporting `WinError 1314`. Real Windows-junction tests pass.

## Scope

This PR does not add:

* OCR or handwriting recognition;
* grading or rating inference;
* automatic route correction;
* automatic evidence selection;
* automatic post-dispatch resolution;
* PDS1 compatibility;
* legacy record migration;
* changes to PDS Core;
* changes to ScoreForm;
* package-version changes;
* release preparation;
* publication;
* or deployment.

Repository-wide deletion of dormant internal PDS1 components remains assigned to #342.
