### PR TITLE
feat: define privacy-safe publication projections

### DIFF
--- a/docs/academic_result_manifest_v1.md
+++ b/docs/academic_result_manifest_v1.md
@@ -16,8 +16,9 @@ policy says so.
 The module is a pure contract: it performs no workspace, registry, catalog,
 artifact, roster, or standards-library I/O and calculates no proficiency,
 Grade, missing-work state, or portfolio policy. Construction belongs to #361;
-privacy projection to #357; revision/withdrawal policy to #358; and Core
-integration to #359–#364.
+privacy projection is defined by
+[Quillan Publication Projection Policy v1](publication_projection_policy_v1.md);
+revision/withdrawal policy belongs to #358; and Core integration to #359–#364.
 
 ## Exact schema
 
@@ -130,9 +131,12 @@ digital_provenance
 ```
 
 Identity fields must agree with their envelope. Locator paths, retained-source
-paths, filenames, and QR payloads are excluded. #357 may further restrict
-whether structurally supported references are emitted; withholding cannot be
-interpreted as weak or missing academic evidence. Discovery is not access.
+paths, filenames, and QR payloads are excluded. The
+[publication projection policy](publication_projection_policy_v1.md) restricts
+evidence references to authoritative selected evidence; candidate, unselected
+replacement, excluded, and unselected duplicate evidence are not published.
+Withholding cannot be interpreted as weak or missing academic evidence.
+Discovery is not access.
 
 PDS2 typed identities use the current native Quillan forms:
 
@@ -170,7 +174,9 @@ Minimum-requirement outcome separately preserves `status`, explicit return flag,
 nullable `updated_at`, and teacher-note publication state. Status is
 `not_checked`, `met`, `unmet_continue_review`, or
 `returned_without_full_review`; return status, flag, and review state agree.
-Individual checks remain outside v1 and are a #357 projection decision.
+Individual checks remain outside v1. The publication projection policy permits
+only a narrow configured-unmet view in the separate returned-work feedback
+artifact; it does not add individual requirement checks to this manifest.
 
 Review units have unique IDs and positive increasing sequences. Each contains
 at most one observation per assignment Focus Standard. Observations preserve
@@ -197,17 +203,19 @@ evidence remain distinct.
 otherwise null. This distinguishes absent source text from deliberate redaction.
 The value object has no default disposition and neither its constructor, mapping
 parser, validator, nor serializer examines native source text or promotes text to
-`included`. A later #357 projection must choose the disposition explicitly; the
-existence of a rationale, note, or comment in `review.json` is not permission to
-publish it.
+`included`. The
+[publication projection policy](publication_projection_policy_v1.md) chooses
+the disposition explicitly; the existence of a rationale, note, or comment in
+`review.json` is not permission to publish it.
 
 Feedback preserves global and per-standard inclusion choices, selected
 observation IDs, and bounded included comment records. Observation/overall
-rationales, minimum-outcome notes, and comment text use `PublishedText`, leaving
-#357 able to include or withhold them without changing educational meaning.
+rationales, minimum-outcome notes, and comment text use `PublishedText`; the
+publication projection policy includes, withholds, or omits them without changing
+educational meaning.
 Reusable-comment source/provenance fields are not part of the public comment
 object. Individual requirement checks and detailed evidence disclosure remain
-#357 inputs.
+bounded by the publication projection policy and later artifact-reader contracts.
 
 Always excluded: `private_notes`, roster display data, live reusable-comment
 state, arbitrary `module_details`, exception/debug text, diagnostics, absolute or
@@ -216,8 +224,9 @@ ratings nor completion, publication/Grade eligibility, or proficiency.
 
 The contract deliberately contains no workspace projection helper or default
 mapping from native review text. It can represent withheld/absent text without a
-placeholder or empty string, while #357 retains ownership of the allow/deny
-policy and later generation workflows retain responsibility for applying it.
+placeholder or empty string, while the publication projection policy owns the
+allow/deny decision and later generation workflows retain responsibility for
+applying it.
 
 ## Immutability, canonical JSON, and fixture
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -5,6 +5,13 @@ The pure `quillan_academic_result_manifest_v1` contract is defined in
 native review meaning, Core verifies publication envelopes, and an authorized
 consumer owns later grading/reporting policy.
 
+The producer-owned privacy floor for manifest and later artifact projections is
+defined in
+[Quillan Publication Projection Policy v1](publication_projection_policy_v1.md).
+It uses closed allowlists, preserves `absent`/`withheld`/`included` text
+semantics, permits only authoritative selected PDS2 evidence, and keeps discovery
+separate from source or artifact authorization.
+
 Quillan-owned assignment records and all dependent submission, review, and export
 records are rooted exclusively beneath
 `classes/<class_id>/modules/quillan/work/<assignment_id>/`. Contextual loaders

--- a/docs/feedback_export_contract.md
+++ b/docs/feedback_export_contract.md
@@ -60,6 +60,14 @@ This contract follows the standards-based redesign direction established in:
 * [`assignment_contract.md`](assignment_contract.md)
 * [`review_record_contract.md`](review_record_contract.md)
 * [`focus_standard_comment_contract.md`](focus_standard_comment_contract.md)
+* [`publication_projection_policy_v1.md`](publication_projection_policy_v1.md)
+
+The publication projection policy does not redefine this local student-feedback
+export contract. Instead, it uses this contract's explicit student-facing
+selection behavior as the producer privacy floor for future immutable manifest
+generation and authorized public readers. A generated feedback file remains a
+derived artifact; its existence or export metadata does not authorize publication
+or artifact access.
 
 The relevant target contracts define the following responsibilities:
 

--- a/docs/publication_projection_policy_v1.md
+++ b/docs/publication_projection_policy_v1.md
@@ -1,0 +1,666 @@
+# Quillan Publication Projection Policy v1
+
+## Purpose and ownership
+
+`quillan_publication_projection_v1` is Quillan's producer-owned privacy floor for
+publication projections derived from validated assignment, submission, and review
+records.
+
+The policy answers one narrow question:
+
+```text
+which already-valid Quillan-native values may cross the producer publication boundary?
+```
+
+It does not answer:
+
+```text
+who may discover a publication
+who may inspect a student-level manifest
+who may open student work
+who may receive a feedback artifact
+which result affects a Grade
+which artifact belongs in a Portfolio
+```
+
+The governing separation is:
+
+```text
+native field exists
+  != field is publication-approved
+  != Core discovery authorizes manifest inspection
+  != manifest inspection authorizes source access
+  != source identity authorizes artifact retrieval
+  != producer projection authorizes disclosure to a recipient
+```
+
+Quillan owns the producer projection and its closed allowlists. Core owns
+publication envelopes and integrity verification. Application/deployment policy owns
+authorization. Meridian and Vitrine may narrow Quillan output for their own purposes
+but may not broaden it.
+
+## Relationship to Academic Result Manifest v1
+
+The policy is designed for `quillan_academic_result_manifest_v1` without changing
+that contract's exact JSON key set.
+
+The manifest already has the public value object:
+
+```text
+PublishedText
+  disposition = absent | withheld | included
+  text
+```
+
+This policy decides those dispositions for privacy-sensitive native text.
+
+The distinction is normative:
+
+```text
+absent    = no source text exists
+withheld  = source text exists but is not publication-approved
+included  = source text exists and explicit Quillan policy approves publication
+```
+
+`withheld` must never be converted to an empty string, placeholder, low rating,
+missing evidence, failed requirement, or other academic state.
+
+The policy module is pure and side-effect free. It does not read workspace files,
+load rosters or standards, inspect Core registry state, open evidence, hash files,
+write manifests, publish through Core, or apply consumer policy.
+
+## Policy identity
+
+Stable policy version:
+
+```text
+quillan_publication_projection_v1
+```
+
+The policy version is independent from:
+
+- assignment schema version;
+- submission schema version;
+- review schema version;
+- Academic Result Manifest contract version;
+- record-set revision;
+- Core registration revision;
+- Core Publication Record identity or schema;
+- package version;
+- Meridian policy;
+- and Vitrine Profile policy.
+
+Issue #358 owns the historical/revision consequences of material future policy
+changes.
+
+## Closed allowlist
+
+The publication rule is:
+
+```text
+publish only declared fields and declared text selections
+```
+
+The rejected rule is:
+
+```text
+publish everything except fields currently known to be secret
+```
+
+Unknown native fields and future schema extensions do not become public
+implicitly. `publication_field_disposition()` is intentionally closed and fails on
+an undeclared field rather than defaulting it to allowed.
+
+There is no caller-controlled privacy bypass such as:
+
+```text
+include_private
+teacher_mode
+admin_mode
+include_all
+debug
+```
+
+A downstream consumer may suppress more. It cannot use a role or audience setting
+to widen the canonical Quillan projection.
+
+## Observation rationales
+
+Native source:
+
+```text
+review.json.review_units[].standard_observations[].rationale
+```
+
+The observation's structured academic state remains distinct from its text:
+
+```text
+standard_id
+applicable
+evidence_present
+rating
+include_in_feedback
+updated_at
+```
+
+An existing rationale is `included` only when both are true:
+
+```text
+review.feedback.include_review_unit_observations == true
+```
+
+and
+
+```text
+observation_id is explicitly listed for the same standard_id in
+review.feedback.standard_feedback[].included_observation_ids
+```
+
+Otherwise an existing rationale is `withheld`.
+
+No source rationale produces `absent`.
+
+The observation-level `include_in_feedback` flag is intentionally not sufficient by
+itself. Current Quillan feedback export selects observation content through the
+global observation-feedback switch plus the same-standard selected-observation ID
+set. The publication policy preserves that existing behavior rather than inventing
+a second selection model.
+
+## Overall Focus Standard rationales
+
+Native source:
+
+```text
+review.json.overall_standard_ratings[].rationale
+```
+
+Overall ratings are teacher-entered native results. Their publication meaning is
+separate from whether the rationale text is student-facing.
+
+First apply:
+
+```text
+review.feedback.include_overall_standard_ratings
+```
+
+If the global setting is false, any existing rationale is `withheld`.
+
+When matching `feedback.standard_feedback` exists, current Quillan semantics use:
+
+```text
+include_overall_rating
+include_overall_rationale
+```
+
+The rationale is included only when both select it through the per-standard feedback
+record.
+
+When no per-standard feedback record exists, Quillan's existing feedback exporter
+falls back to:
+
+```text
+overall_standard_ratings[].include_in_feedback
+```
+
+The projection policy preserves that fallback. It does not invent a stricter or
+looser replacement rule.
+
+A missing rationale is always `absent`.
+
+## Feedback comments
+
+Native source:
+
+```text
+review.json.feedback.standard_feedback[].comments[]
+```
+
+Only a comment with:
+
+```text
+include_in_feedback == true
+```
+
+may appear in the public feedback-comment collection.
+
+A selected comment publishes the exact text copied into `review.json`. An unselected
+comment is omitted from the public collection rather than represented with its
+private text.
+
+The projection never publishes reusable-comment provenance or live reusable-comment
+state, including:
+
+```text
+source
+reusable_comment_id
+save_for_reuse
+comment_set_id
+module_details
+```
+
+A reusable comment selected into a review is already a stable copied native
+snapshot. Publication must not look up the source comment set again.
+
+## Minimum-requirement outcome
+
+Assignment-level basic requirements are ordinary assignment context:
+
+```text
+paragraphs_min
+paragraphs_max
+word_count_min
+word_count_max
+required_elements
+minimum_requirement_policy
+```
+
+The manifest separately preserves the aggregate native minimum-requirement outcome.
+
+### Outcome teacher note
+
+Native source:
+
+```text
+review.json.minimum_requirement_outcome.teacher_note
+```
+
+Quillan's current returned-work workflow requires a nonempty note when all three
+returned signals agree:
+
+```text
+status = returned_without_full_review
+returned_without_full_review = true
+review_state = returned_without_full_review
+```
+
+The existing student feedback exporter renders this note as the student's Return
+Note. Therefore the exact returned-work outcome note is `included`.
+
+For other statuses, including:
+
+```text
+met
+unmet_continue_review
+not_checked
+```
+
+an existing outcome note is `withheld`. The generic field name `teacher_note` does
+not itself establish publication permission.
+
+A missing note is `absent`.
+
+Contradictory returned status, flag, and review state fail closed.
+
+### Individual requirement checks
+
+Academic Result Manifest v1 does not contain an individual requirement-check array,
+and this policy does not add one.
+
+The complete native fields remain outside the structured academic-result manifest:
+
+```text
+requirement_check_id
+requirement_key
+label
+expected
+met
+teacher_note
+updated_at
+module_details
+```
+
+The existing returned-work feedback artifact may present a narrower student-facing
+view of configured checks that are actually unmet. That derived artifact may use:
+
+```text
+label
+expected
+optional teacher_note
+```
+
+It must not turn requirement-check IDs, module details, arbitrary checks, or internal
+timestamps into public structured result data.
+
+## PDS2 evidence policy
+
+Quillan submission records distinguish:
+
+```text
+candidate
+selected
+replacement
+excluded
+```
+
+A PDS2 evidence record is eligible for Academic Result Manifest provenance only when
+these native facts agree:
+
+```text
+page.selected_evidence_id == evidence.evidence_id
+AND
+evidence.evidence_role == selected
+```
+
+Contradiction fails closed.
+
+Candidate, unselected replacement, excluded, and unselected duplicate evidence are
+not published. A page with no selected evidence contributes no evidence reference.
+
+### Allowed selected-evidence provenance
+
+The current manifest's bounded PDS2 reference fields are:
+
+```text
+page_id
+evidence_id
+observation_id
+route_id
+issuance_id
+generation_id
+artifact_id
+source_page_number
+source_scan_id
+source_sha256
+routed_evidence_sha256
+```
+
+They are provenance and integrity references only. They are not paths, URLs,
+capability tokens, authorization grants, or instructions to bypass the Quillan
+reader.
+
+### Prohibited evidence information
+
+Do not publish:
+
+```text
+routed_evidence_path
+retained_source_path
+source_filename
+QR payload
+raw route payload
+scan-intake diagnostics
+routing failure details
+duplicate_number
+candidate evidence lists
+excluded evidence lists
+replacement history
+quillan_before_page_exclusion
+arbitrary module_details
+private absolute paths
+```
+
+Raw retained scans are not direct Academic Result Manifest artifacts.
+
+Optional native review-unit locators such as `page_number` and `evidence_id` remain
+outside Academic Result Manifest v1. Publishing an observation does not turn the
+review record into a source-navigation API.
+
+Plain-paper submissions retain:
+
+```text
+expected_pages = null
+digital_provenance = null
+```
+
+and never receive fabricated PDS2 identity.
+
+## Native files and derived artifacts
+
+The canonical files:
+
+```text
+assignment.json
+submission.json
+review.json
+```
+
+remain source-only. A consumer must not expose a native file merely because it can
+locate it.
+
+`review.json.private_notes` are prohibited. The prohibition includes unnecessary
+existence leakage such as:
+
+```text
+has_private_notes
+private_note_count
+private_notes_redacted = true
+```
+
+Class-wide and standards-wide reports are not individual student artifacts merely
+because one student appears in them.
+
+### Structured feedback
+
+A future structured feedback reader may return only content approved by this policy.
+It must not return complete `review.json`, unselected comments, withheld rationales,
+private notes, or arbitrary requirement history.
+
+### Feedback PDF and Markdown
+
+The existing PDF and Markdown exports are derived student-facing artifacts, not
+canonical review state. Their existence or metadata in `review.json.exports` does
+not grant publication or access permission.
+
+A later artifact reader may expose an exact feedback export only after verifying its
+relationship, source/projection provenance, applicable historical state, and
+separate artifact-access authorization.
+
+### Original student work
+
+A later student-work artifact projection may resolve only producer-confirmed selected
+evidence. It must not fall back to candidate evidence, duplicate alternatives,
+excluded evidence, unrelated replacement history, complete retained scans, another
+student's pages, or arbitrary source bytes.
+
+Artifact resolution belongs to #364, not this policy module.
+
+## Discovery is not authorization
+
+Core publication discovery supplies bounded candidate metadata and exact publication
+integrity information. It does not establish authority to inspect student-level
+manifest contents or underlying artifacts.
+
+The intended flow is:
+
+```text
+discover candidate publication through Core
+-> reload canonical Core publication state
+-> evaluate compatibility
+-> establish authorization for exact student/work/purpose
+-> verify exact manifest path and SHA-256
+-> parse through Quillan's public contract
+-> return only the bounded authorized projection
+```
+
+The access gates remain distinct:
+
+```text
+authorized manifest/result lookup
+  != authorized feedback-artifact lookup
+  != authorized student-work lookup
+  != authorized underlying source resolution
+```
+
+A manifest identifier, source digest, route ID, page ID, or scan ID does not by
+itself authorize any later lookup.
+
+Ordinary denial must not unnecessarily reveal private-note existence, hidden
+feedback text, candidate/duplicate evidence counts, retained-scan paths, or another
+student's submission details.
+
+## Producer and consumer ownership
+
+Quillan owns:
+
+- native educational semantics;
+- projection version and field allowlists;
+- privacy-sensitive text disposition;
+- selected-evidence eligibility;
+- prohibited producer fields;
+- and later public-reader behavior.
+
+Core owns:
+
+- Academic Work and publication envelopes;
+- exact manifest-path and digest binding;
+- publication-series state;
+- compatibility metadata;
+- and rebuildable discovery catalogs.
+
+The application/deployment layer owns actual actor, purpose, and source/artifact
+authorization.
+
+Meridian owns grading/reporting policy after authorized producer parsing.
+
+Vitrine owns portfolio Candidate/Selection/Profile policy after authorized producer
+parsing.
+
+Neither consumer may broaden this producer privacy floor.
+
+## Synthetic examples
+
+These examples are illustrative policy inputs only. They are not workspace records,
+manifest fixtures, authorization examples, or permission grants.
+
+### Selected observation rationale
+
+Given validated native feedback state:
+
+```text
+include_review_unit_observations = true
+standard_id = njsls-ela:RL.CR.9-10.1
+observation_id = observation_0001
+included_observation_ids for that same standard = [observation_0001]
+rationale = "The claim is supported by a precise quotation."
+```
+
+the publication decision is:
+
+```text
+PublishedText(
+  disposition = included,
+  text = "The claim is supported by a precise quotation."
+)
+```
+
+If the observation ID is not selected for that same standard, the same existing
+rationale becomes:
+
+```text
+PublishedText(disposition = withheld, text = null)
+```
+
+### Overall rationale withheld by per-standard feedback
+
+Given:
+
+```text
+include_overall_standard_ratings = true
+overall_standard_ratings[].include_in_feedback = true
+standard_feedback.include_overall_rating = true
+standard_feedback.include_overall_rationale = false
+rationale = "The response is consistent but needs more developed analysis."
+```
+
+the numeric native rating remains result data, while the rationale decision is:
+
+```text
+PublishedText(disposition = withheld, text = null)
+```
+
+### Returned-work note and requirement detail
+
+Given:
+
+```text
+status = returned_without_full_review
+returned_without_full_review = true
+review_state = returned_without_full_review
+outcome teacher_note = "Add the missing textual evidence and resubmit."
+configured requirement_key = required_elements:textual evidence
+check.met = false
+```
+
+the outcome note is `included`. A separate returned-work feedback artifact may show
+that configured unmet check's `label`, `expected`, and optional `teacher_note`; it
+must not show the check ID, module details, or internal timestamp.
+
+### Selected PDS2 evidence
+
+Given one page with:
+
+```text
+selected_evidence_id = obs_00000000000000000000000000000001
+```
+
+and one same-page evidence record with:
+
+```text
+evidence_id = obs_00000000000000000000000000000001
+evidence_role = selected
+```
+
+that evidence record is eligible to contribute the bounded `EvidenceReference`
+provenance fields. A different candidate, replacement, excluded, or duplicate
+alternative on the same page is not eligible, and the IDs themselves do not
+authorize source or artifact access.
+
+## Decision matrix
+
+| Native content | Academic Result Manifest v1 | Separate artifact projection | Rule |
+| --- | --- | --- | --- |
+| overall Focus Standard rating | included native result | may appear in feedback | preserve assignment-local scale |
+| overall rationale | conditional `PublishedText` | conditional | current global/per-standard feedback selection |
+| review-unit observation | included structured meaning | conditional | rationale separately gated |
+| observation rationale | conditional `PublishedText` | conditional | global switch + same-standard selected observation |
+| selected feedback comment | included | feedback | exact copied review text only |
+| unselected feedback comment | omitted | omitted | no private text leakage |
+| minimum outcome | included native state | return feedback when applicable | preserve non-score semantics |
+| returned-work outcome note | `included` | included in return feedback | existing student-facing return contract |
+| other outcome note | `withheld` when present | not automatically exposed | teacher-note name is insufficient |
+| individual requirement checks | omitted | returned-work minimum view only | configured unmet checks only |
+| selected PDS2 evidence | bounded provenance | possible student-work source | exact selected evidence only |
+| candidate/duplicate/excluded evidence | omitted | prohibited fallback | selection does not broaden |
+| `private_notes` | prohibited | prohibited | no existence leakage |
+| feedback export path/metadata | omitted | internal resolution input | metadata is not permission |
+| raw retained scan | omitted | prohibited direct | separate sanitized contract required |
+| class report | omitted | prohibited as individual artifact | multi-student data |
+
+## Downstream boundaries
+
+### #358 — revision, correction, and withdrawal
+
+Defines historical consequences when native data, selected evidence, approved text, or
+projection policy changes.
+
+### #361 — immutable manifest generation
+
+Loads and validates authoritative native records, applies this pure policy, constructs
+Academic Result Manifest v1, binds exact source bytes, and writes immutable manifest
+revisions.
+
+### #364 — consumer-neutral reader
+
+Implements bounded authorized manifest/result and artifact lookup. It must not broaden
+this policy or use private-native-file fallback.
+
+The Core upgrade, Academic Work Registration, producer profile, Core publication, and
+end-to-end integration remain assigned to their existing milestone issues.
+
+## Non-goals
+
+This policy does not:
+
+- change Academic Result Manifest v1's JSON schema;
+- generate or write manifests;
+- allocate record-set revisions;
+- upgrade the Core dependency;
+- register Academic Work;
+- publish through Core;
+- open submissions or retained scans;
+- generate new teacher feedback;
+- mutate native review records;
+- create an authorization system;
+- define recipient/audience redaction;
+- calculate Grades or proficiency;
+- or select Portfolio artifacts.

--- a/quillan/publication_projection_policy.py
+++ b/quillan/publication_projection_policy.py
@@ -1,0 +1,385 @@
+"""Pure privacy policy for Quillan publication projections."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from typing import Final, Literal, TypeAlias
+
+from quillan.academic_result_manifest import PublishedText
+
+PUBLICATION_PROJECTION_POLICY_VERSION: Final = "quillan_publication_projection_v1"
+PUBLISHED_TEXT_MAX_CHARS: Final = 20_000
+
+PublicationFieldDisposition: TypeAlias = Literal["allowed", "source_only", "prohibited"]
+
+_REVIEW_STATES: Final[frozenset[str]] = frozenset(
+    {
+        "not_started",
+        "requirements_checked",
+        "returned_without_full_review",
+        "observations_in_progress",
+        "observations_complete",
+        "ratings_complete",
+        "feedback_composed",
+        "ready_for_export",
+        "exported",
+    }
+)
+_MINIMUM_REQUIREMENT_STATUSES: Final[frozenset[str]] = frozenset(
+    {"not_checked", "met", "unmet_continue_review", "returned_without_full_review"}
+)
+_EVIDENCE_ROLES: Final[frozenset[str]] = frozenset(
+    {"candidate", "selected", "replacement", "excluded"}
+)
+
+RETURNED_REQUIREMENT_FEEDBACK_FIELDS: Final[frozenset[str]] = frozenset(
+    {"label", "expected", "teacher_note"}
+)
+
+PUBLIC_PDS2_EVIDENCE_REFERENCE_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "page_id",
+        "evidence_id",
+        "observation_id",
+        "route_id",
+        "issuance_id",
+        "generation_id",
+        "artifact_id",
+        "source_page_number",
+        "source_scan_id",
+        "source_sha256",
+        "routed_evidence_sha256",
+    }
+)
+
+SOURCE_ONLY_NATIVE_RECORDS: Final[frozenset[str]] = frozenset(
+    {"assignment.json", "submission.json", "review.json"}
+)
+
+PROHIBITED_PUBLICATION_NATIVE_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "review.private_notes",
+        "review.module_details",
+        "review.exports.feedback_pdf.path",
+        "review.exports.feedback_markdown.path",
+        "feedback.comments.source",
+        "feedback.comments.reusable_comment_id",
+        "feedback.comments.save_for_reuse",
+        "feedback.comments.module_details",
+        "minimum_requirement_checks.requirement_check_id",
+        "minimum_requirement_checks.module_details",
+        "submission.evidence.routed_evidence_path",
+        "submission.evidence.duplicate_number",
+        "submission.evidence.retained_source.source_filename",
+        "submission.evidence.retained_source.retained_source_path",
+        "submission.evidence.module_details",
+        "submission.module_details",
+        "roster.display_data",
+        "class_reports",
+        "qr_payload",
+        "routing_diagnostics",
+    }
+)
+
+
+class QuillanPublicationProjectionPolicyError(ValueError):
+    """Raised when privacy-policy inputs are malformed or contradictory."""
+
+
+def _boolean(value: object, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise QuillanPublicationProjectionPolicyError(f"{field} must be a boolean.")
+    return value
+
+
+def _required_text(value: object, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or "\x00" in value
+        or len(value) > PUBLISHED_TEXT_MAX_CHARS
+    ):
+        raise QuillanPublicationProjectionPolicyError(
+            f"{field} must be nonempty publication text of at most "
+            f"{PUBLISHED_TEXT_MAX_CHARS} characters."
+        )
+    return value
+
+
+def _optional_text(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _required_text(value, field)
+
+
+def _native_id(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip() or "\x00" in value:
+        raise QuillanPublicationProjectionPolicyError(
+            f"{field} must be nonempty native identifier text."
+        )
+    return value
+
+
+def _published_text(
+    source_text: object,
+    *,
+    include: bool,
+    field: str,
+) -> PublishedText:
+    text = _optional_text(source_text, field)
+    if text is None:
+        return PublishedText(disposition="absent", text=None)
+    if include:
+        return PublishedText(disposition="included", text=text)
+    return PublishedText(disposition="withheld", text=None)
+
+
+def observation_is_selected_for_feedback(
+    *,
+    include_review_unit_observations: bool,
+    observation_id: str,
+    standard_id: str,
+    included_observation_ids_by_standard: Mapping[str, Collection[str]],
+) -> bool:
+    """Return whether one observation is explicitly selected for student feedback.
+
+    The native observation-level ``include_in_feedback`` flag is intentionally not
+    an input. Current Quillan export semantics require the global feedback switch
+    plus same-standard membership in ``included_observation_ids``.
+    """
+    if not _boolean(
+        include_review_unit_observations, "include_review_unit_observations"
+    ):
+        return False
+    observation = _native_id(observation_id, "observation_id")
+    standard = _native_id(standard_id, "standard_id")
+    selected = included_observation_ids_by_standard.get(standard, ())
+    if isinstance(selected, (str, bytes)) or not isinstance(selected, Collection):
+        raise QuillanPublicationProjectionPolicyError(
+            "included_observation_ids_by_standard values must be collections of IDs."
+        )
+    for candidate in selected:
+        _native_id(candidate, "included_observation_id")
+    return observation in selected
+
+
+def project_observation_rationale(
+    rationale: str | None,
+    *,
+    include_review_unit_observations: bool,
+    observation_id: str,
+    standard_id: str,
+    included_observation_ids_by_standard: Mapping[str, Collection[str]],
+) -> PublishedText:
+    """Project one observation rationale under current feedback-selection rules."""
+    include = observation_is_selected_for_feedback(
+        include_review_unit_observations=include_review_unit_observations,
+        observation_id=observation_id,
+        standard_id=standard_id,
+        included_observation_ids_by_standard=included_observation_ids_by_standard,
+    )
+    return _published_text(
+        rationale,
+        include=include,
+        field="standard_observation.rationale",
+    )
+
+
+def overall_rating_is_selected_for_feedback(
+    *,
+    include_overall_standard_ratings: bool,
+    rating_include_in_feedback: bool,
+    standard_feedback_include_overall_rating: bool | None,
+    standard_feedback_include_overall_rationale: bool | None,
+) -> bool:
+    """Return whether an overall rating is selected by native feedback semantics."""
+    global_enabled = _boolean(
+        include_overall_standard_ratings, "include_overall_standard_ratings"
+    )
+    fallback_enabled = _boolean(
+        rating_include_in_feedback, "rating_include_in_feedback"
+    )
+    pair = (
+        standard_feedback_include_overall_rating,
+        standard_feedback_include_overall_rationale,
+    )
+    if (pair[0] is None) != (pair[1] is None):
+        raise QuillanPublicationProjectionPolicyError(
+            "per-standard overall-rating and rationale controls must both be present "
+            "or both be absent."
+        )
+    if not global_enabled:
+        return False
+    if pair[0] is None:
+        return fallback_enabled
+    return _boolean(pair[0], "standard_feedback.include_overall_rating")
+
+
+def project_overall_rating_rationale(
+    rationale: str | None,
+    *,
+    include_overall_standard_ratings: bool,
+    rating_include_in_feedback: bool,
+    standard_feedback_include_overall_rating: bool | None,
+    standard_feedback_include_overall_rationale: bool | None,
+) -> PublishedText:
+    """Project one overall-rating rationale without broadening feedback selection."""
+    rating_selected = overall_rating_is_selected_for_feedback(
+        include_overall_standard_ratings=include_overall_standard_ratings,
+        rating_include_in_feedback=rating_include_in_feedback,
+        standard_feedback_include_overall_rating=(
+            standard_feedback_include_overall_rating
+        ),
+        standard_feedback_include_overall_rationale=(
+            standard_feedback_include_overall_rationale
+        ),
+    )
+    if standard_feedback_include_overall_rationale is None:
+        rationale_selected = rating_selected
+    else:
+        rationale_selected = rating_selected and _boolean(
+            standard_feedback_include_overall_rationale,
+            "standard_feedback.include_overall_rationale",
+        )
+    return _published_text(
+        rationale,
+        include=rationale_selected,
+        field="overall_standard_rating.rationale",
+    )
+
+
+def project_feedback_comment_text(
+    text: str,
+    *,
+    include_in_feedback: bool,
+) -> PublishedText | None:
+    """Return selected feedback-comment text, or omit an unselected comment."""
+    selected = _boolean(include_in_feedback, "feedback_comment.include_in_feedback")
+    if not selected:
+        return None
+    return PublishedText(
+        disposition="included",
+        text=_required_text(text, "feedback_comment.text"),
+    )
+
+
+def _returned_without_full_review(
+    *,
+    status: str,
+    returned_without_full_review: bool,
+    review_state: str,
+) -> bool:
+    if status not in _MINIMUM_REQUIREMENT_STATUSES:
+        raise QuillanPublicationProjectionPolicyError(
+            "minimum_requirement_outcome.status is invalid."
+        )
+    if review_state not in _REVIEW_STATES:
+        raise QuillanPublicationProjectionPolicyError("review_state is invalid.")
+    returned_flag = _boolean(
+        returned_without_full_review, "returned_without_full_review"
+    )
+    returned_signals = (
+        status == "returned_without_full_review",
+        returned_flag,
+        review_state == "returned_without_full_review",
+    )
+    if len(set(returned_signals)) != 1:
+        raise QuillanPublicationProjectionPolicyError(
+            "returned-without-full-review status, flag, and review state must agree."
+        )
+    return returned_signals[0]
+
+
+def project_minimum_outcome_teacher_note(
+    teacher_note: str | None,
+    *,
+    status: str,
+    returned_without_full_review: bool,
+    review_state: str,
+) -> PublishedText:
+    """Project the minimum-outcome note only for the student-facing return state."""
+    returned = _returned_without_full_review(
+        status=status,
+        returned_without_full_review=returned_without_full_review,
+        review_state=review_state,
+    )
+    return _published_text(
+        teacher_note,
+        include=returned,
+        field="minimum_requirement_outcome.teacher_note",
+    )
+
+
+def returned_requirement_check_is_feedback_publishable(
+    *,
+    requirement_key: str,
+    met: bool,
+    configured_requirement_keys: Collection[str],
+    status: str,
+    returned_without_full_review: bool,
+    review_state: str,
+) -> bool:
+    """Return whether one configured unmet check may appear in return feedback."""
+    returned = _returned_without_full_review(
+        status=status,
+        returned_without_full_review=returned_without_full_review,
+        review_state=review_state,
+    )
+    key = _native_id(requirement_key, "requirement_key")
+    checked_met = _boolean(met, "minimum_requirement_check.met")
+    if isinstance(configured_requirement_keys, (str, bytes)) or not isinstance(
+        configured_requirement_keys, Collection
+    ):
+        raise QuillanPublicationProjectionPolicyError(
+            "configured_requirement_keys must be a collection of requirement keys."
+        )
+    for configured_key in configured_requirement_keys:
+        _native_id(configured_key, "configured_requirement_key")
+    return returned and not checked_met and key in configured_requirement_keys
+
+
+def selected_pds2_evidence_is_publishable(
+    *,
+    page_selected_evidence_id: str | None,
+    evidence_id: str,
+    evidence_role: str,
+) -> bool:
+    """Return whether one PDS2 evidence record is the authoritative page selection.
+
+    Contradiction between the page selection and evidence role fails closed. Native
+    submission validation should establish the same invariant before this policy is
+    applied, but the projection policy does not silently broaden malformed input.
+    """
+    evidence = _native_id(evidence_id, "evidence_id")
+    if evidence_role not in _EVIDENCE_ROLES:
+        raise QuillanPublicationProjectionPolicyError("evidence_role is invalid.")
+    selected = (
+        None
+        if page_selected_evidence_id is None
+        else _native_id(page_selected_evidence_id, "page_selected_evidence_id")
+    )
+    role_selected = evidence_role == "selected"
+    id_selected = selected == evidence
+    if role_selected != id_selected:
+        raise QuillanPublicationProjectionPolicyError(
+            "page selected_evidence_id and evidence_role='selected' disagree."
+        )
+    return role_selected and id_selected
+
+
+def publication_field_disposition(field_path: str) -> PublicationFieldDisposition:
+    """Classify fixed high-risk native fields used by policy audits and callers.
+
+    This is intentionally a closed classifier, not a wildcard allowlist. Unknown
+    fields fail rather than becoming public by default.
+    """
+    field = _native_id(field_path, "field_path")
+    if field in PROHIBITED_PUBLICATION_NATIVE_FIELDS:
+        return "prohibited"
+    if field in SOURCE_ONLY_NATIVE_RECORDS:
+        return "source_only"
+    if field in PUBLIC_PDS2_EVIDENCE_REFERENCE_FIELDS:
+        return "allowed"
+    raise QuillanPublicationProjectionPolicyError(
+        f"field {field!r} has no declared publication disposition."
+    )

--- a/tests/test_publication_projection_policy.py
+++ b/tests/test_publication_projection_policy.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+import quillan.publication_projection_policy as policy_module
+
+from quillan.publication_projection_policy import (
+    PROHIBITED_PUBLICATION_NATIVE_FIELDS,
+    PUBLICATION_PROJECTION_POLICY_VERSION,
+    PUBLIC_PDS2_EVIDENCE_REFERENCE_FIELDS,
+    RETURNED_REQUIREMENT_FEEDBACK_FIELDS,
+    SOURCE_ONLY_NATIVE_RECORDS,
+    QuillanPublicationProjectionPolicyError,
+    observation_is_selected_for_feedback,
+    overall_rating_is_selected_for_feedback,
+    project_feedback_comment_text,
+    project_minimum_outcome_teacher_note,
+    project_observation_rationale,
+    project_overall_rating_rationale,
+    publication_field_disposition,
+    returned_requirement_check_is_feedback_publishable,
+    selected_pds2_evidence_is_publishable,
+)
+
+
+def assert_text(value: object, disposition: str, text: str | None) -> None:
+    assert getattr(value, "disposition") == disposition
+    assert getattr(value, "text") == text
+
+
+def test_policy_version_is_stable() -> None:
+    assert PUBLICATION_PROJECTION_POLICY_VERSION == "quillan_publication_projection_v1"
+
+
+def test_observation_selected_by_global_and_same_standard_reference() -> None:
+    assert observation_is_selected_for_feedback(
+        include_review_unit_observations=True,
+        observation_id="observation_0001",
+        standard_id="njsls-ela:RL.CR.9-10.1",
+        included_observation_ids_by_standard={
+            "njsls-ela:RL.CR.9-10.1": ("observation_0001",),
+        },
+    )
+
+
+def test_observation_global_disable_withholds_rationale() -> None:
+    result = project_observation_rationale(
+        "Selected teacher explanation.",
+        include_review_unit_observations=False,
+        observation_id="observation_0001",
+        standard_id="std:1",
+        included_observation_ids_by_standard={"std:1": ("observation_0001",)},
+    )
+    assert_text(result, "withheld", None)
+
+
+def test_observation_unselected_withholds_rationale() -> None:
+    result = project_observation_rationale(
+        "Private observation explanation.",
+        include_review_unit_observations=True,
+        observation_id="observation_0002",
+        standard_id="std:1",
+        included_observation_ids_by_standard={"std:1": ("observation_0001",)},
+    )
+    assert_text(result, "withheld", None)
+
+
+def test_observation_selected_in_other_standard_does_not_publish() -> None:
+    result = project_observation_rationale(
+        "Wrong-standard selection must not broaden disclosure.",
+        include_review_unit_observations=True,
+        observation_id="observation_0001",
+        standard_id="std:1",
+        included_observation_ids_by_standard={"std:2": ("observation_0001",)},
+    )
+    assert_text(result, "withheld", None)
+
+
+def test_observation_selected_includes_exact_rationale() -> None:
+    result = project_observation_rationale(
+        "Keep this exact text.",
+        include_review_unit_observations=True,
+        observation_id="observation_0001",
+        standard_id="std:1",
+        included_observation_ids_by_standard={"std:1": ("observation_0001",)},
+    )
+    assert_text(result, "included", "Keep this exact text.")
+
+
+def test_missing_observation_rationale_is_absent_even_when_selected() -> None:
+    result = project_observation_rationale(
+        None,
+        include_review_unit_observations=True,
+        observation_id="observation_0001",
+        standard_id="std:1",
+        included_observation_ids_by_standard={"std:1": ("observation_0001",)},
+    )
+    assert_text(result, "absent", None)
+
+
+def test_overall_global_disable_withholds_rationale() -> None:
+    result = project_overall_rating_rationale(
+        "Teacher rationale.",
+        include_overall_standard_ratings=False,
+        rating_include_in_feedback=True,
+        standard_feedback_include_overall_rating=True,
+        standard_feedback_include_overall_rationale=True,
+    )
+    assert_text(result, "withheld", None)
+
+
+def test_overall_per_standard_rating_and_rationale_include() -> None:
+    result = project_overall_rating_rationale(
+        "Teacher rationale.",
+        include_overall_standard_ratings=True,
+        rating_include_in_feedback=False,
+        standard_feedback_include_overall_rating=True,
+        standard_feedback_include_overall_rationale=True,
+    )
+    assert_text(result, "included", "Teacher rationale.")
+
+
+def test_overall_per_standard_rationale_disable_withholds() -> None:
+    result = project_overall_rating_rationale(
+        "Teacher rationale.",
+        include_overall_standard_ratings=True,
+        rating_include_in_feedback=True,
+        standard_feedback_include_overall_rating=True,
+        standard_feedback_include_overall_rationale=False,
+    )
+    assert_text(result, "withheld", None)
+
+
+def test_overall_per_standard_rating_disable_withholds_rationale() -> None:
+    result = project_overall_rating_rationale(
+        "Teacher rationale.",
+        include_overall_standard_ratings=True,
+        rating_include_in_feedback=True,
+        standard_feedback_include_overall_rating=False,
+        standard_feedback_include_overall_rationale=True,
+    )
+    assert_text(result, "withheld", None)
+
+
+def test_overall_fallback_preserves_native_rating_include_flag() -> None:
+    assert overall_rating_is_selected_for_feedback(
+        include_overall_standard_ratings=True,
+        rating_include_in_feedback=True,
+        standard_feedback_include_overall_rating=None,
+        standard_feedback_include_overall_rationale=None,
+    )
+    result = project_overall_rating_rationale(
+        "Fallback rationale.",
+        include_overall_standard_ratings=True,
+        rating_include_in_feedback=True,
+        standard_feedback_include_overall_rating=None,
+        standard_feedback_include_overall_rationale=None,
+    )
+    assert_text(result, "included", "Fallback rationale.")
+
+
+def test_overall_fallback_false_withholds() -> None:
+    result = project_overall_rating_rationale(
+        "Not selected.",
+        include_overall_standard_ratings=True,
+        rating_include_in_feedback=False,
+        standard_feedback_include_overall_rating=None,
+        standard_feedback_include_overall_rationale=None,
+    )
+    assert_text(result, "withheld", None)
+
+
+def test_overall_missing_rationale_is_absent() -> None:
+    result = project_overall_rating_rationale(
+        None,
+        include_overall_standard_ratings=True,
+        rating_include_in_feedback=True,
+        standard_feedback_include_overall_rating=None,
+        standard_feedback_include_overall_rationale=None,
+    )
+    assert_text(result, "absent", None)
+
+
+def test_partial_per_standard_overall_controls_fail_closed() -> None:
+    with pytest.raises(QuillanPublicationProjectionPolicyError):
+        project_overall_rating_rationale(
+            "Teacher rationale.",
+            include_overall_standard_ratings=True,
+            rating_include_in_feedback=True,
+            standard_feedback_include_overall_rating=True,
+            standard_feedback_include_overall_rationale=None,
+        )
+
+
+def test_selected_feedback_comment_is_included_exactly() -> None:
+    result = project_feedback_comment_text(
+        "Use this exact copied review text.", include_in_feedback=True
+    )
+    assert result is not None
+    assert_text(result, "included", "Use this exact copied review text.")
+
+
+def test_unselected_feedback_comment_is_omitted() -> None:
+    assert (
+        project_feedback_comment_text("Do not publish me.", include_in_feedback=False)
+        is None
+    )
+
+
+def test_returned_work_outcome_note_is_included() -> None:
+    result = project_minimum_outcome_teacher_note(
+        "Add the required textual evidence and resubmit.",
+        status="returned_without_full_review",
+        returned_without_full_review=True,
+        review_state="returned_without_full_review",
+    )
+    assert_text(result, "included", "Add the required textual evidence and resubmit.")
+
+
+@pytest.mark.parametrize("status", ["met", "unmet_continue_review", "not_checked"])
+def test_non_return_outcome_notes_are_withheld(status: str) -> None:
+    result = project_minimum_outcome_teacher_note(
+        "Teacher-only outcome note.",
+        status=status,
+        returned_without_full_review=False,
+        review_state="requirements_checked",
+    )
+    assert_text(result, "withheld", None)
+
+
+def test_missing_minimum_outcome_note_is_absent() -> None:
+    result = project_minimum_outcome_teacher_note(
+        None,
+        status="met",
+        returned_without_full_review=False,
+        review_state="requirements_checked",
+    )
+    assert_text(result, "absent", None)
+
+
+def test_returned_work_signals_must_agree() -> None:
+    with pytest.raises(QuillanPublicationProjectionPolicyError):
+        project_minimum_outcome_teacher_note(
+            "Contradictory source.",
+            status="returned_without_full_review",
+            returned_without_full_review=False,
+            review_state="returned_without_full_review",
+        )
+
+
+
+def test_returned_work_only_publishes_configured_unmet_requirement() -> None:
+    assert returned_requirement_check_is_feedback_publishable(
+        requirement_key="required_elements:textual evidence",
+        met=False,
+        configured_requirement_keys={"required_elements:textual evidence"},
+        status="returned_without_full_review",
+        returned_without_full_review=True,
+        review_state="returned_without_full_review",
+    )
+
+
+def test_returned_work_does_not_publish_met_or_unconfigured_requirement() -> None:
+    assert not returned_requirement_check_is_feedback_publishable(
+        requirement_key="paragraphs_min",
+        met=True,
+        configured_requirement_keys={"paragraphs_min"},
+        status="returned_without_full_review",
+        returned_without_full_review=True,
+        review_state="returned_without_full_review",
+    )
+    assert not returned_requirement_check_is_feedback_publishable(
+        requirement_key="word_count_min",
+        met=False,
+        configured_requirement_keys={"paragraphs_min"},
+        status="returned_without_full_review",
+        returned_without_full_review=True,
+        review_state="returned_without_full_review",
+    )
+
+
+def test_requirement_check_not_publishable_outside_returned_work() -> None:
+    assert not returned_requirement_check_is_feedback_publishable(
+        requirement_key="paragraphs_min",
+        met=False,
+        configured_requirement_keys={"paragraphs_min"},
+        status="unmet_continue_review",
+        returned_without_full_review=False,
+        review_state="requirements_checked",
+    )
+
+def test_selected_pds2_evidence_is_publishable() -> None:
+    assert selected_pds2_evidence_is_publishable(
+        page_selected_evidence_id="obs_01",
+        evidence_id="obs_01",
+        evidence_role="selected",
+    )
+
+
+@pytest.mark.parametrize("role", ["candidate", "replacement", "excluded"])
+def test_unselected_pds2_evidence_is_not_publishable(role: str) -> None:
+    assert not selected_pds2_evidence_is_publishable(
+        page_selected_evidence_id="obs_selected",
+        evidence_id="obs_other",
+        evidence_role=role,
+    )
+
+
+def test_page_without_selected_evidence_publishes_no_candidate() -> None:
+    assert not selected_pds2_evidence_is_publishable(
+        page_selected_evidence_id=None,
+        evidence_id="obs_candidate",
+        evidence_role="candidate",
+    )
+
+
+@pytest.mark.parametrize(
+    ("selected_id", "evidence_id", "role"),
+    [
+        ("obs_01", "obs_01", "candidate"),
+        ("obs_02", "obs_01", "selected"),
+        (None, "obs_01", "selected"),
+    ],
+)
+def test_selected_evidence_disagreement_fails_closed(
+    selected_id: str | None, evidence_id: str, role: str
+) -> None:
+    with pytest.raises(QuillanPublicationProjectionPolicyError):
+        selected_pds2_evidence_is_publishable(
+            page_selected_evidence_id=selected_id,
+            evidence_id=evidence_id,
+            evidence_role=role,
+        )
+
+
+def test_field_classifier_has_closed_high_risk_allowlist() -> None:
+    assert publication_field_disposition("route_id") == "allowed"
+    assert publication_field_disposition("review.json") == "source_only"
+    assert publication_field_disposition("review.private_notes") == "prohibited"
+    with pytest.raises(QuillanPublicationProjectionPolicyError):
+        publication_field_disposition("future.unknown_field")
+
+
+def test_field_sets_preserve_expected_privacy_boundary() -> None:
+    assert "source_filename" not in PUBLIC_PDS2_EVIDENCE_REFERENCE_FIELDS
+    assert "retained_source_path" not in PUBLIC_PDS2_EVIDENCE_REFERENCE_FIELDS
+    assert "review.private_notes" in PROHIBITED_PUBLICATION_NATIVE_FIELDS
+    assert "submission.json" in SOURCE_ONLY_NATIVE_RECORDS
+    assert RETURNED_REQUIREMENT_FEEDBACK_FIELDS == {
+        "label",
+        "expected",
+        "teacher_note",
+    }
+
+
+def test_overlong_selected_text_fails_instead_of_truncating() -> None:
+    with pytest.raises(QuillanPublicationProjectionPolicyError):
+        project_feedback_comment_text("x" * 20_001, include_in_feedback=True)
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "feedback.comments.source",
+        "feedback.comments.reusable_comment_id",
+        "feedback.comments.save_for_reuse",
+        "feedback.comments.module_details",
+    ],
+)
+def test_reusable_comment_provenance_fields_are_prohibited(field: str) -> None:
+    assert publication_field_disposition(field) == "prohibited"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "review.private_notes",
+        "review.module_details",
+        "minimum_requirement_checks.module_details",
+        "submission.evidence.routed_evidence_path",
+        "submission.evidence.retained_source.source_filename",
+        "class_reports",
+        "routing_diagnostics",
+    ],
+)
+def test_private_operational_and_classwide_fields_are_prohibited(field: str) -> None:
+    assert publication_field_disposition(field) == "prohibited"
+
+
+def test_selected_evidence_reference_allowlist_is_exact() -> None:
+    assert PUBLIC_PDS2_EVIDENCE_REFERENCE_FIELDS == {
+        "page_id",
+        "evidence_id",
+        "observation_id",
+        "route_id",
+        "issuance_id",
+        "generation_id",
+        "artifact_id",
+        "source_page_number",
+        "source_scan_id",
+        "source_sha256",
+        "routed_evidence_sha256",
+    }
+
+
+def test_unselected_duplicate_alternative_is_not_publishable() -> None:
+    assert not selected_pds2_evidence_is_publishable(
+        page_selected_evidence_id="obs_selected",
+        evidence_id="obs_duplicate_alternative",
+        evidence_role="candidate",
+    )
+
+
+def test_source_only_native_record_allowlist_is_exact() -> None:
+    assert SOURCE_ONLY_NATIVE_RECORDS == {
+        "assignment.json",
+        "submission.json",
+        "review.json",
+    }
+
+
+def test_unknown_roster_extension_fails_closed() -> None:
+    with pytest.raises(QuillanPublicationProjectionPolicyError):
+        publication_field_disposition("roster.guardian_email")
+
+
+def test_policy_module_imports_only_pure_contract_dependencies() -> None:
+    tree = ast.parse(inspect.getsource(policy_module))
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.add(node.module)
+    assert imported_modules == {
+        "__future__",
+        "collections.abc",
+        "typing",
+        "quillan.academic_result_manifest",
+    }
+
+
+def test_policy_module_has_no_direct_file_or_dynamic_execution_calls() -> None:
+    tree = ast.parse(inspect.getsource(policy_module))
+    prohibited_calls = {"open", "exec", "eval", "__import__"}
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert called_names.isdisjoint(prohibited_calls)
+
+
+def test_policy_functions_have_no_privacy_bypass_parameters() -> None:
+    function_names = [
+        "observation_is_selected_for_feedback",
+        "project_observation_rationale",
+        "overall_rating_is_selected_for_feedback",
+        "project_overall_rating_rationale",
+        "project_feedback_comment_text",
+        "project_minimum_outcome_teacher_note",
+        "returned_requirement_check_is_feedback_publishable",
+        "selected_pds2_evidence_is_publishable",
+        "publication_field_disposition",
+    ]
+    forbidden_parameters = {
+        "include_private",
+        "teacher_mode",
+        "admin_mode",
+        "include_all",
+        "debug",
+        "role",
+        "audience",
+        "actor",
+        "authorization",
+        "workspace_root",
+        "catalog",
+        "publication_record",
+        "manifest_path",
+        "source_path",
+        "artifact_path",
+    }
+    for name in function_names:
+        parameters = set(inspect.signature(getattr(policy_module, name)).parameters)
+        assert parameters.isdisjoint(forbidden_parameters)
+


### PR DESCRIPTION
## Summary

Defines Quillan's versioned, producer-owned privacy projection policy for Academic Result Manifest v1.

This PR introduces:

```text
quillan_publication_projection_v1
```

as a pure, side-effect-free policy that determines which validated Quillan-native feedback text, teacher notes, requirement details, and PDS2 provenance values may cross the producer publication boundary.

The policy is intentionally consumer-neutral and fail-closed:

```text
native field exists
    != field may be published
    != publication may be discovered
    != manifest may be inspected
    != underlying source may be opened
    != artifact may be disclosed
