### PR TITLE
359 upgrade quillan core 0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,19 @@ jobs:
           }
           $pdftoppm.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           & (Join-Path $pdftoppm.DirectoryName "pdfinfo.exe") -v
-      - name: Download and verify released Core 0.5.0
+      - name: Download released Core 0.6.0
         shell: python
         run: |
           import os
           from pathlib import Path
           from urllib.request import urlretrieve
-          url = "https://github.com/Paper-Data-Suite/pds-core/releases/download/v0.5.0/pds_core-0.5.0-py3-none-any.whl"
-          path = Path(os.environ["RUNNER_TEMP"]) / "pds_core-0.5.0-py3-none-any.whl"
+          url = "https://github.com/Paper-Data-Suite/pds-core/releases/download/v0.6.0/pds_core-0.6.0-py3-none-any.whl"
+          path = Path(os.environ["RUNNER_TEMP"]) / "pds_core-0.6.0-py3-none-any.whl"
           urlretrieve(url, path)
-      - name: Authenticate released Core 0.5.0
-        run: python scripts/verify_core_wheel.py "${{ runner.temp }}/pds_core-0.5.0-py3-none-any.whl"
+      - name: Authenticate released Core 0.6.0
+        run: python scripts/verify_core_wheel.py "${{ runner.temp }}/pds_core-0.6.0-py3-none-any.whl"
       - name: Install
-        run: python -m pip install "${{ runner.temp }}/pds_core-0.5.0-py3-none-any.whl" ".[dev]"
+        run: python -m pip install "${{ runner.temp }}/pds_core-0.6.0-py3-none-any.whl" ".[dev]"
       - name: Remove local build residue
         shell: python
         run: |
@@ -66,7 +66,7 @@ jobs:
               if path.exists():
                   shutil.rmtree(path)
       - name: Verify installed Core identity
-        run: python scripts/verify_core_wheel.py "${{ runner.temp }}/pds_core-0.5.0-py3-none-any.whl" --verify-installed
+        run: python scripts/verify_core_wheel.py "${{ runner.temp }}/pds_core-0.6.0-py3-none-any.whl" --verify-installed
       - name: Dependency check
         run: python -m pip check
       - name: Full pytest

--- a/README.md
+++ b/README.md
@@ -345,15 +345,15 @@ development extras:
 py -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
-python -m pip install "C:\path\to\pds_core-0.5.x-py3-none-any.whl"
+python -m pip install "C:\path\to\pds_core-0.6.0-py3-none-any.whl"
 python -m pip install -e ".[dev]"
 python -m pip check
 ```
 
 The configured package index did not provide a compatible PDS Core distribution
-during the Core 0.5 baseline validation, so install a verified compatible wheel
+during the Core 0.6 baseline validation, so install a verified compatible wheel
 first. Pip then confirms that wheel satisfies Quillan's declared
-`pds-core>=0.5,<0.6` runtime dependency. A sibling Core checkout is not required,
+`pds-core>=0.6,<0.7` runtime dependency. A sibling Core checkout is not required,
 and no neighboring Core source path is used. `requirements-dev.txt` is a
 convenience wrapper around `.[dev]` and may be used instead of the direct
 editable-install command.
@@ -364,7 +364,7 @@ To validate clean editable and noneditable installations, run:
 powershell -ExecutionPolicy Bypass `
     -File .\scripts\validate_development_install.ps1 `
     -Python .\.venv\Scripts\python.exe `
-    -PdsCoreWheel "C:\path\to\pds_core-0.5.x-py3-none-any.whl"
+    -PdsCoreWheel "C:\path\to\pds_core-0.6.0-py3-none-any.whl"
 ```
 
 The equivalent `PDS_CORE_WHEEL` environment variable may be used instead of
@@ -372,6 +372,11 @@ The equivalent `PDS_CORE_WHEEL` environment variable may be used instead of
 checks package metadata, editable and noneditable installation, installed import
 origins, CLI availability, and workspace side effects. The v0.8.9 runtime is
 PDS2-only and uses module-qualified storage throughout.
+
+Core 0.6 adoption is compatibility infrastructure only. It does not register
+Academic Work, generate or publish Academic Result manifests, create Publication
+Records or withdrawals, rebuild the academic catalog, assign Academic Periods,
+calculate proficiency or Grades, or create portfolio Candidates.
 
 
 PDF scan intake uses `pdf2image` and requires Poppler installed on the user's

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -1,5 +1,11 @@
 # Quillan Data Contracts
 
+Quillan requires `pds-core>=0.6,<0.7`; release qualification uses the exact
+released Core 0.6.0 wheel. This dependency upgrade preserves the routing contract
+`"1"`, PDS2 payloads, route-registration schema `"1"`, and the existing Quillan
+producer contracts. It does not itself create Academic Work Registration,
+Academic Period, manifest, Publication Record, withdrawal, or catalog state.
+
 The pure `quillan_academic_result_manifest_v1` contract is defined in
 [Academic Result Manifest v1](academic_result_manifest_v1.md). Quillan preserves
 native review meaning, Core verifies publication envelopes, and an authorized

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -9,7 +9,7 @@ Classification: **active authority** for the v0.8.9 release candidate.
 ## Current status
 
 Quillan v0.8.9 is a local-first, teacher-controlled writing-evidence module for
-PDS Core 0.5. Its supported workflow is:
+PDS Core 0.6. Its supported workflow is:
 
 ```text
 PDS2 locator -> immutable Core route -> Quillan page context
