### PR TITLE
feat: define publication revision and correction policy

### DIFF
--- a/docs/academic_result_manifest_v1.md
+++ b/docs/academic_result_manifest_v1.md
@@ -18,7 +18,9 @@ artifact, roster, or standards-library I/O and calculates no proficiency,
 Grade, missing-work state, or portfolio policy. Construction belongs to #361;
 privacy projection is defined by
 [Quillan Publication Projection Policy v1](publication_projection_policy_v1.md);
-revision/withdrawal policy belongs to #358; and Core integration to #359–#364.
+revision, correction, and withdrawal behavior is defined by
+[Quillan Publication Revision Policy](publication_revision_policy.md); and Core
+integration belongs to #359–#364.
 
 ## Exact schema
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -12,6 +12,12 @@ It uses closed allowlists, preserves `absent`/`withheld`/`included` text
 semantics, permits only authoritative selected PDS2 evidence, and keeps discovery
 separate from source or artifact authorization.
 
+The producer-owned immutable history rules are defined in
+[Quillan Publication Revision Policy](publication_revision_policy.md). Production
+Academic Result series use `record_set_id=academic_results`; exact source lineage,
+corrections, historical reversion, supersession, and withdrawal remain distinct from
+consumer grading or portfolio policy.
+
 Quillan-owned assignment records and all dependent submission, review, and export
 records are rooted exclusively beneath
 `classes/<class_id>/modules/quillan/work/<assignment_id>/`. Contextual loaders

--- a/docs/publication_projection_policy_v1.md
+++ b/docs/publication_projection_policy_v1.md
@@ -90,8 +90,8 @@ The policy version is independent from:
 - Meridian policy;
 - and Vitrine Profile policy.
 
-Issue #358 owns the historical/revision consequences of material future policy
-changes.
+Historical and revision consequences of material policy changes are defined by
+[Quillan Publication Revision Policy](publication_revision_policy.md).
 
 ## Closed allowlist
 
@@ -628,10 +628,12 @@ authorize source or artifact access.
 
 ## Downstream boundaries
 
-### #358 — revision, correction, and withdrawal
+### Revision, correction, and withdrawal
 
-Defines historical consequences when native data, selected evidence, approved text, or
-projection policy changes.
+[Quillan Publication Revision Policy](publication_revision_policy.md) defines
+immutable producer revision identity, exact replay, correction history, historical
+reversion, and the producer rules that later Core supersession/withdrawal workflows
+must preserve.
 
 ### #361 — immutable manifest generation
 