```

Downstream consumers may narrow Quillan's projection, but they may not broaden it.

## Policy implementation

Added:

```text
quillan/publication_projection_policy.py
```

with stable policy identity:

```text
quillan_publication_projection_v1
```

The policy:

* is deterministic and side-effect free;
* performs no workspace, registry, catalog, roster, standards-library, source-file, or artifact I/O;
* uses closed allowlists;
* has no caller-controlled private/admin/debug/include-all bypass;
* constructs explicit `PublishedText` dispositions;
* identifies authoritative selected PDS2 evidence;
* classifies fixed public, source-only, and prohibited field categories;
* fails closed on malformed or contradictory policy inputs.

Academic Result Manifest v1's exact JSON schema is unchanged.

## Closed publication allowlist

The public PDS2 evidence-reference allowlist remains limited to:

```text
page_id
evidence_id
observation_id
route_id
issuance_id
generation_id
artifact_id
source_page_number
source_scan_id
source_sha256
routed_evidence_sha256
```

These values are provenance/integrity references only. They do not grant source or artifact access.

Canonical native records remain source-only:

```text
assignment.json
submission.json
review.json
```

Unknown fields fail closed instead of becoming public automatically.

## Observation-rationale policy

An existing observation rationale is included only when:

```text
feedback.include_review_unit_observations == true
AND
observation_id appears in the same-standard
feedback.standard_feedback[].included_observation_ids
```

Otherwise the rationale is withheld.

The observation-level:

```text
include_in_feedback
```

flag is not independently sufficient to authorize publication.

A missing rationale remains:

```text
PublishedText(disposition="absent", text=None)
```

## Overall-rationale policy

Overall-rationale publication preserves current Quillan feedback-export semantics.

If:

```text
feedback.include_overall_standard_ratings == false
```

the rationale is withheld.

When matching per-standard feedback exists:

```text
include_overall_rating
include_overall_rationale
```

control publication.

When no matching per-standard feedback entry exists, the existing:

```text
overall_standard_ratings[].include_in_feedback
```

fallback is preserved.

Missing rationale remains `absent`.

## Feedback comments

Only comments with:

```text
include_in_feedback == true
```

may enter the public feedback-comment projection.

Selected comments use the exact text already copied into `review.json`.

Unselected comments are omitted rather than represented with withheld private text.

Reusable-comment provenance and live reusable state remain excluded, including:

```text
source
reusable_comment_id
save_for_reuse
module_details
```

No reusable-comment source file is consulted during projection.

## Minimum requirements and teacher notes

Assignment-level basic requirements remain public assignment context.

The aggregate native minimum-requirement outcome remains part of Academic Result Manifest v1.

For:

```text
status = returned_without_full_review
returned_without_full_review = true
review_state = returned_without_full_review
```

the existing outcome teacher note is recognized as student-facing return feedback and is included.

Outcome notes associated with:

```text
met
unmet_continue_review
not_checked
```

are withheld when present.

Individual requirement checks are not added to Academic Result Manifest v1.

The separate returned-work artifact boundary permits only configured unmet requirements and only the bounded student-facing fields:

```text
label
expected
teacher_note
```

Requirement-check IDs, module details, and internal timestamps remain private/internal.

## PDS2 selected-evidence policy

An evidence record is eligible for Academic Result Manifest provenance only when:

```text
page.selected_evidence_id == evidence.evidence_id
AND
evidence.evidence_role == "selected"
```

Contradiction fails closed.

The following do not produce public evidence references:

* candidate evidence;
* unselected duplicate alternatives;
* unselected replacement evidence;
* excluded evidence;
* pages with no selected evidence.

The policy does not expose:

```text
routed_evidence_path
retained_source_path
source_filename
QR payloads
raw route payloads
routing diagnostics
scan-intake diagnostics
duplicate_number
candidate/excluded evidence lists
replacement history
arbitrary module_details
private absolute paths
```

Plain-paper submissions do not acquire fabricated digital provenance.

Raw retained scans are not directly exposed.

## Private and operational data

The policy explicitly prohibits publication of private or operational state including:

* `review.private_notes`;
* arbitrary `module_details`;
* reusable-comment provenance;
* export paths and metadata;
* routing diagnostics;
* private source paths;
* roster display data;
* class-wide report data.

`private_notes` are prohibited without existence leakage; the projection does not expose counts, presence flags, or redaction placeholders.

## Artifact boundaries

The policy documents separate future boundaries for:

```text
student feedback summary
feedback Markdown
feedback PDF
original student work
```

Generated feedback artifacts remain derived artifacts rather than canonical review state.

Artifact existence or export metadata does not grant publication or retrieval permission.

Original-work resolution may use only producer-confirmed selected evidence and must not fall back to candidate, duplicate, excluded, replacement-history, retained-scan, or arbitrary native bytes.

Authorized artifact/source resolution remains #364.

## Discovery and authorization

The policy preserves the separation:

```text
Core discovery
    != manifest authorization
    != student-level manifest inspection
    != source-record authorization
    != feedback artifact authorization
    != student-work authorization
    != retained-scan authorization
