### PR TITLE
Implement immutable academic result manifest generation (#361)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Quillan
 
 Quillan's immutable producer-owned result contract is documented in
-[Academic Result Manifest v1](docs/academic_result_manifest_v1.md).
+[Academic Result Manifest v1](docs/academic_result_manifest_v1.md). Explicit
+workspace generation and immutable producer storage are documented in
+[Academic Result Manifest Generation](docs/academic_result_manifest_generation.md).
 
 > **Storage contract:** Quillan assignment, submission, review, feedback, and
 > assignment-report services use only
@@ -66,6 +68,7 @@ Quillan currently supports:
 * minimum-requirements review with explicit teacher-entered outcomes;
 * review-unit Focus Standard observations;
 * overall Focus Standard ratings;
+* explicit immutable Academic Result manifest generation and byte-exact replay;
 * Focus Standard feedback composition;
 * reusable Focus Standard comments in `shared/focus_standard_comments/`;
 * student feedback export to Markdown, PDF, or both;
@@ -92,6 +95,7 @@ classes/<class_id>/modules/quillan/work/<assignment_id>/submissions/<student_id>
 classes/<class_id>/modules/quillan/work/<assignment_id>/exports/student_performance_summary.csv
 classes/<class_id>/modules/quillan/work/<assignment_id>/exports/class_summary.csv
 classes/<class_id>/modules/quillan/work/<assignment_id>/exports/standards_summary.csv
+classes/<class_id>/modules/quillan/work/<assignment_id>/exports/manifests/academic_results/<revision>.json
 shared/focus_standard_comments/<comment_set_id>.json
 shared/standards/library.json
 scans/source/YYYY-MM-DD/
@@ -138,7 +142,9 @@ Assignment Management supports:
 1. Create writing assignment
 2. View/validate assignment
 3. Printable Response Pages
-4. Back
+4. Academic Work Registration
+5. Academic Result Manifests
+B. Back
 ```
 
 Assignment creation requires an existing roster and writes:
@@ -301,6 +307,7 @@ quillan review-status <class_id> <assignment_id> <student_id> --format json
 quillan assignment --help
 quillan roster --help
 quillan printable-responses --help
+quillan manifest --help
 quillan requirements --help
 quillan review-units --help
 quillan observations --help
@@ -322,6 +329,7 @@ Primary contracts:
 
 ```text
 docs/data_contracts.md
+docs/academic_result_manifest_generation.md
 docs/assignment_contract.md
 docs/review_record_contract.md
 docs/focus_standard_comment_contract.md

--- a/docs/academic_result_manifest_generation.md
+++ b/docs/academic_result_manifest_generation.md
@@ -1,0 +1,274 @@
+# Quillan Academic Result Manifest Generation
+
+## Purpose
+
+Quillan explicitly generates immutable producer-owned Academic Result Manifest
+revisions from one existing canonical managed assignment and its represented
+native submission/review records.
+
+The generated contract remains:
+
+```text
+record_type        = quillan_academic_result_manifest
+contract_version   = quillan_academic_result_manifest_v1
+producer_module_id = quillan
+record_set_id      = academic_results
+```
+
+Generation creates producer bytes only. It does not register Academic Work,
+create a Core Publication Record, publish or withdraw through Core, rebuild the
+academic catalog, infer Academic Period membership, calculate proficiency or a
+Grade, or select portfolio content.
+
+## Canonical storage
+
+Each immutable revision lives at:
+
+```text
+classes/<class_id>/modules/quillan/work/<assignment_id>/
+  exports/
+    manifests/
+      academic_results/
+        <revision>.json
+```
+
+Revision names are canonical positive decimal integers such as `1.json` and
+`17.json`. Quillan creates no mutable `latest.json`, `current.json`, or similar
+alias. The workspace-relative path is validated through Core's publication
+manifest path contract.
+
+## Native source population
+
+Generation starts from canonical schema-2 `assignment.json`. Student population
+is discovered only from direct canonical student directories under
+`submissions/`; the roster does not create result entries.
+
+A represented student requires both:
+
+```text
+submissions/<student_id>/submission.json  # schema 1
+submissions/<student_id>/review.json      # schema 2
+```
+
+A valid submission with no review is omitted as no represented result. An orphan
+review, malformed existing native record, unsafe/link-like path, or identity
+mismatch fails closed. An absent student entry means only that the manifest does
+not represent a Quillan result for that student; it is not zero, failure,
+missing work, excused work, or an inferred review state.
+
+Represented students are sorted deterministically by `student_id`.
+
+## Exact-byte source lineage
+
+Generation reuses Quillan's canonical record-context loaders. The exact bytes
+that are parsed and validated are the bytes hashed into manifest source
+snapshots.
+
+Source paths are work-root relative:
+
+```text
+assignment.json
+submissions/<student_id>/submission.json
+submissions/<student_id>/review.json
+```
+
+SHA-256 is calculated over exact source bytes without JSON normalization,
+line-ending normalization, decoding/re-encoding, or source rewriting.
+
+Before a new durable manifest revision is installed, Quillan reloads the
+generation context and requires the authoritative native source snapshot to
+remain unchanged. Concurrent edits, disappearance, type changes, unsafe links,
+or changed exact bytes fail the operation before the new manifest is claimed.
+
+## Standards and native educational meaning
+
+Generation loads the current Core standards library and validates the
+assignment's exact `standards_profile_id` and ordered `focus_standard_ids`.
+Unknown, duplicate, or out-of-profile standards fail closed.
+
+The manifest preserves the assignment-local rating scale exactly, including
+level order, integer values, labels, and descriptions. Every represented
+observation or overall rating must use one exact native scale value.
+
+Quillan does not map ratings to percentages, proficiency thresholds, mastery,
+Meridian values, or Grades. Overall Focus Standard ratings remain explicit
+teacher judgments and are never calculated from review-unit observations.
+Missing ratings remain missing rather than becoming the lowest scale value.
+
+Review state, submission state, minimum-requirement outcome, applicability,
+evidence presence, and nullable ratings remain distinct native states.
+
+## Plain paper and PDS2 provenance
+
+`plain_paper_manual` preserves:
+
+```text
+expected_pages = null
+digital_provenance = null
+```
+
+and never receives fabricated issuance, page, route, scan, observation, or
+artifact identity.
+
+For `pds2_response_pages`, generation publishes only authoritative selected
+evidence permitted by `quillan_publication_projection_v1`. Each selected
+reference must agree with its canonical response-page observation. Quillan
+also validates retained-source provenance and independently recomputes the
+retained source SHA-256, then verifies exact routed-evidence size and SHA-256.
+
+Candidate, unselected replacement, excluded, and unselected duplicate evidence
+do not enter the manifest. Source filenames, retained-source paths,
+routed-evidence paths, QR payloads, and other private locators are excluded.
+
+## Privacy projection
+
+Generation applies the existing pure
+`quillan_publication_projection_v1` functions for:
+
+- minimum-requirement outcome teacher notes;
+- review-unit observation rationales;
+- overall-rating rationales;
+- feedback comments; and
+- selected PDS2 evidence.
+
+`PublishedText` preserves `absent`, `withheld`, and `included` as different
+states. Existing native text is not automatically publication-approved.
+
+Always excluded from Manifest v1 are private notes, individual requirement-check
+internals, roster display data, emails/guardian data, reusable-comment
+provenance/live state, feedback-export metadata, arbitrary module details,
+private locator paths, and diagnostic/debug content.
+
+## Pure builder and workspace orchestration
+
+`quillan.academic_result_manifest_generation` separates validated immutable
+generation context from durable workspace orchestration.
+
+Pure builders construct the existing Manifest v1 model and serialize only
+through the canonical Manifest v1 serializer. They perform no registry,
+publication, catalog, roster, or consumer-policy I/O.
+
+Workspace orchestration owns native discovery, source/evidence validation,
+history loading, revision planning, locking, immutable creation, replay, and
+digest verification.
+
+## Strict history and revision planning
+
+Durable history is read only from the exact `academic_results` manifest
+directory. Every revision must:
+
+- use canonical `<positive integer>.json` naming;
+- be an ordinary non-link file;
+- contain exact canonical Manifest v1 bytes;
+- identify the expected work and `academic_results` record set; and
+- contain the same revision encoded by its filename.
+
+Unexpected durable entries fail closed. Revision gaps remain allocated.
+The highest durable revision is the producer predecessor.
+
+Generation delegates all revision classification to
+`quillan_publication_revision_v1`; it does not implement a second revision
+policy.
+
+The normal outcomes are:
+
+```text
+reuse_existing / exact_replay
+create_initial / initial_publication
+create_successor / native_source_changed
+create_successor / publication_projection_changed
+create_successor / historical_reversion
+create_successor / republication_after_withdrawal
+```
+
+## Exact replay
+
+When current publication content matches the producer head, generation returns
+the predecessor's exact stored bytes, path, revision, original `generated_at`,
+and SHA-256.
+
+Replay does not rewrite or touch the predecessor, call the production clock,
+create another revision, or allocate another revision number.
+
+## Immutable creation and durability
+
+One producer-owned lock covers the whole series operation:
+
+```text
+exports/manifests/academic_results/.write.lock
+```
+
+A pre-existing lock is a conflict and is never automatically deleted as stale.
+
+New revisions are installed exclusively through Quillan's immutable
+exclusive-record primitive. Manifest files never use the mutable
+`revision_guarded_update()` path. Existing revisions are never overwritten,
+repaired, deleted, renumbered, or normalized.
+
+The allocation boundary is:
+
+```text
+failure before durable immutable creation -> revision not consumed
+durable immutable creation               -> revision consumed
+```
+
+If failure occurs after a revision may be durable, Quillan preserves that file
+and returns explicit partial-success metadata rather than rolling it back or
+reusing the revision number.
+
+The returned digest is lowercase SHA-256 over the exact stored canonical
+manifest bytes, including the final newline.
+
+## Read-only producer APIs
+
+Producer-local read APIs list, load, and validate exact immutable revisions.
+They do not repair history or create Core publication state.
+
+The direct CLI is:
+
+```powershell
+quillan manifest list --class-id <class_id> --assignment-id <assignment_id>
+quillan manifest show --class-id <class_id> --assignment-id <assignment_id> --revision <revision>
+quillan manifest validate --class-id <class_id> --assignment-id <assignment_id> --revision <revision>
+quillan manifest generate --class-id <class_id> --assignment-id <assignment_id>
+```
+
+Routine output is privacy-minimized to producer metadata such as revision,
+timestamp, path, digest, and represented-student count. It does not print raw
+manifest JSON, student IDs, ratings, rationales, comments, observations, or
+evidence arrays.
+
+The teacher menu exposes:
+
+```text
+Assignment Management -> Academic Result Manifests
+```
+
+and requires typed `GENERATE` confirmation before generation.
+
+## Registration and publication boundaries
+
+Academic Work Registration and manifest generation are independent explicit
+operations. A manifest can exist without a registration, and a registration
+change alone does not allocate a manifest revision.
+
+Later #363 publication orchestration must independently reload canonical Core
+state and bind the exact applicable Academic Work Registration revision, exact
+manifest path, and exact manifest SHA-256 in the Core Publication Record.
+
+Producer profile registration belongs to #362; Core publication/supersession/
+withdrawal to #363; consumer-neutral authorized reading to #364; installed
+end-to-end producer acceptance to #365; and final release audit/version work to
+#366.
+
+## Explicit-only generation boundary
+
+Ordinary Quillan workflows do not generate manifests. This includes assignment
+creation/editing, Academic Work Registration, printable response generation,
+PDS2 routing/intake, observation persistence, submission assembly, plain-paper
+submission creation, page management, requirement review, review observations,
+overall ratings, feedback composition/export, reports, scan-review resolution,
+imports, help/version display, and module-profile discovery.
+
+Only the explicit manifest CLI/menu surfaces and later deliberately added typed
+producer orchestration may call durable manifest generation.

--- a/docs/academic_result_manifest_v1.md
+++ b/docs/academic_result_manifest_v1.md
@@ -13,16 +13,18 @@ consumer applies grading/reporting policy. A Quillan native rating scale is not
 a Meridian proficiency scale unless an explicit downstream versioned mapping
 policy says so.
 
-The module is a pure contract: it performs no workspace, registry, catalog,
-artifact, roster, or standards-library I/O and calculates no proficiency,
-Grade, missing-work state, or portfolio policy. Construction belongs to #361;
+The manifest model and canonical serializer remain a pure contract: they
+perform no workspace, registry, catalog, artifact, roster, or standards-library
+I/O and calculate no proficiency, Grade, missing-work state, or portfolio policy.
+Explicit workspace generation and immutable storage are implemented separately by
+[Academic Result Manifest Generation](academic_result_manifest_generation.md);
 privacy projection is defined by
 [Quillan Publication Projection Policy v1](publication_projection_policy_v1.md);
 revision, correction, and withdrawal behavior is defined by
 [Quillan Publication Revision Policy](publication_revision_policy.md); explicit
 assignment eligibility and Core registration are defined by
-[Quillan Academic Work Registration](academic_work_registration.md); and manifest
-generation/publication integration remains #361–#364.
+[Quillan Academic Work Registration](academic_work_registration.md); and Core producer-profile,
+publication, and reader integration remains #362–#364.
 
 ## Exact schema
 

--- a/docs/academic_work_registration.md
+++ b/docs/academic_work_registration.md
@@ -177,7 +177,7 @@ managed Quillan assignment
 -> Core Publication Record references registration revision N
 ```
 
-A later registration revision never rewrites an older manifest or Publication Record. Manifest generation belongs to #361; publication/supersession/withdrawal orchestration belongs to #363.
+A later registration revision never rewrites an older manifest or Publication Record. Explicit manifest generation is implemented independently under #361; see [Academic Result Manifest Generation](academic_result_manifest_generation.md). Publication/supersession/withdrawal orchestration belongs to #363.
 
 ## Explicit-only boundary
 

--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -50,6 +50,36 @@ concise and nonzero; partial success warns that durable Core state may exist.
 See [Quillan Academic Work Registration](academic_work_registration.md) for the
 eligibility, immutability, concurrency, and publication-boundary contract.
 
+## Academic Result Manifest Generation
+
+`quillan manifest` is the explicit producer-local namespace for immutable
+Quillan Academic Result Manifest revisions:
+
+```powershell
+quillan manifest list --class-id <class_id> --assignment-id <assignment_id>
+quillan manifest show --class-id <class_id> --assignment-id <assignment_id> --revision <revision>
+quillan manifest validate --class-id <class_id> --assignment-id <assignment_id> --revision <revision>
+quillan manifest generate --class-id <class_id> --assignment-id <assignment_id>
+```
+
+`list`, `show`, and `validate` are read-only producer-storage operations.
+`generate` validates current canonical native state and either creates the
+policy-selected immutable revision or returns a byte-exact replay of the
+existing producer head. The caller never supplies a revision.
+
+Routine output is privacy-minimized to work/revision metadata, path, digest,
+timestamp, and represented-student count. It does not print student IDs,
+ratings, rationales, comments, observations, evidence arrays, or raw manifest
+JSON. Expected validation, history, lock, and write failures are concise and
+nonzero without traceback. Partial success warns that an immutable revision may
+already be durable.
+
+Generation is independent of Academic Work Registration and creates no Core
+Publication Record, withdrawal, catalog, Academic Period, proficiency, Grade,
+or portfolio state. There is no overwrite, delete, repair, mutable-alias, or
+forced-revision command. See
+[Academic Result Manifest Generation](academic_result_manifest_generation.md).
+
 ## Direct Student Review Status
 
 `quillan review-status <class_id> <assignment_id> <student_id> [--format text|json]`
@@ -253,7 +283,9 @@ other suite data.
 ## Current Command Surface
 
 The current top-level command surface includes `quillan academic-work` for
-explicit Core Academic Work Registration of existing managed Quillan assignments.
+explicit Core Academic Work Registration of existing managed Quillan assignments
+and `quillan manifest` for explicit immutable producer-manifest generation and
+validation.
 
 The implemented command surface currently exposed through argparse is:
 
@@ -267,6 +299,10 @@ quillan review-workflow set-state <class_id> <assignment_id> <student_id> --stat
 quillan assignment create <class_id> <assignment_id> --title <title> --writing-type <type> (--prompt <text> | --prompt-file <path>) --standards-profile-id <profile_id> --focus-standard-ids <id,...> [--review-unit-type <type>] [--review-unit-singular <label>] [--review-unit-plural <label>] [--rating-scale default] [--paragraphs-min N] [--paragraphs-max N] [--word-count-min N] [--word-count-max N] [--required-elements <items>] [--allow-return-without-full-review true|false] [--overwrite] [--yes | --dry-run]
 quillan assignment show <class_id> <assignment_id>
 quillan assignment validate <class_id> <assignment_id>
+quillan manifest list --class-id <class_id> --assignment-id <assignment_id>
+quillan manifest show --class-id <class_id> --assignment-id <assignment_id> --revision <revision>
+quillan manifest validate --class-id <class_id> --assignment-id <assignment_id> --revision <revision>
+quillan manifest generate --class-id <class_id> --assignment-id <assignment_id>
 quillan printable-responses generate <class_id> <assignment_id> [--pages-per-student N] [--overwrite] (--yes | --dry-run)
 quillan requirements list <class_id> <assignment_id> <student_id>
 quillan requirements set-check <class_id> <assignment_id> <student_id> --requirement-key <key> --met true|false [--note <text>]

--- a/docs/cli_contract_inventory.json
+++ b/docs/cli_contract_inventory.json
@@ -705,6 +705,169 @@
     {
       "path": [
         "quillan",
+        "manifest"
+      ],
+      "aliases": [],
+      "short_help": "Create and inspect immutable Quillan Academic Result Manifests.",
+      "description": "List, show, validate, or explicitly generate immutable producer-owned Academic Result Manifest revisions. Generation does not publish through Core and does not create a Grade.",
+      "arguments": [],
+      "mutex_groups": []
+    },
+    {
+      "path": [
+        "quillan",
+        "manifest",
+        "list"
+      ],
+      "aliases": [],
+      "short_help": "List immutable manifest revisions with privacy-minimized metadata.",
+      "description": "",
+      "arguments": [
+        {
+          "names": [
+            "--class-id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Class identifier.",
+          "mutex_group": null
+        },
+        {
+          "names": [
+            "--assignment-id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Assignment identifier.",
+          "mutex_group": null
+        }
+      ],
+      "mutex_groups": []
+    },
+    {
+      "path": [
+        "quillan",
+        "manifest",
+        "show"
+      ],
+      "aliases": [],
+      "short_help": "Show privacy-minimized metadata for one immutable revision.",
+      "description": "",
+      "arguments": [
+        {
+          "names": [
+            "--class-id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Class identifier.",
+          "mutex_group": null
+        },
+        {
+          "names": [
+            "--assignment-id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Assignment identifier.",
+          "mutex_group": null
+        },
+        {
+          "names": [
+            "--revision"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Exact immutable manifest revision.",
+          "mutex_group": null
+        }
+      ],
+      "mutex_groups": []
+    },
+    {
+      "path": [
+        "quillan",
+        "manifest",
+        "validate"
+      ],
+      "aliases": [],
+      "short_help": "Strictly validate one immutable producer revision.",
+      "description": "",
+      "arguments": [
+        {
+          "names": [
+            "--class-id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Class identifier.",
+          "mutex_group": null
+        },
+        {
+          "names": [
+            "--assignment-id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Assignment identifier.",
+          "mutex_group": null
+        },
+        {
+          "names": [
+            "--revision"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Exact immutable manifest revision.",
+          "mutex_group": null
+        }
+      ],
+      "mutex_groups": []
+    },
+    {
+      "path": [
+        "quillan",
+        "manifest",
+        "generate"
+      ],
+      "aliases": [],
+      "short_help": "Generate the required next revision or byte-exactly replay the head.",
+      "description": "",
+      "arguments": [
+        {
+          "names": [
+            "--class-id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Class identifier.",
+          "mutex_group": null
+        },
+        {
+          "names": [
+            "--assignment-id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Assignment identifier.",
+          "mutex_group": null
+        }
+      ],
+      "mutex_groups": []
+    },
+    {
+      "path": [
+        "quillan",
         "printable-responses"
       ],
       "aliases": [],

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -11,6 +11,12 @@ The pure `quillan_academic_result_manifest_v1` contract is defined in
 native review meaning, Core verifies publication envelopes, and an authorized
 consumer owns later grading/reporting policy.
 
+Explicit native-source validation, privacy-safe projection, immutable revision
+storage, byte-exact replay, and producer digest generation are implemented in
+[Academic Result Manifest Generation](academic_result_manifest_generation.md).
+Manifest generation remains independent of Academic Work Registration and does
+not create Core publication or Grade state.
+
 The producer-owned privacy floor for manifest and later artifact projections is
 defined in
 [Quillan Publication Projection Policy v1](publication_projection_policy_v1.md).

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -1,8 +1,10 @@
 # Quillan Development Plan
 
-The pure Quillan Academic Result Manifest v1 contract now provides the base for
-later privacy, revision, Core integration, generation, publication, and reader
-work (#357–#364); this phase does not generate or publish workspace manifests.
+Quillan now has the complete producer-side foundation through #361:
+Academic Result Manifest v1, privacy projection, revision policy, Core 0.6
+compatibility, explicit Academic Work Registration, and explicit immutable
+workspace manifest generation/replay. Producer profile, Core publication
+lifecycle, and consumer-neutral reading remain #362–#364.
 
 Classification: **active authority** for the v0.8.9 release candidate.
 
@@ -28,8 +30,8 @@ regeneration, installed module-profile discovery, retained-once image/PDF/folder
 intake, Core routing review, Quillan post-dispatch review, digital and plain-paper
 submissions, teacher-controlled page management and standards-based review,
 feedback export, three assignment-local reports, dashboard schema version 2,
-student review status schema version 1, direct CLI commands, and the compact
-teacher menu.
+student review status schema version 1, explicit immutable Academic Result
+manifest generation/replay, direct CLI commands, and the compact teacher menu.
 
 ## Product boundaries
 
@@ -43,14 +45,30 @@ PDF scan intake uses `pdf2image` and requires Poppler on the host. Supported
 Python versions are CPython 3.11 through 3.14. Runtime Core compatibility is
 `pds-core>=0.6,<0.7`, with released Core 0.6.0 as the qualification baseline.
 
-Quillan now supports explicit Academic Work Registration for eligible managed
+Quillan supports explicit Academic Work Registration for eligible managed
 assignments through Core under `quillan_academic_work_v1`; ordinary assignment,
 PDS2, review, feedback, and reporting workflows never register work implicitly.
-Registration does not generate workspace Academic Result manifests, publish
-results, create Publication Records or withdrawals, rebuild the academic catalog,
+Registration itself does not generate manifests. A separate explicit #361
+workflow now validates native state and creates/replays immutable producer-owned
+Academic Result manifest revisions under
+`exports/manifests/academic_results/`. That workflow does not publish through
+Core, create Publication Records or withdrawals, rebuild the academic catalog,
 assign Academic Period membership, calculate proficiency or Grades, or create
-portfolio Candidates. #361 through #365 own those remaining producer workflows;
+portfolio Candidates. #362–#365 own the remaining producer integration;
 #366 owns the final release audit.
+
+## Core 0.6 academic-publication milestone status
+
+```text
+#359 Core 0.6 adoption                         complete
+#360 Academic Work Registration                complete
+#361 immutable manifest generation/validation complete
+#362 publication producer profile              remaining
+#363 publication lifecycle                     remaining
+#364 consumer-neutral reader                   remaining
+#365 installed end-to-end producer acceptance  remaining
+#366 release audit/version closeout             remaining
+```
 
 ## Release closeout
 

--- a/docs/publication_projection_policy_v1.md
+++ b/docs/publication_projection_policy_v1.md
@@ -637,9 +637,11 @@ must preserve.
 
 ### #361 — immutable manifest generation
 
-Loads and validates authoritative native records, applies this pure policy, constructs
-Academic Result Manifest v1, binds exact source bytes, and writes immutable manifest
-revisions.
+Implemented by
+[Academic Result Manifest Generation](academic_result_manifest_generation.md).
+The workspace layer loads and validates authoritative native records, applies
+this pure policy, constructs Academic Result Manifest v1, binds exact source
+bytes, and creates or byte-exactly replays immutable manifest revisions.
 
 ### #364 — consumer-neutral reader
 

--- a/docs/publication_revision_policy.md
+++ b/docs/publication_revision_policy.md
@@ -71,9 +71,10 @@ Quillan package version
 manifest models and returns immutable planning values.
 
 It performs no workspace, filesystem, hashing, registry, catalog, publication,
-withdrawal, authorization, grading, proficiency, or portfolio work. Manifest
-filesystem history belongs to #361. Core-backed publication lifecycle belongs to
-#363.
+withdrawal, authorization, grading, proficiency, or portfolio work. The separate
+[Academic Result Manifest Generation](academic_result_manifest_generation.md)
+implementation applies this pure policy to durable producer filesystem history.
+Core-backed publication lifecycle belongs to #363.
 
 ## Revision allocation
 
@@ -289,8 +290,9 @@ Producer manifest allocation and Core publication are independent histories. A
 manifest may exist without publication, and Core may still point to an older
 published producer revision.
 
-The pure revision policy does not inspect Core state. #361 owns durable producer
-manifest history. #363 reloads canonical Core state and reconciles publication.
+The pure revision policy does not inspect Core state. The #361 manifest
+generation/storage layer owns durable producer manifest history. #363 reloads
+canonical Core state and reconciles publication.
 
 ## Supersession
 
@@ -426,11 +428,11 @@ Academic Period membership, reporting, and downstream correction consequences.
 
 Vitrine owns portfolio candidacy, selection, snapshot, and disclosure policy.
 
-Follow-up implementation remains:
+Milestone implementation status:
 
-- #359: Core 0.6 dependency upgrade;
-- #360: Academic Work Registration;
-- #361: source loading, hashing, immutable manifest generation/storage;
+- #359: Core 0.6 dependency upgrade — complete;
+- #360: Academic Work Registration — complete;
+- #361: source loading, hashing, immutable manifest generation/storage — complete;
 - #362: producer compatibility profile;
 - #363: Core publication, supersession, withdrawal, reconciliation;
 - #364: consumer-neutral reader and authorized source/artifact resolution;

--- a/quillan/academic_result_manifest_generation.py
+++ b/quillan/academic_result_manifest_generation.py
@@ -1,0 +1,2327 @@
+"""Native validation and pure construction for Quillan Academic Result Manifest v1."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from datetime import date, datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.routing_models import ModuleWorkRef
+from pds_core.scan_retention import RetainedSourceScan
+from pds_core.standards import load_workspace_standards_library
+
+from quillan._path_safety import is_link_like
+from quillan.academic_result_manifest import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    ACADEMIC_RESULT_MANIFEST_PRODUCER_MODULE_ID,
+    ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+    ASSIGNMENT_SOURCE_CONTRACT_VERSION,
+    REVIEW_SOURCE_CONTRACT_VERSION,
+    SUBMISSION_SOURCE_CONTRACT_VERSION,
+    AcademicResultManifest,
+    AssignmentSnapshot,
+    BasicRequirements,
+    DigitalSubmissionProvenance,
+    EvidenceReference,
+    FeedbackComment,
+    FeedbackComposition,
+    MinimumRequirementOutcome,
+    MinimumRequirementPolicy,
+    MinimumRequirementStatus,
+    OverallStandardRating,
+    RatingScale,
+    RatingScaleLevel,
+    RecordSet,
+    ReviewSnapshot,
+    ReviewState,
+    ReviewUnit,
+    ReviewUnitDefinition,
+    SourceRecordSnapshot,
+    StandardFeedback,
+    StandardObservation,
+    StudentResult,
+    StudentSourceSnapshot,
+    SubmissionEntryMethod,
+    SubmissionSnapshot,
+    WorkReference,
+    manifest_from_json_bytes,
+    manifest_to_canonical_json_bytes,
+    validate_manifest,
+)
+from quillan.atomic_record_io import (
+    AtomicRecordConcurrencyError,
+    AtomicRecordDurabilityError,
+    AtomicRecordError,
+    create_exclusive_record,
+)
+from quillan.assignments import (
+    AssignmentConfigError,
+    validate_assignment_standards_selection,
+)
+from quillan.module_errors import (
+    QuillanRetainedSourceError,
+    QuillanRoutedEvidenceError,
+)
+from quillan.plain_paper_submission import (
+    PLAIN_PAPER_ENTRY_METHOD,
+    PLAIN_PAPER_PHYSICAL_EVIDENCE_STATUS,
+    PLAIN_PAPER_WORKFLOW,
+)
+from quillan.publication_projection_policy import (
+    QuillanPublicationProjectionPolicyError,
+    project_feedback_comment_text,
+    project_minimum_outcome_teacher_note,
+    project_observation_rationale,
+    project_overall_rating_rationale,
+    selected_pds2_evidence_is_publishable,
+)
+from quillan.publication_revision_policy import (
+    QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID,
+    ManifestRevisionDisposition,
+    ManifestRevisionReason,
+    next_record_set_revision,
+    plan_manifest_revision,
+)
+from quillan.record_context import (
+    LoadedJsonRecord,
+    MissingAssignmentError,
+    QuillanRecordContextError,
+    ReviewLoadingPolicy,
+    canonical_workspace_root,
+    load_quillan_assignment_context,
+    load_quillan_student_review_context,
+    mutable_json_copy,
+    student_record_paths,
+)
+from quillan.module_errors import QuillanObservationValidationError
+from quillan.response_page_observations import (
+    QuillanResponsePageObservation,
+    load_contextual_response_page_observation,
+)
+from quillan.retained_source import validate_quillan_retained_source
+from quillan.routed_evidence import verify_contextual_routed_page_evidence
+from quillan.submission_manifest import PDS2_SUBMISSION_ENTRY_METHOD
+from quillan.work_paths import (
+    academic_result_manifest_relative_path,
+    academic_result_manifest_revision_path,
+    academic_result_manifests_dir,
+    manifest_exports_dir,
+    preflight_work_directory_destination,
+    preflight_work_file_destination,
+    quillan_work_paths,
+    quillan_work_ref,
+)
+
+
+class QuillanManifestGenerationError(Exception):
+    """Base error for native manifest preparation and generation."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self._lock_cleanup_failure: ManifestGenerationCleanupFailure | None = None
+
+    @property
+    def lock_cleanup_failure(self) -> ManifestGenerationCleanupFailure | None:
+        """Describe a producer-lock cleanup failure accompanying this error."""
+        return self._lock_cleanup_failure
+
+    def _record_lock_cleanup_failure(
+        self, failure: ManifestGenerationCleanupFailure
+    ) -> None:
+        self._lock_cleanup_failure = failure
+
+
+class QuillanManifestGenerationValidationError(QuillanManifestGenerationError):
+    """Native data or caller input cannot form a valid manifest."""
+
+
+class QuillanManifestGenerationNotFoundError(QuillanManifestGenerationError):
+    """Required managed Quillan state does not exist."""
+
+
+class QuillanManifestGenerationConflictError(QuillanManifestGenerationError):
+    """Validated native state changed during one generation operation."""
+
+
+class QuillanManifestGenerationIntegrityError(QuillanManifestGenerationError):
+    """Persisted native provenance or immutable history contradicts identity."""
+
+
+class QuillanManifestGenerationWriteError(QuillanManifestGenerationError):
+    """Immutable producer storage could not be completed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestGenerationCleanupFailure:
+    """Privacy-minimized record of an owned generation lock cleanup failure."""
+
+    path: Path
+    relative_path: str
+    message: str
+    error: OSError
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, Path) or not self.path.is_absolute():
+            raise TypeError("Cleanup failure path must be an absolute Path.")
+        if type(self.relative_path) is not str or not self.relative_path:
+            raise ValueError("Cleanup failure relative_path must be nonempty text.")
+        if type(self.message) is not str or not self.message:
+            raise ValueError("Cleanup failure message must be nonempty text.")
+        if not isinstance(self.error, OSError):
+            raise TypeError("Cleanup failure error must be an OSError.")
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestGenerationPartialSuccessState:
+    """Bounded producer metadata for a revision that may already be durable."""
+
+    operation: str
+    work: ModuleWorkRef
+    revision: int
+    path: Path
+    relative_path: str
+    expected_sha256: str | None
+    durable_file_exists: bool
+    lock_cleanup_failure: ManifestGenerationCleanupFailure | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.operation) is not str or not self.operation:
+            raise ValueError("Partial-success operation must be nonempty text.")
+        _validate_work_ref(self.work)
+        if isinstance(self.revision, bool) or not isinstance(self.revision, int) or self.revision < 1:
+            raise ValueError("Partial-success revision must be a positive integer.")
+        if not isinstance(self.path, Path) or not self.path.is_absolute():
+            raise TypeError("Partial-success path must be an absolute Path.")
+        expected_relative = academic_result_manifest_relative_path(
+            self.work, self.revision
+        )
+        if self.relative_path != expected_relative:
+            raise ValueError("Partial-success relative path is not canonical.")
+        if self.expected_sha256 is not None and (
+            type(self.expected_sha256) is not str
+            or len(self.expected_sha256) != 64
+            or any(character not in "0123456789abcdef" for character in self.expected_sha256)
+        ):
+            raise ValueError("Partial-success digest must be lowercase SHA-256 text.")
+        if type(self.durable_file_exists) is not bool:
+            raise TypeError("durable_file_exists must be a Boolean.")
+        if (
+            self.lock_cleanup_failure is not None
+            and type(self.lock_cleanup_failure) is not ManifestGenerationCleanupFailure
+        ):
+            raise TypeError("lock_cleanup_failure has the wrong type.")
+
+
+class QuillanManifestGenerationPartialSuccessError(
+    QuillanManifestGenerationWriteError
+):
+    """A manifest revision may be durable although completion failed."""
+
+    def __init__(
+        self, message: str, state: ManifestGenerationPartialSuccessState
+    ) -> None:
+        super().__init__(message)
+        self.state = state
+        if state.lock_cleanup_failure is not None:
+            self._record_lock_cleanup_failure(state.lock_cleanup_failure)
+
+
+class _DurableManifestCreationError(Exception):
+    """Internal signal that immutable installation preceded a later failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class StoredAcademicResultManifest:
+    """One exact canonical immutable manifest revision read from producer storage."""
+
+    manifest: AcademicResultManifest
+    revision: int
+    path: Path
+    relative_path: str
+    content: bytes
+    sha256: str
+
+    def __post_init__(self) -> None:
+        _validate_stored_manifest_value(self)
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultManifestGenerationResult:
+    """One exact replay/creation result with immutable stored bytes."""
+
+    disposition: ManifestRevisionDisposition
+    reason: ManifestRevisionReason
+    manifest: AcademicResultManifest
+    revision: int
+    path: Path
+    relative_path: str
+    content: bytes
+    sha256: str
+
+    def __post_init__(self) -> None:
+        if self.disposition not in {
+            "reuse_existing",
+            "create_initial",
+            "create_successor",
+        }:
+            raise QuillanManifestGenerationValidationError(
+                "Generation result disposition is invalid."
+            )
+        if self.reason not in {
+            "exact_replay",
+            "initial_publication",
+            "native_source_changed",
+            "publication_projection_changed",
+            "historical_reversion",
+            "republication_after_withdrawal",
+        }:
+            raise QuillanManifestGenerationValidationError(
+                "Generation result reason is invalid."
+            )
+        _validate_stored_manifest_value(self)
+
+
+@dataclass(frozen=True, slots=True)
+class NativeRecordByteSnapshot:
+    """One exact validated native record bound to work-root-relative source bytes."""
+
+    path: Path
+    relative_path: str
+    content: bytes
+    sha256: str
+    contract_version: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, Path) or not self.path.is_absolute():
+            raise QuillanManifestGenerationValidationError(
+                "Native source path must be an absolute Path."
+            )
+        if type(self.relative_path) is not str or not self.relative_path:
+            raise QuillanManifestGenerationValidationError(
+                "Native source relative_path must be nonempty POSIX text."
+            )
+        relative = PurePosixPath(self.relative_path)
+        if (
+            relative.is_absolute()
+            or relative.as_posix() != self.relative_path
+            or any(part in {"", ".", ".."} for part in relative.parts)
+        ):
+            raise QuillanManifestGenerationValidationError(
+                "Native source relative_path must be canonical work-root-relative POSIX text."
+            )
+        if type(self.content) is not bytes:
+            raise QuillanManifestGenerationValidationError(
+                "Native source content must be exact bytes."
+            )
+        if self.sha256 != hashlib.sha256(self.content).hexdigest():
+            raise QuillanManifestGenerationIntegrityError(
+                "Native source digest disagrees with its exact bytes."
+            )
+        if type(self.contract_version) is not str or not self.contract_version:
+            raise QuillanManifestGenerationValidationError(
+                "Native source contract_version must be nonempty text."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestNativeStudentState:
+    """Validated direct submission-directory state for one student identity."""
+
+    student_id: str
+    submission_source: NativeRecordByteSnapshot | None
+    review_source: NativeRecordByteSnapshot | None
+    result: StudentResult | None
+
+    def __post_init__(self) -> None:
+        try:
+            validate_identifier(self.student_id, "student_id")
+        except (IdentifierValidationError, TypeError, ValueError) as error:
+            raise QuillanManifestGenerationValidationError(
+                "Native student state has an invalid student_id."
+            ) from error
+        if self.review_source is not None and self.submission_source is None:
+            raise QuillanManifestGenerationIntegrityError(
+                "Native student state cannot contain a review without a submission."
+            )
+        if self.result is not None:
+            if self.submission_source is None or self.review_source is None:
+                raise QuillanManifestGenerationIntegrityError(
+                    "A represented student requires both native source snapshots."
+                )
+            if self.result.student_id != self.student_id:
+                raise QuillanManifestGenerationIntegrityError(
+                    "Represented student identity disagrees with native directory identity."
+                )
+        elif self.review_source is not None:
+            raise QuillanManifestGenerationIntegrityError(
+                "A valid submission/review pair must produce a represented result."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultManifestGenerationContext:
+    """One immutable, fully validated native snapshot ready for pure construction."""
+
+    workspace_root: Path
+    work: ModuleWorkRef
+    assignment_source: NativeRecordByteSnapshot
+    assignment: AssignmentSnapshot
+    submissions_dir_present: bool
+    native_students: tuple[ManifestNativeStudentState, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.workspace_root, Path) or not self.workspace_root.is_absolute():
+            raise QuillanManifestGenerationValidationError(
+                "Generation workspace_root must be an absolute Path."
+            )
+        if Path(os.path.abspath(self.workspace_root)) != self.workspace_root:
+            raise QuillanManifestGenerationValidationError(
+                "Generation workspace_root must be canonical."
+            )
+        expected = quillan_work_ref(self.work.class_id, self.work.work_id)
+        if self.work != expected:
+            raise QuillanManifestGenerationValidationError(
+                "Generation work must be an exact Quillan ModuleWorkRef."
+            )
+        paths = quillan_work_paths(
+            self.workspace_root, self.work.class_id, self.work.work_id
+        )
+        if (
+            self.assignment_source.relative_path != "assignment.json"
+            or self.assignment_source.path != paths.assignment_path
+        ):
+            raise QuillanManifestGenerationIntegrityError(
+                "Assignment source must be the exact canonical assignment.json."
+            )
+        if self.assignment_source.contract_version != ASSIGNMENT_SOURCE_CONTRACT_VERSION:
+            raise QuillanManifestGenerationIntegrityError(
+                "Assignment source contract version is not schema 2."
+            )
+        if self.assignment.assignment_id != self.work.work_id:
+            raise QuillanManifestGenerationIntegrityError(
+                "Assignment snapshot identity disagrees with work identity."
+            )
+        if type(self.submissions_dir_present) is not bool:
+            raise QuillanManifestGenerationValidationError(
+                "submissions_dir_present must be a Boolean."
+            )
+        object.__setattr__(self, "native_students", tuple(self.native_students))
+        student_ids = tuple(item.student_id for item in self.native_students)
+        if student_ids != tuple(sorted(student_ids)) or len(set(student_ids)) != len(
+            student_ids
+        ):
+            raise QuillanManifestGenerationIntegrityError(
+                "Native student states must be unique and sorted by student_id."
+            )
+        if not self.submissions_dir_present and self.native_students:
+            raise QuillanManifestGenerationIntegrityError(
+                "Native student state cannot exist when the submissions directory is absent."
+            )
+        for state in self.native_students:
+            for source, suffix in (
+                (state.submission_source, "submission.json"),
+                (state.review_source, "review.json"),
+            ):
+                if source is None:
+                    continue
+                expected_relative = f"submissions/{state.student_id}/{suffix}"
+                expected_path = paths.work_root.joinpath(
+                    *PurePosixPath(expected_relative).parts
+                )
+                if (
+                    source.relative_path != expected_relative
+                    or source.path != expected_path
+                ):
+                    raise QuillanManifestGenerationIntegrityError(
+                        "Native student source is not stored at its exact canonical path."
+                    )
+            if state.result is not None:
+                if state.submission_source is None or state.review_source is None:
+                    raise QuillanManifestGenerationIntegrityError(
+                        "Represented native result is missing an exact source snapshot."
+                    )
+                if (
+                    state.result.source_snapshot.submission
+                    != SourceRecordSnapshot(
+                        state.submission_source.relative_path,
+                        state.submission_source.sha256,
+                        state.submission_source.contract_version,
+                    )
+                    or state.result.source_snapshot.review
+                    != SourceRecordSnapshot(
+                        state.review_source.relative_path,
+                        state.review_source.sha256,
+                        state.review_source.contract_version,
+                    )
+                ):
+                    raise QuillanManifestGenerationIntegrityError(
+                        "Represented native result source lineage disagrees with captured bytes."
+                    )
+
+    @property
+    def students(self) -> tuple[StudentResult, ...]:
+        """Return only represented results, preserving deterministic student order."""
+        return tuple(
+            state.result for state in self.native_students if state.result is not None
+        )
+
+
+@dataclass(slots=True)
+class _EvidenceValidationCache:
+    retained_by_path: dict[str, str]
+    retained_by_scan: dict[str, str]
+    retained_page_to_page_id: dict[tuple[str, int], str]
+    routed_by_path: dict[str, tuple[str, int]]
+    verified_retained: set[tuple[str, str]]
+    verified_routed: set[tuple[str, str, int]]
+
+    @classmethod
+    def empty(cls) -> _EvidenceValidationCache:
+        return cls({}, {}, {}, {}, set(), set())
+
+
+def discover_manifest_student_ids(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> tuple[bool, tuple[str, ...]]:
+    """Discover only safe direct submission-directory student identities."""
+    try:
+        root = canonical_workspace_root(workspace_root)
+        work_ref = _validate_work_ref(work_ref)
+        assignment_context = load_quillan_assignment_context(root, work_ref)
+        directory = assignment_context.paths.submissions_dir
+        if not os.path.lexists(directory):
+            return False, ()
+        if is_link_like(directory) or not directory.is_dir():
+            raise QuillanManifestGenerationValidationError(
+                "Submission collection must be an ordinary non-link directory."
+            )
+        student_ids: list[str] = []
+        for child in sorted(directory.iterdir(), key=lambda item: item.name):
+            if is_link_like(child) or not child.is_dir():
+                raise QuillanManifestGenerationValidationError(
+                    "Submission collection contains an unexpected direct child."
+                )
+            try:
+                student_ids.append(validate_identifier(child.name, "student_id"))
+            except (IdentifierValidationError, TypeError, ValueError) as error:
+                raise QuillanManifestGenerationValidationError(
+                    "Submission collection contains an invalid student directory name."
+                ) from error
+        return True, tuple(student_ids)
+    except QuillanManifestGenerationError:
+        raise
+    except MissingAssignmentError as error:
+        raise QuillanManifestGenerationNotFoundError(
+            "Managed Quillan assignment is missing."
+        ) from error
+    except QuillanRecordContextError as error:
+        raise QuillanManifestGenerationValidationError(
+            "Managed Quillan assignment context is invalid."
+        ) from error
+    except OSError as error:
+        raise QuillanManifestGenerationValidationError(
+            "Could not discover Quillan submission directories."
+        ) from error
+
+
+def load_academic_result_manifest_generation_context(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> AcademicResultManifestGenerationContext:
+    """Load and fully validate the native state used by one manifest candidate."""
+    try:
+        root = canonical_workspace_root(workspace_root)
+        work_ref = _validate_work_ref(work_ref)
+        assignment_context = load_quillan_assignment_context(root, work_ref)
+        assignment_record = assignment_context.assignment_record
+        assignment_data = mutable_json_copy(assignment_record.value)
+        class_ids = _list(assignment_data["class_ids"], "assignment.class_ids")
+        if work_ref.class_id not in class_ids:
+            raise QuillanManifestGenerationValidationError(
+                f"Class {work_ref.class_id!r} is not included in the assignment."
+            )
+        try:
+            standards_library = load_workspace_standards_library(root)
+            selected = validate_assignment_standards_selection(
+                assignment_data, standards_library
+            )
+        except (AssignmentConfigError, OSError, ValueError) as error:
+            raise QuillanManifestGenerationValidationError(
+                f"Assignment standards are not valid for manifest generation: {error}"
+            ) from error
+        native_focus = tuple(
+            _string(item, "assignment.focus_standard_ids[]")
+            for item in _list(
+                assignment_data["focus_standard_ids"],
+                "assignment.focus_standard_ids",
+            )
+        )
+        if selected != native_focus:
+            raise QuillanManifestGenerationIntegrityError(
+                "Validated Focus Standard order disagrees with the native assignment."
+            )
+        assignment = _build_assignment_snapshot(assignment_data)
+        assignment_source = _native_record_snapshot(
+            assignment_record,
+            assignment_context.paths.work_root,
+            expected_relative_path="assignment.json",
+            expected_contract_version=ASSIGNMENT_SOURCE_CONTRACT_VERSION,
+        )
+        submissions_present, student_ids = discover_manifest_student_ids(root, work_ref)
+        native_students: list[ManifestNativeStudentState] = []
+        evidence_cache = _EvidenceValidationCache.empty()
+        for student_id in student_ids:
+            paths = student_record_paths(root, work_ref, student_id)
+            submission_exists = os.path.lexists(paths.submission_manifest_path)
+            review_exists = os.path.lexists(paths.review_record_path)
+            if not submission_exists and not review_exists:
+                native_students.append(
+                    ManifestNativeStudentState(student_id, None, None, None)
+                )
+                continue
+            try:
+                student_context = load_quillan_student_review_context(
+                    root,
+                    work_ref,
+                    student_id,
+                    review_policy=ReviewLoadingPolicy.REVIEW_OPTIONAL,
+                )
+            except QuillanRecordContextError as error:
+                raise QuillanManifestGenerationIntegrityError(
+                    "Existing native student result state is invalid."
+                ) from error
+            submission_source = _native_record_snapshot(
+                student_context.submission_record,
+                assignment_context.paths.work_root,
+                expected_relative_path=f"submissions/{student_id}/submission.json",
+                expected_contract_version=SUBMISSION_SOURCE_CONTRACT_VERSION,
+            )
+            if student_context.review_record is None:
+                # The submission is validated but intentionally omitted from the
+                # publication result set. Its bytes are not manifest source lineage.
+                native_students.append(
+                    ManifestNativeStudentState(student_id, None, None, None)
+                )
+                continue
+            review_source = _native_record_snapshot(
+                student_context.review_record,
+                assignment_context.paths.work_root,
+                expected_relative_path=f"submissions/{student_id}/review.json",
+                expected_contract_version=REVIEW_SOURCE_CONTRACT_VERSION,
+            )
+            submission_data = mutable_json_copy(student_context.submission)
+            review_value = student_context.review
+            if review_value is None:
+                raise QuillanManifestGenerationIntegrityError(
+                    "Required represented review disappeared from its validated context."
+                )
+            review_data = mutable_json_copy(review_value)
+            submission = _build_submission_snapshot(
+                root,
+                work_ref,
+                submission_data,
+                evidence_cache,
+            )
+            review = _build_review_snapshot(review_data, assignment)
+            result = StudentResult(
+                student_id=student_id,
+                source_snapshot=StudentSourceSnapshot(
+                    submission=_source_record_snapshot(submission_source),
+                    review=_source_record_snapshot(review_source),
+                ),
+                submission=submission,
+                review=review,
+            )
+            native_students.append(
+                ManifestNativeStudentState(
+                    student_id,
+                    submission_source,
+                    review_source,
+                    result,
+                )
+            )
+        context = AcademicResultManifestGenerationContext(
+            workspace_root=root,
+            work=work_ref,
+            assignment_source=assignment_source,
+            assignment=assignment,
+            submissions_dir_present=submissions_present,
+            native_students=tuple(native_students),
+        )
+        # Validate the projected educational semantics now, before storage orchestration.
+        build_academic_result_manifest(
+            context,
+            record_set_revision=1,
+            generated_at=datetime(2000, 1, 1, tzinfo=timezone.utc),
+        )
+        return context
+    except QuillanManifestGenerationError:
+        raise
+    except MissingAssignmentError as error:
+        raise QuillanManifestGenerationNotFoundError(
+            "Managed Quillan assignment is missing."
+        ) from error
+    except QuillanRecordContextError as error:
+        raise QuillanManifestGenerationValidationError(
+            "Managed Quillan record context is invalid."
+        ) from error
+    except (
+        QuillanPublicationProjectionPolicyError,
+        QuillanObservationValidationError,
+    ) as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Native publication projection or selected observation is invalid."
+        ) from error
+    except (QuillanRetainedSourceError, QuillanRoutedEvidenceError) as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Selected publication evidence failed integrity validation."
+        ) from error
+    except OSError as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Could not validate manifest-native evidence."
+        ) from error
+
+
+def verify_generation_context_unchanged(
+    context: AcademicResultManifestGenerationContext,
+) -> None:
+    """Reload all native state and require exact equality with a captured context."""
+    if type(context) is not AcademicResultManifestGenerationContext:
+        raise QuillanManifestGenerationValidationError(
+            "context must be an AcademicResultManifestGenerationContext."
+        )
+    try:
+        current = load_academic_result_manifest_generation_context(
+            context.workspace_root, context.work
+        )
+    except QuillanManifestGenerationError as error:
+        raise QuillanManifestGenerationConflictError(
+            "Native Quillan state changed or became invalid after the generation snapshot."
+        ) from error
+    if current != context:
+        raise QuillanManifestGenerationConflictError(
+            "Native Quillan state changed after the generation snapshot."
+        )
+
+
+def build_academic_result_manifest(
+    context: AcademicResultManifestGenerationContext,
+    *,
+    record_set_revision: int,
+    generated_at: datetime,
+) -> AcademicResultManifest:
+    """Purely construct and validate one existing Quillan manifest-v1 model."""
+    if type(context) is not AcademicResultManifestGenerationContext:
+        raise QuillanManifestGenerationValidationError(
+            "context must be an AcademicResultManifestGenerationContext."
+        )
+    if isinstance(record_set_revision, bool) or not isinstance(
+        record_set_revision, int
+    ) or record_set_revision < 1:
+        raise QuillanManifestGenerationValidationError(
+            "record_set_revision must be a positive non-Boolean integer."
+        )
+    if (
+        not isinstance(generated_at, datetime)
+        or generated_at.tzinfo is None
+        or generated_at.utcoffset() is None
+    ):
+        raise QuillanManifestGenerationValidationError(
+            "generated_at must be a timezone-aware datetime."
+        )
+    manifest = AcademicResultManifest(
+        record_type=ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+        contract_version=ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+        producer_module_id=ACADEMIC_RESULT_MANIFEST_PRODUCER_MODULE_ID,
+        generated_at=generated_at,
+        record_set=RecordSet(
+            record_set_id=QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID,
+            revision=record_set_revision,
+        ),
+        work=WorkReference(
+            module_id=context.work.module_id,
+            class_id=context.work.class_id,
+            work_id=context.work.work_id,
+        ),
+        source_snapshot=_source_record_snapshot(context.assignment_source),
+        assignment=context.assignment,
+        students=context.students,
+    )
+    try:
+        return validate_manifest(manifest)
+    except Exception as error:
+        raise QuillanManifestGenerationValidationError(
+            f"Projected native state does not satisfy manifest v1: {error}"
+        ) from error
+
+
+def build_academic_result_manifest_bytes(
+    context: AcademicResultManifestGenerationContext,
+    *,
+    record_set_revision: int,
+    generated_at: datetime,
+) -> bytes:
+    """Purely construct and canonically serialize one manifest candidate."""
+    manifest = build_academic_result_manifest(
+        context,
+        record_set_revision=record_set_revision,
+        generated_at=generated_at,
+    )
+    return manifest_to_canonical_json_bytes(manifest)
+
+
+def _validate_stored_manifest_value(value: object) -> None:
+    manifest = getattr(value, "manifest", None)
+    revision = getattr(value, "revision", None)
+    path = getattr(value, "path", None)
+    relative_path = getattr(value, "relative_path", None)
+    content = getattr(value, "content", None)
+    digest = getattr(value, "sha256", None)
+    if (
+        not isinstance(manifest, AcademicResultManifest)
+        or isinstance(revision, bool)
+        or not isinstance(revision, int)
+        or revision < 1
+        or not isinstance(path, Path)
+        or not path.is_absolute()
+        or type(relative_path) is not str
+        or type(content) is not bytes
+        or type(digest) is not str
+    ):
+        raise QuillanManifestGenerationValidationError(
+            "Stored manifest value contains invalid typed fields."
+        )
+    try:
+        decoded = manifest_from_json_bytes(content)
+        canonical = manifest_to_canonical_json_bytes(decoded)
+        work = quillan_work_ref(
+            manifest.work.class_id,
+            manifest.work.work_id,
+        )
+        expected_relative = academic_result_manifest_relative_path(work, revision)
+    except Exception as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Stored manifest bytes or identity are invalid."
+        ) from error
+    relative_parts = PurePosixPath(expected_relative).parts
+    if (
+        decoded != manifest
+        or canonical != content
+        or manifest.producer_module_id != ACADEMIC_RESULT_MANIFEST_PRODUCER_MODULE_ID
+        or manifest.record_set.record_set_id != QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID
+        or manifest.record_set.revision != revision
+        or manifest.work.module_id != work.module_id
+        or relative_path != expected_relative
+        or tuple(path.parts[-len(relative_parts) :]) != relative_parts
+        or path.name != f"{revision}.json"
+        or digest != hashlib.sha256(content).hexdigest()
+    ):
+        raise QuillanManifestGenerationIntegrityError(
+            "Stored manifest fields do not agree."
+        )
+
+
+def _canonical_revision_name(name: str) -> int | None:
+    if not name.endswith(".json"):
+        return None
+    stem = name[:-5]
+    if not stem.isdecimal() or stem == "0":
+        return None
+    try:
+        revision = int(stem)
+    except ValueError:
+        return None
+    if str(revision) != stem:
+        return None
+    return revision
+
+
+def _load_manifest_history(
+    workspace_root: Path,
+    work_ref: ModuleWorkRef,
+    *,
+    allow_generation_lock: bool,
+) -> tuple[StoredAcademicResultManifest, ...]:
+    root = canonical_workspace_root(workspace_root)
+    work = _validate_work_ref(work_ref)
+    directory = academic_result_manifests_dir(root, work)
+    try:
+        preflight_work_directory_destination(
+            root,
+            work,
+            Path("exports") / "manifests" / "academic_results",
+        )
+    except Exception as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Academic-result manifest history path is unsafe."
+        ) from error
+    if not os.path.lexists(directory):
+        return ()
+    if is_link_like(directory) or not directory.is_dir():
+        raise QuillanManifestGenerationIntegrityError(
+            "Academic-result manifest history must be an ordinary non-link directory."
+        )
+    stored: list[StoredAcademicResultManifest] = []
+    try:
+        entries = sorted(directory.iterdir(), key=lambda item: item.name)
+    except OSError as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Could not enumerate immutable manifest history."
+        ) from error
+    for entry in entries:
+        if allow_generation_lock and entry.name == ".write.lock":
+            continue
+        revision = _canonical_revision_name(entry.name)
+        if revision is None:
+            raise QuillanManifestGenerationIntegrityError(
+                "Manifest history contains an unexpected or noncanonical entry."
+            )
+        if is_link_like(entry) or not entry.is_file():
+            raise QuillanManifestGenerationIntegrityError(
+                "Manifest revision must be an ordinary non-link file."
+            )
+        try:
+            content = entry.read_bytes()
+            manifest = manifest_from_json_bytes(content)
+            canonical = manifest_to_canonical_json_bytes(manifest)
+        except Exception as error:
+            raise QuillanManifestGenerationIntegrityError(
+                f"Manifest revision {revision} is invalid."
+            ) from error
+        if canonical != content:
+            raise QuillanManifestGenerationIntegrityError(
+                f"Manifest revision {revision} does not contain canonical bytes."
+            )
+        if (
+            manifest.record_type != ACADEMIC_RESULT_MANIFEST_RECORD_TYPE
+            or manifest.contract_version != ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION
+            or manifest.producer_module_id != ACADEMIC_RESULT_MANIFEST_PRODUCER_MODULE_ID
+            or manifest.record_set.record_set_id != QUILLAN_ACADEMIC_RESULT_RECORD_SET_ID
+            or manifest.record_set.revision != revision
+            or manifest.work.module_id != work.module_id
+            or manifest.work.class_id != work.class_id
+            or manifest.work.work_id != work.work_id
+        ):
+            raise QuillanManifestGenerationIntegrityError(
+                f"Manifest revision {revision} disagrees with its series or path."
+            )
+        stored.append(
+            StoredAcademicResultManifest(
+                manifest=manifest,
+                revision=revision,
+                path=entry,
+                relative_path=academic_result_manifest_relative_path(work, revision),
+                content=content,
+                sha256=hashlib.sha256(content).hexdigest(),
+            )
+        )
+    revisions = tuple(item.revision for item in stored)
+    if len(revisions) != len(set(revisions)):
+        raise QuillanManifestGenerationIntegrityError(
+            "Manifest history contains duplicate revisions."
+        )
+    return tuple(sorted(stored, key=lambda item: item.revision))
+
+
+def list_academic_result_manifest_revisions(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> tuple[StoredAcademicResultManifest, ...]:
+    """Read and strictly validate every durable producer revision in one series."""
+    try:
+        root = canonical_workspace_root(workspace_root)
+        work = _validate_work_ref(work_ref)
+        return _load_manifest_history(root, work, allow_generation_lock=False)
+    except QuillanManifestGenerationError:
+        raise
+    except QuillanRecordContextError as error:
+        raise QuillanManifestGenerationValidationError(
+            "Workspace root is invalid for manifest history loading."
+        ) from error
+
+
+def load_academic_result_manifest_revision(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    revision: int,
+) -> StoredAcademicResultManifest:
+    """Read one exact revision while validating the complete durable series."""
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+        raise QuillanManifestGenerationValidationError(
+            "revision must be a positive non-Boolean integer."
+        )
+    for stored in list_academic_result_manifest_revisions(workspace_root, work_ref):
+        if stored.revision == revision:
+            return stored
+    raise QuillanManifestGenerationNotFoundError(
+        f"Academic-result manifest revision {revision} was not found."
+    )
+
+
+def validate_academic_result_manifest_revision(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    revision: int,
+) -> StoredAcademicResultManifest:
+    """Read-only validation alias for one exact immutable producer revision."""
+    return load_academic_result_manifest_revision(workspace_root, work_ref, revision)
+
+
+def _prepare_manifest_generation_directory(
+    workspace_root: Path,
+    work_ref: ModuleWorkRef,
+) -> Path:
+    paths = quillan_work_paths(
+        workspace_root, work_ref.class_id, work_ref.work_id
+    )
+    try:
+        preflight_work_file_destination(
+            workspace_root, work_ref, "assignment.json"
+        )
+        preflight_work_directory_destination(
+            workspace_root,
+            work_ref,
+            Path("exports") / "manifests" / "academic_results",
+        )
+    except Exception as error:
+        raise QuillanManifestGenerationValidationError(
+            "Managed Quillan generation path is unsafe."
+        ) from error
+    if (
+        not os.path.lexists(paths.work_root)
+        or is_link_like(paths.work_root)
+        or not paths.work_root.is_dir()
+        or not os.path.lexists(paths.assignment_path)
+        or is_link_like(paths.assignment_path)
+        or not paths.assignment_path.is_file()
+    ):
+        raise QuillanManifestGenerationNotFoundError(
+            "Managed Quillan assignment does not exist as ordinary canonical work."
+        )
+    manifests = manifest_exports_dir(workspace_root, work_ref)
+    directory = academic_result_manifests_dir(workspace_root, work_ref)
+    for candidate in (paths.exports_dir, manifests, directory):
+        if os.path.lexists(candidate):
+            if is_link_like(candidate) or not candidate.is_dir():
+                raise QuillanManifestGenerationConflictError(
+                    "Manifest generation path contains an unsafe filesystem entry."
+                )
+            continue
+        try:
+            candidate.mkdir()
+        except FileExistsError:
+            if is_link_like(candidate) or not candidate.is_dir():
+                raise QuillanManifestGenerationConflictError(
+                    "Manifest generation directory was concurrently replaced."
+                )
+        except OSError as error:
+            raise QuillanManifestGenerationWriteError(
+                "Could not create the contained manifest generation directory."
+            ) from error
+        if is_link_like(candidate) or not candidate.is_dir():
+            raise QuillanManifestGenerationConflictError(
+                "Manifest generation directory changed filesystem type."
+            )
+    try:
+        preflight_work_directory_destination(
+            workspace_root,
+            work_ref,
+            Path("exports") / "manifests" / "academic_results",
+        )
+    except Exception as error:
+        raise QuillanManifestGenerationConflictError(
+            "Manifest generation directory became unsafe."
+        ) from error
+    return directory
+
+
+def _generation_lock_relative_path(work_ref: ModuleWorkRef) -> str:
+    return (
+        academic_result_manifest_relative_path(work_ref, 1).rsplit("/", 1)[0]
+        + "/.write.lock"
+    )
+
+
+def _acquire_generation_lock(directory: Path) -> tuple[Path, bytes]:
+    lock_path = directory / ".write.lock"
+    token = b"quillan-manifest-generation-v1\0" + os.urandom(32)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except FileExistsError as error:
+        raise QuillanManifestGenerationConflictError(
+            "Another manifest generation operation holds .write.lock."
+        ) from error
+    except OSError as error:
+        raise QuillanManifestGenerationWriteError(
+            "Could not create the manifest generation lock."
+        ) from error
+    write_error: OSError | None = None
+    try:
+        written = os.write(descriptor, token)
+        if written != len(token):
+            raise OSError("Generation lock token write was incomplete.")
+        os.fsync(descriptor)
+    except OSError as error:
+        write_error = error
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError as error:
+            if write_error is None:
+                write_error = error
+    if write_error is not None:
+        cleanup: OSError | None = None
+        try:
+            _release_generation_lock(lock_path, token)
+        except OSError as error:
+            cleanup = error
+        failure = QuillanManifestGenerationWriteError(
+            "Could not durably establish the manifest generation lock."
+        )
+        if cleanup is not None:
+            failure.add_note("Owned generation lock cleanup also failed.")
+        raise failure from write_error
+    return lock_path, token
+
+
+def _release_generation_lock(lock_path: Path, token: bytes) -> None:
+    try:
+        if is_link_like(lock_path) or not lock_path.is_file():
+            raise OSError("Owned generation lock changed filesystem type.")
+        if lock_path.read_bytes() != token:
+            raise OSError("Owned generation lock token changed.")
+        lock_path.unlink()
+    except OSError:
+        raise
+
+
+def _sync_directory(directory: Path) -> None:
+    if os.name == "nt":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(directory, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _verify_created_manifest_bytes(
+    actual: bytes,
+    *,
+    expected_manifest: AcademicResultManifest,
+    expected_bytes: bytes,
+) -> None:
+    try:
+        decoded = manifest_from_json_bytes(actual)
+        canonical = manifest_to_canonical_json_bytes(decoded)
+    except Exception as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Created manifest bytes are invalid."
+        ) from error
+    if actual != expected_bytes or canonical != actual or decoded != expected_manifest:
+        raise QuillanManifestGenerationIntegrityError(
+            "Created manifest bytes contradict the generated candidate."
+        )
+
+
+def _create_immutable_manifest_revision(
+    workspace_root: Path,
+    work_ref: ModuleWorkRef,
+    *,
+    revision: int,
+    manifest: AcademicResultManifest,
+    content: bytes,
+) -> Path:
+    target = academic_result_manifest_revision_path(
+        workspace_root, work_ref, revision
+    )
+    relative_work_path = (
+        Path("exports") / "manifests" / "academic_results" / f"{revision}.json"
+    )
+
+    def preflight() -> None:
+        try:
+            checked = preflight_work_file_destination(
+                workspace_root, work_ref, relative_work_path
+            )
+        except Exception as error:
+            raise QuillanManifestGenerationConflictError(
+                "Planned manifest revision path became unsafe."
+            ) from error
+        if checked != target:
+            raise QuillanManifestGenerationIntegrityError(
+                "Planned manifest revision path is not canonical."
+            )
+
+    def verify_bytes(actual: bytes) -> None:
+        _verify_created_manifest_bytes(
+            actual,
+            expected_manifest=manifest,
+            expected_bytes=content,
+        )
+
+    try:
+        result = create_exclusive_record(
+            target,
+            content,
+            preflight=preflight,
+            verify_bytes=verify_bytes,
+        )
+    except AtomicRecordConcurrencyError as error:
+        raise QuillanManifestGenerationConflictError(
+            "The planned immutable manifest revision already exists or changed."
+        ) from error
+    except AtomicRecordDurabilityError as error:
+        if error.possibly_durable_path is not None:
+            raise _DurableManifestCreationError(
+                "Manifest revision may be durable after atomic creation failure."
+            ) from error
+        raise QuillanManifestGenerationWriteError(
+            "Manifest revision creation guard cleanup failed before durable creation."
+        ) from error
+    except AtomicRecordError as error:
+        raise QuillanManifestGenerationWriteError(
+            "Could not exclusively create the immutable manifest revision."
+        ) from error
+    if result.status != "created" or result.path != target:
+        raise QuillanManifestGenerationIntegrityError(
+            "Exclusive manifest writer returned an unexpected result."
+        )
+    try:
+        _sync_directory(target.parent)
+    except OSError as error:
+        raise _DurableManifestCreationError(
+            "Manifest revision is installed but directory sync failed."
+        ) from error
+    return target
+
+
+def _clock_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_generation_time(clock: Callable[[], datetime]) -> datetime:
+    try:
+        value = clock()
+    except Exception as error:
+        raise QuillanManifestGenerationValidationError(
+            "Manifest generation clock failed."
+        ) from error
+    if (
+        not isinstance(value, datetime)
+        or value.tzinfo is None
+        or value.utcoffset() is None
+    ):
+        raise QuillanManifestGenerationValidationError(
+            "Manifest generation clock must return an aware datetime."
+        )
+    return value.astimezone(timezone.utc)
+
+
+def _run_prewrite_verification_hook(
+    context: AcademicResultManifestGenerationContext,
+) -> None:
+    """No-op seam for deterministic concurrency/failure tests."""
+
+
+def generate_academic_result_manifest(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    *,
+    republish_after_withdrawal: bool = False,
+    clock: Callable[[], datetime] = _clock_now,
+) -> AcademicResultManifestGenerationResult:
+    """Generate or byte-exactly replay one immutable producer manifest revision."""
+    if type(republish_after_withdrawal) is not bool:
+        raise QuillanManifestGenerationValidationError(
+            "republish_after_withdrawal must be a Boolean."
+        )
+    if not callable(clock):
+        raise QuillanManifestGenerationValidationError("clock must be callable.")
+    try:
+        root = canonical_workspace_root(workspace_root)
+        work = quillan_work_ref(class_id, assignment_id)
+        _validate_work_ref(work)
+    except QuillanRecordContextError as error:
+        raise QuillanManifestGenerationValidationError(
+            "workspace_root is invalid."
+        ) from error
+    except Exception as error:
+        raise QuillanManifestGenerationValidationError(
+            "class_id and assignment_id must be safe identifiers."
+        ) from error
+
+    directory = _prepare_manifest_generation_directory(root, work)
+    lock_path, lock_token = _acquire_generation_lock(directory)
+    operation_error: BaseException | None = None
+    durable_path: Path | None = None
+    durable_revision: int | None = None
+    expected_digest: str | None = None
+    try:
+        history = _load_manifest_history(
+            root, work, allow_generation_lock=True
+        )
+        revisions = tuple(item.revision for item in history)
+        predecessor = history[-1] if history else None
+        context = load_academic_result_manifest_generation_context(root, work)
+        candidate_revision = next_record_set_revision(revisions)
+        provisional_time = (
+            predecessor.manifest.generated_at
+            if predecessor is not None
+            else _new_generation_time(clock)
+        )
+        candidate = build_academic_result_manifest(
+            context,
+            record_set_revision=candidate_revision,
+            generated_at=provisional_time,
+        )
+        plan = plan_manifest_revision(
+            predecessor=(predecessor.manifest if predecessor is not None else None),
+            candidate=candidate,
+            allocated_revisions=revisions,
+            historical_manifests=tuple(item.manifest for item in history[:-1]),
+            republish_after_withdrawal=republish_after_withdrawal,
+        )
+        if plan.disposition != "reuse_existing" and predecessor is not None:
+            generated_at = _new_generation_time(clock)
+            candidate = build_academic_result_manifest(
+                context,
+                record_set_revision=candidate_revision,
+                generated_at=generated_at,
+            )
+            replanned = plan_manifest_revision(
+                predecessor=predecessor.manifest,
+                candidate=candidate,
+                allocated_revisions=revisions,
+                historical_manifests=tuple(item.manifest for item in history[:-1]),
+                republish_after_withdrawal=republish_after_withdrawal,
+            )
+            if (
+                replanned.disposition != plan.disposition
+                or replanned.reason != plan.reason
+                or replanned.record_set_revision != plan.record_set_revision
+            ):
+                raise QuillanManifestGenerationIntegrityError(
+                    "Revision planning changed when only generated_at changed."
+                )
+            plan = replanned
+        _run_prewrite_verification_hook(context)
+        verify_generation_context_unchanged(context)
+        if plan.disposition == "reuse_existing":
+            if predecessor is None or not plan.reuse_existing_bytes:
+                raise QuillanManifestGenerationIntegrityError(
+                    "Exact replay plan does not identify existing immutable bytes."
+                )
+            return AcademicResultManifestGenerationResult(
+                disposition=plan.disposition,
+                reason=plan.reason,
+                manifest=predecessor.manifest,
+                revision=predecessor.revision,
+                path=predecessor.path,
+                relative_path=predecessor.relative_path,
+                content=predecessor.content,
+                sha256=predecessor.sha256,
+            )
+        if (
+            plan.record_set_revision != candidate_revision
+            or candidate.record_set.revision != plan.record_set_revision
+        ):
+            raise QuillanManifestGenerationIntegrityError(
+                "Revision planner and candidate revision disagree."
+            )
+        candidate_bytes = manifest_to_canonical_json_bytes(candidate)
+        expected_digest = hashlib.sha256(candidate_bytes).hexdigest()
+        target = academic_result_manifest_revision_path(
+            root, work, plan.record_set_revision
+        )
+        relative = academic_result_manifest_relative_path(
+            work, plan.record_set_revision
+        )
+        try:
+            _create_immutable_manifest_revision(
+                root,
+                work,
+                revision=plan.record_set_revision,
+                manifest=candidate,
+                content=candidate_bytes,
+            )
+        except _DurableManifestCreationError as error:
+            durable_path = target
+            durable_revision = plan.record_set_revision
+            state = ManifestGenerationPartialSuccessState(
+                operation="durable_create",
+                work=work,
+                revision=plan.record_set_revision,
+                path=target,
+                relative_path=relative,
+                expected_sha256=expected_digest,
+                durable_file_exists=os.path.lexists(target),
+            )
+            raise QuillanManifestGenerationPartialSuccessError(
+                "Manifest revision may be durable but creation did not finish cleanly.",
+                state,
+            ) from error
+        durable_path = target
+        durable_revision = plan.record_set_revision
+        try:
+            stored_history = _load_manifest_history(
+                root, work, allow_generation_lock=True
+            )
+            stored = next(
+                item
+                for item in stored_history
+                if item.revision == plan.record_set_revision
+            )
+            if (
+                stored.content != candidate_bytes
+                or stored.manifest != candidate
+                or stored.sha256 != expected_digest
+            ):
+                raise QuillanManifestGenerationIntegrityError(
+                    "Durable manifest revision contradicts the generated candidate."
+                )
+            result_value = AcademicResultManifestGenerationResult(
+                disposition=plan.disposition,
+                reason=plan.reason,
+                manifest=stored.manifest,
+                revision=stored.revision,
+                path=stored.path,
+                relative_path=stored.relative_path,
+                content=stored.content,
+                sha256=stored.sha256,
+            )
+        except Exception as error:
+            state = ManifestGenerationPartialSuccessState(
+                operation="final_verification",
+                work=work,
+                revision=plan.record_set_revision,
+                path=target,
+                relative_path=relative,
+                expected_sha256=expected_digest,
+                durable_file_exists=os.path.lexists(target),
+            )
+            raise QuillanManifestGenerationPartialSuccessError(
+                "Manifest revision is durable but final verification failed.",
+                state,
+            ) from error
+        return result_value
+    except QuillanManifestGenerationError as error:
+        operation_error = error
+        raise
+    except Exception as error:
+        normalized = QuillanManifestGenerationIntegrityError(
+            "Manifest generation validation or revision planning failed."
+        )
+        operation_error = normalized
+        raise normalized from error
+    except BaseException as error:
+        operation_error = error
+        raise
+    finally:
+        try:
+            _release_generation_lock(lock_path, lock_token)
+        except OSError as cleanup_error:
+            cleanup_failure = ManifestGenerationCleanupFailure(
+                path=lock_path,
+                relative_path=_generation_lock_relative_path(work),
+                message="Owned manifest generation lock cleanup failed.",
+                error=cleanup_error,
+            )
+            if operation_error is None:
+                if durable_path is not None and durable_revision is not None:
+                    state = ManifestGenerationPartialSuccessState(
+                        operation="lock_cleanup",
+                        work=work,
+                        revision=durable_revision,
+                        path=durable_path,
+                        relative_path=academic_result_manifest_relative_path(
+                            work, durable_revision
+                        ),
+                        expected_sha256=expected_digest,
+                        durable_file_exists=os.path.lexists(durable_path),
+                        lock_cleanup_failure=cleanup_failure,
+                    )
+                    raise QuillanManifestGenerationPartialSuccessError(
+                        "Manifest is durable but generation lock cleanup failed.",
+                        state,
+                    ) from cleanup_error
+                cleanup_failure_error = QuillanManifestGenerationWriteError(
+                    "Manifest generation lock cleanup failed."
+                )
+                cleanup_failure_error._record_lock_cleanup_failure(cleanup_failure)
+                raise cleanup_failure_error from cleanup_error
+            if isinstance(operation_error, QuillanManifestGenerationError):
+                operation_error._record_lock_cleanup_failure(cleanup_failure)
+                if isinstance(
+                    operation_error, QuillanManifestGenerationPartialSuccessError
+                ):
+                    operation_error.state = replace(
+                        operation_error.state,
+                        lock_cleanup_failure=cleanup_failure,
+                    )
+            else:
+                operation_error.add_note(
+                    "Owned manifest generation lock cleanup also failed."
+                )
+
+
+def _native_record_snapshot(
+    record: LoadedJsonRecord,
+    work_root: Path,
+    *,
+    expected_relative_path: str,
+    expected_contract_version: str,
+) -> NativeRecordByteSnapshot:
+    if type(record) is not LoadedJsonRecord:
+        raise QuillanManifestGenerationValidationError(
+            "Native source must be a validated LoadedJsonRecord."
+        )
+    try:
+        relative = record.path.relative_to(work_root).as_posix()
+    except ValueError as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Native record path escapes the selected managed work root."
+        ) from error
+    if relative != expected_relative_path:
+        raise QuillanManifestGenerationIntegrityError(
+            "Native source is not stored at its required canonical work-relative path."
+        )
+    contract = record.value.get("schema_version")
+    if contract != expected_contract_version:
+        raise QuillanManifestGenerationIntegrityError(
+            "Native source has the wrong contract version for manifest generation."
+        )
+    return NativeRecordByteSnapshot(
+        path=record.path,
+        relative_path=relative,
+        content=record.original_bytes,
+        sha256=hashlib.sha256(record.original_bytes).hexdigest(),
+        contract_version=expected_contract_version,
+    )
+
+
+def _source_record_snapshot(value: NativeRecordByteSnapshot) -> SourceRecordSnapshot:
+    return SourceRecordSnapshot(
+        relative_path=value.relative_path,
+        sha256=value.sha256,
+        contract_version=value.contract_version,
+    )
+
+
+def _build_assignment_snapshot(assignment: dict[str, Any]) -> AssignmentSnapshot:
+    review_unit = _mapping(assignment["review_unit"], "assignment.review_unit")
+    rating_scale = _mapping(assignment["rating_scale"], "assignment.rating_scale")
+    levels = tuple(
+        RatingScaleLevel(
+            value=_integer(level["value"], "rating_scale.level.value"),
+            label=_string(level["label"], "rating_scale.level.label"),
+            description=_string(
+                level["description"], "rating_scale.level.description"
+            ),
+        )
+        for level in (
+            _mapping(item, "assignment.rating_scale.levels[]")
+            for item in _list(
+                rating_scale["levels"], "assignment.rating_scale.levels"
+            )
+        )
+    )
+    basic = _mapping(
+        assignment["basic_requirements"], "assignment.basic_requirements"
+    )
+    policy = _mapping(
+        assignment["minimum_requirement_policy"],
+        "assignment.minimum_requirement_policy",
+    )
+    return AssignmentSnapshot(
+        assignment_id=_string(assignment["assignment_id"], "assignment.assignment_id"),
+        title=_string(assignment["title"], "assignment.title"),
+        writing_type=_string(assignment["writing_type"], "assignment.writing_type"),
+        student_prompt=_string(
+            assignment["student_prompt"], "assignment.student_prompt"
+        ),
+        standards_profile_id=_string(
+            assignment["standards_profile_id"], "assignment.standards_profile_id"
+        ),
+        focus_standard_ids=tuple(
+            _string(item, "assignment.focus_standard_ids[]")
+            for item in _list(
+                assignment["focus_standard_ids"], "assignment.focus_standard_ids"
+            )
+        ),
+        review_unit=ReviewUnitDefinition(
+            type=_string(review_unit["type"], "assignment.review_unit.type"),
+            singular_label=_string(
+                review_unit["singular_label"], "assignment.review_unit.singular_label"
+            ),
+            plural_label=_string(
+                review_unit["plural_label"], "assignment.review_unit.plural_label"
+            ),
+        ),
+        rating_scale=RatingScale(
+            scale_id=_string(rating_scale["scale_id"], "assignment.rating_scale.scale_id"),
+            levels=levels,
+        ),
+        basic_requirements=BasicRequirements(
+            paragraphs_min=_optional_integer(basic.get("paragraphs_min")),
+            paragraphs_max=_optional_integer(basic.get("paragraphs_max")),
+            word_count_min=_optional_integer(basic.get("word_count_min")),
+            word_count_max=_optional_integer(basic.get("word_count_max")),
+            required_elements=tuple(
+                _string(item, "assignment.basic_requirements.required_elements[]")
+                for item in _list(
+                    basic.get("required_elements", []),
+                    "assignment.basic_requirements.required_elements",
+                )
+            ),
+        ),
+        minimum_requirement_policy=MinimumRequirementPolicy(
+            allow_return_without_full_review=_boolean(
+                policy["allow_return_without_full_review"],
+                "assignment.minimum_requirement_policy.allow_return_without_full_review",
+            )
+        ),
+    )
+
+
+def _build_submission_snapshot(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    submission: dict[str, Any],
+    cache: _EvidenceValidationCache,
+) -> SubmissionSnapshot:
+    details = _mapping(submission["module_details"], "submission.module_details")
+    entry_method = details.get("submission_entry_method")
+    class_id = _string(submission["class_id"], "submission.class_id")
+    assignment_id = _string(submission["assignment_id"], "submission.assignment_id")
+    student_id = _string(submission["student_id"], "submission.student_id")
+    submission_state = _string(
+        submission["submission_state"], "submission.submission_state"
+    )
+    if entry_method == PLAIN_PAPER_ENTRY_METHOD:
+        expected_plain_details = {
+            "submission_entry_method": PLAIN_PAPER_ENTRY_METHOD,
+            "physical_evidence_status": PLAIN_PAPER_PHYSICAL_EVIDENCE_STATUS,
+            "created_by_workflow": PLAIN_PAPER_WORKFLOW,
+        }
+        if details != expected_plain_details:
+            raise QuillanManifestGenerationValidationError(
+                "Plain-paper native provenance markers are incomplete or contradictory."
+            )
+        if submission["expected_pages"] is not None or _list(
+            submission["pages"], "submission.pages"
+        ):
+            raise QuillanManifestGenerationValidationError(
+                "Plain-paper native submissions require null expected_pages and no page evidence."
+            )
+        return SubmissionSnapshot(
+            class_id=class_id,
+            assignment_id=assignment_id,
+            student_id=student_id,
+            submission_state=submission_state,
+            entry_method=cast(SubmissionEntryMethod, PLAIN_PAPER_ENTRY_METHOD),
+            expected_pages=None,
+            digital_provenance=None,
+        )
+    if entry_method != PDS2_SUBMISSION_ENTRY_METHOD:
+        raise QuillanManifestGenerationValidationError(
+            "Native submission_entry_method must be 'plain_paper_manual' or "
+            "'pds2_response_pages' for publication."
+        )
+    expected_pages = _positive_integer(
+        submission["expected_pages"], "submission.expected_pages"
+    )
+    issuance_id = _string(details["response_issuance_id"], "response_issuance_id")
+    generation_id = _string(details["generation_id"], "generation_id")
+    artifact_id = _string(details["artifact_id"], "artifact_id")
+    expected_page_ids = tuple(
+        _string(item, "expected_page_ids[]")
+        for item in _list(details["expected_page_ids"], "expected_page_ids")
+    )
+    references: list[EvidenceReference] = []
+    for page_value in _list(submission["pages"], "submission.pages"):
+        page = _mapping(page_value, "submission.pages[]")
+        selected_id = page["selected_evidence_id"]
+        if selected_id is not None:
+            selected_id = _string(selected_id, "page.selected_evidence_id")
+        for evidence_value in _list(page["evidence"], "page.evidence"):
+            evidence = _mapping(evidence_value, "page.evidence[]")
+            try:
+                publishable = selected_pds2_evidence_is_publishable(
+                    page_selected_evidence_id=selected_id,
+                    evidence_id=_string(evidence["evidence_id"], "evidence.evidence_id"),
+                    evidence_role=_string(evidence["evidence_role"], "evidence.evidence_role"),
+                )
+            except QuillanPublicationProjectionPolicyError as error:
+                raise QuillanManifestGenerationIntegrityError(str(error)) from error
+            if publishable:
+                references.append(
+                    _build_selected_evidence_reference(
+                        root,
+                        work_ref,
+                        page,
+                        evidence,
+                        expected_pages=expected_pages,
+                        expected_student_id=student_id,
+                        cache=cache,
+                    )
+                )
+    provenance = DigitalSubmissionProvenance(
+        issuance_id=issuance_id,
+        generation_id=generation_id,
+        artifact_id=artifact_id,
+        expected_page_ids=expected_page_ids,
+        evidence_references=tuple(references),
+    )
+    return SubmissionSnapshot(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        submission_state=submission_state,
+        entry_method=cast(SubmissionEntryMethod, PDS2_SUBMISSION_ENTRY_METHOD),
+        expected_pages=expected_pages,
+        digital_provenance=provenance,
+    )
+
+
+def _build_selected_evidence_reference(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    page: dict[str, Any],
+    evidence: dict[str, Any],
+    *,
+    expected_pages: int,
+    expected_student_id: str,
+    cache: _EvidenceValidationCache,
+) -> EvidenceReference:
+    evidence_id = _string(evidence["evidence_id"], "evidence.evidence_id")
+    detail = _mapping(evidence["module_details"], "evidence.module_details")
+    retained = _mapping(evidence["retained_source"], "evidence.retained_source")
+    try:
+        observation = load_contextual_response_page_observation(
+            root, work_ref, evidence_id
+        )
+    except (QuillanObservationValidationError, OSError) as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Selected evidence has no valid canonical observation."
+        ) from error
+    _require_observation_agreement(
+        observation,
+        work_ref=work_ref,
+        page=page,
+        evidence=evidence,
+        detail=detail,
+        retained=retained,
+        expected_pages=expected_pages,
+        expected_student_id=expected_student_id,
+    )
+    _validate_observation_evidence_files(root, work_ref, observation, cache)
+    return EvidenceReference(
+        page_id=observation.page_id,
+        evidence_id=observation.observation_id,
+        observation_id=observation.observation_id,
+        route_id=observation.route_id,
+        issuance_id=observation.issuance_id,
+        generation_id=observation.generation_id,
+        artifact_id=observation.artifact_id,
+        source_page_number=observation.source_page_number,
+        source_scan_id=observation.source_scan_id,
+        source_sha256=observation.source_sha256,
+        routed_evidence_sha256=observation.routed_evidence_sha256,
+    )
+
+
+def _require_observation_agreement(
+    observation: QuillanResponsePageObservation,
+    *,
+    work_ref: ModuleWorkRef,
+    page: dict[str, Any],
+    evidence: dict[str, Any],
+    detail: dict[str, Any],
+    retained: dict[str, Any],
+    expected_pages: int,
+    expected_student_id: str,
+) -> None:
+    page_number = _positive_integer(page["page_number"], "page.page_number")
+    expected: tuple[tuple[object, object, str], ...] = (
+        (observation.class_id, work_ref.class_id, "class_id"),
+        (observation.assignment_id, work_ref.work_id, "assignment_id"),
+        (observation.student_id, expected_student_id, "student_id"),
+        (observation.observation_id, evidence["evidence_id"], "observation_id/evidence_id"),
+        (observation.observation_id, detail["observation_id"], "module observation_id"),
+        (observation.page_id, detail["page_id"], "page_id"),
+        (observation.route_id, detail["route_id"], "route_id"),
+        (observation.issuance_id, detail["issuance_id"], "issuance_id"),
+        (observation.generation_id, detail["generation_id"], "generation_id"),
+        (observation.artifact_id, detail["artifact_id"], "artifact_id"),
+        (observation.logical_page, page_number, "logical_page"),
+        (observation.logical_page, detail["logical_page"], "module logical_page"),
+        (observation.total_pages, expected_pages, "total_pages"),
+        (observation.total_pages, detail["total_pages"], "module total_pages"),
+        (observation.page_role, detail["page_role"], "page_role"),
+        (observation.source_scan_id, retained["source_scan_id"], "source_scan_id"),
+        (observation.source_filename, retained["source_filename"], "source_filename"),
+        (observation.source_sha256, retained["source_sha256"], "source_sha256"),
+        (
+            observation.source_page_number,
+            retained["source_page_number"],
+            "source_page_number",
+        ),
+        (
+            observation.retained_source_path,
+            retained["retained_source_path"],
+            "retained_source_path",
+        ),
+        (
+            observation.routed_evidence_path,
+            evidence["routed_evidence_path"],
+            "routed_evidence_path",
+        ),
+        (
+            observation.routed_evidence_sha256,
+            detail["routed_evidence_sha256"],
+            "routed_evidence_sha256",
+        ),
+        (
+            observation.routed_evidence_kind,
+            detail["routed_evidence_kind"],
+            "routed_evidence_kind",
+        ),
+    )
+    for actual, native, field in expected:
+        if actual != native:
+            raise QuillanManifestGenerationIntegrityError(
+                f"Selected evidence canonical observation disagrees on {field}."
+            )
+
+
+def _validate_observation_evidence_files(
+    root: Path,
+    work_ref: ModuleWorkRef,
+    observation: QuillanResponsePageObservation,
+    cache: _EvidenceValidationCache,
+) -> None:
+    previous_path_digest = cache.retained_by_path.setdefault(
+        observation.retained_source_path, observation.source_sha256
+    )
+    if previous_path_digest != observation.source_sha256:
+        raise QuillanManifestGenerationIntegrityError(
+            "One retained-source path identifies contradictory source digests."
+        )
+    previous_scan_digest = cache.retained_by_scan.setdefault(
+        observation.source_scan_id, observation.source_sha256
+    )
+    if previous_scan_digest != observation.source_sha256:
+        raise QuillanManifestGenerationIntegrityError(
+            "One source_scan_id identifies contradictory source digests."
+        )
+    source_page_key = (observation.source_scan_id, observation.source_page_number)
+    previous_page_id = cache.retained_page_to_page_id.setdefault(
+        source_page_key, observation.page_id
+    )
+    if previous_page_id != observation.page_id:
+        raise QuillanManifestGenerationIntegrityError(
+            "One retained source page identifies contradictory page IDs."
+        )
+    routed_claim = (
+        observation.routed_evidence_sha256,
+        observation.routed_evidence_size_bytes,
+    )
+    previous_routed_claim = cache.routed_by_path.setdefault(
+        observation.routed_evidence_path, routed_claim
+    )
+    if previous_routed_claim != routed_claim:
+        raise QuillanManifestGenerationIntegrityError(
+            "One routed-evidence path identifies contradictory digest or size claims."
+        )
+
+    retained_key = (observation.retained_source_path, observation.source_sha256)
+    if retained_key not in cache.verified_retained:
+        retained_path = root.joinpath(
+            *PurePosixPath(observation.retained_source_path).parts
+        )
+        retained = RetainedSourceScan(
+            source_scan_id=observation.source_scan_id,
+            source_filename=observation.source_filename,
+            source_sha256=observation.source_sha256,
+            retained_source_path=retained_path,
+            retained_source_relative_path=observation.retained_source_path,
+            intake_timestamp=_timestamp(observation.intake_timestamp, "intake_timestamp"),
+            intake_date=_date(observation.intake_date, "intake_date"),
+        )
+        try:
+            validate_quillan_retained_source(
+                retained,
+                workspace_root=root,
+                source_page_number=observation.source_page_number,
+            )
+        except (QuillanRetainedSourceError, ValueError, OSError) as error:
+            raise QuillanManifestGenerationIntegrityError(
+                "Selected evidence retained-source provenance is invalid."
+            ) from error
+        digest, _ = _stable_file_digest(retained_path)
+        if digest != observation.source_sha256:
+            raise QuillanManifestGenerationIntegrityError(
+                "Selected evidence retained-source bytes do not match source_sha256."
+            )
+        cache.verified_retained.add(retained_key)
+
+    routed_key = (
+        observation.routed_evidence_path,
+        observation.routed_evidence_sha256,
+        observation.routed_evidence_size_bytes,
+    )
+    if routed_key not in cache.verified_routed:
+        extension = PurePosixPath(observation.routed_evidence_path).suffix
+        try:
+            routed_path = verify_contextual_routed_page_evidence(
+                root,
+                work_ref,
+                issuance_id=observation.issuance_id,
+                student_id=observation.student_id,
+                logical_page=observation.logical_page,
+                observation_id=observation.observation_id,
+                extension=extension,
+                relative_path=observation.routed_evidence_path,
+                expected_sha256=observation.routed_evidence_sha256,
+                expected_size_bytes=observation.routed_evidence_size_bytes,
+            )
+        except (QuillanRoutedEvidenceError, OSError) as error:
+            raise QuillanManifestGenerationIntegrityError(
+                "Selected routed evidence failed canonical size/hash validation."
+            ) from error
+        digest, size = _stable_file_digest(routed_path)
+        if (
+            digest != observation.routed_evidence_sha256
+            or size != observation.routed_evidence_size_bytes
+        ):
+            raise QuillanManifestGenerationIntegrityError(
+                "Selected routed evidence changed during integrity validation."
+            )
+        cache.verified_routed.add(routed_key)
+
+
+def _build_review_snapshot(
+    review: dict[str, Any], assignment: AssignmentSnapshot
+) -> ReviewSnapshot:
+    feedback_data = _mapping(review["feedback"], "review.feedback")
+    standard_feedback_values = tuple(
+        _mapping(item, "review.feedback.standard_feedback[]")
+        for item in _list(
+            feedback_data["standard_feedback"],
+            "review.feedback.standard_feedback",
+        )
+    )
+    standard_feedback_by_id = {
+        _string(item["standard_id"], "standard_feedback.standard_id"): item
+        for item in standard_feedback_values
+    }
+    included_by_standard: Mapping[str, tuple[str, ...]] = {
+        standard_id: tuple(
+            _string(value, "standard_feedback.included_observation_ids[]")
+            for value in _list(
+                item["included_observation_ids"],
+                "standard_feedback.included_observation_ids",
+            )
+        )
+        for standard_id, item in standard_feedback_by_id.items()
+    }
+    include_units = _boolean(
+        feedback_data["include_review_unit_observations"],
+        "feedback.include_review_unit_observations",
+    )
+    include_overall = _boolean(
+        feedback_data["include_overall_standard_ratings"],
+        "feedback.include_overall_standard_ratings",
+    )
+    review_units: list[ReviewUnit] = []
+    for unit_value in _list(review["review_units"], "review.review_units"):
+        unit = _mapping(unit_value, "review.review_units[]")
+        observations: list[StandardObservation] = []
+        for observation_value in _list(
+            unit["standard_observations"], "review_unit.standard_observations"
+        ):
+            observation = _mapping(
+                observation_value, "review_unit.standard_observations[]"
+            )
+            observation_id = _string(
+                observation["observation_id"], "standard_observation.observation_id"
+            )
+            standard_id = _string(
+                observation["standard_id"], "standard_observation.standard_id"
+            )
+            rationale = project_observation_rationale(
+                _optional_string(observation["rationale"]),
+                include_review_unit_observations=include_units,
+                observation_id=observation_id,
+                standard_id=standard_id,
+                included_observation_ids_by_standard=included_by_standard,
+            )
+            observations.append(
+                StandardObservation(
+                    observation_id=observation_id,
+                    standard_id=standard_id,
+                    applicable=_boolean(
+                        observation["applicable"], "standard_observation.applicable"
+                    ),
+                    evidence_present=_optional_boolean(
+                        observation["evidence_present"],
+                        "standard_observation.evidence_present",
+                    ),
+                    rating=_optional_integer(observation["rating"]),
+                    rationale=rationale,
+                    include_in_feedback=_boolean(
+                        observation["include_in_feedback"],
+                        "standard_observation.include_in_feedback",
+                    ),
+                    updated_at=_timestamp(
+                        observation["updated_at"], "standard_observation.updated_at"
+                    ),
+                )
+            )
+        review_units.append(
+            ReviewUnit(
+                unit_id=_string(unit["unit_id"], "review_unit.unit_id"),
+                sequence=_positive_integer(unit["sequence"], "review_unit.sequence"),
+                label=_string(unit["label"], "review_unit.label"),
+                unit_type=_string(unit["unit_type"], "review_unit.unit_type"),
+                standard_observations=tuple(observations),
+            )
+        )
+
+    overall_ratings: list[OverallStandardRating] = []
+    for rating_value in _list(
+        review["overall_standard_ratings"], "review.overall_standard_ratings"
+    ):
+        rating = _mapping(rating_value, "review.overall_standard_ratings[]")
+        standard_id = _string(
+            rating["standard_id"], "overall_standard_rating.standard_id"
+        )
+        controls = standard_feedback_by_id.get(standard_id)
+        rationale = project_overall_rating_rationale(
+            _optional_string(rating["rationale"]),
+            include_overall_standard_ratings=include_overall,
+            rating_include_in_feedback=_boolean(
+                rating["include_in_feedback"],
+                "overall_standard_rating.include_in_feedback",
+            ),
+            standard_feedback_include_overall_rating=(
+                None
+                if controls is None
+                else _boolean(
+                    controls["include_overall_rating"],
+                    "standard_feedback.include_overall_rating",
+                )
+            ),
+            standard_feedback_include_overall_rationale=(
+                None
+                if controls is None
+                else _boolean(
+                    controls["include_overall_rationale"],
+                    "standard_feedback.include_overall_rationale",
+                )
+            ),
+        )
+        overall_ratings.append(
+            OverallStandardRating(
+                standard_id=standard_id,
+                rating=_integer(rating["rating"], "overall_standard_rating.rating"),
+                rationale=rationale,
+                include_in_feedback=_boolean(
+                    rating["include_in_feedback"],
+                    "overall_standard_rating.include_in_feedback",
+                ),
+                updated_at=_timestamp(
+                    rating["updated_at"], "overall_standard_rating.updated_at"
+                ),
+            )
+        )
+
+    standard_feedback: list[StandardFeedback] = []
+    for item in standard_feedback_values:
+        comments: list[FeedbackComment] = []
+        for comment_value in _list(item["comments"], "standard_feedback.comments"):
+            comment = _mapping(comment_value, "standard_feedback.comments[]")
+            projected = project_feedback_comment_text(
+                _string(comment["text"], "feedback_comment.text"),
+                include_in_feedback=_boolean(
+                    comment["include_in_feedback"],
+                    "feedback_comment.include_in_feedback",
+                ),
+            )
+            if projected is None:
+                continue
+            comments.append(
+                FeedbackComment(
+                    feedback_comment_id=_string(
+                        comment["feedback_comment_id"],
+                        "feedback_comment.feedback_comment_id",
+                    ),
+                    text=projected,
+                    include_in_feedback=True,
+                    created_at=_timestamp(
+                        comment["created_at"], "feedback_comment.created_at"
+                    ),
+                )
+            )
+        standard_feedback.append(
+            StandardFeedback(
+                standard_id=_string(
+                    item["standard_id"], "standard_feedback.standard_id"
+                ),
+                include_overall_rating=_boolean(
+                    item["include_overall_rating"],
+                    "standard_feedback.include_overall_rating",
+                ),
+                include_overall_rationale=_boolean(
+                    item["include_overall_rationale"],
+                    "standard_feedback.include_overall_rationale",
+                ),
+                included_observation_ids=tuple(
+                    _string(value, "standard_feedback.included_observation_ids[]")
+                    for value in _list(
+                        item["included_observation_ids"],
+                        "standard_feedback.included_observation_ids",
+                    )
+                ),
+                comments=tuple(comments),
+            )
+        )
+
+    outcome_data = _mapping(
+        review["minimum_requirement_outcome"],
+        "review.minimum_requirement_outcome",
+    )
+    returned = _boolean(
+        outcome_data["returned_without_full_review"],
+        "minimum_requirement_outcome.returned_without_full_review",
+    )
+    if returned and not assignment.minimum_requirement_policy.allow_return_without_full_review:
+        raise QuillanManifestGenerationValidationError(
+            "Review returns work without full review but assignment policy forbids that outcome."
+        )
+    review_state = _string(review["review_state"], "review.review_state")
+    teacher_note = project_minimum_outcome_teacher_note(
+        _optional_string(outcome_data["teacher_note"]),
+        status=_string(outcome_data["status"], "minimum_requirement_outcome.status"),
+        returned_without_full_review=returned,
+        review_state=review_state,
+    )
+    outcome = MinimumRequirementOutcome(
+        status=cast(
+            MinimumRequirementStatus,
+            _string(outcome_data["status"], "minimum_requirement_outcome.status"),
+        ),
+        returned_without_full_review=returned,
+        updated_at=(
+            None
+            if outcome_data["updated_at"] is None
+            else _timestamp(
+                outcome_data["updated_at"], "minimum_requirement_outcome.updated_at"
+            )
+        ),
+        teacher_note=teacher_note,
+    )
+    return ReviewSnapshot(
+        class_id=_string(review["class_id"], "review.class_id"),
+        assignment_id=_string(review["assignment_id"], "review.assignment_id"),
+        student_id=_string(review["student_id"], "review.student_id"),
+        review_state=cast(ReviewState, review_state),
+        minimum_requirement_outcome=outcome,
+        review_units=tuple(review_units),
+        overall_standard_ratings=tuple(overall_ratings),
+        feedback=FeedbackComposition(
+            include_review_unit_observations=include_units,
+            include_overall_standard_ratings=include_overall,
+            standard_feedback=tuple(standard_feedback),
+        ),
+    )
+
+
+def _stable_file_digest(path: Path) -> tuple[str, int]:
+    if is_link_like(path):
+        raise QuillanManifestGenerationIntegrityError(
+            "Evidence source must not be a symbolic link or junction."
+        )
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Could not open exact evidence bytes."
+        ) from error
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise QuillanManifestGenerationIntegrityError(
+                "Evidence source must be an ordinary file."
+            )
+        digest = hashlib.sha256()
+        size = 0
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+            size += len(chunk)
+        after = os.fstat(descriptor)
+    except OSError as error:
+        raise QuillanManifestGenerationIntegrityError(
+            "Could not read stable exact evidence bytes."
+        ) from error
+    finally:
+        os.close(descriptor)
+    if (
+        before.st_dev != after.st_dev
+        or before.st_ino != after.st_ino
+        or before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+        or size != before.st_size
+    ):
+        raise QuillanManifestGenerationConflictError(
+            "Evidence changed while being validated."
+        )
+    return digest.hexdigest(), size
+
+
+def _validate_work_ref(work_ref: object) -> ModuleWorkRef:
+    if not isinstance(work_ref, ModuleWorkRef):
+        raise QuillanManifestGenerationValidationError(
+            "work_ref must be a ModuleWorkRef."
+        )
+    expected = quillan_work_ref(work_ref.class_id, work_ref.work_id)
+    if work_ref != expected:
+        raise QuillanManifestGenerationValidationError(
+            "work_ref must be an exact Quillan work reference."
+        )
+    return work_ref
+
+
+
+def _mapping(value: object, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise QuillanManifestGenerationValidationError(f"{field} must be an object.")
+    return cast(dict[str, Any], value)
+
+
+def _list(value: object, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise QuillanManifestGenerationValidationError(f"{field} must be a list.")
+    return value
+
+
+def _string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise QuillanManifestGenerationValidationError(
+            f"{field} must be nonempty text."
+        )
+    return value
+
+
+def _boolean(value: object, field: str) -> bool:
+    if type(value) is not bool:
+        raise QuillanManifestGenerationValidationError(f"{field} must be a Boolean.")
+    return value
+
+
+def _optional_boolean(value: object, field: str) -> bool | None:
+    if value is None:
+        return None
+    return _boolean(value, field)
+
+
+def _integer(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise QuillanManifestGenerationValidationError(f"{field} must be an integer.")
+    return value
+
+
+def _positive_integer(value: object, field: str) -> int:
+    result = _integer(value, field)
+    if result < 1:
+        raise QuillanManifestGenerationValidationError(
+            f"{field} must be a positive integer."
+        )
+    return result
+
+
+def _optional_integer(value: object) -> int | None:
+    if value is None:
+        return None
+    return _integer(value, "optional integer")
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    return _string(value, "optional text")
+
+
+def _timestamp(value: object, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise QuillanManifestGenerationValidationError(
+            f"{field} must be timezone-aware ISO timestamp text."
+        )
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise QuillanManifestGenerationValidationError(
+            f"{field} must be valid ISO timestamp text."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise QuillanManifestGenerationValidationError(
+            f"{field} must be timezone-aware."
+        )
+    return parsed
+
+
+def _date(value: object, field: str) -> date:
+    if not isinstance(value, str):
+        raise QuillanManifestGenerationValidationError(
+            f"{field} must be ISO date text."
+        )
+    try:
+        return date.fromisoformat(value)
+    except ValueError as error:
+        raise QuillanManifestGenerationValidationError(
+            f"{field} must be valid ISO date text."
+        ) from error
+
+
+__all__ = [
+    "AcademicResultManifestGenerationContext",
+    "AcademicResultManifestGenerationResult",
+    "ManifestGenerationCleanupFailure",
+    "ManifestGenerationPartialSuccessState",
+    "ManifestNativeStudentState",
+    "NativeRecordByteSnapshot",
+    "QuillanManifestGenerationConflictError",
+    "QuillanManifestGenerationError",
+    "QuillanManifestGenerationIntegrityError",
+    "QuillanManifestGenerationNotFoundError",
+    "QuillanManifestGenerationPartialSuccessError",
+    "QuillanManifestGenerationValidationError",
+    "QuillanManifestGenerationWriteError",
+    "StoredAcademicResultManifest",
+    "build_academic_result_manifest",
+    "build_academic_result_manifest_bytes",
+    "discover_manifest_student_ids",
+    "generate_academic_result_manifest",
+    "list_academic_result_manifest_revisions",
+    "load_academic_result_manifest_generation_context",
+    "load_academic_result_manifest_revision",
+    "validate_academic_result_manifest_revision",
+    "verify_generation_context_unchanged",
+]

--- a/quillan/assignment_workflows.py
+++ b/quillan/assignment_workflows.py
@@ -1242,6 +1242,7 @@ def launch_assignment_menu() -> int:
             print("2. View/validate assignment")
             print("3. Printable Response Pages")
             print("4. Academic Work Registration")
+            print("5. Academic Result Manifests")
             print_navigation_options()
             print()
             choice = input("Select an option: ").strip()
@@ -1267,6 +1268,12 @@ def launch_assignment_menu() -> int:
                 )
 
                 launch_academic_work_registration_menu()
+            elif choice == "5":
+                from quillan.manifest_menu import (
+                    launch_academic_result_manifest_menu,
+                )
+
+                launch_academic_result_manifest_menu()
             elif workflow is None:
                 print(f"Invalid selection. {navigation_hint()}")
             else:

--- a/quillan/cli_app/handlers/manifest.py
+++ b/quillan/cli_app/handlers/manifest.py
@@ -1,0 +1,140 @@
+"""Direct immutable Academic Result Manifest command handlers."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.academic_result_manifest_generation import (
+    QuillanManifestGenerationError,
+    QuillanManifestGenerationPartialSuccessError,
+    StoredAcademicResultManifest,
+    generate_academic_result_manifest,
+    list_academic_result_manifest_revisions,
+    load_academic_result_manifest_revision,
+    validate_academic_result_manifest_revision,
+)
+from quillan.work_paths import quillan_work_ref
+
+
+def _generated_at_text(stored: StoredAcademicResultManifest) -> str:
+    return stored.manifest.generated_at.isoformat()
+
+
+def _print_revision_summary(stored: StoredAcademicResultManifest) -> None:
+    print(f"revision: {stored.revision}")
+    print(f"generated_at: {_generated_at_text(stored)}")
+    print(f"manifest path: {stored.relative_path}")
+    print(f"manifest sha256: {stored.sha256}")
+    print(f"represented student count: {len(stored.manifest.students)}")
+
+
+def _print_revision_detail(stored: StoredAcademicResultManifest) -> None:
+    manifest = stored.manifest
+    print(f"module_id: {manifest.work.module_id}")
+    print(f"class_id: {manifest.work.class_id}")
+    print(f"assignment_id: {manifest.work.work_id}")
+    print(f"record_set_id: {manifest.record_set.record_set_id}")
+    print(f"revision: {stored.revision}")
+    print(f"manifest contract: {manifest.contract_version}")
+    print(f"generated_at: {_generated_at_text(stored)}")
+    print(f"assignment source path: {manifest.source_snapshot.relative_path}")
+    print(f"assignment source sha256: {manifest.source_snapshot.sha256}")
+    print(f"represented student count: {len(manifest.students)}")
+    print(f"manifest path: {stored.relative_path}")
+    print(f"manifest sha256: {stored.sha256}")
+
+
+def _error(action: str, error: Exception) -> int:
+    print(f"Error: manifest {action}: {error}", file=sys.stderr)
+    if isinstance(error, QuillanManifestGenerationPartialSuccessError):
+        state = error.state
+        print(
+            "Warning: an immutable manifest revision may already be durable; "
+            "validate producer storage before retrying.",
+            file=sys.stderr,
+        )
+        print(f"operation: {state.operation}", file=sys.stderr)
+        print(f"revision: {state.revision}", file=sys.stderr)
+        print(f"manifest path: {state.relative_path}", file=sys.stderr)
+        if state.expected_sha256 is not None:
+            print(f"expected sha256: {state.expected_sha256}", file=sys.stderr)
+        print(
+            "durable file exists: "
+            f"{'yes' if state.durable_file_exists else 'no'}",
+            file=sys.stderr,
+        )
+        if state.lock_cleanup_failure is not None:
+            print(
+                "generation lock cleanup failed: "
+                f"{state.lock_cleanup_failure.relative_path}",
+                file=sys.stderr,
+            )
+    return 1
+
+
+def handle_manifest_list(args: argparse.Namespace) -> int:
+    """List privacy-minimized metadata for all immutable revisions."""
+    try:
+        root = resolve_workspace_root()
+        work = quillan_work_ref(args.class_id, args.assignment_id)
+        revisions = list_academic_result_manifest_revisions(root, work)
+        if not revisions:
+            print("manifest revisions: none")
+            return 0
+        print(f"manifest revisions: {len(revisions)}")
+        for index, stored in enumerate(revisions):
+            if index:
+                print()
+            _print_revision_summary(stored)
+        return 0
+    except (QuillanManifestGenerationError, WorkspaceRootError, ValueError) as error:
+        return _error("list failed", error)
+
+
+def handle_manifest_show(args: argparse.Namespace) -> int:
+    """Show privacy-minimized producer metadata for one immutable revision."""
+    try:
+        root = resolve_workspace_root()
+        work = quillan_work_ref(args.class_id, args.assignment_id)
+        stored = load_academic_result_manifest_revision(root, work, args.revision)
+        _print_revision_detail(stored)
+        return 0
+    except (QuillanManifestGenerationError, WorkspaceRootError, ValueError) as error:
+        return _error("show failed", error)
+
+
+def handle_manifest_validate(args: argparse.Namespace) -> int:
+    """Strictly validate one immutable producer revision."""
+    try:
+        root = resolve_workspace_root()
+        work = quillan_work_ref(args.class_id, args.assignment_id)
+        stored = validate_academic_result_manifest_revision(
+            root, work, args.revision
+        )
+        print("valid: yes")
+        _print_revision_summary(stored)
+        return 0
+    except (QuillanManifestGenerationError, WorkspaceRootError, ValueError) as error:
+        return _error("validation failed", error)
+
+
+def handle_manifest_generate(args: argparse.Namespace) -> int:
+    """Generate a new immutable revision or byte-exactly replay the producer head."""
+    try:
+        result = generate_academic_result_manifest(
+            resolve_workspace_root(),
+            args.class_id,
+            args.assignment_id,
+        )
+        print(f"disposition: {result.disposition}")
+        print(f"reason: {result.reason}")
+        print(f"revision: {result.revision}")
+        print(f"manifest path: {result.relative_path}")
+        print(f"manifest sha256: {result.sha256}")
+        print(f"represented student count: {len(result.manifest.students)}")
+        return 0
+    except (QuillanManifestGenerationError, WorkspaceRootError, ValueError) as error:
+        return _error("generation failed", error)

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -91,6 +91,12 @@ from quillan.cli_app.handlers.academic_work import (
     handle_academic_work_show,
     handle_academic_work_update,
 )
+from quillan.cli_app.handlers.manifest import (
+    handle_manifest_generate,
+    handle_manifest_list,
+    handle_manifest_show,
+    handle_manifest_validate,
+)
 from quillan.cli_app.handlers.assignments import (
     handle_assignment_create,
     handle_assignment_show,
@@ -318,6 +324,64 @@ def build_parser() -> argparse.ArgumentParser:
         help="Exact Core registration revision observed before this update.",
     )
     academic_work_update_parser.set_defaults(handler=handle_academic_work_update)
+
+    manifest_parser = subparsers.add_parser(
+        "manifest",
+        help="Create and inspect immutable Quillan Academic Result Manifests.",
+        description=(
+            "List, show, validate, or explicitly generate immutable producer-owned "
+            "Academic Result Manifest revisions. Generation does not publish through "
+            "Core and does not create a Grade."
+        ),
+    )
+    manifest_parser.set_defaults(
+        handler=partial(_print_parser_help, manifest_parser)
+    )
+    manifest_subparsers = manifest_parser.add_subparsers(
+        dest="manifest_command"
+    )
+
+    manifest_list_parser = manifest_subparsers.add_parser(
+        "list",
+        help="List immutable manifest revisions with privacy-minimized metadata.",
+    )
+    _add_academic_work_identity_options(manifest_list_parser)
+    manifest_list_parser.set_defaults(handler=handle_manifest_list)
+
+    manifest_show_parser = manifest_subparsers.add_parser(
+        "show",
+        help="Show privacy-minimized metadata for one immutable revision.",
+    )
+    _add_academic_work_identity_options(manifest_show_parser)
+    manifest_show_parser.add_argument(
+        "--revision",
+        required=True,
+        type=positive_integer,
+        action=StoreOnceAction,
+        help="Exact immutable manifest revision.",
+    )
+    manifest_show_parser.set_defaults(handler=handle_manifest_show)
+
+    manifest_validate_parser = manifest_subparsers.add_parser(
+        "validate",
+        help="Strictly validate one immutable producer revision.",
+    )
+    _add_academic_work_identity_options(manifest_validate_parser)
+    manifest_validate_parser.add_argument(
+        "--revision",
+        required=True,
+        type=positive_integer,
+        action=StoreOnceAction,
+        help="Exact immutable manifest revision.",
+    )
+    manifest_validate_parser.set_defaults(handler=handle_manifest_validate)
+
+    manifest_generate_parser = manifest_subparsers.add_parser(
+        "generate",
+        help="Generate the required next revision or byte-exactly replay the head.",
+    )
+    _add_academic_work_identity_options(manifest_generate_parser)
+    manifest_generate_parser.set_defaults(handler=handle_manifest_generate)
 
     printable_responses_parser = subparsers.add_parser(
         "printable-responses",

--- a/quillan/manifest_menu.py
+++ b/quillan/manifest_menu.py
@@ -1,0 +1,248 @@
+"""Teacher-facing immutable Academic Result Manifest workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.academic_result_manifest_generation import (
+    AcademicResultManifestGenerationContext,
+    QuillanManifestGenerationError,
+    QuillanManifestGenerationPartialSuccessError,
+    StoredAcademicResultManifest,
+    generate_academic_result_manifest,
+    list_academic_result_manifest_revisions,
+    load_academic_result_manifest_generation_context,
+    load_academic_result_manifest_revision,
+    validate_academic_result_manifest_revision,
+)
+from quillan.academic_work_registration import (
+    QuillanAcademicWorkRegistrationError,
+    load_current_quillan_academic_work_registration,
+)
+from quillan.assignment_picker import prompt_assignment_choice
+from quillan.menu_navigation import (
+    NavigationChoice,
+    navigation_hint,
+    parse_navigation_choice,
+    print_navigation_options,
+)
+from quillan.work_paths import quillan_work_ref
+
+
+def _represented_count(context: AcademicResultManifestGenerationContext) -> int:
+    return sum(1 for item in context.native_students if item.result is not None)
+
+
+def _print_history(revisions: tuple[StoredAcademicResultManifest, ...]) -> None:
+    if not revisions:
+        print("Manifest revisions: none")
+        return
+    print(f"Manifest revisions: {len(revisions)}")
+    for stored in revisions:
+        print(
+            f"- revision {stored.revision}; generated {stored.manifest.generated_at.isoformat()}; "
+            f"students {len(stored.manifest.students)}; sha256 {stored.sha256}"
+        )
+
+
+def _print_revision(stored: StoredAcademicResultManifest) -> None:
+    manifest = stored.manifest
+    print(f"Revision: {stored.revision}")
+    print(f"Generated: {manifest.generated_at.isoformat()}")
+    print(f"Manifest contract: {manifest.contract_version}")
+    print(f"Record set: {manifest.record_set.record_set_id}")
+    print(f"Assignment source: {manifest.source_snapshot.relative_path}")
+    print(f"Assignment source SHA-256: {manifest.source_snapshot.sha256}")
+    print(f"Represented students: {len(manifest.students)}")
+    print(f"Manifest path: {stored.relative_path}")
+    print(f"Manifest SHA-256: {stored.sha256}")
+
+
+def _print_error(error: Exception) -> None:
+    print(f"Error: {error}")
+    if isinstance(error, QuillanManifestGenerationPartialSuccessError):
+        state = error.state
+        print("Warning: an immutable manifest revision may already be durable.")
+        print(f"Operation: {state.operation}")
+        print(f"Revision: {state.revision}")
+        print(f"Manifest path: {state.relative_path}")
+        if state.expected_sha256 is not None:
+            print(f"Expected SHA-256: {state.expected_sha256}")
+        print(f"Durable file exists: {'yes' if state.durable_file_exists else 'no'}")
+        if state.lock_cleanup_failure is not None:
+            print(
+                "Generation lock cleanup failed: "
+                f"{state.lock_cleanup_failure.relative_path}"
+            )
+        print("Validate producer storage before retrying.")
+
+
+def _prompt_revision(
+    revisions: tuple[StoredAcademicResultManifest, ...],
+) -> int | None:
+    if not revisions:
+        print("No immutable manifest revisions exist.")
+        return None
+    response = input("Revision number: ").strip()
+    navigation = parse_navigation_choice(response)
+    if response == "" or navigation is NavigationChoice.BACK:
+        return None
+    if response.isdecimal():
+        revision = int(response)
+        if any(item.revision == revision for item in revisions):
+            return revision
+    print("Invalid revision selection.")
+    return None
+
+
+def _registration_status(
+    workspace_root: Path, class_id: str, assignment_id: str
+) -> str:
+    try:
+        current = load_current_quillan_academic_work_registration(
+            workspace_root, class_id, assignment_id
+        )
+    except QuillanAcademicWorkRegistrationError:
+        return "unavailable"
+    if current is None:
+        return "not registered"
+    return f"registered revision {current.registration_revision}"
+
+
+def launch_academic_result_manifest_menu() -> int:
+    """Run the explicit teacher-controlled immutable manifest workflow."""
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    try:
+        workspace_root = resolve_workspace_root()
+    except WorkspaceRootError as error:
+        _print_error(error)
+        return 1
+
+    try:
+        while True:
+            clear_screen()
+            print_menu_header("Academic Result Manifests")
+            choice = prompt_assignment_choice(workspace_root)
+            if choice is None:
+                return 0
+
+            work = quillan_work_ref(choice.class_id, choice.assignment_id)
+            try:
+                context = load_academic_result_manifest_generation_context(
+                    workspace_root, work
+                )
+                revisions = list_academic_result_manifest_revisions(
+                    workspace_root, work
+                )
+            except QuillanManifestGenerationError as error:
+                _print_error(error)
+                print()
+                pause_for_user()
+                continue
+
+            clear_screen()
+            print_menu_header("Academic Result Manifests")
+            print(f"Class: {choice.class_id}")
+            print(f"Assignment: {choice.assignment_id}")
+            print(f"Assignment title: {context.assignment.title}")
+            print(f"Represented native results ready: {_represented_count(context)}")
+            print(
+                "Academic Work Registration: "
+                f"{_registration_status(workspace_root, choice.class_id, choice.assignment_id)}"
+            )
+            print()
+            _print_history(revisions)
+            print()
+            print("1. Generate / exact replay")
+            print("2. List revisions")
+            print("3. Validate revision")
+            print("4. Show revision summary")
+            print_navigation_options()
+            action = input("Select an option: ").strip()
+            navigation = parse_navigation_choice(action)
+            if action == "" or navigation is NavigationChoice.BACK:
+                return 0
+
+            if action == "1":
+                print()
+                print("Proposed operation:")
+                print(
+                    "Validate the current native assignment/result state and either "
+                    "byte-exactly replay the immutable producer head or create the "
+                    "next revision required by Quillan's revision policy."
+                )
+                print("This does not publish through Core and does not create a Grade.")
+                confirmation = input(
+                    "Type GENERATE to continue: "
+                ).strip()
+                if confirmation != "GENERATE":
+                    print("Canceled: no manifest revision was generated.")
+                    print()
+                    pause_for_user()
+                    continue
+                try:
+                    result = generate_academic_result_manifest(
+                        workspace_root,
+                        choice.class_id,
+                        choice.assignment_id,
+                    )
+                except QuillanManifestGenerationError as error:
+                    _print_error(error)
+                    print()
+                    pause_for_user()
+                    continue
+                print()
+                print(f"Disposition: {result.disposition}")
+                print(f"Reason: {result.reason}")
+                print(f"Revision: {result.revision}")
+                print(f"Manifest path: {result.relative_path}")
+                print(f"Manifest SHA-256: {result.sha256}")
+                print(f"Represented students: {len(result.manifest.students)}")
+                print()
+                pause_for_user()
+                continue
+
+            if action == "2":
+                print()
+                _print_history(revisions)
+                print()
+                pause_for_user()
+                continue
+
+            if action in {"3", "4"}:
+                revision = _prompt_revision(revisions)
+                if revision is None:
+                    print()
+                    pause_for_user()
+                    continue
+                try:
+                    if action == "3":
+                        stored = validate_academic_result_manifest_revision(
+                            workspace_root, work, revision
+                        )
+                        print()
+                        print("Manifest revision is valid.")
+                    else:
+                        stored = load_academic_result_manifest_revision(
+                            workspace_root, work, revision
+                        )
+                        print()
+                    _print_revision(stored)
+                except QuillanManifestGenerationError as error:
+                    _print_error(error)
+                print()
+                pause_for_user()
+                continue
+
+            print(f"Invalid selection. {navigation_hint()}")
+            print()
+            pause_for_user()
+    except KeyboardInterrupt:
+        print("\nExiting Academic Result Manifests.")
+        return 0
+
+
+__all__ = ["launch_academic_result_manifest_menu"]

--- a/quillan/work_paths.py
+++ b/quillan/work_paths.py
@@ -7,6 +7,10 @@ import os
 from pathlib import Path
 
 from pds_core.identifiers import validate_identifier
+from pds_core.publication_records import (
+    PublicationRecordValidationError,
+    validate_publication_manifest_path,
+)
 from pds_core.routes import (
     class_roster_path,
     module_work_collection_dir,
@@ -349,6 +353,66 @@ def student_performance_summary_path(
     )
 
 
+def manifest_exports_dir(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> Path:
+    """Return the producer-owned manifest export directory without mutation."""
+    return safe_module_work_descendant(
+        workspace_root,
+        _require_quillan_work_ref(work_ref),
+        Path("exports") / "manifests",
+    )
+
+
+def academic_result_manifests_dir(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+) -> Path:
+    """Return the immutable Academic Result manifest collection."""
+    return safe_module_work_descendant(
+        workspace_root,
+        _require_quillan_work_ref(work_ref),
+        Path("exports") / "manifests" / "academic_results",
+    )
+
+
+def academic_result_manifest_revision_path(
+    workspace_root: str | Path,
+    work_ref: ModuleWorkRef,
+    revision: int,
+) -> Path:
+    """Return one immutable revision-addressed manifest path without I/O."""
+    validated_work = _require_quillan_work_ref(work_ref)
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+        raise QuillanWorkPathError(
+            "revision must be a positive non-Boolean integer."
+        )
+    return safe_module_work_descendant(
+        workspace_root,
+        validated_work,
+        Path("exports")
+        / "manifests"
+        / "academic_results"
+        / f"{revision}.json",
+    )
+
+
+def academic_result_manifest_relative_path(
+    work_ref: ModuleWorkRef,
+    revision: int,
+) -> str:
+    """Return and Core-validate one workspace-relative publication path."""
+    validated_work = _require_quillan_work_ref(work_ref)
+    relative = academic_result_manifest_revision_path(
+        Path(), validated_work, revision
+    ).as_posix()
+    try:
+        return validate_publication_manifest_path(validated_work, relative)
+    except PublicationRecordValidationError as error:
+        raise QuillanWorkPathError(str(error)) from error
+
+
 def post_dispatch_review_dir(
     workspace_root: str | Path,
     work_ref: ModuleWorkRef,
@@ -634,11 +698,15 @@ def _lexists(path: Path) -> bool:
 __all__ = [
     "QuillanWorkPathError",
     "QuillanWorkPaths",
+    "academic_result_manifest_relative_path",
+    "academic_result_manifest_revision_path",
+    "academic_result_manifests_dir",
     "class_summary_path",
     "feedback_markdown_path",
     "feedback_pdf_path",
     "initialize_managed_work_layout",
     "initialize_student_submission_dir",
+    "manifest_exports_dir",
     "preflight_managed_work_layout",
     "preflight_quillan_work_collection",
     "preflight_work_file_destination",

--- a/scripts/run_installed_acceptance.py
+++ b/scripts/run_installed_acceptance.py
@@ -41,6 +41,7 @@ SIDE_EFFECT_FREE_HELP_COMMANDS = (
     ("printable-responses", "--help"),
     ("workspace", "--help"),
     ("academic-work", "--help"),
+    ("manifest", "--help"),
 )
 
 

--- a/tests/test_academic_result_manifest_generation.py
+++ b/tests/test_academic_result_manifest_generation.py
@@ -1,0 +1,586 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import pytest
+from pds_core.standards import (
+    StandardDefinition,
+    StandardsLibrary,
+    StandardsProfile,
+    write_workspace_standards_library,
+)
+
+from quillan.academic_result_manifest import manifest_to_canonical_json_bytes
+from quillan.academic_result_manifest_generation import (
+    QuillanManifestGenerationConflictError,
+    QuillanManifestGenerationIntegrityError,
+    QuillanManifestGenerationValidationError,
+    build_academic_result_manifest,
+    discover_manifest_student_ids,
+    load_academic_result_manifest_generation_context,
+    verify_generation_context_unchanged,
+)
+from quillan.response_page_observation_persistence import (
+    persist_quillan_page_observation,
+)
+from quillan.review_record import build_empty_review_record, validate_review_record
+from quillan.submission_manifest import validate_submission_manifest
+from quillan.submission_observation_assembly import (
+    assemble_quillan_submission_manifests,
+)
+from quillan.work_paths import (
+    academic_result_manifest_relative_path,
+    academic_result_manifest_revision_path,
+    academic_result_manifests_dir,
+    manifest_exports_dir,
+    quillan_work_ref,
+    review_record_path,
+    submission_manifest_path,
+)
+from tests.observation_test_support import successful_image_page
+from tests.review_test_support import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STUDENT_ID,
+    TIMESTAMP,
+    _write_assignment,
+)
+
+STANDARD_ID = "synthetic:W.A"
+PROFILE_ID = "synthetic_profile"
+
+
+def _write_standards(workspace: Path) -> None:
+    library = StandardsLibrary(
+        standards=(
+            StandardDefinition(
+                standard_id=STANDARD_ID,
+                code="W.A",
+                source="synthetic",
+                short_name="Synthetic Writing",
+                description="Synthetic writing standard for manifest tests.",
+            ),
+        ),
+        profiles=(StandardsProfile(profile_id=PROFILE_ID, standards=(STANDARD_ID,)),),
+    )
+    write_workspace_standards_library(workspace, library)
+
+
+def _plain_submission(
+    *,
+    class_id: str = CLASS_ID,
+    assignment_id: str = ASSIGNMENT_ID,
+    student_id: str = STUDENT_ID,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": class_id,
+        "assignment_id": assignment_id,
+        "student_id": student_id,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {
+            "submission_entry_method": "plain_paper_manual",
+            "physical_evidence_status": "teacher_has_external_plain_paper",
+            "created_by_workflow": "plain_paper_submission",
+        },
+    }
+
+
+def _review(
+    *,
+    class_id: str = CLASS_ID,
+    assignment_id: str = ASSIGNMENT_ID,
+    student_id: str = STUDENT_ID,
+) -> dict[str, Any]:
+    return build_empty_review_record(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        created_at=TIMESTAMP,
+    )
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_plain_submission(
+    workspace: Path,
+    *,
+    class_id: str = CLASS_ID,
+    assignment_id: str = ASSIGNMENT_ID,
+    student_id: str = STUDENT_ID,
+) -> Path:
+    value = _plain_submission(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+    )
+    validate_submission_manifest(value)
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    path = submission_manifest_path(workspace, work_ref, student_id)
+    _write_json(path, value)
+    return path
+
+
+def _write_review(
+    workspace: Path,
+    value: dict[str, Any],
+    *,
+    class_id: str = CLASS_ID,
+    assignment_id: str = ASSIGNMENT_ID,
+    student_id: str = STUDENT_ID,
+) -> Path:
+    validate_review_record(value)
+    work_ref = quillan_work_ref(class_id, assignment_id)
+    path = review_record_path(workspace, work_ref, student_id)
+    _write_json(path, value)
+    return path
+
+
+def _prepare_plain_pair(workspace: Path) -> None:
+    _write_assignment(workspace)
+    _write_standards(workspace)
+    _write_plain_submission(workspace)
+    _write_review(workspace, _review())
+
+
+def test_manifest_work_paths_are_revision_addressed_and_side_effect_free(
+    tmp_path: Path,
+) -> None:
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    expected = (
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
+        "exports/manifests/academic_results/7.json"
+    )
+
+    assert academic_result_manifest_relative_path(work, 7) == expected
+    assert academic_result_manifest_revision_path(tmp_path, work, 7) == tmp_path.joinpath(
+        *PurePosixPath(expected).parts
+    )
+    assert manifest_exports_dir(tmp_path, work).name == "manifests"
+    assert academic_result_manifests_dir(tmp_path, work).name == "academic_results"
+    assert not academic_result_manifests_dir(tmp_path, work).exists()
+
+    with pytest.raises(ValueError, match="positive non-Boolean"):
+        academic_result_manifest_revision_path(tmp_path, work, True)
+    with pytest.raises(ValueError, match="positive non-Boolean"):
+        academic_result_manifest_relative_path(work, 0)
+
+
+def test_empty_submission_population_builds_empty_manifest(tmp_path: Path) -> None:
+    assignment_path = _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+    context = load_academic_result_manifest_generation_context(tmp_path, work)
+    manifest = build_academic_result_manifest(
+        context,
+        record_set_revision=1,
+        generated_at=datetime(2026, 8, 12, 20, 0, tzinfo=timezone.utc),
+    )
+
+    assert context.submissions_dir_present is False
+    assert context.native_students == ()
+    assert manifest.students == ()
+    assert manifest.record_set.record_set_id == "academic_results"
+    assert manifest.source_snapshot.sha256 == hashlib.sha256(
+        assignment_path.read_bytes()
+    ).hexdigest()
+    assert manifest.source_snapshot.relative_path == "assignment.json"
+
+
+def test_plain_paper_pair_is_represented_with_exact_source_hashes(tmp_path: Path) -> None:
+    _prepare_plain_pair(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    context = load_academic_result_manifest_generation_context(tmp_path, work)
+    manifest = build_academic_result_manifest(
+        context,
+        record_set_revision=3,
+        generated_at=datetime(2026, 8, 12, 20, 0, tzinfo=timezone.utc),
+    )
+
+    assert [student.student_id for student in manifest.students] == [STUDENT_ID]
+    student = manifest.students[0]
+    assert student.submission.entry_method == "plain_paper_manual"
+    assert student.submission.expected_pages is None
+    assert student.submission.digital_provenance is None
+    assert student.source_snapshot.submission.relative_path == (
+        f"submissions/{STUDENT_ID}/submission.json"
+    )
+    assert student.source_snapshot.review.relative_path == (
+        f"submissions/{STUDENT_ID}/review.json"
+    )
+    submission = submission_manifest_path(tmp_path, work, STUDENT_ID)
+    review = review_record_path(tmp_path, work, STUDENT_ID)
+    assert student.source_snapshot.submission.sha256 == hashlib.sha256(
+        submission.read_bytes()
+    ).hexdigest()
+    assert student.source_snapshot.review.sha256 == hashlib.sha256(
+        review.read_bytes()
+    ).hexdigest()
+    assert manifest.record_set.revision == 3
+
+
+def test_plain_paper_requires_exact_native_provenance_markers(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    submission = _plain_submission()
+    submission["module_details"]["created_by_workflow"] = "other_workflow"
+    validate_submission_manifest(submission)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    _write_json(submission_manifest_path(tmp_path, work, STUDENT_ID), submission)
+    _write_review(tmp_path, _review())
+
+    with pytest.raises(
+        QuillanManifestGenerationValidationError, match="provenance markers"
+    ):
+        load_academic_result_manifest_generation_context(tmp_path, work)
+
+
+def test_submission_without_review_is_validated_but_not_represented(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    _write_plain_submission(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+    context = load_academic_result_manifest_generation_context(tmp_path, work)
+
+    assert len(context.native_students) == 1
+    state = context.native_students[0]
+    assert state.student_id == STUDENT_ID
+    assert state.submission_source is None
+    assert state.review_source is None
+    assert state.result is None
+    assert context.students == ()
+
+
+def test_orphan_review_fails_closed(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    _write_review(tmp_path, _review())
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+    with pytest.raises(
+        QuillanManifestGenerationIntegrityError, match="native student result"
+    ):
+        load_academic_result_manifest_generation_context(tmp_path, work)
+
+
+def test_direct_nonstudent_child_fails_discovery(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    submissions = (
+        tmp_path
+        / "classes"
+        / CLASS_ID
+        / "modules"
+        / "quillan"
+        / "work"
+        / ASSIGNMENT_ID
+        / "submissions"
+    )
+    submissions.mkdir(parents=True)
+    (submissions / "unexpected.txt").write_text("x", encoding="utf-8")
+
+    with pytest.raises(
+        QuillanManifestGenerationValidationError, match="unexpected direct child"
+    ):
+        discover_manifest_student_ids(tmp_path, work)
+
+
+def test_standards_profile_is_required_and_focus_order_is_preserved(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    with pytest.raises(
+        QuillanManifestGenerationValidationError, match="standards"
+    ):
+        load_academic_result_manifest_generation_context(tmp_path, work)
+
+    _write_standards(tmp_path)
+    context = load_academic_result_manifest_generation_context(tmp_path, work)
+    assert context.assignment.focus_standard_ids == (STANDARD_ID,)
+
+
+def test_context_recheck_detects_formatting_only_assignment_change(
+    tmp_path: Path,
+) -> None:
+    assignment_path = _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    context = load_academic_result_manifest_generation_context(tmp_path, work)
+    before = assignment_path.read_bytes()
+
+    assignment_path.write_bytes(before + b"\n")
+
+    with pytest.raises(QuillanManifestGenerationConflictError, match="changed"):
+        verify_generation_context_unchanged(context)
+
+
+def test_review_text_is_projected_without_private_field_leakage(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    _write_plain_submission(tmp_path)
+    review = _review()
+    review["review_state"] = "ratings_complete"
+    review["review_units"] = [
+        {
+            "unit_id": "paragraph_1",
+            "sequence": 1,
+            "label": "Paragraph 1",
+            "unit_type": "paragraph",
+            "standard_observations": [
+                {
+                    "observation_id": "local_observation_1",
+                    "standard_id": STANDARD_ID,
+                    "applicable": True,
+                    "evidence_present": True,
+                    "rating": 1,
+                    "rationale": "Student-facing observation rationale.",
+                    "include_in_feedback": False,
+                    "updated_at": TIMESTAMP,
+                    "module_details": {"private": "do not publish"},
+                }
+            ],
+            "module_details": {"private": "do not publish"},
+        }
+    ]
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": STANDARD_ID,
+            "rating": 1,
+            "rationale": "Teacher-only overall rationale.",
+            "include_in_feedback": True,
+            "updated_at": TIMESTAMP,
+            "module_details": {"private": "do not publish"},
+        }
+    ]
+    review["minimum_requirement_outcome"] = {
+        "status": "met",
+        "returned_without_full_review": False,
+        "teacher_note": "Teacher-only minimum note.",
+        "updated_at": TIMESTAMP,
+    }
+    review["feedback"] = {
+        "include_review_unit_observations": True,
+        "include_overall_standard_ratings": True,
+        "standard_feedback": [
+            {
+                "standard_id": STANDARD_ID,
+                "include_overall_rating": True,
+                "include_overall_rationale": False,
+                "included_observation_ids": ["local_observation_1"],
+                "comments": [
+                    {
+                        "feedback_comment_id": "comment_included",
+                        "source": "custom",
+                        "text": "Included student comment.",
+                        "reusable_comment_id": None,
+                        "save_for_reuse": False,
+                        "include_in_feedback": True,
+                        "created_at": TIMESTAMP,
+                        "module_details": {"private": "do not publish"},
+                    },
+                    {
+                        "feedback_comment_id": "comment_private",
+                        "source": "custom",
+                        "text": "Unselected private comment.",
+                        "reusable_comment_id": None,
+                        "save_for_reuse": False,
+                        "include_in_feedback": False,
+                        "created_at": TIMESTAMP,
+                        "module_details": {},
+                    },
+                ],
+                "module_details": {"private": "do not publish"},
+            }
+        ],
+    }
+    review["private_notes"] = [
+        {
+            "private_note_id": "private_1",
+            "text": "Never publish this private note.",
+            "created_at": TIMESTAMP,
+            "updated_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    _write_review(tmp_path, review)
+
+    context = load_academic_result_manifest_generation_context(
+        tmp_path, quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    )
+    manifest = build_academic_result_manifest(
+        context,
+        record_set_revision=1,
+        generated_at=datetime(2026, 8, 12, 20, 0, tzinfo=timezone.utc),
+    )
+    projected = manifest.students[0].review
+
+    observation = projected.review_units[0].standard_observations[0]
+    assert observation.rationale.disposition == "included"
+    assert observation.rationale.text == "Student-facing observation rationale."
+    assert projected.overall_standard_ratings[0].rationale.disposition == "withheld"
+    assert projected.minimum_requirement_outcome.teacher_note.disposition == "withheld"
+    comments = projected.feedback.standard_feedback[0].comments
+    assert [comment.feedback_comment_id for comment in comments] == ["comment_included"]
+    encoded = manifest_to_canonical_json_bytes(manifest)
+    assert b"Never publish this private note" not in encoded
+    assert b"Unselected private comment" not in encoded
+    assert b'"module_details"' not in encoded
+
+
+def test_review_rating_must_belong_to_assignment_native_scale(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    _write_plain_submission(tmp_path)
+    review = _review()
+    review["review_state"] = "ratings_complete"
+    review["overall_standard_ratings"] = [
+        {
+            "standard_id": STANDARD_ID,
+            "rating": 99,
+            "rationale": None,
+            "include_in_feedback": False,
+            "updated_at": TIMESTAMP,
+            "module_details": {},
+        }
+    ]
+    _write_review(tmp_path, review)
+
+    with pytest.raises(
+        QuillanManifestGenerationValidationError, match="assignment rating scale"
+    ):
+        load_academic_result_manifest_generation_context(
+            tmp_path, quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+        )
+
+
+def test_return_without_full_review_must_be_allowed_by_assignment(tmp_path: Path) -> None:
+    assignment_path = _write_assignment(tmp_path)
+    assignment = json.loads(assignment_path.read_text(encoding="utf-8"))
+    assignment["minimum_requirement_policy"]["allow_return_without_full_review"] = False
+    _write_json(assignment_path, assignment)
+    _write_standards(tmp_path)
+    _write_plain_submission(tmp_path)
+    review = _review()
+    review["review_state"] = "returned_without_full_review"
+    review["minimum_requirement_outcome"] = {
+        "status": "returned_without_full_review",
+        "returned_without_full_review": True,
+        "teacher_note": "Please complete the required elements.",
+        "updated_at": TIMESTAMP,
+    }
+    _write_review(tmp_path, review)
+
+    with pytest.raises(
+        QuillanManifestGenerationValidationError, match="forbids"
+    ):
+        load_academic_result_manifest_generation_context(
+            tmp_path, quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+        )
+
+
+def _prepare_pds2_pair(tmp_path: Path) -> tuple[str, str, str, Path, Path]:
+    outcome = successful_image_page(tmp_path)
+    persisted = persist_quillan_page_observation(tmp_path, outcome)
+    observation = persisted.observation
+    assembled = assemble_quillan_submission_manifests(
+        tmp_path, observation.class_id, observation.assignment_id
+    )
+    assert not assembled.failures
+    _write_standards(tmp_path)
+    review = _review(
+        class_id=observation.class_id,
+        assignment_id=observation.assignment_id,
+        student_id=observation.student_id,
+    )
+    _write_review(
+        tmp_path,
+        review,
+        class_id=observation.class_id,
+        assignment_id=observation.assignment_id,
+        student_id=observation.student_id,
+    )
+    retained = tmp_path.joinpath(*PurePosixPath(observation.retained_source_path).parts)
+    routed = tmp_path.joinpath(*PurePosixPath(observation.routed_evidence_path).parts)
+    return (
+        observation.class_id,
+        observation.assignment_id,
+        observation.student_id,
+        retained,
+        routed,
+    )
+
+
+def test_selected_pds2_evidence_is_validated_and_projected(tmp_path: Path) -> None:
+    class_id, assignment_id, student_id, _, _ = _prepare_pds2_pair(tmp_path)
+    context = load_academic_result_manifest_generation_context(
+        tmp_path, quillan_work_ref(class_id, assignment_id)
+    )
+    assert [student.student_id for student in context.students] == [student_id]
+    digital = context.students[0].submission.digital_provenance
+    assert digital is not None
+    assert len(digital.evidence_references) == 1
+    reference = digital.evidence_references[0]
+    assert reference.evidence_id == reference.observation_id
+    assert reference.source_sha256
+    assert reference.routed_evidence_sha256
+
+
+def test_changed_retained_bytes_fail_selected_evidence_integrity(tmp_path: Path) -> None:
+    class_id, assignment_id, _, retained, _ = _prepare_pds2_pair(tmp_path)
+    retained.write_bytes(retained.read_bytes() + b"tampered")
+
+    with pytest.raises(
+        QuillanManifestGenerationIntegrityError, match="retained-source bytes"
+    ):
+        load_academic_result_manifest_generation_context(
+            tmp_path, quillan_work_ref(class_id, assignment_id)
+        )
+
+
+def test_changed_routed_bytes_fail_selected_evidence_integrity(tmp_path: Path) -> None:
+    class_id, assignment_id, _, _, routed = _prepare_pds2_pair(tmp_path)
+    routed.write_bytes(routed.read_bytes() + b"tampered")
+
+    with pytest.raises(
+        QuillanManifestGenerationIntegrityError, match="routed evidence"
+    ):
+        load_academic_result_manifest_generation_context(
+            tmp_path, quillan_work_ref(class_id, assignment_id)
+        )
+
+
+def test_pure_builder_rejects_naive_generation_time(tmp_path: Path) -> None:
+    _prepare_plain_pair(tmp_path)
+    context = load_academic_result_manifest_generation_context(
+        tmp_path, quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    )
+    with pytest.raises(
+        QuillanManifestGenerationValidationError, match="timezone-aware"
+    ):
+        build_academic_result_manifest(
+            context,
+            record_set_revision=1,
+            generated_at=datetime(2026, 8, 12, 20, 0),
+        )

--- a/tests/test_academic_result_manifest_storage.py
+++ b/tests/test_academic_result_manifest_storage.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.routing_models import ModuleWorkRef
+
+import quillan.academic_result_manifest_generation as generation
+from quillan.academic_result_manifest_generation import (
+    QuillanManifestGenerationConflictError,
+    QuillanManifestGenerationIntegrityError,
+    QuillanManifestGenerationNotFoundError,
+    QuillanManifestGenerationPartialSuccessError,
+    generate_academic_result_manifest,
+    list_academic_result_manifest_revisions,
+    load_academic_result_manifest_revision,
+)
+from quillan.work_paths import (
+    academic_result_manifest_revision_path,
+    academic_result_manifests_dir,
+    quillan_work_ref,
+)
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID, _write_assignment
+from tests.test_academic_result_manifest_generation import (
+    _prepare_plain_pair,
+    _write_standards,
+)
+
+UTC_1 = datetime(2026, 8, 12, 20, 0, tzinfo=timezone.utc)
+UTC_2 = datetime(2026, 8, 12, 21, 0, tzinfo=timezone.utc)
+UTC_3 = datetime(2026, 8, 12, 22, 0, tzinfo=timezone.utc)
+
+
+def test_initial_creation_and_exact_replay_preserve_exact_bytes(tmp_path: Path) -> None:
+    _prepare_plain_pair(tmp_path)
+
+    first = generate_academic_result_manifest(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        clock=lambda: UTC_1,
+    )
+    original = first.path.read_bytes()
+    original_mtime = first.path.stat().st_mtime_ns
+
+    def replay_clock_must_not_run() -> datetime:
+        raise AssertionError("exact replay must not call the clock")
+
+    replay = generate_academic_result_manifest(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        clock=replay_clock_must_not_run,
+    )
+
+    assert first.disposition == "create_initial"
+    assert first.reason == "initial_publication"
+    assert first.revision == 1
+    assert first.sha256 == hashlib.sha256(original).hexdigest()
+    assert replay.disposition == "reuse_existing"
+    assert replay.reason == "exact_replay"
+    assert replay.revision == 1
+    assert replay.content == original
+    assert replay.sha256 == first.sha256
+    assert replay.manifest.generated_at == first.manifest.generated_at
+    assert replay.path.read_bytes() == original
+    assert replay.path.stat().st_mtime_ns == original_mtime
+    assert not (first.path.parent / ".write.lock").exists()
+
+
+def test_formatting_only_assignment_change_creates_native_source_successor(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    first = generate_academic_result_manifest(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+    )
+    assignment = _write_assignment(tmp_path)
+    original_semantics = assignment.read_bytes()
+    assignment.write_bytes(original_semantics + b"\n")
+
+    second = generate_academic_result_manifest(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_2
+    )
+
+    assert first.revision == 1
+    assert second.disposition == "create_successor"
+    assert second.reason == "native_source_changed"
+    assert second.revision == 2
+    assert second.manifest.source_snapshot.sha256 != first.manifest.source_snapshot.sha256
+    assert first.path.read_bytes() == first.content
+
+
+def test_historical_reversion_allocates_new_greater_revision(tmp_path: Path) -> None:
+    _prepare_plain_pair(tmp_path)
+    assignment = _write_assignment(tmp_path)
+    original = assignment.read_bytes()
+    first = generate_academic_result_manifest(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+    )
+    assignment.write_bytes(original + b"\n")
+    second = generate_academic_result_manifest(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_2
+    )
+    assignment.write_bytes(original)
+
+    third = generate_academic_result_manifest(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_3
+    )
+
+    assert (first.revision, second.revision, third.revision) == (1, 2, 3)
+    assert third.disposition == "create_successor"
+    assert third.reason == "historical_reversion"
+    assert third.content != first.content
+    assert third.manifest.generated_at == UTC_3
+
+
+def test_history_loader_rejects_unexpected_and_noncanonical_entries(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    created = generate_academic_result_manifest(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+    )
+    unexpected = created.path.parent / "latest.json"
+    unexpected.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(
+        QuillanManifestGenerationIntegrityError, match="unexpected or noncanonical"
+    ):
+        list_academic_result_manifest_revisions(tmp_path, work)
+
+    unexpected.unlink()
+    noncanonical = created.path.parent / "01.json"
+    noncanonical.write_bytes(created.content)
+    with pytest.raises(
+        QuillanManifestGenerationIntegrityError, match="unexpected or noncanonical"
+    ):
+        list_academic_result_manifest_revisions(tmp_path, work)
+
+
+def test_history_loader_rejects_semantically_valid_noncanonical_bytes(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    created = generate_academic_result_manifest(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+    )
+    created.path.write_bytes(created.content.replace(b"  ", b"    ", 1))
+
+    with pytest.raises(QuillanManifestGenerationIntegrityError):
+        list_academic_result_manifest_revisions(tmp_path, work)
+
+
+def test_read_only_list_does_not_create_manifest_storage(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    directory = academic_result_manifests_dir(tmp_path, work)
+
+    assert list_academic_result_manifest_revisions(tmp_path, work) == ()
+    assert not directory.exists()
+    with pytest.raises(QuillanManifestGenerationNotFoundError):
+        load_academic_result_manifest_revision(tmp_path, work, 1)
+    assert not directory.exists()
+
+
+def test_preexisting_generation_lock_blocks_generation(tmp_path: Path) -> None:
+    _prepare_plain_pair(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    directory = academic_result_manifests_dir(tmp_path, work)
+    directory.mkdir(parents=True)
+    lock = directory / ".write.lock"
+    lock.write_bytes(b"someone-else")
+
+    with pytest.raises(QuillanManifestGenerationConflictError, match="write.lock"):
+        generate_academic_result_manifest(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+        )
+
+    assert lock.read_bytes() == b"someone-else"
+    assert not academic_result_manifest_revision_path(tmp_path, work, 1).exists()
+
+
+def test_failure_before_durable_creation_consumes_no_revision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+    def fail_before_write(
+        context: generation.AcademicResultManifestGenerationContext,
+    ) -> None:
+        raise QuillanManifestGenerationConflictError("synthetic prewrite conflict")
+
+    monkeypatch.setattr(generation, "_run_prewrite_verification_hook", fail_before_write)
+    with pytest.raises(QuillanManifestGenerationConflictError):
+        generate_academic_result_manifest(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+        )
+
+    assert not academic_result_manifest_revision_path(tmp_path, work, 1).exists()
+    assert not (academic_result_manifests_dir(tmp_path, work) / ".write.lock").exists()
+
+
+def test_concurrent_target_creation_is_never_overwritten(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    target = academic_result_manifest_revision_path(tmp_path, work, 1)
+    intruder = b"concurrently-created\n"
+
+    def create_target(
+        context: generation.AcademicResultManifestGenerationContext,
+    ) -> None:
+        target.write_bytes(intruder)
+
+    monkeypatch.setattr(generation, "_run_prewrite_verification_hook", create_target)
+    with pytest.raises(QuillanManifestGenerationConflictError):
+        generate_academic_result_manifest(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+        )
+
+    assert target.read_bytes() == intruder
+
+
+def test_post_durable_verification_failure_preserves_revision_as_partial_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+    original = generation._load_manifest_history
+    calls = 0
+
+    def fail_second_history_load(
+        workspace_root: Path,
+        work_ref: ModuleWorkRef,
+        *,
+        allow_generation_lock: bool,
+    ) -> tuple[generation.StoredAcademicResultManifest, ...]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise QuillanManifestGenerationIntegrityError(
+                "synthetic final verification failure"
+            )
+        return original(
+            workspace_root,
+            work_ref,
+            allow_generation_lock=allow_generation_lock,
+        )
+
+    monkeypatch.setattr(generation, "_load_manifest_history", fail_second_history_load)
+    with pytest.raises(QuillanManifestGenerationPartialSuccessError) as captured:
+        generate_academic_result_manifest(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+        )
+
+    error = captured.value
+    target = academic_result_manifest_revision_path(tmp_path, work, 1)
+    assert error.state.operation == "final_verification"
+    assert error.state.revision == 1
+    assert error.state.durable_file_exists is True
+    assert target.is_file()
+    assert not (target.parent / ".write.lock").exists()
+
+
+def test_lock_cleanup_failure_after_creation_is_partial_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+    def fail_cleanup(lock_path: Path, token: bytes) -> None:
+        raise OSError("synthetic cleanup failure")
+
+    monkeypatch.setattr(generation, "_release_generation_lock", fail_cleanup)
+    with pytest.raises(QuillanManifestGenerationPartialSuccessError) as captured:
+        generate_academic_result_manifest(
+            tmp_path, CLASS_ID, ASSIGNMENT_ID, clock=lambda: UTC_1
+        )
+
+    error = captured.value
+    target = academic_result_manifest_revision_path(tmp_path, work, 1)
+    assert error.state.operation == "lock_cleanup"
+    assert error.state.lock_cleanup_failure is not None
+    assert target.is_file()
+    assert (target.parent / ".write.lock").is_file()
+
+
+def test_storage_source_has_no_revision_update_or_delete_primitive() -> None:
+    source = inspect.getsource(generation)
+    assert "revision_guarded_update(" not in source
+    assert "def delete_academic_result_manifest" not in source
+    assert '"latest.json"' not in source
+    assert '"current.json"' not in source

--- a/tests/test_cli_manifest.py
+++ b/tests/test_cli_manifest.py
@@ -1,0 +1,200 @@
+"""Tests for direct immutable Academic Result Manifest CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pds_core.standards import (
+    StandardDefinition,
+    StandardsLibrary,
+    StandardsProfile,
+    write_workspace_standards_library,
+)
+
+from quillan.cli import main
+import quillan.cli_app.handlers.manifest as handlers
+from quillan.review_record import build_empty_review_record, validate_review_record
+from quillan.submission_manifest import validate_submission_manifest
+from quillan.work_paths import quillan_work_ref, review_record_path, submission_manifest_path
+from tests.review_test_support import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STUDENT_ID,
+    TIMESTAMP,
+    _write_assignment,
+)
+
+STANDARD_ID = "synthetic:W.A"
+PROFILE_ID = "synthetic_profile"
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_standards(workspace: Path) -> None:
+    write_workspace_standards_library(
+        workspace,
+        StandardsLibrary(
+            standards=(
+                StandardDefinition(
+                    standard_id=STANDARD_ID,
+                    code="W.A",
+                    source="synthetic",
+                    short_name="Synthetic Writing",
+                    description="Synthetic writing standard for manifest CLI tests.",
+                ),
+            ),
+            profiles=(
+                StandardsProfile(profile_id=PROFILE_ID, standards=(STANDARD_ID,)),
+            ),
+        ),
+    )
+
+
+def _plain_submission() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "module": "quillan",
+        "record_type": "submission_manifest",
+        "class_id": CLASS_ID,
+        "assignment_id": ASSIGNMENT_ID,
+        "student_id": STUDENT_ID,
+        "expected_pages": None,
+        "submission_state": "unreviewed",
+        "pages": [],
+        "created_at": TIMESTAMP,
+        "updated_at": TIMESTAMP,
+        "module_details": {
+            "submission_entry_method": "plain_paper_manual",
+            "physical_evidence_status": "teacher_has_external_plain_paper",
+            "created_by_workflow": "plain_paper_submission",
+        },
+    }
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _write_assignment(tmp_path)
+    _write_standards(tmp_path)
+    work = quillan_work_ref(CLASS_ID, ASSIGNMENT_ID)
+
+    submission = _plain_submission()
+    validate_submission_manifest(submission)
+    _write_json(submission_manifest_path(tmp_path, work, STUDENT_ID), submission)
+
+    review = build_empty_review_record(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        student_id=STUDENT_ID,
+        created_at=TIMESTAMP,
+    )
+    validate_review_record(review)
+    _write_json(review_record_path(tmp_path, work, STUDENT_ID), review)
+
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    return tmp_path
+
+
+def _identity() -> list[str]:
+    return ["--class-id", CLASS_ID, "--assignment-id", ASSIGNMENT_ID]
+
+
+def test_manifest_help_surface(capsys: pytest.CaptureFixture[str]) -> None:
+    for argv, expected in (
+        (["--help"], "manifest"),
+        (["manifest", "--help"], "generate"),
+        (["manifest", "list", "--help"], "--class-id"),
+        (["manifest", "show", "--help"], "--revision"),
+        (["manifest", "validate", "--help"], "--revision"),
+        (["manifest", "generate", "--help"], "--assignment-id"),
+    ):
+        with pytest.raises(SystemExit) as error:
+            main(argv)
+        assert error.value.code == 0
+        captured = capsys.readouterr()
+        assert expected in captured.out + captured.err
+
+
+def test_list_generate_replay_show_and_validate(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["manifest", "list", *_identity()]) == 0
+    assert "manifest revisions: none" in capsys.readouterr().out
+
+    assert main(["manifest", "generate", *_identity()]) == 0
+    created = capsys.readouterr().out
+    assert "disposition: create_initial" in created
+    assert "reason: initial_publication" in created
+    assert "revision: 1" in created
+    assert "represented student count: 1" in created
+    assert STUDENT_ID not in created
+
+    assert main(["manifest", "generate", *_identity()]) == 0
+    replay = capsys.readouterr().out
+    assert "disposition: reuse_existing" in replay
+    assert "reason: exact_replay" in replay
+    assert "revision: 1" in replay
+
+    assert main(["manifest", "list", *_identity()]) == 0
+    listed = capsys.readouterr().out
+    assert "manifest revisions: 1" in listed
+    assert "manifest sha256:" in listed
+    assert STUDENT_ID not in listed
+
+    assert main(["manifest", "show", *_identity(), "--revision", "1"]) == 0
+    shown = capsys.readouterr().out
+    assert "manifest contract: quillan_academic_result_manifest_v1" in shown
+    assert "assignment source path: assignment.json" in shown
+    assert "represented student count: 1" in shown
+    assert STUDENT_ID not in shown
+
+    assert main(["manifest", "validate", *_identity(), "--revision", "1"]) == 0
+    validated = capsys.readouterr().out
+    assert "valid: yes" in validated
+    assert STUDENT_ID not in validated
+
+
+def test_manifest_cli_rejects_invalid_duplicate_and_unknown_options(
+    workspace: Path,
+) -> None:
+    with pytest.raises(SystemExit) as invalid_revision:
+        main(["manifest", "show", *_identity(), "--revision", "0"])
+    assert invalid_revision.value.code == 2
+
+    with pytest.raises(SystemExit) as duplicate:
+        main(
+            [
+                "manifest",
+                "list",
+                *_identity(),
+                "--class-id",
+                CLASS_ID,
+            ]
+        )
+    assert duplicate.value.code == 2
+
+    with pytest.raises(SystemExit) as unknown:
+        main(["manifest", "generate", *_identity(), "--force"])
+    assert unknown.value.code == 2
+
+
+def test_missing_assignment_fails_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(handlers, "resolve_workspace_root", lambda: tmp_path)
+    result = main(["manifest", "generate", *_identity()])
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.out + captured.err
+    assert "Error: manifest generation failed" in captured.err
+    assert not (tmp_path / "registry").exists()

--- a/tests/test_installed_acceptance_contract.py
+++ b/tests/test_installed_acceptance_contract.py
@@ -164,8 +164,9 @@ def test_retained_source_added_count_is_derived(tmp_path: Path) -> None:
     assert result["retained_source_events_added"] == 2
 
 
-def test_installed_acceptance_probes_academic_work_help() -> None:
+def test_installed_acceptance_probes_academic_work_and_manifest_help() -> None:
     assert ("academic-work", "--help") in SIDE_EFFECT_FREE_HELP_COMMANDS
+    assert ("manifest", "--help") in SIDE_EFFECT_FREE_HELP_COMMANDS
 
 
 def test_no_academic_state_accepts_ordinary_workspace(tmp_path: Path) -> None:

--- a/tests/test_manifest_generation_boundaries.py
+++ b/tests/test_manifest_generation_boundaries.py
@@ -1,0 +1,47 @@
+"""Source-level regression for the explicit-only manifest generation boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QUILLAN = ROOT / "quillan"
+
+_ALLOWED_RUNTIME_REFERENCES = {
+    Path("academic_result_manifest_generation.py"),
+    Path("cli_app/handlers/manifest.py"),
+    Path("manifest_menu.py"),
+}
+
+
+def test_durable_manifest_generation_has_only_explicit_runtime_references() -> None:
+    references: list[str] = []
+    for path in sorted(QUILLAN.rglob("*.py")):
+        relative = path.relative_to(QUILLAN)
+        text = path.read_text(encoding="utf-8")
+        if "generate_academic_result_manifest" not in text:
+            continue
+        if relative not in _ALLOWED_RUNTIME_REFERENCES:
+            references.append(relative.as_posix())
+    assert references == []
+
+
+def test_manifest_generation_never_uses_mutable_revision_update_primitive() -> None:
+    source = (QUILLAN / "academic_result_manifest_generation.py").read_text(
+        encoding="utf-8"
+    )
+    assert "revision_guarded_update" not in source
+    assert "create_exclusive_record" in source
+
+
+def test_ordinary_runtime_modules_do_not_import_manifest_generation() -> None:
+    imports: list[str] = []
+    needle = "quillan.academic_result_manifest_generation"
+    for path in sorted(QUILLAN.rglob("*.py")):
+        relative = path.relative_to(QUILLAN)
+        if relative in _ALLOWED_RUNTIME_REFERENCES:
+            continue
+        if needle in path.read_text(encoding="utf-8"):
+            imports.append(relative.as_posix())
+    assert imports == []

--- a/tests/test_menu_manifest.py
+++ b/tests/test_menu_manifest.py
@@ -1,0 +1,177 @@
+"""Teacher-menu tests for explicit immutable Academic Result Manifests."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+
+import quillan.assignment_workflows as assignment_workflows
+import quillan.manifest_menu as menu
+from quillan.academic_result_manifest import (
+    AcademicResultManifest,
+    manifest_from_mapping,
+    manifest_to_canonical_json_bytes,
+)
+from quillan.academic_result_manifest_generation import (
+    AcademicResultManifestGenerationResult,
+    StoredAcademicResultManifest,
+)
+from tests.test_academic_result_manifest import valid_mapping
+
+
+def _manifest() -> AcademicResultManifest:
+    mapping = valid_mapping()
+    mapping["record_set"]["record_set_id"] = "academic_results"
+    mapping["record_set"]["revision"] = 1
+    mapping["work"]["class_id"] = "english12_p3"
+    mapping["work"]["work_id"] = "villainy_essay"
+    mapping["assignment"]["assignment_id"] = "villainy_essay"
+    mapping["students"] = []
+    return manifest_from_mapping(mapping)
+
+
+def _result(tmp_path: Path) -> AcademicResultManifestGenerationResult:
+    manifest = _manifest()
+    content = manifest_to_canonical_json_bytes(manifest)
+    relative = (
+        "classes/english12_p3/modules/quillan/work/villainy_essay/"
+        "exports/manifests/academic_results/1.json"
+    )
+    return AcademicResultManifestGenerationResult(
+        disposition="create_initial",
+        reason="initial_publication",
+        manifest=manifest,
+        revision=1,
+        path=tmp_path.joinpath(*Path(relative).parts),
+        relative_path=relative,
+        content=content,
+        sha256=sha256(content).hexdigest(),
+    )
+
+
+def _stored(tmp_path: Path) -> StoredAcademicResultManifest:
+    result = _result(tmp_path)
+    return StoredAcademicResultManifest(
+        manifest=result.manifest,
+        revision=result.revision,
+        path=result.path,
+        relative_path=result.relative_path,
+        content=result.content,
+        sha256=result.sha256,
+    )
+
+
+def _patch_shell(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(menu, "resolve_workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        menu,
+        "prompt_assignment_choice",
+        lambda _root: SimpleNamespace(
+            class_id="english12_p3",
+            assignment_id="villainy_essay",
+            title="Villainy Essay",
+        ),
+    )
+    context = SimpleNamespace(
+        assignment=SimpleNamespace(title="Villainy Essay"),
+        native_students=(),
+    )
+    monkeypatch.setattr(
+        menu,
+        "load_academic_result_manifest_generation_context",
+        lambda *_args: context,
+    )
+    monkeypatch.setattr(
+        menu, "list_academic_result_manifest_revisions", lambda *_args: ()
+    )
+    monkeypatch.setattr(
+        menu,
+        "load_current_quillan_academic_work_registration",
+        lambda *_args: None,
+    )
+    import quillan.menu as root_menu
+
+    monkeypatch.setattr(root_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(root_menu, "pause_for_user", lambda: None)
+    monkeypatch.setattr(root_menu, "print_menu_header", lambda _title=None: None)
+
+
+def test_manifest_menu_cancellation_does_not_generate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_shell(monkeypatch, tmp_path)
+    called = False
+
+    def generate(*_args: object, **_kwargs: object) -> None:
+        nonlocal called
+        called = True
+        raise AssertionError("generation should not be called")
+
+    monkeypatch.setattr(menu, "generate_academic_result_manifest", generate)
+    responses = iter(["1", "NOPE", "B"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+    assert menu.launch_academic_result_manifest_menu() == 0
+    assert called is False
+
+
+def test_manifest_menu_requires_generate_and_reports_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _patch_shell(monkeypatch, tmp_path)
+    result = _result(tmp_path)
+    calls = 0
+
+    def generate(
+        *_args: object, **_kwargs: object
+    ) -> AcademicResultManifestGenerationResult:
+        nonlocal calls
+        calls += 1
+        return result
+
+    monkeypatch.setattr(menu, "generate_academic_result_manifest", generate)
+    responses = iter(["1", "GENERATE", "B"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+    assert menu.launch_academic_result_manifest_menu() == 0
+    assert calls == 1
+    output = capsys.readouterr().out
+    assert "Proposed operation:" in output
+    assert "does not publish through Core" in output
+    assert "Disposition: create_initial" in output
+    assert "Manifest SHA-256:" in output
+
+
+def test_assignment_management_routes_option_five_to_manifest_menu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = 0
+
+    def launch() -> int:
+        nonlocal called
+        called += 1
+        return 0
+
+    monkeypatch.setattr(menu, "launch_academic_result_manifest_menu", launch)
+    import quillan.menu as root_menu
+
+    monkeypatch.setattr(root_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(root_menu, "pause_for_user", lambda: None)
+    monkeypatch.setattr(root_menu, "print_menu_header", lambda _title=None: None)
+    responses = iter(["5", "B"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+
+    assert assignment_workflows.launch_assignment_menu() == 0
+    assert called == 1
+
+
+def test_menu_history_display_contains_no_student_ids(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    menu._print_history((_stored(tmp_path),))
+    output = capsys.readouterr().out
+    assert "students 0" in output
+    assert "student_" not in output


### PR DESCRIPTION
## Summary

Implements #361: immutable Quillan Academic Result Manifest generation and native validation.

- validates canonical assignment/submission/review source state and exact source bytes
- applies the approved privacy-safe publication projection
- validates plain-paper and PDS2 provenance/evidence
- implements strict immutable manifest history, locking, revision planning, replay, and exclusive durable creation
- adds producer-local manifest list/show/validate/generate CLI commands
- adds teacher-facing Academic Result Manifest management
- documents storage, privacy, revision, registration, and publication boundaries
- extends installed acceptance and explicit-only generation boundary coverage

## Validation

- `2203 passed, 19 skipped`
- Ruff: PASS
- strict mypy: PASS — 265 source files
- `pip check`: PASS
- documentation integrity: PASS
- `run_tests.ps1`: PASS
- authenticated released `pds-core 0.6.0` wheel
- editable and noneditable install validation: PASS
- wheel/sdist build, Twine, and artifact inspection: PASS
- installed wheel full synthetic workflow: PASS
- installed sdist acceptance: PASS
- automated release-candidate validation: PASS

Closes #361