--- a/docs/publication_revision_policy.md
+++ b/docs/publication_revision_policy.md
@@ -1,0 +1,439 @@
+# Quillan Publication Revision Policy
+
+## Purpose and ownership
+
+`quillan_publication_revision_v1` is Quillan's producer-owned policy for immutable
+Academic Result manifest history. It defines stable record-set identity, revision
+allocation, exact replay, correction history, historical reversion, supersession,
+withdrawal boundaries, and explicit republication after withdrawal.
+
+It governs `quillan_academic_result_manifest_v1` without changing that manifest's
+serialized shape and without changing `quillan_publication_projection_v1`.
+
+The central rule is:
+
+```text
+mutable current Quillan native state
+-> immutable manifest revision
+-> immutable Core Publication Record
+-> later correction
+-> new immutable manifest revision
+-> explicit Core supersession
+```
+
+Current `assignment.json`, `submission.json`, and `review.json` are mutable producer
+records. Published manifest history is not.
+
+## Policy identity
+
+Stable policy version:
+
+```text
+quillan_publication_revision_v1
+```
+
+Production Academic Result record-set ID:
+
+```text
+academic_results
+```
+
+The production series identity is the complete Quillan work identity plus:
+
+```text
+publication_kind = academic_result_set
+record_set_id = academic_results
+```
+
+The record-set ID is stable across ordinary review progress, corrections,
+withdrawal, and later republication.
+
+The following remain independent concepts:
+
+```text
+assignment schema version
+submission schema version
+review schema version
+review_state
+manifest contract version
+publication projection policy version
+publication revision policy version
+record-set revision
+Core Academic Work Registration revision
+Core Publication Record identity
+Core publication-series head
+Quillan package version
+```
+
+## Pure policy boundary
+
+`quillan.publication_revision_policy` is side-effect free. It compares already-valid
+manifest models and returns immutable planning values.
+
+It performs no workspace, filesystem, hashing, registry, catalog, publication,
+withdrawal, authorization, grading, proficiency, or portfolio work. Manifest
+filesystem history belongs to #361. Core-backed publication lifecycle belongs to
+#363.
+
+## Revision allocation
+
+The first production manifest revision is `1`.
+
+Normal allocation is:
+
+```text
+highest already allocated producer revision + 1
+```
+
+Allocated gaps remain consumed. A revision number is not freed by nonpublication,
+withdrawal, a missing historical manifest, or later cleanup.
+
+Explicit transition validation permits a greater noncontiguous revision. Revision
+order never comes from timestamps, filenames, directory order, or Core catalog state.
+
+## Publication-content equality
+
+Two valid manifests have the same publication content only when every serialized
+value matches except:
+
+```text
+generated_at
+record_set.revision
+```
+
+Everything else remains significant, including work and record-set identity, exact
+source paths/versions/digests, assignment context, represented students, submission
+state/provenance, review state, minimum-requirement outcome, observations, ratings,
+feedback projection, `PublishedText` dispositions, comments, and selected evidence
+references.
+
+The comparison is deterministic, in-memory, and nonmutating.
+
+## Exact native source lineage
+
+Exact assignment, submission, and review source snapshots are publication content.
+A changed source path, contract version, or SHA-256 prevents exact replay even when
+visible academic values otherwise appear unchanged.
+
+This preserves the meaning:
+
+```text
+these exact native source bytes produced this immutable projection
+```
+
+A privacy-sensitive source-only change uses the bounded reason:
+
+```text
+native_source_changed
+```
+
+The policy does not reveal whether a private note, hidden comment, or another
+nonpublished field caused that source-byte change.
+
+Native changes do not automatically publish anything. They affect the decision only
+when an explicit manifest-generation operation occurs.
+
+## Revision dispositions
+
+The policy returns one of:
+
+```text
+reuse_existing
+create_initial
+create_successor
+```
+
+and one bounded reason:
+
+```text
+exact_replay
+initial_publication
+native_source_changed
+publication_projection_changed
+historical_reversion
+republication_after_withdrawal
+```
+
+Reasons are producer planning metadata. They are not added to Academic Result
+Manifest v1.
+
+## Exact replay
+
+If complete publication content matches the current producer head, reuse the existing
+manifest revision and exact bytes.
+
+Replay preserves:
+
+```text
+record_set_id
+record_set revision
+generated_at
+canonical manifest bytes
+manifest SHA-256
+```
+
+Replay does not allocate another revision or create a new authoritative timestamp.
+A withdrawn publication is not reactivated through replay.
+
+## Changes requiring a successor
+
+A complete successor snapshot is required when publication content changes.
+Representative cases include:
+
+- assignment source or assignment snapshot changes;
+- submission source, state, entry method, or selected provenance changes;
+- review source or review-state changes;
+- minimum-requirement outcome changes;
+- overall rating, rationale, or feedback-inclusion changes;
+- observation or feedback-composition changes;
+- selected evidence changes;
+- represented student additions or removals;
+- privacy-safe serialized projection changes.
+
+A successor is a complete record-set snapshot, never a delta containing only the
+changed rating or student.
+
+Package versions, report regeneration, catalog rebuilds, profile rediscovery, and
+consumer grading/proficiency/portfolio policy do not by themselves create producer
+manifest revisions.
+
+## Quillan correction semantics
+
+Quillan does not add ScoreForm-style attempt semantics to mutable teacher review.
+Current review workflows may replace an overall Focus Standard rating, rationale,
+feedback selection, observation, or review state in `review.json`.
+
+When a published value is corrected:
+
+1. preserve the historical manifest and Publication Record;
+2. update current native Quillan state through the existing review workflow;
+3. create a new complete immutable manifest revision;
+4. later explicitly supersede the current Core publication head.
+
+No native `rating_attempt`, `rating_revision_id`, `corrected_rating_id`, or similar
+history field is introduced.
+
+## Corrected ratings and missingness
+
+A historical overall rating is distinguished by its work, record-set revision,
+student, and Focus Standard context.
+
+Example:
+
+```text
+revision 1: student_alpha / standard_x / rating 2
+revision 2: student_alpha / standard_x / rating 3
+```
+
+Revision 1 continues to preserve rating `2`; revision 2 preserves the corrected
+rating `3`.
+
+If a later valid review removes an overall rating, the successor represents current
+absence. Absence is not zero, the assignment scale minimum,
+`returned_without_full_review`, or an inferred Grade state.
+
+Each historical manifest carries the assignment-local scale that interprets its own
+ratings. A later scale-label or scale-definition correction never retroactively
+changes older rating meaning.
+
+## Review state and minimum requirements
+
+Review states and minimum-requirement outcomes are explicit native states, not
+performance levels.
+
+A valid current change may therefore require a successor without implying stronger or
+weaker performance. In particular, `exported` is not academically stronger than
+`ratings_complete`, and `returned_without_full_review` is not a low numeric rating.
+
+## Selected-evidence corrections
+
+When authoritative selected PDS2 evidence changes, the successor records the new
+bounded selected provenance. Historical manifests retain the provenance that was
+authoritative for their own revisions.
+
+Old manifests must not be rewritten to current evidence and must not fall back to
+candidate, duplicate, replacement, or excluded evidence.
+
+## Historical reversion
+
+If current publication content returns exactly to an older historical state while the
+current head differs, allocate a new greater revision.
+
+```text
+revision 1 = A
+revision 2 = B
+revision 3 = A
+```
+
+Do not reuse revision 1 or restore its Publication Record as current. The full
+`A -> B -> A` history remains explicit.
+
+## Same logical revision means one immutable state
+
+The identity:
+
+```text
+work
++ academic_result_set
++ academic_results
++ record_set_revision
+```
+
+must identify exactly one immutable manifest state. Explicit transition validation
+rejects same-revision reuse and backwards revision movement. Different work or
+record-set identity is a different series, not a successor.
+
+## Producer history and Core history are separate
+
+Producer manifest allocation and Core publication are independent histories. A
+manifest may exist without publication, and Core may still point to an older
+published producer revision.
+
+The pure revision policy does not inspect Core state. #361 owns durable producer
+manifest history. #363 reloads canonical Core state and reconciles publication.
+
+## Supersession
+
+Ordinary valid corrections and newer result snapshots use Core supersession when
+published.
+
+The later Core workflow must retain the same work, publication kind, and record-set
+ID; use a greater producer revision; reload the exact canonical Core head; and
+supersede that expected head explicitly.
+
+Do not infer the predecessor from revision magnitude, timestamp, filename, or catalog
+ordering. Supersession preserves the predecessor as historical; it does not withdraw
+it.
+
+## Withdrawal
+
+Withdrawal is stronger than ordinary correction. It is appropriate when one exact
+published revision should no longer be newly relied upon because of a serious
+privacy, authorization, identity, selected-evidence, or integrity defect.
+
+Routine rating, rationale, feedback, review-state, or assignment corrections normally
+use successor publication rather than withdrawal.
+
+Withdrawal is publication-level, not rating-level. Quillan does not invent
+`withdraw_rating`, `withdraw_observation`, or similar Core lifecycle concepts.
+
+Withdrawal preserves the immutable Publication Record, producer manifest, native
+records, supersession history, and prior consumer provenance. It is not deletion,
+erasure, historical rewriting, or predecessor restoration. Withdrawal reasons must
+remain privacy-minimized.
+
+## Republishing after withdrawal
+
+Exact replay does not restore a withdrawn publication. When publication intentionally
+resumes after withdrawal, create a new greater producer revision and later supersede
+the withdrawn Core head.
+
+This is permitted even when current native source bytes are unchanged from the
+withdrawn revision. The pure planner receives an explicit Boolean
+`republish_after_withdrawal`; it never inspects Core withdrawal state itself and never
+infers republication automatically.
+
+## Missing or altered historical manifests
+
+If trusted exact historical bytes are available and reproduce the recorded digest,
+restoring those exact bytes is recovery, not a new revision.
+
+If exact historical bytes are unavailable, do not reconstruct different bytes under
+the old revision. The later lifecycle workflow may withdraw the unverifiable
+publication and publish a new greater revision from current authoritative native
+state.
+
+A missing or corrupt derived Core catalog does not create a producer revision.
+
+## Historical native-source drift
+
+After current native records are corrected, an older manifest's recorded source digest
+may no longer match the current file at the same path. That is expected historical
+drift and never authorizes rewriting the old manifest.
+
+A future reader must not silently substitute current native bytes when a historical
+manifest records a different digest. Historical native-file archival is outside this
+policy.
+
+## Privacy-policy evolution
+
+A future privacy-policy change never rewrites historical manifests.
+
+If current serialized projection content changes, create a successor. If already
+published bytes are no longer safe for continued selection, withdraw those exact
+Publication Records explicitly.
+
+A policy implementation/version change with identical publication content does not by
+itself require another record-set revision. An incompatible semantic change requires
+an appropriate manifest-contract decision rather than disguising it as an ordinary
+record-set revision.
+
+## Decision matrix
+
+| Change | New revision? | Later Core action | Rule |
+| --- | --- | --- | --- |
+| exact replay | no | reuse existing | preserve exact bytes |
+| only candidate `generated_at`/revision differs | no | none | non-content fields |
+| assignment source changes | yes | supersede | complete snapshot |
+| submission source changes | yes | supersede | exact source lineage |
+| review source changes | yes | supersede | includes corrections |
+| rating corrected | yes | supersede | old rating stays historical |
+| rating removed | yes | supersede | missing is not low |
+| feedback projection changes | yes | supersede | never rewrite old projection |
+| selected evidence changes | yes | supersede | old provenance stays historical |
+| represented students change | yes | supersede | complete result-set snapshot |
+| state returns to older content | yes | supersede current head | new greater revision |
+| ordinary newer publication | yes | supersede | do not withdraw predecessor |
+| exact publication unsafe | context | withdraw exact publication | stronger lifecycle action |
+| unchanged state republished after withdrawal | yes | supersede withdrawn head | explicit only |
+| Core catalog rebuild | no | none | derived state |
+| consumer grading policy changes | no | none | consumer-owned |
+
+## Worked correction sequence
+
+```text
+revision 1
+  rating = 2
+
+revision 2
+  corrected rating = 3
+  later publication supersedes revision 1 publication
+
+revision 3
+  feedback corrected
+  later publication supersedes revision 2 publication
+
+publication for revision 3 withdrawn
+  revision 2 does not become current again
+
+revision 4
+  current native state intentionally republished
+  later publication supersedes the withdrawn revision 3 publication
+```
+
+## Ownership and downstream boundaries
+
+Quillan owns native educational semantics, Manifest v1, privacy projection, stable
+record-set identity, producer revision rules, correction semantics, and later producer
+orchestration.
+
+Core owns Academic Work Registration, Publication Records, exact manifest path/digest
+binding, supersession, withdrawal, canonical publication state, and the rebuildable
+catalog.
+
+Meridian owns authorized evidence selection, rating/proficiency mapping, Grades,
+Academic Period membership, reporting, and downstream correction consequences.
+
+Vitrine owns portfolio candidacy, selection, snapshot, and disclosure policy.
+
+Follow-up implementation remains:
+
+- #359: Core 0.6 dependency upgrade;
+- #360: Academic Work Registration;
+- #361: source loading, hashing, immutable manifest generation/storage;
+- #362: producer compatibility profile;
+- #363: Core publication, supersession, withdrawal, reconciliation;
+- #364: consumer-neutral reader and authorized source/artifact resolution;
+- #365–#366: installed acceptance and release audit.
+
+No consumer policy belongs in this revision module.