```

A manifest identifier, student ID, page ID, route ID, scan ID, digest, or artifact identity is not itself an access grant.

No native-file fallback is permitted.

## Documentation

Added:

```text
docs/publication_projection_policy_v1.md
```

covering:

* policy ownership and versioning;
* relation to Academic Result Manifest v1;
* closed allowlists;
* deterministic producer privacy floor;
* `absent` / `withheld` / `included` semantics;
* observation and overall rationale rules;
* comment rules;
* minimum-requirement rules;
* selected-evidence rules;
* prohibited fields;
* feedback and original-work artifact boundaries;
* discovery versus authorization;
* downstream issue boundaries;
* synthetic policy examples;
* compact decision matrix.

Updated:

```text
docs/academic_result_manifest_v1.md
docs/data_contracts.md
docs/feedback_export_contract.md
```

to point to the completed #357 policy and remove stale language treating privacy projection as future work.

## Tests

Added:

```text
tests/test_publication_projection_policy.py
```

covering:

* policy-version stability;
* all `PublishedText` dispositions;
* observation-rationale selection and withholding;
* same-standard observation selection;
* overall-rationale global/per-standard/fallback behavior;
* selected versus omitted feedback comments;
* returned-work outcome notes;
* non-return teacher-note withholding;
* configured unmet requirement checks;
* contradictory return-state failure;
* selected/candidate/replacement/excluded PDS2 evidence;
* selected-evidence disagreement failure;
* exact evidence-reference allowlist;
* prohibited reusable/private/operational fields;
* source-only native-record allowlist;
* unknown-field fail-closed behavior;
* absence of file/dynamic execution in the policy module;
* absence of privacy-bypass or authorization parameters.

Focused result:

```text
55 passed
```

## Validation

Full local qualification:

```text
55 passed
2027 passed, 17 skipped
Ruff: PASS
mypy: PASS — 249 source files
pip check: PASS
Documentation integrity: PASS
git diff --check: PASS
```

## Changed-file scope

Exactly six repository files:

```text
docs/academic_result_manifest_v1.md
docs/data_contracts.md
docs/feedback_export_contract.md
docs/publication_projection_policy_v1.md
quillan/publication_projection_policy.py
tests/test_publication_projection_policy.py
```

No Core dependency change was made.

No Core publication workflow or workspace manifest generation was added.

No Meridian or Vitrine runtime dependency was added.

No sibling repository was modified.

Academic Result Manifest v1's JSON schema was not widened.

Closes #357