@@ -41,7 +41,13 @@ dashboards, and cross-assignment analytics are outside this milestone.
 
 PDF scan intake uses `pdf2image` and requires Poppler on the host. Supported
 Python versions are CPython 3.11 through 3.14. Runtime Core compatibility is
-`pds-core>=0.5,<0.6`, with released Core 0.5.0 as the acceptance baseline.
+`pds-core>=0.6,<0.7`, with released Core 0.6.0 as the qualification baseline.
+
+Adopting Core 0.6 alone does not register Quillan Academic Work, generate
+workspace Academic Result manifests, publish results, create Publication Records
+or withdrawals, rebuild the academic catalog, assign Academic Period membership,
+calculate proficiency or Grades, or create portfolio Candidates. Those workflows
+remain owned by #360 through #365; #366 owns the final release audit.
 
 ## Release closeout
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -3,7 +3,7 @@
 Classification: **active authority**.
 
 1. Begin from the approved baseline with a clean tree and use synthetic data.
-2. Supply the released PDS Core 0.5.0 wheel explicitly to the release validator.
+2. Supply the released PDS Core 0.6.0 wheel explicitly to the release validator.
 3. Run source tests, Ruff, mypy without incremental state, documentation and
    parser drift checks, repository hard-cutover checks, and `git diff --check`.
 4. Build exactly `quillan-0.8.9-py3-none-any.whl` and