--- a/quillan/publication_revision_policy.py
+++ b/quillan/publication_revision_policy.py
@@ -1,0 +1,331 @@
+"""Pure revision policy for Quillan Academic Result Manifest publication history."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from dataclasses import dataclass
+from typing import Any, Final, Literal, TypeAlias, cast
+
+from quillan.academic_result_manifest import (
+    AcademicResultManifest,
+    QuillanAcademicResultManifestValidationError,
+    StudentSourceSnapshot,
+    manifest_to_mapping,
+    validate_manifest,
+)
+
+PUBLICATION_REVISION_POLICY_VERSION: Final = "quillan_publication_revision_v1"
+QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID: Final = "academic_results"
+
+ManifestRevisionDisposition: TypeAlias = Literal[
+    "reuse_existing", "create_initial", "create_successor"
+]
+ManifestRevisionReason: TypeAlias = Literal[
+    "exact_replay",
+    "initial_publication",
+    "native_source_changed",
+    "publication_projection_changed",
+    "historical_reversion",
+    "republication_after_withdrawal",
+]
+
+
+class QuillanPublicationRevisionPolicyError(ValueError):
+    """Base error for Quillan publication-revision policy decisions."""
+
+
+class QuillanPublicationRevisionValidationError(QuillanPublicationRevisionPolicyError):
+    """Raised when revision-policy inputs are malformed or cross series."""
+
+
+class QuillanPublicationRevisionConflictError(QuillanPublicationRevisionPolicyError):
+    """Raised when immutable revision history would be contradicted or reused."""
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestRevisionPlan:
+    """One immutable producer decision about an Academic Result manifest revision."""
+
+    disposition: ManifestRevisionDisposition
+    reason: ManifestRevisionReason
+    record_set_id: str
+    record_set_revision: int
+    reuse_existing_bytes: bool
+
+    @property
+    def requires_new_revision(self) -> bool:
+        """Return whether the plan requires new immutable manifest bytes."""
+        return self.disposition != "reuse_existing"
+
+
+def _validated_manifest(manifest: AcademicResultManifest) -> AcademicResultManifest:
+    try:
+        return validate_manifest(manifest)
+    except QuillanAcademicResultManifestValidationError as error:
+        raise QuillanPublicationRevisionValidationError(
+            "manifest must satisfy Quillan Academic Result Manifest v1."
+        ) from error
+
+
+def _validate_boolean(value: object, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise QuillanPublicationRevisionValidationError(f"{field} must be a boolean.")
+    return value
+
+
+def _validate_revision(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise QuillanPublicationRevisionValidationError(
+            f"{field} must be a positive non-Boolean integer."
+        )
+    return value
+
+
+def _validated_allocated_revisions(
+    allocated_revisions: Collection[int],
+) -> tuple[int, ...]:
+    if isinstance(allocated_revisions, (str, bytes)) or not isinstance(
+        allocated_revisions, Collection
+    ):
+        raise QuillanPublicationRevisionValidationError(
+            "allocated_revisions must be a collection of positive integers."
+        )
+    revisions = tuple(
+        _validate_revision(value, "allocated_revisions[]")
+        for value in allocated_revisions
+    )
+    if len(set(revisions)) != len(revisions):
+        raise QuillanPublicationRevisionConflictError(
+            "allocated_revisions must not contain duplicate revision identities."
+        )
+    return tuple(sorted(revisions))
+
+
+def _series_identity(manifest: AcademicResultManifest) -> tuple[str, ...]:
+    return (
+        manifest.record_type,
+        manifest.contract_version,
+        manifest.producer_module_id,
+        manifest.work.module_id,
+        manifest.work.class_id,
+        manifest.work.work_id,
+        manifest.record_set.record_set_id,
+    )
+
+
+def _validate_production_identity(manifest: AcademicResultManifest) -> None:
+    if manifest.record_set.record_set_id != QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID:
+        raise QuillanPublicationRevisionValidationError(
+            "production Quillan Academic Result manifests must use "
+            f"record_set_id={QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID!r}."
+        )
+
+
+def _validate_same_series(
+    previous: AcademicResultManifest,
+    candidate: AcademicResultManifest,
+) -> None:
+    if _series_identity(previous) != _series_identity(candidate):
+        raise QuillanPublicationRevisionValidationError(
+            "manifest transition must remain within one Quillan publication series."
+        )
+
+
+def _publication_content_mapping(manifest: AcademicResultManifest) -> dict[str, Any]:
+    content = manifest_to_mapping(_validated_manifest(manifest))
+    content.pop("generated_at")
+    record_set = dict(cast(dict[str, Any], content["record_set"]))
+    record_set.pop("revision")
+    content["record_set"] = record_set
+    return content
+
+
+def manifests_have_same_publication_content(
+    previous: AcademicResultManifest,
+    candidate: AcademicResultManifest,
+) -> bool:
+    """Compare complete publication content while ignoring time and revision only."""
+    return _publication_content_mapping(previous) == _publication_content_mapping(
+        candidate
+    )
+
+
+def next_record_set_revision(allocated_revisions: Collection[int]) -> int:
+    """Return the normal next immutable producer revision, starting at one."""
+    revisions = _validated_allocated_revisions(allocated_revisions)
+    return 1 if not revisions else revisions[-1] + 1
+
+
+def validate_manifest_revision_transition(
+    previous: AcademicResultManifest,
+    candidate: AcademicResultManifest,
+) -> None:
+    """Validate one explicit immutable same-series successor transition."""
+    previous = _validated_manifest(previous)
+    candidate = _validated_manifest(candidate)
+    _validate_production_identity(previous)
+    _validate_production_identity(candidate)
+    _validate_same_series(previous, candidate)
+    previous_revision = _validate_revision(
+        previous.record_set.revision, "previous.record_set.revision"
+    )
+    candidate_revision = _validate_revision(
+        candidate.record_set.revision, "candidate.record_set.revision"
+    )
+    if candidate_revision == previous_revision:
+        raise QuillanPublicationRevisionConflictError(
+            "one logical record-set revision cannot identify a second manifest state."
+        )
+    if candidate_revision < previous_revision:
+        raise QuillanPublicationRevisionValidationError(
+            "candidate revision must be greater than the predecessor revision."
+        )
+
+
+def _student_sources(
+    manifest: AcademicResultManifest,
+) -> dict[str, StudentSourceSnapshot]:
+    return {
+        student.student_id: student.source_snapshot for student in manifest.students
+    }
+
+
+def _native_source_changed(
+    previous: AcademicResultManifest,
+    candidate: AcademicResultManifest,
+) -> bool:
+    if previous.source_snapshot != candidate.source_snapshot:
+        return True
+    previous_students = _student_sources(previous)
+    candidate_students = _student_sources(candidate)
+    if previous_students.keys() != candidate_students.keys():
+        return False
+    return any(
+        previous_students[student_id] != candidate_students[student_id]
+        for student_id in previous_students
+    )
+
+
+def _validate_history(
+    *,
+    predecessor: AcademicResultManifest,
+    historical_manifests: Collection[AcademicResultManifest],
+) -> tuple[AcademicResultManifest, ...]:
+    if isinstance(historical_manifests, (str, bytes)) or not isinstance(
+        historical_manifests, Collection
+    ):
+        raise QuillanPublicationRevisionValidationError(
+            "historical_manifests must be a collection of manifests."
+        )
+    validated: list[AcademicResultManifest] = []
+    seen_revisions: set[int] = set()
+    for historical in historical_manifests:
+        historical = _validated_manifest(historical)
+        _validate_production_identity(historical)
+        _validate_same_series(predecessor, historical)
+        revision = _validate_revision(
+            historical.record_set.revision, "historical.record_set.revision"
+        )
+        if revision >= predecessor.record_set.revision:
+            raise QuillanPublicationRevisionValidationError(
+                "historical manifests must precede the current producer head."
+            )
+        if revision in seen_revisions:
+            raise QuillanPublicationRevisionConflictError(
+                "historical manifest revisions must be unique."
+            )
+        seen_revisions.add(revision)
+        validated.append(historical)
+    return tuple(validated)
+
+
+def plan_manifest_revision(
+    *,
+    predecessor: AcademicResultManifest | None,
+    candidate: AcademicResultManifest,
+    allocated_revisions: Collection[int],
+    historical_manifests: Collection[AcademicResultManifest] = (),
+    republish_after_withdrawal: bool = False,
+) -> ManifestRevisionPlan:
+    """Plan exact replay, initial creation, or one immutable successor revision."""
+    candidate = _validated_manifest(candidate)
+    _validate_production_identity(candidate)
+    revisions = _validated_allocated_revisions(allocated_revisions)
+    republish = _validate_boolean(
+        republish_after_withdrawal, "republish_after_withdrawal"
+    )
+
+    if predecessor is None:
+        if republish:
+            raise QuillanPublicationRevisionValidationError(
+                "republication after withdrawal requires an existing predecessor."
+            )
+        if historical_manifests:
+            raise QuillanPublicationRevisionValidationError(
+                "historical manifests require an existing predecessor."
+            )
+        if revisions:
+            raise QuillanPublicationRevisionConflictError(
+                "initial creation is invalid when producer revisions are allocated."
+            )
+        return ManifestRevisionPlan(
+            disposition="create_initial",
+            reason="initial_publication",
+            record_set_id=QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID,
+            record_set_revision=1,
+            reuse_existing_bytes=False,
+        )
+
+    predecessor = _validated_manifest(predecessor)
+    _validate_production_identity(predecessor)
+    _validate_same_series(predecessor, candidate)
+    predecessor_revision = predecessor.record_set.revision
+    if predecessor_revision not in revisions:
+        raise QuillanPublicationRevisionConflictError(
+            "allocated_revisions must include the predecessor revision."
+        )
+    if not revisions or revisions[-1] != predecessor_revision:
+        raise QuillanPublicationRevisionConflictError(
+            "predecessor must be the highest allocated producer revision."
+        )
+
+    history = _validate_history(
+        predecessor=predecessor,
+        historical_manifests=historical_manifests,
+    )
+
+    if republish:
+        return ManifestRevisionPlan(
+            disposition="create_successor",
+            reason="republication_after_withdrawal",
+            record_set_id=QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID,
+            record_set_revision=next_record_set_revision(revisions),
+            reuse_existing_bytes=False,
+        )
+
+    if manifests_have_same_publication_content(predecessor, candidate):
+        return ManifestRevisionPlan(
+            disposition="reuse_existing",
+            reason="exact_replay",
+            record_set_id=predecessor.record_set.record_set_id,
+            record_set_revision=predecessor_revision,
+            reuse_existing_bytes=True,
+        )
+
+    if any(
+        manifests_have_same_publication_content(historical, candidate)
+        for historical in history
+    ):
+        reason: ManifestRevisionReason = "historical_reversion"
+    elif _native_source_changed(predecessor, candidate):
+        reason = "native_source_changed"
+    else:
+        reason = "publication_projection_changed"
+
+    return ManifestRevisionPlan(
+        disposition="create_successor",
+        reason=reason,
+        record_set_id=QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID,
+        record_set_revision=next_record_set_revision(revisions),
+        reuse_existing_bytes=False,
+    )

--- a/tests/test_publication_revision_policy.py
+++ b/tests/test_publication_revision_policy.py
@@ -1,0 +1,639 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from quillan.academic_result_manifest import (
+    AcademicResultManifest,
+    manifest_from_json_bytes,
+    manifest_from_mapping,
+    manifest_to_mapping,
+)
+from quillan.publication_revision_policy import (
+    PUBLICATION_REVISION_POLICY_VERSION,
+    QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID,
+    ManifestRevisionPlan,
+    QuillanPublicationRevisionConflictError,
+    QuillanPublicationRevisionValidationError,
+    manifests_have_same_publication_content,
+    next_record_set_revision,
+    plan_manifest_revision,
+    validate_manifest_revision_transition,
+)
+
+FIXTURE = Path("tests/fixtures/publication/quillan_academic_result_manifest_v1.json")
+
+
+def _mapping(*, revision: int = 1) -> dict[str, Any]:
+    mapping = manifest_to_mapping(manifest_from_json_bytes(FIXTURE.read_bytes()))
+    mapping["record_set"] = {
+        "record_set_id": QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID,
+        "revision": revision,
+    }
+    return mapping
+
+
+def _manifest(*, revision: int = 1) -> AcademicResultManifest:
+    return manifest_from_mapping(_mapping(revision=revision))
+
+
+def _with_revision(mapping: dict[str, Any], revision: int) -> dict[str, Any]:
+    updated = copy.deepcopy(mapping)
+    updated["record_set"]["revision"] = revision
+    return updated
+
+
+def _student(mapping: dict[str, Any], index: int = 0) -> dict[str, Any]:
+    return cast(dict[str, Any], mapping["students"][index])
+
+
+def _review(mapping: dict[str, Any], index: int = 0) -> dict[str, Any]:
+    return cast(dict[str, Any], _student(mapping, index)["review"])
+
+
+def _overall_rating(mapping: dict[str, Any]) -> dict[str, Any]:
+    return cast(dict[str, Any], _review(mapping)["overall_standard_ratings"][0])
+
+
+def _successor_plan(
+    predecessor: AcademicResultManifest,
+    candidate: AcademicResultManifest,
+    *,
+    history: tuple[AcademicResultManifest, ...] = (),
+    republish_after_withdrawal: bool = False,
+) -> ManifestRevisionPlan:
+    return plan_manifest_revision(
+        predecessor=predecessor,
+        candidate=candidate,
+        allocated_revisions=(predecessor.record_set.revision,),
+        historical_manifests=history,
+        republish_after_withdrawal=republish_after_withdrawal,
+    )
+
+
+def test_policy_identity_is_stable() -> None:
+    assert PUBLICATION_REVISION_POLICY_VERSION == "quillan_publication_revision_v1"
+    assert QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID == "academic_results"
+
+
+def test_initial_plan_uses_revision_one() -> None:
+    plan = plan_manifest_revision(
+        predecessor=None,
+        candidate=_manifest(revision=99),
+        allocated_revisions=(),
+    )
+    assert plan == ManifestRevisionPlan(
+        disposition="create_initial",
+        reason="initial_publication",
+        record_set_id="academic_results",
+        record_set_revision=1,
+        reuse_existing_bytes=False,
+    )
+    assert plan.requires_new_revision is True
+
+
+def test_plan_is_frozen() -> None:
+    plan = plan_manifest_revision(
+        predecessor=None,
+        candidate=_manifest(),
+        allocated_revisions=(),
+    )
+    with pytest.raises(FrozenInstanceError):
+        plan.record_set_revision = 2  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("allocated", "expected"),
+    [
+        ((), 1),
+        ((1,), 2),
+        ((1, 3), 4),
+        ((8, 2, 5), 9),
+    ],
+)
+def test_next_record_set_revision_uses_highest_allocated_plus_one(
+    allocated: tuple[int, ...], expected: int
+) -> None:
+    assert next_record_set_revision(allocated) == expected
+
+
+@pytest.mark.parametrize("invalid", [(True,), (0,), (-1,), (1.0,)])
+def test_next_revision_rejects_invalid_revision_values(invalid: object) -> None:
+    with pytest.raises(QuillanPublicationRevisionValidationError):
+        next_record_set_revision(cast(Any, invalid))
+
+
+@pytest.mark.parametrize("invalid", [None, 1, 1.5])
+def test_next_revision_rejects_noncollection_allocations(invalid: object) -> None:
+    with pytest.raises(
+        QuillanPublicationRevisionValidationError, match="collection"
+    ):
+        next_record_set_revision(cast(Any, invalid))
+
+
+def test_next_revision_rejects_duplicate_allocations() -> None:
+    with pytest.raises(QuillanPublicationRevisionConflictError, match="duplicate"):
+        next_record_set_revision((1, 2, 2))
+
+
+def test_initial_plan_rejects_existing_allocated_history() -> None:
+    with pytest.raises(QuillanPublicationRevisionConflictError, match="initial"):
+        plan_manifest_revision(
+            predecessor=None,
+            candidate=_manifest(),
+            allocated_revisions=(1,),
+        )
+
+
+def test_content_comparison_ignores_only_generated_at_and_revision() -> None:
+    previous = _mapping(revision=1)
+    candidate = copy.deepcopy(previous)
+    candidate["generated_at"] = "2026-08-11T20:00:00Z"
+    candidate["record_set"]["revision"] = 17
+    assert manifests_have_same_publication_content(
+        manifest_from_mapping(previous), manifest_from_mapping(candidate)
+    )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda m: m["record_set"].update(record_set_id="other_results"),
+        lambda m: m["work"].update(work_id="other_assignment"),
+        lambda m: m["source_snapshot"].update(sha256="a" * 64),
+        lambda m: m["assignment"].update(title="Corrected title"),
+        lambda m: m["students"].pop(),
+        lambda m: m["students"][0]["source_snapshot"]["submission"].update(
+            sha256="b" * 64
+        ),
+        lambda m: m["students"][0]["source_snapshot"]["review"].update(
+            sha256="c" * 64
+        ),
+        lambda m: m["students"][0]["submission"].update(submission_state="in_progress"),
+        lambda m: m["students"][0]["review"].update(review_state="exported"),
+        lambda m: m["students"][0]["review"]["overall_standard_ratings"][0].update(
+            rating=2
+        ),
+        lambda m: m["students"][0]["review"]["feedback"].update(
+            include_review_unit_observations=False
+        ),
+        lambda m: m["students"][0]["submission"]["digital_provenance"][
+            "evidence_references"
+        ][0].update(source_sha256="d" * 64),
+    ],
+)
+def test_content_comparison_keeps_all_other_manifest_content_significant(
+    mutate: Any,
+) -> None:
+    previous = _mapping(revision=1)
+    candidate = copy.deepcopy(previous)
+    mutate(candidate)
+    if candidate["work"]["work_id"] == "other_assignment":
+        candidate["assignment"]["assignment_id"] = "other_assignment"
+        for student in candidate["students"]:
+            student["submission"]["assignment_id"] = "other_assignment"
+            student["review"]["assignment_id"] = "other_assignment"
+    assert not manifests_have_same_publication_content(
+        manifest_from_mapping(previous), manifest_from_mapping(candidate)
+    )
+
+
+def test_exact_replay_reuses_predecessor_revision_and_bytes() -> None:
+    predecessor = _manifest(revision=4)
+    candidate_mapping = _mapping(revision=91)
+    candidate_mapping["generated_at"] = "2026-08-11T20:00:00Z"
+    plan = plan_manifest_revision(
+        predecessor=predecessor,
+        candidate=manifest_from_mapping(candidate_mapping),
+        allocated_revisions=(1, 2, 4),
+    )
+    assert plan.disposition == "reuse_existing"
+    assert plan.reason == "exact_replay"
+    assert plan.record_set_revision == 4
+    assert plan.reuse_existing_bytes is True
+    assert plan.requires_new_revision is False
+
+
+def test_predecessor_must_be_highest_allocated_producer_revision() -> None:
+    with pytest.raises(QuillanPublicationRevisionConflictError, match="highest"):
+        plan_manifest_revision(
+            predecessor=_manifest(revision=2),
+            candidate=_manifest(revision=9),
+            allocated_revisions=(1, 2, 3),
+        )
+
+
+def test_allocations_must_include_predecessor_revision() -> None:
+    with pytest.raises(QuillanPublicationRevisionConflictError, match="include"):
+        plan_manifest_revision(
+            predecessor=_manifest(revision=2),
+            candidate=_manifest(revision=9),
+            allocated_revisions=(1, 3),
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda m: _overall_rating(m).update(rating=2),
+        lambda m: _overall_rating(m)["rationale"].update(
+            disposition="included", text="Corrected rationale."
+        ),
+        lambda m: _overall_rating(m).update(include_in_feedback=False),
+        lambda m: _review(m)["overall_standard_ratings"].clear(),
+        lambda m: _review(m).update(review_state="exported"),
+        lambda m: _review(m)["feedback"].update(
+            include_review_unit_observations=False
+        ),
+        lambda m: _student(m)["submission"]["digital_provenance"][
+            "evidence_references"
+        ][0].update(source_sha256="a" * 64),
+        lambda m: m["assignment"].update(title="Corrected assignment title"),
+        lambda m: m["students"].pop(),
+    ],
+)
+def test_changed_publication_projection_requires_successor(mutate: Any) -> None:
+    predecessor = _manifest(revision=1)
+    candidate_mapping = _mapping(revision=77)
+    mutate(candidate_mapping)
+    candidate = manifest_from_mapping(candidate_mapping)
+    plan = _successor_plan(predecessor, candidate)
+    assert plan.disposition == "create_successor"
+    assert plan.record_set_revision == 2
+    assert plan.reuse_existing_bytes is False
+    assert plan.requires_new_revision is True
+
+
+def test_rating_removal_preserves_historical_low_rating_without_coercion() -> None:
+    predecessor = _manifest(revision=1)
+    assert predecessor.students[0].review.overall_standard_ratings[0].rating == 0
+
+    candidate_mapping = _mapping(revision=2)
+    _review(candidate_mapping)["overall_standard_ratings"] = []
+    candidate = manifest_from_mapping(candidate_mapping)
+    assert candidate.students[0].review.overall_standard_ratings == ()
+
+    plan = _successor_plan(predecessor, candidate)
+    assert plan.disposition == "create_successor"
+    assert predecessor.students[0].review.overall_standard_ratings[0].rating == 0
+    assert candidate.students[0].review.overall_standard_ratings == ()
+
+
+@pytest.mark.parametrize(
+    "source_mutation",
+    [
+        lambda m: m["source_snapshot"].update(sha256="a" * 64),
+        lambda m: _student(m)["source_snapshot"]["submission"].update(
+            sha256="b" * 64
+        ),
+        lambda m: _student(m)["source_snapshot"]["review"].update(sha256="c" * 64),
+    ],
+)
+def test_exact_native_source_change_requires_successor_with_private_safe_reason(
+    source_mutation: Any,
+) -> None:
+    predecessor = _manifest(revision=1)
+    candidate_mapping = _mapping(revision=2)
+    source_mutation(candidate_mapping)
+    plan = _successor_plan(predecessor, manifest_from_mapping(candidate_mapping))
+    assert plan.disposition == "create_successor"
+    assert plan.reason == "native_source_changed"
+
+
+def test_source_hash_reason_does_not_name_private_field() -> None:
+    predecessor = _manifest(revision=1)
+    candidate_mapping = _mapping(revision=2)
+    _student(candidate_mapping)["source_snapshot"]["review"]["sha256"] = "f" * 64
+    plan = _successor_plan(predecessor, manifest_from_mapping(candidate_mapping))
+    assert plan.reason == "native_source_changed"
+    assert "private" not in plan.reason
+    assert "note" not in plan.reason
+
+
+def test_projection_only_change_uses_projection_reason() -> None:
+    predecessor = _manifest(revision=1)
+    candidate_mapping = _mapping(revision=2)
+    _overall_rating(candidate_mapping)["rating"] = 2
+    plan = _successor_plan(predecessor, manifest_from_mapping(candidate_mapping))
+    assert plan.reason == "publication_projection_changed"
+
+
+def test_historical_reversion_allocates_new_revision_instead_of_reusing_old_one(
+) -> None:
+    state_a = _mapping(revision=1)
+    state_b = copy.deepcopy(state_a)
+    state_b["record_set"]["revision"] = 2
+    _overall_rating(state_b)["rating"] = 2
+    candidate = _with_revision(state_a, 99)
+
+    plan = plan_manifest_revision(
+        predecessor=manifest_from_mapping(state_b),
+        candidate=manifest_from_mapping(candidate),
+        allocated_revisions=(1, 2),
+        historical_manifests=(manifest_from_mapping(state_a),),
+    )
+    assert plan.disposition == "create_successor"
+    assert plan.reason == "historical_reversion"
+    assert plan.record_set_revision == 3
+
+
+def test_historical_reversion_does_not_mutate_prior_manifest() -> None:
+    old = _manifest(revision=1)
+    current_mapping = _mapping(revision=2)
+    _overall_rating(current_mapping)["rating"] = 2
+    current = manifest_from_mapping(current_mapping)
+    candidate = _manifest(revision=20)
+    old_before = manifest_to_mapping(old)
+
+    plan_manifest_revision(
+        predecessor=current,
+        candidate=candidate,
+        allocated_revisions=(1, 2),
+        historical_manifests=(old,),
+    )
+    assert manifest_to_mapping(old) == old_before
+
+
+def test_republication_after_withdrawal_forces_successor_even_when_content_matches(
+) -> None:
+    predecessor = _manifest(revision=7)
+    plan = plan_manifest_revision(
+        predecessor=predecessor,
+        candidate=_manifest(revision=100),
+        allocated_revisions=(1, 3, 7),
+        republish_after_withdrawal=True,
+    )
+    assert plan.disposition == "create_successor"
+    assert plan.reason == "republication_after_withdrawal"
+    assert plan.record_set_revision == 8
+    assert plan.reuse_existing_bytes is False
+
+
+def test_republication_after_withdrawal_requires_predecessor() -> None:
+    with pytest.raises(QuillanPublicationRevisionValidationError, match="predecessor"):
+        plan_manifest_revision(
+            predecessor=None,
+            candidate=_manifest(),
+            allocated_revisions=(),
+            republish_after_withdrawal=True,
+        )
+
+
+def test_republication_flag_must_be_boolean() -> None:
+    with pytest.raises(QuillanPublicationRevisionValidationError, match="boolean"):
+        plan_manifest_revision(
+            predecessor=_manifest(),
+            candidate=_manifest(revision=2),
+            allocated_revisions=(1,),
+            republish_after_withdrawal=cast(Any, 1),
+        )
+
+
+def test_explicit_transition_accepts_greater_noncontiguous_revision() -> None:
+    validate_manifest_revision_transition(_manifest(revision=2), _manifest(revision=8))
+
+
+def test_explicit_transition_rejects_same_logical_revision() -> None:
+    previous = _manifest(revision=2)
+    candidate_mapping = _mapping(revision=2)
+    _overall_rating(candidate_mapping)["rating"] = 2
+    with pytest.raises(QuillanPublicationRevisionConflictError, match="logical"):
+        validate_manifest_revision_transition(
+            previous, manifest_from_mapping(candidate_mapping)
+        )
+
+
+def test_explicit_transition_rejects_lower_revision() -> None:
+    with pytest.raises(QuillanPublicationRevisionValidationError, match="greater"):
+        validate_manifest_revision_transition(
+            _manifest(revision=3), _manifest(revision=2)
+        )
+
+
+def test_cross_work_transition_is_rejected() -> None:
+    candidate_mapping = _mapping(revision=2)
+    candidate_mapping["work"]["work_id"] = "different_assignment"
+    candidate_mapping["assignment"]["assignment_id"] = "different_assignment"
+    for student in candidate_mapping["students"]:
+        student["submission"]["assignment_id"] = "different_assignment"
+        student["review"]["assignment_id"] = "different_assignment"
+    with pytest.raises(QuillanPublicationRevisionValidationError, match="series"):
+        validate_manifest_revision_transition(
+            _manifest(revision=1), manifest_from_mapping(candidate_mapping)
+        )
+
+
+def test_cross_record_set_transition_is_rejected() -> None:
+    candidate_mapping = _mapping(revision=2)
+    candidate_mapping["record_set"]["record_set_id"] = "other_results"
+    candidate = manifest_from_mapping(candidate_mapping)
+    with pytest.raises(
+        QuillanPublicationRevisionValidationError, match="academic_results"
+    ):
+        validate_manifest_revision_transition(_manifest(revision=1), candidate)
+
+
+def test_planner_rejects_nonproduction_record_set_identity() -> None:
+    candidate_mapping = _mapping(revision=1)
+    candidate_mapping["record_set"]["record_set_id"] = "synthetic_results"
+    with pytest.raises(
+        QuillanPublicationRevisionValidationError, match="academic_results"
+    ):
+        plan_manifest_revision(
+            predecessor=None,
+            candidate=manifest_from_mapping(candidate_mapping),
+            allocated_revisions=(),
+        )
+
+
+@pytest.mark.parametrize("invalid", [None, 1, 1.5])
+def test_planner_rejects_noncollection_historical_manifests(invalid: object) -> None:
+    with pytest.raises(
+        QuillanPublicationRevisionValidationError, match="collection"
+    ):
+        plan_manifest_revision(
+            predecessor=_manifest(revision=1),
+            candidate=_manifest(revision=2),
+            allocated_revisions=(1,),
+            historical_manifests=cast(Any, invalid),
+        )
+
+
+def test_historical_manifest_must_precede_current_head() -> None:
+    with pytest.raises(QuillanPublicationRevisionValidationError, match="precede"):
+        plan_manifest_revision(
+            predecessor=_manifest(revision=2),
+            candidate=_manifest(revision=3),
+            allocated_revisions=(1, 2),
+            historical_manifests=(_manifest(revision=3),),
+        )
+
+
+def test_historical_manifest_must_be_same_series() -> None:
+    historical_mapping = _mapping(revision=1)
+    historical_mapping["work"]["work_id"] = "other_assignment"
+    historical_mapping["assignment"]["assignment_id"] = "other_assignment"
+    for student in historical_mapping["students"]:
+        student["submission"]["assignment_id"] = "other_assignment"
+        student["review"]["assignment_id"] = "other_assignment"
+    with pytest.raises(QuillanPublicationRevisionValidationError, match="series"):
+        plan_manifest_revision(
+            predecessor=_manifest(revision=2),
+            candidate=_manifest(revision=3),
+            allocated_revisions=(1, 2),
+            historical_manifests=(manifest_from_mapping(historical_mapping),),
+        )
+
+
+def test_policy_decisions_do_not_mutate_candidate_or_predecessor() -> None:
+    predecessor = _manifest(revision=1)
+    candidate_mapping = _mapping(revision=44)
+    _overall_rating(candidate_mapping)["rating"] = 2
+    candidate = manifest_from_mapping(candidate_mapping)
+    previous_before = manifest_to_mapping(predecessor)
+    candidate_before = manifest_to_mapping(candidate)
+
+    _successor_plan(predecessor, candidate)
+
+    assert manifest_to_mapping(predecessor) == previous_before
+    assert manifest_to_mapping(candidate) == candidate_before
+
+
+def test_minimum_requirement_correction_requires_successor_without_numeric_coercion(
+) -> None:
+    predecessor_mapping = _mapping(revision=1)
+    current_mapping = _mapping(revision=2)
+    returned_review = _review(current_mapping, 1)
+    returned_review["review_state"] = "not_started"
+    outcome = returned_review["minimum_requirement_outcome"]
+    outcome["status"] = "not_checked"
+    outcome["returned_without_full_review"] = False
+    outcome["teacher_note"] = {"disposition": "absent", "text": None}
+    outcome["updated_at"] = None
+
+    predecessor = manifest_from_mapping(predecessor_mapping)
+    candidate = manifest_from_mapping(current_mapping)
+    plan = _successor_plan(predecessor, candidate)
+
+    assert plan.disposition == "create_successor"
+    assert candidate.students[1].review.review_state == "not_started"
+    assert candidate.students[1].review.overall_standard_ratings == ()
+
+
+def test_historical_rating_keeps_its_own_assignment_scale_meaning() -> None:
+    predecessor = _manifest(revision=1)
+    assert predecessor.assignment.rating_scale.levels[0].label == "Beginning"
+    assert predecessor.students[0].review.overall_standard_ratings[0].rating == 0
+
+    candidate_mapping = _mapping(revision=2)
+    candidate_mapping["assignment"]["rating_scale"]["levels"][0]["label"] = (
+        "Needs Development"
+    )
+    candidate = manifest_from_mapping(candidate_mapping)
+    plan = _successor_plan(predecessor, candidate)
+
+    assert plan.disposition == "create_successor"
+    assert predecessor.assignment.rating_scale.levels[0].label == "Beginning"
+    assert candidate.assignment.rating_scale.levels[0].label == "Needs Development"
+
+
+def test_adding_represented_student_requires_complete_successor_snapshot() -> None:
+    predecessor_mapping = _mapping(revision=1)
+    predecessor_mapping["students"] = predecessor_mapping["students"][:1]
+    predecessor = manifest_from_mapping(predecessor_mapping)
+
+    candidate = _manifest(revision=2)
+    plan = _successor_plan(predecessor, candidate)
+
+    assert plan.disposition == "create_successor"
+    assert len(predecessor.students) == 1
+    assert len(candidate.students) == 2
+
+
+def test_normative_manifest_fixture_remains_byte_exact() -> None:
+    from quillan.academic_result_manifest import manifest_to_canonical_json_bytes
+
+    fixture = FIXTURE.read_bytes()
+    manifest = manifest_from_json_bytes(fixture)
+    assert manifest_to_canonical_json_bytes(manifest) == fixture
+
+
+def test_policy_module_imports_only_contract_and_standard_library() -> None:
+    import ast
+    import inspect
+
+    import quillan.publication_revision_policy as policy_module
+
+    tree = ast.parse(inspect.getsource(policy_module))
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.add(node.module)
+
+    assert imported_modules == {
+        "__future__",
+        "collections.abc",
+        "dataclasses",
+        "typing",
+        "quillan.academic_result_manifest",
+    }
+
+
+def test_policy_module_has_no_io_hashing_or_dynamic_execution_calls() -> None:
+    import ast
+    import inspect
+
+    import quillan.publication_revision_policy as policy_module
+
+    tree = ast.parse(inspect.getsource(policy_module))
+    prohibited_names = {
+        "open",
+        "exec",
+        "eval",
+        "__import__",
+        "Path",
+        "sha256",
+    }
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert called_names.isdisjoint(prohibited_names)
+
+
+def test_policy_public_functions_have_no_workspace_core_or_consumer_parameters(
+) -> None:
+    import inspect
+
+    import quillan.publication_revision_policy as policy_module
+
+    function_names = [
+        "manifests_have_same_publication_content",
+        "next_record_set_revision",
+        "validate_manifest_revision_transition",
+        "plan_manifest_revision",
+    ]
+    forbidden = {
+        "workspace_root",
+        "manifest_path",
+        "source_path",
+        "catalog",
+        "registry",
+        "publication_record",
+        "withdrawal",
+        "authorization",
+        "audience",
+        "grade",
+        "proficiency",
+        "portfolio",
+    }
+    for name in function_names:
+        parameters = set(inspect.signature(getattr(policy_module, name)).parameters)
+        assert parameters.isdisjoint(forbidden)


### PR DESCRIPTION
## Summary

Defines Quillan’s producer-owned policy for Academic Result manifest revisions, corrections, historical traceability, supersession, withdrawal, and republication.

This PR adds the versioned pure policy:

```text
quillan_publication_revision_v1
```

and establishes the production Academic Result record-set identity:

```text
academic_results
```

The central invariant is:

```text
mutable current Quillan native state
-> immutable manifest revision
-> later correction
-> new immutable manifest revision
```

Previously published ratings, review states, feedback projections, and selected-evidence references are never rewritten. Corrections appear only in later complete manifest revisions.

This PR defines policy only. It does not generate manifests, perform filesystem I/O, upgrade Core, register Academic Work, publish through Core, create withdrawals, or add consumer grading/portfolio behavior.

## Revision policy

Added:

```text
quillan/publication_revision_policy.py
```

The policy distinguishes:

```text
reuse_existing
create_initial
create_successor
```

with bounded reasons including:

```text
exact_replay
initial_publication
native_source_changed
publication_projection_changed
historical_reversion
republication_after_withdrawal
```

The policy is deterministic and side-effect free.

It performs no:

* workspace resolution;
* filesystem reads or writes;
* workspace hashing;
* Core registry/catalog access;
* Core publication-service calls;
* Meridian or Vitrine imports;
* Grade or proficiency calculation;
* portfolio selection.

## Record-set identity and allocation

Production Quillan Academic Result publications use:

```text
record_set_id = academic_results
```

The first production revision is:

```text
1
```

Normal successor allocation is:

```text
highest allocated producer revision + 1
```

Existing gaps remain consumed, and allocated revision numbers are never reused.

Producer manifest revision remains distinct from:

* native schema versions;
* `review_state`;
* rating values;
* Core Academic Work Registration revisions;
* Core Publication Record IDs;
* package versions.

## Exact replay

Two validated manifests represent the same publication content only when all fields match except:

```text
generated_at
record_set.revision
```

Exact replay:

* reuses the existing immutable revision;
* preserves the original `generated_at`;
* preserves canonical manifest bytes;
* does not allocate another revision.

## Exact source lineage

Exact native source snapshots are part of publication content.

Changes to the SHA-256 of:

```text
assignment.json
submission.json
review.json
```

prevent exact replay even when the visible educational projection otherwise appears unchanged.

Privacy-sensitive native changes use a bounded classification such as:

```text
native_source_changed
```

rather than exposing which private field changed.

## Correction semantics

Quillan does not introduce ScoreForm-style attempts or rating-revision IDs.

Current `review.json` remains mutable through Quillan’s normal teacher-review workflow.

If a published rating is corrected:

```text
revision 1: rating = 2
revision 2: rating = 3
```

revision 1 remains immutable historical evidence of the earlier published judgment, while revision 2 contains the corrected current judgment.

The older manifest is never rewritten.

The same rule applies to corrections involving:

* rating rationales;
* review state;
* minimum-requirement outcome;
* observations;
* feedback composition;
* selected feedback;
* assignment context;
* selected evidence;
* represented students.

Every successor is a complete result-set snapshot rather than a delta.

## Missing ratings remain distinct

If an earlier manifest contains a rating and a valid successor contains no current rating for that standard, the successor preserves absence.

Absence is not converted to:

* zero;
* the native scale minimum;
* returned-without-full-review;
* missing-work status;
* a Grade.

Historical ratings continue to be interpreted using the native rating scale copied into their own manifest revision.

## Historical reversion

Returning current native state to an older historical result still requires a new greater revision.

Example:

```text
revision 1 = state A
revision 2 = state B
revision 3 = state A
```

Revision 1 is not reused or restored as current.

This preserves the complete historical sequence:

```text
A -> B -> A
```

## Supersession and withdrawal policy

Ordinary corrections use:

```text
correct native state
-> successor manifest
-> explicit Core supersession
```

They do not automatically require withdrawal.

Withdrawal is reserved for stronger publication-level integrity or privacy defects, such as:

* accidental publication;
* incorrect work/student association;
* privacy-floor violation;
* publication of non-authoritative evidence;
* unrecoverable manifest integrity failure.

Withdrawal preserves the immutable manifest and Publication Record. It is not deletion or erasure.

Core-backed supersession and withdrawal execution remain #363.

## Republication after withdrawal

Exact replay does not reactivate a withdrawn Core publication.

Explicit republication after withdrawal requires a new greater producer revision even when the current native source state is unchanged.

Conceptually:

```text
revision 3 published
revision 3 withdrawn

native state unchanged

revision 4 created for republication
revision 4 later supersedes the withdrawn head
```

The pure policy supports this explicitly without inspecting Core withdrawal state itself.

## Historical source drift

Current:

```text
assignment.json
submission.json
review.json
```

remain mutable producer records.

A historical manifest may therefore reference source hashes that no longer match the current bytes at those paths.

That does not authorize rewriting the historical manifest or silently substituting current native bytes.

Historical source/artifact resolution remains #364.

## Privacy-policy evolution

Future producer privacy changes never rewrite historical manifests.

If a changed privacy projection changes serialized current manifest content, a successor revision is required.

If previously published content becomes unsafe for continued use, the exact affected publication may additionally be withdrawn.

A policy implementation change that produces identical manifest content does not itself require a new record-set revision.

## Documentation

Added:

```text
docs/publication_revision_policy.md
```

Updated:

```text
docs/academic_result_manifest_v1.md
docs/publication_projection_policy_v1.md
docs/data_contracts.md
```

The documentation now defines:

* production record-set identity;
* revision allocation;
* exact replay;
* source-byte sensitivity;
* rating/review correction history;
* missing-rating behavior;
* complete snapshots;
* historical reversion;
* supersession;
* withdrawal;
* republication after withdrawal;
* historical source drift;
* privacy-policy evolution;
* downstream ownership boundaries.

Academic Result Manifest v1’s serialized schema is unchanged.

Publication Projection Policy v1 is not widened.

## Tests

Added:

```text
tests/test_publication_revision_policy.py
```

Coverage includes:

* policy/version identity;
* initial and successor allocation;
* revision gaps and reuse rejection;
* exact replay;
* source-hash changes;
* rating correction and removal;
* missing versus genuine low rating;
* historical native-scale interpretation;
* review-state changes;
* minimum-requirement changes;
* assignment changes;
* feedback/projection changes;
* selected-evidence changes;
* represented-student changes;
* historical reversion;
* republication after withdrawal;
* contradictory logical revision reuse;
* cross-series rejection;
* malformed collection/error-boundary handling;
* immutable plan values;
* AST-level purity boundaries;
* byte-exact preservation of the normative Manifest v1 fixture.

Focused publication-contract validation:

```text
181 passed
```

## Full validation

```text
2098 passed, 17 skipped
Ruff: PASS
mypy: PASS — 251 source files
compileall: PASS
pip check: PASS
Documentation integrity: PASS
git diff --check: PASS
```

## Changed-file scope

Exactly six repository files:

```text
docs/academic_result_manifest_v1.md
docs/data_contracts.md
docs/publication_projection_policy_v1.md
docs/publication_revision_policy.md
quillan/publication_revision_policy.py
tests/test_publication_revision_policy.py
```

No:

* Core dependency change;
* Quillan package-version change;
* native schema change;
* manifest-schema change;
* publication workflow implementation;
* filesystem manifest generation;
* Meridian dependency;
* Vitrine dependency;
* grading/proficiency policy;
* portfolio policy;
* sibling-repository change.

## Follow-up ownership

* #359 — upgrade Quillan to Core 0.6
* #360 — Academic Work Registration
* #361 — immutable manifest generation and filesystem history
* #362 — producer profile
* #363 — Core publication, supersession, and withdrawal workflows
* #364 — consumer-neutral historical manifest/artifact reader
* #365–#366 — installed acceptance and release audit

Closes #358