@@ -27,6 +27,6 @@ Run the automated candidate gate with:
 ```powershell
 .\scripts\validate_release_candidate.ps1 `
   -Python .\.venv\Scripts\python.exe `
-  -PdsCoreWheel C:\path\to\pds_core-0.5.0-py3-none-any.whl `
+  -PdsCoreWheel C:\path\to\pds_core-0.6.0-py3-none-any.whl `
   -ArtifactOutputDirectory C:\path\outside\repository\quillan-0.8.9-candidate
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 dependencies = [
     "numpy<2.5",
     "opencv-python",
-    "pds-core>=0.5,<0.6",
+    "pds-core>=0.6,<0.7",
     "pdf2image",
     "qrcode[pil]",
     "reportlab",
@@ -58,7 +58,7 @@ strict = true
 explicit_package_bases = true
 
 [[tool.mypy.overrides]]
-# Core 0.5 ships inspectable source but no py.typed marker.
+# Core 0.6 ships inspectable source but no py.typed marker.
 module = ["pds_core", "pds_core.*"]
 follow_untyped_imports = true
 

--- a/scripts/inspect_release_artifacts.py
+++ b/scripts/inspect_release_artifacts.py
@@ -12,6 +12,7 @@ import tarfile
 import zipfile
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 EXPECTED_VERSION = "0.8.9"
 REMOVED = {
@@ -56,10 +57,11 @@ def _metadata_contract(raw: str) -> dict[str, object]:
     assert metadata["Requires-Python"] == ">=3.11", metadata["Requires-Python"]
     assert metadata["License-Expression"] == "MIT", metadata.items()
     assert "License-File" in metadata and "LICENSE" in metadata["License-File"]
+    parsed_requirements = [Requirement(value) for value in requirements]
     core_requirements = [
-        Requirement(value)
-        for value in requirements
-        if Requirement(value).name == "pds-core"
+        requirement
+        for requirement in parsed_requirements
+        if canonicalize_name(requirement.name) == "pds-core"
     ]
     assert len(core_requirements) == 1, core_requirements
     core_requirement = core_requirements[0]

--- a/scripts/inspect_release_artifacts.py
+++ b/scripts/inspect_release_artifacts.py
@@ -11,6 +11,8 @@ import re
 import tarfile
 import zipfile
 
+from packaging.requirements import Requirement
+
 EXPECTED_VERSION = "0.8.9"
 REMOVED = {
     "quillan/submissions.py",
@@ -41,6 +43,7 @@ def _validate_names(names: set[str]) -> None:
         parts = normalized.parts
         if parts and parts[0] == f"quillan-{EXPECTED_VERSION}":
             parts = parts[1:]
+        assert not (parts and parts[0] == "pds_core"), name
         normalized_names.add(PurePosixPath(*parts).as_posix())
     assert not (REMOVED & normalized_names), names
 
@@ -53,11 +56,24 @@ def _metadata_contract(raw: str) -> dict[str, object]:
     assert metadata["Requires-Python"] == ">=3.11", metadata["Requires-Python"]
     assert metadata["License-Expression"] == "MIT", metadata.items()
     assert "License-File" in metadata and "LICENSE" in metadata["License-File"]
-    assert any(value.startswith("pds-core<0.6,>=0.5") for value in requirements)
+    core_requirements = [
+        Requirement(value)
+        for value in requirements
+        if Requirement(value).name == "pds-core"
+    ]
+    assert len(core_requirements) == 1, core_requirements
+    core_requirement = core_requirements[0]
+    assert core_requirement.url is None, core_requirement
+    assert core_requirement.marker is None, core_requirement
+    assert not core_requirement.extras, core_requirement
+    assert {str(value) for value in core_requirement.specifier} == {
+        ">=0.6",
+        "<0.7",
+    }, core_requirement
     return {
         "version": metadata["Version"],
         "requires_python": metadata["Requires-Python"],
-        "core_requirement": next(v for v in requirements if v.startswith("pds-core")),
+        "core_requirement": str(core_requirement),
         "license": metadata["License-Expression"],
     }
 
@@ -72,6 +88,7 @@ def inspect_wheel(path: Path) -> dict[str, object]:
         entries = archive.read(entry_name).decode("utf-8")
         assert "quillan = quillan.cli:main" in entries
         assert "quillan = quillan.pds_module:get_module_profile" in entries
+        assert "paper_data_suite.publication_producers" not in entries
         assert "quillan/_version.py" in names
         assert any(name.endswith(".dist-info/licenses/LICENSE") for name in names)
     return {"filename": path.name, "sha256": _sha256(path), **metadata}

--- a/scripts/run_installed_acceptance.py
+++ b/scripts/run_installed_acceptance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib
 import importlib.metadata as metadata
 import json
 import os
@@ -17,12 +18,42 @@ EXPECTED_VERSION = "0.8.9"
 CLASS_ID = "synthetic_release_class"
 ASSIGNMENT_ID = "synthetic_release_digital"
 STANDARD_ID = "synthetic:W.RELEASE.1"
+ACADEMIC_STATE_PATHS = (
+    Path("settings/academic_periods"),
+    Path("registry/work"),
+    Path("registry/publications"),
+    Path("registry/withdrawals"),
+    Path("registry/catalog.sqlite"),
+    Path("registry/.locks"),
+)
+CORE_06_ACADEMIC_MODULES = (
+    "pds_core.academic_work_registrations",
+    "pds_core.academic_work_registration_storage",
+    "pds_core.registry_services",
+    "pds_core.publication_records",
+    "pds_core.publication_storage",
+    "pds_core.publication_compatibility",
+    "pds_core.academic_catalog",
+)
 
 
 def _load_object(path: Path) -> dict[str, Any]:
     value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
     assert type(value) is dict, path
     return value
+
+
+def _assert_no_academic_state(workspace: Path) -> None:
+    """Prove ordinary Quillan operations did not create Core academic state."""
+    created = [path.as_posix() for path in ACADEMIC_STATE_PATHS if (workspace / path).exists()]
+    assert not created, created
+
+
+def _module_origin(module_name: str) -> Path:
+    module = importlib.import_module(module_name)
+    raw_origin = module.__file__
+    assert raw_origin is not None, module_name
+    return Path(raw_origin).resolve()
 
 
 def _verify_digital_durable_state(
@@ -446,10 +477,23 @@ def main() -> int:
     env.pop("PYTHONPATH", None)
 
     distribution = metadata.distribution("quillan")
+    core_distribution = metadata.distribution("pds-core")
     assert distribution.version == EXPECTED_VERSION
+    assert core_distribution.version == "0.6.0"
     root = Path(str(distribution.locate_file(""))).resolve()
     import quillan
     import quillan.pds_module
+    import pds_core
+
+    assert pds_core.__version__ == core_distribution.version
+    raw_core_origin = pds_core.__file__
+    assert raw_core_origin is not None
+    core_origin = Path(raw_core_origin).resolve()
+    assert not core_origin.is_relative_to(repository), core_origin
+    academic_module_origins = {
+        name: str(_module_origin(name))
+        for name in CORE_06_ACADEMIC_MODULES
+    }
 
     origins = [Path(quillan.__file__).resolve(), Path(quillan.pds_module.__file__).resolve()]
     assert all(not path.is_relative_to(repository) for path in origins), origins
@@ -473,8 +517,12 @@ def main() -> int:
         result = _run(_cli(arguments), cwd=work, env=env, stdin="q\n")
         assert "Quit" in result.stdout and result.stderr == ""
     assert not sentinel.exists()
-    workflow = _run_full_workflow(work / "workflow-workspace", work=work, env=env) if args.full_workflow else None
-    print(json.dumps({"version": distribution.version, "distribution_root": str(root), "origins": [str(path) for path in origins], "module_count": len(modules), "module_profile": profile.module_id, "workspace_side_effects": False, "workflow": workflow}, indent=2, sort_keys=True))
+    _assert_no_academic_state(sentinel)
+    workflow_workspace = work / "workflow-workspace"
+    workflow = _run_full_workflow(workflow_workspace, work=work, env=env) if args.full_workflow else None
+    if args.full_workflow:
+        _assert_no_academic_state(workflow_workspace)
+    print(json.dumps({"version": distribution.version, "distribution_root": str(root), "origins": [str(path) for path in origins], "core_version": core_distribution.version, "core_origin": str(core_origin), "core_06_academic_modules": academic_module_origins, "module_count": len(modules), "module_profile": profile.module_id, "workspace_side_effects": False, "academic_registry_side_effects": False, "workflow": workflow}, indent=2, sort_keys=True))
     return 0
 
 

--- a/scripts/validate_development_install.ps1
+++ b/scripts/validate_development_install.ps1
@@ -211,11 +211,15 @@ import pathlib
 import sys
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 quillan = metadata.distribution('quillan')
 requirements = [Requirement(value) for value in quillan.requires or []]
-core = [value for value in requirements if value.name == 'pds-core']
+core = [
+    value for value in requirements
+    if canonicalize_name(value.name) == 'pds-core'
+]
 assert len(core) == 1, core
 assert core[0].url is None, core[0]
 assert {str(value) for value in core[0].specifier} == {'>=0.6', '<0.7'}, core[0]

--- a/scripts/validate_development_install.ps1
+++ b/scripts/validate_development_install.ps1
@@ -192,7 +192,7 @@ try {
         if ($InstallExitCode -ne 0) {
             if (-not $ResolvedCoreWheel) {
                 throw (
-                    "Quillan requires pds-core>=0.5,<0.6, but no compatible " +
+                    "Quillan requires pds-core>=0.6,<0.7, but no compatible " +
                     "distribution was resolved. Supply a verified Core wheel with " +
                     "-PdsCoreWheel or PDS_CORE_WHEEL. This script will not fall " +
                     "back to a neighboring source checkout."
@@ -218,9 +218,9 @@ requirements = [Requirement(value) for value in quillan.requires or []]
 core = [value for value in requirements if value.name == 'pds-core']
 assert len(core) == 1, core
 assert core[0].url is None, core[0]
-assert {str(value) for value in core[0].specifier} == {'>=0.5', '<0.6'}, core[0]
+assert {str(value) for value in core[0].specifier} == {'>=0.6', '<0.7'}, core[0]
 installed_core = metadata.distribution('pds-core')
-assert Version(installed_core.version) in SpecifierSet('>=0.5,<0.6'), installed_core.version
+assert Version(installed_core.version) in SpecifierSet('>=0.6,<0.7'), installed_core.version
 scripts = [entry for entry in quillan.entry_points if entry.group == 'console_scripts']
 assert any(entry.name == 'quillan' and entry.value == 'quillan.cli:main' for entry in scripts), scripts
 print(json.dumps({

--- a/scripts/verify_core_wheel.py
+++ b/scripts/verify_core_wheel.py
@@ -1,4 +1,4 @@
-"""Authenticate the exact official PDS Core 0.5.0 release wheel."""
+"""Authenticate the exact official PDS Core 0.6.0 release wheel."""
 
 from __future__ import annotations
 
@@ -15,12 +15,12 @@ from typing import Final
 import zipfile
 
 
-AUTHORITATIVE_CORE_FILENAME: Final = "pds_core-0.5.0-py3-none-any.whl"
+AUTHORITATIVE_CORE_FILENAME: Final = "pds_core-0.6.0-py3-none-any.whl"
 AUTHORITATIVE_CORE_SHA256: Final = (
-    "336676fa4b72e2b4094f654e77b5746b0d6670946cb4c5d3022c4c0be7963400"
+    "be28c061b38463ef59ebc328ed1aa443767fe7f2c626babb769c2d8e5932f308"
 )
 AUTHORITATIVE_CORE_DISTRIBUTION: Final = "pds-core"
-AUTHORITATIVE_CORE_VERSION: Final = "0.5.0"
+AUTHORITATIVE_CORE_VERSION: Final = "0.6.0"
 
 
 class CoreWheelVerificationError(ValueError):

--- a/tests/test_core_wheel_verification.py
+++ b/tests/test_core_wheel_verification.py
@@ -26,7 +26,7 @@ def _wheel(
     *,
     filename: str = AUTHORITATIVE_CORE_FILENAME,
     distribution: str = "pds-core",
-    version: str = "0.5.0",
+    version: str = "0.6.0",
     include_metadata: bool = True,
 ) -> Path:
     path = root / filename
@@ -34,7 +34,7 @@ def _wheel(
         archive.writestr("pds_core/__init__.py", "")
         if include_metadata:
             archive.writestr(
-                "pds_core-0.5.0.dist-info/METADATA",
+                "pds_core-0.6.0.dist-info/METADATA",
                 f"Metadata-Version: 2.4\nName: {distribution}\nVersion: {version}\n",
             )
     return path
@@ -49,7 +49,7 @@ def test_correct_metadata_and_hash_contract_is_accepted(tmp_path: Path) -> None:
     verified = verify_core_wheel(wheel, _matching_contract(wheel))
     assert verified.filename == AUTHORITATIVE_CORE_FILENAME
     assert verified.distribution == "pds-core"
-    assert verified.version == "0.5.0"
+    assert verified.version == "0.6.0"
 
 
 def test_wrong_filename_is_rejected(tmp_path: Path) -> None:
@@ -60,7 +60,7 @@ def test_wrong_filename_is_rejected(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     ("field", "value", "message"),
-    (("distribution", "not-core", "distribution"), ("version", "0.5.1", "version")),
+    (("distribution", "not-core", "distribution"), ("version", "0.6.1", "version")),
 )
 def test_wrong_embedded_identity_is_rejected(
     tmp_path: Path, field: str, value: str, message: str
@@ -102,7 +102,7 @@ def _installed_identity(
     environment: Path,
     distribution_location: Path,
     import_path: Path,
-    version: str = "0.5.0",
+    version: str = "0.6.0",
 ) -> None:
     import_path.parent.mkdir(parents=True, exist_ok=True)
     import_path.touch()
@@ -127,7 +127,7 @@ def test_installed_metadata_version_mismatch_is_rejected(
         environment=environment,
         distribution_location=location,
         import_path=location / "pds_core" / "__init__.py",
-        version="0.5.1",
+        version="0.6.1",
     )
     with pytest.raises(CoreWheelVerificationError, match="version"):
         installed_core_identity()

--- a/tests/test_installed_acceptance_contract.py
+++ b/tests/test_installed_acceptance_contract.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 
 from scripts.run_installed_acceptance import (
+    ACADEMIC_STATE_PATHS,
+    _assert_no_academic_state,
     _compare_retained_source_inventories,
     _retained_source_inventory,
     _verify_digital_durable_state,
@@ -159,3 +161,23 @@ def test_retained_source_added_count_is_derived(tmp_path: Path) -> None:
         before, after, require_unchanged=False
     )
     assert result["retained_source_events_added"] == 2
+
+
+def test_no_academic_state_accepts_ordinary_workspace(tmp_path: Path) -> None:
+    (tmp_path / "classes").mkdir()
+    (tmp_path / "scans" / "source").mkdir(parents=True)
+    _assert_no_academic_state(tmp_path)
+
+
+@pytest.mark.parametrize("relative_path", ACADEMIC_STATE_PATHS)
+def test_no_academic_state_rejects_each_forbidden_path(
+    tmp_path: Path, relative_path: Path
+) -> None:
+    target = tmp_path / relative_path
+    if target.suffix:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.touch()
+    else:
+        target.mkdir(parents=True)
+    with pytest.raises(AssertionError, match=relative_path.as_posix().replace(".", r"\.")):
+        _assert_no_academic_state(tmp_path)

--- a/tests/test_packaging_baseline.py
+++ b/tests/test_packaging_baseline.py
@@ -6,6 +6,7 @@ import tomllib
 from pathlib import Path
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 REPOSITORY = Path(__file__).resolve().parents[1]
@@ -25,12 +26,12 @@ def test_runtime_declares_one_ordinary_core_requirement() -> None:
     core_values = [
         value
         for value in dependencies
-        if Requirement(value).name == "pds-core"
+        if canonicalize_name(Requirement(value).name) == "pds-core"
     ]
     assert core_values == ["pds-core>=0.6,<0.7"]
 
     requirement = Requirement(core_values[0])
-    assert requirement.name.lower().replace("_", "-") == "pds-core"
+    assert canonicalize_name(requirement.name) == "pds-core"
     assert requirement.url is None
     assert {str(value) for value in requirement.specifier} == {">=0.6", "<0.7"}
     assert Version("0.6.0") in requirement.specifier
@@ -43,6 +44,25 @@ def test_runtime_declares_one_ordinary_core_requirement() -> None:
         marker in core_values[0].lower()
         for marker in ("file:", "git+", "hg+", "svn+", "bzr+", "../", "..\\")
     )
+
+
+def test_core_requirement_identity_uses_standard_name_normalization() -> None:
+    requirements = [
+        Requirement("pds-core>=0.6,<0.7"),
+        Requirement("pds_core>=0.6,<0.7"),
+        Requirement("PDS.Core>=0.6,<0.7"),
+        Requirement("unrelated>=1"),
+    ]
+    core = [
+        requirement
+        for requirement in requirements
+        if canonicalize_name(requirement.name) == "pds-core"
+    ]
+    assert [requirement.name for requirement in core] == [
+        "pds-core",
+        "pds_core",
+        "PDS.Core",
+    ]
 
 
 def test_development_extras_declare_packaging_directly() -> None:

--- a/tests/test_packaging_baseline.py
+++ b/tests/test_packaging_baseline.py
@@ -6,6 +6,7 @@ import tomllib
 from pathlib import Path
 
 from packaging.requirements import Requirement
+from packaging.version import Version
 
 REPOSITORY = Path(__file__).resolve().parents[1]
 
@@ -26,12 +27,17 @@ def test_runtime_declares_one_ordinary_core_requirement() -> None:
         for value in dependencies
         if Requirement(value).name == "pds-core"
     ]
-    assert core_values == ["pds-core>=0.5,<0.6"]
+    assert core_values == ["pds-core>=0.6,<0.7"]
 
     requirement = Requirement(core_values[0])
     assert requirement.name.lower().replace("_", "-") == "pds-core"
     assert requirement.url is None
-    assert {str(value) for value in requirement.specifier} == {">=0.5", "<0.6"}
+    assert {str(value) for value in requirement.specifier} == {">=0.6", "<0.7"}
+    assert Version("0.6.0") in requirement.specifier
+    assert Version("0.6.9") in requirement.specifier
+    assert Version("0.5.9") not in requirement.specifier
+    assert Version("0.7.0") not in requirement.specifier
+    assert Version("0.6.0a1") not in requirement.specifier
     assert "@" not in core_values[0]
     assert not any(
         marker in core_values[0].lower()

--- a/tests/test_pds_core_dependency.py
+++ b/tests/test_pds_core_dependency.py
@@ -3,6 +3,8 @@
 import importlib.metadata as metadata
 
 import pds_core
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 from pds_core.pds2 import parse_pds2_payload, serialize_pds2_payload
 from pds_core.route_ids import generate_route_id
@@ -27,5 +29,6 @@ def test_pds_core_pds2_dependency_is_available() -> None:
 
 
 def test_installed_core_distribution_and_package_versions_agree() -> None:
-    assert metadata.version("pds-core") == "0.6.0"
-    assert pds_core.__version__ == "0.6.0"
+    installed_version = metadata.version("pds-core")
+    assert Version(installed_version) in SpecifierSet(">=0.6,<0.7")
+    assert pds_core.__version__ == installed_version

--- a/tests/test_pds_core_dependency.py
+++ b/tests/test_pds_core_dependency.py
@@ -1,4 +1,8 @@
-"""Smoke tests for the installed PDS Core 0.5 routing contract."""
+"""Smoke tests for the installed PDS Core 0.6 routing contract."""
+
+import importlib.metadata as metadata
+
+import pds_core
 
 from pds_core.pds2 import parse_pds2_payload, serialize_pds2_payload
 from pds_core.route_ids import generate_route_id
@@ -20,3 +24,8 @@ def test_pds_core_pds2_dependency_is_available() -> None:
     assert ModuleWorkRef.__module__ == "pds_core.routing_models"
     assert RouteLocator.__module__ == "pds_core.routing_models"
     assert RouteRegistration.__module__ == "pds_core.routing_models"
+
+
+def test_installed_core_distribution_and_package_versions_agree() -> None:
+    assert metadata.version("pds-core") == "0.6.0"
+    assert pds_core.__version__ == "0.6.0"

--- a/tests/test_release_artifact_inspection.py
+++ b/tests/test_release_artifact_inspection.py
@@ -23,7 +23,7 @@ METADATA = """Metadata-Version: 2.4
 Name: quillan
 Version: 0.8.9
 Requires-Python: >=3.11
-Requires-Dist: pds-core<0.6,>=0.5
+Requires-Dist: pds-core<0.7,>=0.6
 License-Expression: MIT
 License-File: LICENSE
 """
@@ -79,3 +79,15 @@ def test_sdist_rejects_each_removed_module(tmp_path: Path, removed: str) -> None
 def test_ordinary_current_package_paths_are_accepted(tmp_path: Path) -> None:
     assert inspect_wheel(_wheel(tmp_path / "current.whl"))["version"] == "0.8.9"
     assert inspect_sdist(_sdist(tmp_path / "current.tar.gz"))["version"] == "0.8.9"
+
+
+def test_wheel_rejects_bundled_core_source(tmp_path: Path) -> None:
+    artifact = _wheel(tmp_path / "bundled-core.whl", "pds_core/routing_models.py")
+    with pytest.raises(AssertionError):
+        inspect_wheel(artifact)
+
+
+def test_sdist_rejects_bundled_core_source(tmp_path: Path) -> None:
+    artifact = _sdist(tmp_path / "bundled-core.tar.gz", "pds_core/routing_models.py")
+    with pytest.raises(AssertionError):
+        inspect_sdist(artifact)

--- a/tests/test_release_artifact_inspection.py
+++ b/tests/test_release_artifact_inspection.py
@@ -19,21 +19,33 @@ REMOVED_MODULES = (
 )
 
 
-METADATA = """Metadata-Version: 2.4
+def _metadata(*requirements: str) -> str:
+    requires_dist = "".join(
+        f"Requires-Dist: {requirement}\n" for requirement in requirements
+    )
+    return f"""Metadata-Version: 2.4
 Name: quillan
 Version: 0.8.9
 Requires-Python: >=3.11
-Requires-Dist: pds-core<0.7,>=0.6
+{requires_dist}\
 License-Expression: MIT
 License-File: LICENSE
 """
 
 
-def _wheel(path: Path, extra_name: str = "quillan/current.py") -> Path:
+VALID_METADATA = _metadata("pds-core<0.7,>=0.6")
+
+
+def _wheel(
+    path: Path,
+    extra_name: str = "quillan/current.py",
+    *,
+    metadata: str = VALID_METADATA,
+) -> Path:
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr("quillan/_version.py", '__version__ = "0.8.9"\n')
         archive.writestr(extra_name, "")
-        archive.writestr("quillan-0.8.9.dist-info/METADATA", METADATA)
+        archive.writestr("quillan-0.8.9.dist-info/METADATA", metadata)
         archive.writestr(
             "quillan-0.8.9.dist-info/entry_points.txt",
             "[console_scripts]\nquillan = quillan.cli:main\n"
@@ -44,11 +56,16 @@ def _wheel(path: Path, extra_name: str = "quillan/current.py") -> Path:
     return path
 
 
-def _sdist(path: Path, extra_name: str = "quillan/current.py") -> Path:
-    root = path.parent / "source"
+def _sdist(
+    path: Path,
+    extra_name: str = "quillan/current.py",
+    *,
+    metadata: str = VALID_METADATA,
+) -> Path:
+    root = path.parent / f"{path.name}.source"
     package = root / "quillan-0.8.9"
     (package / "quillan").mkdir(parents=True)
-    (package / "PKG-INFO").write_text(METADATA, encoding="utf-8")
+    (package / "PKG-INFO").write_text(metadata, encoding="utf-8")
     (package / "LICENSE").write_text("MIT\n", encoding="utf-8")
     (package / "README.md").write_text("Quillan\n", encoding="utf-8")
     (package / "quillan" / "_version.py").write_text(
@@ -91,3 +108,50 @@ def test_sdist_rejects_bundled_core_source(tmp_path: Path) -> None:
     artifact = _sdist(tmp_path / "bundled-core.tar.gz", "pds_core/routing_models.py")
     with pytest.raises(AssertionError):
         inspect_sdist(artifact)
+
+
+INVALID_CORE_REQUIREMENTS = (
+    pytest.param((), id="missing"),
+    pytest.param(
+        ("pds-core>=0.6,<0.7", "pds-core>=0.6,<0.7"),
+        id="duplicate-canonical",
+    ),
+    pytest.param(
+        ("pds-core>=0.6,<0.7", "pds_core>=0.6,<0.7"),
+        id="duplicate-underscore-alias",
+    ),
+    pytest.param(
+        ("pds-core>=0.6,<0.7", "PDS.Core>=0.6,<0.7"),
+        id="duplicate-dot-case-alias",
+    ),
+    pytest.param(("pds-core>=0.5,<0.6",), id="old-range"),
+    pytest.param(("pds-core>=0.7,<0.8",), id="core-07-only"),
+    pytest.param(("pds-core>=0.6",), id="unbounded"),
+    pytest.param(
+        ("pds-core @ https://example.invalid/pds_core.whl",),
+        id="direct-url",
+    ),
+    pytest.param(("pds-core[test]>=0.6,<0.7",), id="extra"),
+    pytest.param(
+        ('pds-core>=0.6,<0.7; python_version >= "3.11"',),
+        id="environment-marker",
+    ),
+)
+
+
+@pytest.mark.parametrize("requirements", INVALID_CORE_REQUIREMENTS)
+@pytest.mark.parametrize("artifact_kind", ("wheel", "sdist"))
+def test_artifacts_reject_invalid_core_dependency_contracts(
+    tmp_path: Path,
+    artifact_kind: str,
+    requirements: tuple[str, ...],
+) -> None:
+    metadata = _metadata(*requirements)
+    if artifact_kind == "wheel":
+        artifact = _wheel(tmp_path / "invalid.whl", metadata=metadata)
+        inspect = inspect_wheel
+    else:
+        artifact = _sdist(tmp_path / "invalid.tar.gz", metadata=metadata)
+        inspect = inspect_sdist
+    with pytest.raises(AssertionError):
+        inspect(artifact)


### PR DESCRIPTION
# Upgrade Quillan to released Core 0.6

## Summary

Upgrades Quillan from the Core 0.5 dependency line to the released Core 0.6 line while preserving existing Quillan/PDS2 behavior.

The runtime dependency is now exactly:

```text
pds-core>=0.6,<0.7
```

The official qualification baseline remains the exact released Core 0.6.0 wheel:

```text
pds_core-0.6.0-py3-none-any.whl
SHA-256:
be28c061b38463ef59ebc328ed1aa443767fe7f2c626babb769c2d8e5932f308
```

This PR is limited to compatibility, packaging, CI, release tooling, installed validation, tests, and active documentation.

It does **not** implement Quillan's Core academic-publication workflows.

## What changed

### Core 0.6 dependency and compatibility

* Updated Quillan to `pds-core>=0.6,<0.7`.
* Preserved Quillan version `0.8.9` and Python `>=3.11`.
* Audited existing `pds_core` imports against released Core 0.6.0.
* Preserved strict mypy configuration and the existing scoped Core accommodation because Core 0.6 does not ship `py.typed`.
* Preserved all existing routing and PDS2 contracts.

Ordinary runtime compatibility accepts supported Core 0.6.x releases:

```text
>=0.6,<0.7
```

while official release qualification remains pinned to exact Core 0.6.0.

### Official Core artifact authentication

Updated `scripts/verify_core_wheel.py` to authenticate the released Core 0.6.0 wheel by:

* exact filename;
* exact SHA-256;
* distribution name;
* embedded version;
* wheel metadata structure;
* installed distribution identity;
* installed import origin;
* active-environment containment;
* source-checkout shadowing protection.

### Packaging hardening

Release artifact inspection now requires exactly one ordinary Core dependency equivalent to:

```text
pds-core>=0.6,<0.7
```

Core distribution names are compared using standard Python package-name normalization, so aliases such as:

```text
pds-core
pds_core
PDS.Core
```

are treated as the same distribution.

Wheel and sdist validation reject:

* missing Core requirements;
* duplicate Core requirements;
* duplicate normalized aliases;
* the old Core 0.5 range;
* incompatible Core 0.7 ranges;
* unbounded Core requirements;
* direct URLs;
* extras;
* environment markers;
* bundled `pds_core` source.

No `paper_data_suite.publication_producers` entry point is added.

### Development and release validation

Updated:

```text
scripts/validate_development_install.ps1
scripts/inspect_release_artifacts.py
scripts/run_installed_acceptance.py
.github/workflows/ci.yml
```

Validation now proves:

* editable and noneditable installation under Core 0.6;
* exact package metadata;
* isolated Core and Quillan import origins;
* no sibling-checkout shadowing;
* CLI/help imports remain side-effect free;
* clean wheel and sdist installation;
* installed Quillan workflow compatibility;
* no unintended Academic Period or academic-registry state.

### CI

CI now downloads and authenticates the exact released Core 0.6.0 wheel before installing Quillan.

The existing matrix remains:

```text
Windows + Ubuntu
Python 3.11, 3.12, 3.13, 3.14
```

All eight matrix jobs pass.

### PDS2 preservation

Existing Quillan behavior remains unchanged across:

* module-profile discovery;
* PDS2 routing;
* route registration;
* printable-response generation;
* retained-source intake;
* scan dispatch;
* response-page observation persistence;
* routed evidence;
* submission assembly;
* selected evidence;
* scan-review resolution;
* plain-paper workflows;
* teacher review;
* feedback export;
* assignment-local reporting.

The production chain remains:

```text
printable response
-> immutable response-page record
-> Core route registration
-> retained scan
-> Core dispatch
-> Quillan page observation
-> routed evidence
-> submission assembly
-> selected reviewable evidence
-> teacher review
```

### Publication-foundation preservation

The Core upgrade does not alter the contracts established by #356–#358:

```text
quillan_academic_result_manifest_v1
quillan_publication_projection_v1
quillan_publication_revision_v1
record_set_id = academic_results
```

No manifest generation, Academic Work Registration, publication producer profile, Publication Record workflow, supersession, withdrawal execution, or catalog behavior is added here.

Those remain owned by #360–#365.

## Documentation

Updated active Core/version guidance in:

```text
README.md
docs/data_contracts.md
docs/development_plan.md
docs/release_process.md
```

Historical Core 0.5 release records remain unchanged where they are still accurate historical documentation.

## Validation

Local qualification:

```text
Directly affected tests:
66 passed

Publication-foundation contracts:
181 passed

Required PDS2/Core regressions:
791 passed, 7 skipped

Full pytest:
2,129 passed, 17 skipped

Ruff:
PASS

mypy:
PASS — 251 source files

compileall:
PASS

pip check:
PASS

Documentation integrity:
PASS

Editable development install:
PASS

Noneditable development install:
PASS

run_tests.ps1:
PASS

Release-candidate qualification:
PASS

git diff --check:
PASS
```

The 17 skips are Windows symlink tests requiring privileges unavailable to the local process.

Release-candidate artifact hashes:

```text
Wheel:
0bb45792177dd430cd0665e1526befa3b78ebed7213c32f684e0bc0a070912c2

Sdist:
a56c1a4d46de63879c864b2ca938fc9f4b6a89b81c2066360b895a99983d61fe
```

Push-triggered GitHub Actions also passes the complete 8-job Windows/Linux × Python 3.11–3.14 matrix.

## Scope

This PR does not:

* bump Quillan to 0.9.0;
* change Python support;
* modify Core or another PDS repository;
* change PDS2;
* change the routing profile or route-registration schema;
* change assignment, submission, or review schemas;
* change Manifest v1;
* change Publication Projection Policy v1;
* change Publication Revision Policy v1;
* add Academic Work Registration;
* add Academic Period behavior;
* generate publication manifests;
* add a publication producer entry point;
* create Publication Records;
* implement supersession or withdrawals;
* add catalog behavior;
* add Meridian or Vitrine dependencies;
* add grading, proficiency, or portfolio policy.

## Follow-up ownership

* #360 — Academic Work Registration
* #361 — immutable manifest generation
* #362 — publication producer profile
* #363 — publication, supersession, and withdrawal workflows
* #364 — consumer-neutral reader
* #365 — installed producer acceptance
* #366 — release audit

Closes #359
