### PR TITLE
Register Quillan publication producer profile (#362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Quillan's immutable producer-owned result contract is documented in
 [Academic Result Manifest v1](docs/academic_result_manifest_v1.md). Explicit
 workspace generation and immutable producer storage are documented in
 [Academic Result Manifest Generation](docs/academic_result_manifest_generation.md).
+Installed publication compatibility is documented in
+[Publication Producer Profile](docs/publication_producer_profile.md).
 
 > **Storage contract:** Quillan assignment, submission, review, feedback, and
 > assignment-report services use only
@@ -19,6 +21,15 @@ Quillan registers the `quillan` entry point in `paper_data_suite.modules` throug
 `quillan.pds_module:get_module_profile`. The profile supports Core routing contract
 `1`, QR schema `PDS2`, route-registration schema `1`, and only Core route status
 `active`.
+
+Publication compatibility is discovered separately through
+`paper_data_suite.publication_producers`, with
+`quillan = quillan.pds_publication:get_publication_producer_profile`. The
+metadata-only profile declares Core Publication Record schema `1`, producer
+contract `quillan_academic_work_v1`, publication kind `academic_result_set`,
+manifest contract `quillan_academic_result_manifest_v1`, capability
+`standards_ratings`, and no Publication Record source contract. It does not read
+a workspace, publish records, expose a reader, or change routing behavior.
 
 An active route is only structurally dispatchable. The response-page handler also
 requires the immutable issuance lifecycle to be exactly `issued`. Student and page

--- a/docs/academic_result_manifest_generation.md
+++ b/docs/academic_result_manifest_generation.md
@@ -256,8 +256,9 @@ Later #363 publication orchestration must independently reload canonical Core
 state and bind the exact applicable Academic Work Registration revision, exact
 manifest path, and exact manifest SHA-256 in the Core Publication Record.
 
-Producer profile registration belongs to #362; Core publication/supersession/
-withdrawal to #363; consumer-neutral authorized reading to #364; installed
+The metadata-only [Publication Producer Profile](publication_producer_profile.md)
+implements #362; Core publication/supersession/withdrawal belongs to #363;
+consumer-neutral authorized reading to #364; installed
 end-to-end producer acceptance to #365; and final release audit/version work to
 #366.
 

--- a/docs/academic_result_manifest_v1.md
+++ b/docs/academic_result_manifest_v1.md
@@ -23,8 +23,9 @@ privacy projection is defined by
 revision, correction, and withdrawal behavior is defined by
 [Quillan Publication Revision Policy](publication_revision_policy.md); explicit
 assignment eligibility and Core registration are defined by
-[Quillan Academic Work Registration](academic_work_registration.md); and Core producer-profile,
-publication, and reader integration remains #362–#364.
+[Quillan Academic Work Registration](academic_work_registration.md); the installed
+[Publication Producer Profile](publication_producer_profile.md) declares metadata
+compatibility; and publication and reader integration remain #363–#364.
 
 ## Exact schema
 

--- a/docs/academic_work_registration.md
+++ b/docs/academic_work_registration.md
@@ -177,7 +177,7 @@ managed Quillan assignment
 -> Core Publication Record references registration revision N
 ```
 
-A later registration revision never rewrites an older manifest or Publication Record. Explicit manifest generation is implemented independently under #361; see [Academic Result Manifest Generation](academic_result_manifest_generation.md). Publication/supersession/withdrawal orchestration belongs to #363.
+A later registration revision never rewrites an older manifest or Publication Record. Explicit manifest generation is implemented independently under #361; see [Academic Result Manifest Generation](academic_result_manifest_generation.md). The [Publication Producer Profile](publication_producer_profile.md) declares compatible registration metadata without loading it. Publication/supersession/withdrawal orchestration belongs to #363.
 
 ## Explicit-only boundary
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -17,6 +17,13 @@ storage, byte-exact replay, and producer digest generation are implemented in
 Manifest generation remains independent of Academic Work Registration and does
 not create Core publication or Grade state.
 
+Installed publication compatibility is declared independently by the
+[Publication Producer Profile](publication_producer_profile.md). It advertises
+only Core Publication Record schema `1`, `quillan_academic_work_v1`,
+`academic_result_set`, `quillan_academic_result_manifest_v1`, and
+`standards_ratings`, with `source_record=None`. Discovery is metadata-only and
+does not read manifests, authorize consumers, or create publication state.
+
 The producer-owned privacy floor for manifest and later artifact projections is
 defined in
 [Quillan Publication Projection Policy v1](publication_projection_policy_v1.md).

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -1,10 +1,10 @@
 # Quillan Development Plan
 
-Quillan now has the complete producer-side foundation through #361:
+Quillan now has the complete producer-side foundation through #362:
 Academic Result Manifest v1, privacy projection, revision policy, Core 0.6
-compatibility, explicit Academic Work Registration, and explicit immutable
-workspace manifest generation/replay. Producer profile, Core publication
-lifecycle, and consumer-neutral reading remain #362–#364.
+compatibility, explicit Academic Work Registration, explicit immutable workspace
+manifest generation/replay, and installed publication-producer compatibility.
+Core publication lifecycle and consumer-neutral reading remain #363–#364.
 
 Classification: **active authority** for the v0.8.9 release candidate.
 
@@ -63,7 +63,7 @@ portfolio Candidates. #362–#365 own the remaining producer integration;
 #359 Core 0.6 adoption                         complete
 #360 Academic Work Registration                complete
 #361 immutable manifest generation/validation complete
-#362 publication producer profile              remaining
+#362 publication producer profile              complete
 #363 publication lifecycle                     remaining
 #364 consumer-neutral reader                   remaining
 #365 installed end-to-end producer acceptance  remaining

--- a/docs/publication_producer_profile.md
+++ b/docs/publication_producer_profile.md
@@ -1,0 +1,68 @@
+# Quillan Publication Producer Profile
+
+Quillan exposes publication compatibility independently from PDS2 routing. Core
+discovers the metadata-only provider through the installed entry point:
+
+```text
+paper_data_suite.publication_producers
+    quillan = quillan.pds_publication:get_publication_producer_profile
+```
+
+`quillan.pds_publication:get_publication_producer_profile` is a zero-argument,
+deterministic provider returning Core's immutable `PublicationProducerProfile`.
+It contains no parser, reader, generator, publication callback, route handler,
+registration callback, CLI callback, or menu callback.
+
+## Exact compatibility declaration
+
+| Field | Supported value |
+|---|---|
+| Module ID | `quillan` |
+| Display name | `Quillan` |
+| Core Publication Record schema | `1` |
+| Academic Work producer contract | `quillan_academic_work_v1` |
+| Publication kind | `academic_result_set` |
+| Manifest contract | `quillan_academic_result_manifest_v1` |
+| Capability | `standards_ratings` |
+| Publication source-record contracts | none |
+| Missing Publication Record source | allowed and required for compatibility |
+
+`standards_ratings` means the manifest contract can preserve Quillan's native,
+assignment-local standards ratings. It does not promise that every student or
+standard has a rating and does not make ratings points, percentages, mastery,
+Meridian proficiency, or Grades. Quillan does not advertise `points`,
+`question_evidence`, `multiple_attempts`, `criterion_scores`, `moderated_scores`,
+or any intervention capability. Selected PDS2 writing evidence, review units,
+immutable revisions, and ordinal rating-scale values are not those contracts.
+
+## Source identity boundaries
+
+The Academic Work Registration identifies the canonical assignment as a
+`quillan` / `assignment` / contract `2` source. A compatible Publication Record
+has `source_record=None` because no single native `ModuleRecordRef` represents
+the complete academic result set. The manifest separately binds exact snapshots
+of assignment schema 2, submission schema 1, and review schema 2 records, plus
+privacy-approved selected PDS2 provenance where applicable. These three layers
+must not be collapsed or used to fabricate a result-set source record.
+
+## Purity and responsibility boundaries
+
+Import, direct invocation, installed discovery, and Core registry construction
+read no workspace, environment setting, native record, registration, manifest,
+Publication Record, withdrawal, or catalog and create no state. Discovery makes
+compatibility metadata available; it is neither authorization nor proof that a
+publication exists or that a consumer may read it.
+
+Routing remains independently discoverable through `paper_data_suite.modules`.
+Its `ModuleProfile` owns PDS2 schemas, dispatch status, the route handler, and the
+registration validator; none appears in the publication profile.
+
+Issue #363 owns Publication Record creation, supersession, withdrawal, and
+reconciliation. Issue #364 owns the consumer-neutral authorized reader. Meridian
+owns proficiency and Grade policy; Vitrine owns Candidate, Selection, Snapshot,
+and portfolio policy. Compatibility metadata performs none of those operations.
+
+Core's package version, Publication Record schema, routing contract, registration
+schema, Quillan producer contract, manifest contract, and package version are
+independent version axes. The Core dataclass is not a serialized Quillan profile
+schema and Quillan defines no profile revision or compatibility schema.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ quillan = "quillan.cli:main"
 [project.entry-points."paper_data_suite.modules"]
 quillan = "quillan.pds_module:get_module_profile"
 
+[project.entry-points."paper_data_suite.publication_producers"]
+quillan = "quillan.pds_publication:get_publication_producer_profile"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/quillan/academic_result_manifest.py
+++ b/quillan/academic_result_manifest.py
@@ -12,8 +12,9 @@ from typing import Any, Final, Literal, NoReturn, TypeAlias, cast
 
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
 
+from quillan.pds_contract import ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION
+
 ACADEMIC_RESULT_MANIFEST_RECORD_TYPE: Final = "quillan_academic_result_manifest"
-ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION: Final = "quillan_academic_result_manifest_v1"
 ACADEMIC_RESULT_MANIFEST_PRODUCER_MODULE_ID: Final = "quillan"
 ASSIGNMENT_SOURCE_CONTRACT_VERSION: Final = "2"
 SUBMISSION_SOURCE_CONTRACT_VERSION: Final = "1"

--- a/quillan/academic_work_registration.py
+++ b/quillan/academic_work_registration.py
@@ -49,7 +49,10 @@ from pds_core.registry_services import (
 from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
 
 from quillan._path_safety import is_link_like
-from quillan.pds_contract import QUILLAN_MODULE_ID
+from quillan.pds_contract import (
+    QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION,
+    QUILLAN_MODULE_ID,
+)
 from quillan.record_context import (
     QuillanRecordContextError,
     canonical_workspace_root,
@@ -57,7 +60,6 @@ from quillan.record_context import (
 )
 from quillan.work_paths import quillan_work_paths, quillan_work_ref
 
-QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION: Final[str] = "quillan_academic_work_v1"
 QUILLAN_ACADEMIC_WORK_KIND: Final[str] = "assignment"
 QUILLAN_ASSIGNMENT_SOURCE_RECORD_KIND: Final[str] = "assignment"
 QUILLAN_ASSIGNMENT_SOURCE_CONTRACT_VERSION: Final[str] = "2"

--- a/quillan/pds_contract.py
+++ b/quillan/pds_contract.py
@@ -10,6 +10,10 @@ from pds_core.routing_models import (
 
 QUILLAN_MODULE_ID: Final[str] = "quillan"
 QUILLAN_DISPLAY_NAME: Final[str] = "Quillan"
+QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION: Final[str] = "quillan_academic_work_v1"
+ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION: Final[str] = (
+    "quillan_academic_result_manifest_v1"
+)
 
 RESPONSE_PAGE_RECORD_KIND: Final[str] = "response_page"
 RESPONSE_PAGE_CONTRACT_VERSION: Final[str] = "1"
@@ -24,8 +28,10 @@ SUPPORTED_ROUTE_REGISTRATION_SCHEMA_VERSIONS: Final[frozenset[str]] = frozenset(
 DISPATCHABLE_ROUTE_STATUSES: Final[frozenset[str]] = frozenset({"active"})
 
 __all__ = [
+    "ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION",
     "DISPATCHABLE_ROUTE_STATUSES",
     "QUILLAN_DISPLAY_NAME",
+    "QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION",
     "QUILLAN_MODULE_ID",
     "RESPONSE_PAGE_CONTRACT_VERSION",
     "RESPONSE_PAGE_RECORD_KIND",

--- a/quillan/pds_publication.py
+++ b/quillan/pds_publication.py
@@ -1,0 +1,45 @@
+"""Immutable installed Core publication compatibility metadata for Quillan."""
+
+from pds_core.publication_compatibility import (
+    PublicationContractSupport,
+    PublicationProducerProfile,
+    validate_publication_producer_profile,
+)
+from pds_core.publication_records import PUBLICATION_RECORD_SCHEMA_VERSION
+
+from quillan.pds_contract import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION,
+    QUILLAN_DISPLAY_NAME,
+    QUILLAN_MODULE_ID,
+)
+
+
+def get_publication_producer_profile() -> PublicationProducerProfile:
+    """Return Quillan's validated, metadata-only publication profile."""
+    return validate_publication_producer_profile(
+        PublicationProducerProfile(
+            module_id=QUILLAN_MODULE_ID,
+            display_name=QUILLAN_DISPLAY_NAME,
+            supported_core_publication_schema_versions=frozenset(
+                {PUBLICATION_RECORD_SCHEMA_VERSION}
+            ),
+            supported_academic_work_contract_versions=frozenset(
+                {QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION}
+            ),
+            publication_contracts=(
+                PublicationContractSupport(
+                    publication_kind="academic_result_set",
+                    manifest_contract_versions=frozenset(
+                        {ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION}
+                    ),
+                    supported_capabilities=frozenset({"standards_ratings"}),
+                    source_record_contracts=(),
+                    allows_missing_source_record=True,
+                ),
+            ),
+        )
+    )
+
+
+__all__ = ["get_publication_producer_profile"]

--- a/scripts/inspect_release_artifacts.py
+++ b/scripts/inspect_release_artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import configparser
 from email.parser import Parser
 import hashlib
 import json
@@ -25,6 +26,19 @@ FORBIDDEN_PARTS = {
     ".git", ".venv", ".pytest-tmp", "build", "dist", "__pycache__",
     ".mypy_cache", ".ruff_cache",
 }
+EXPECTED_ENTRY_POINTS = {
+    "paper_data_suite.modules": {
+        "quillan": "quillan.pds_module:get_module_profile",
+    },
+    "paper_data_suite.publication_producers": {
+        "quillan": "quillan.pds_publication:get_publication_producer_profile",
+    },
+}
+
+
+class _EntryPointParser(configparser.ConfigParser):
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
 
 
 def _sha256(path: Path) -> str:
@@ -80,6 +94,18 @@ def _metadata_contract(raw: str) -> dict[str, object]:
     }
 
 
+def validate_entry_points_text(raw: str) -> None:
+    """Require exact, independent Quillan routing and publication providers."""
+    parser = _EntryPointParser(interpolation=None, strict=True)
+    try:
+        parser.read_string(raw)
+    except configparser.Error as error:
+        raise AssertionError(str(error)) from error
+    for group, expected in EXPECTED_ENTRY_POINTS.items():
+        assert parser.has_section(group), group
+        assert dict(parser.items(group)) == expected, dict(parser.items(group))
+
+
 def inspect_wheel(path: Path) -> dict[str, object]:
     with zipfile.ZipFile(path) as archive:
         names = set(archive.namelist())
@@ -89,8 +115,8 @@ def inspect_wheel(path: Path) -> dict[str, object]:
         metadata = _metadata_contract(archive.read(metadata_name).decode("utf-8"))
         entries = archive.read(entry_name).decode("utf-8")
         assert "quillan = quillan.cli:main" in entries
-        assert "quillan = quillan.pds_module:get_module_profile" in entries
-        assert "paper_data_suite.publication_producers" not in entries
+        validate_entry_points_text(entries)
+        assert "quillan/pds_publication.py" in names
         assert "quillan/_version.py" in names
         assert any(name.endswith(".dist-info/licenses/LICENSE") for name in names)
     return {"filename": path.name, "sha256": _sha256(path), **metadata}
@@ -107,6 +133,7 @@ def inspect_sdist(path: Path) -> dict[str, object]:
         assert any(name.endswith("/LICENSE") for name in names)
         assert any(name.endswith("/README.md") for name in names)
         assert any(name.endswith("/quillan/_version.py") for name in names)
+        assert any(name.endswith("/quillan/pds_publication.py") for name in names)
     return {"filename": path.name, "sha256": _sha256(path), **metadata}
 
 

--- a/scripts/run_installed_acceptance.py
+++ b/scripts/run_installed_acceptance.py
@@ -491,7 +491,13 @@ def main() -> int:
     root = Path(str(distribution.locate_file(""))).resolve()
     import quillan
     import quillan.pds_module
+    import quillan.pds_publication
     import pds_core
+    from pds_core.publication_compatibility import (
+        build_publication_producer_registry,
+        discover_publication_producer_profiles,
+        validate_publication_producer_profile,
+    )
 
     assert pds_core.__version__ == core_distribution.version
     raw_core_origin = pds_core.__file__
@@ -503,12 +509,51 @@ def main() -> int:
         for name in CORE_06_ACADEMIC_MODULES
     }
 
-    origins = [Path(quillan.__file__).resolve(), Path(quillan.pds_module.__file__).resolve()]
+    origins = [
+        Path(quillan.__file__).resolve(),
+        Path(quillan.pds_module.__file__).resolve(),
+        Path(quillan.pds_publication.__file__).resolve(),
+    ]
     assert all(not path.is_relative_to(repository) for path in origins), origins
-    profiles = [entry for entry in distribution.entry_points if entry.group == "paper_data_suite.modules"]
-    assert [(entry.name, entry.value) for entry in profiles] == [("quillan", "quillan.pds_module:get_module_profile")]
-    profile = profiles[0].load()()
-    assert profile.module_id == "quillan"
+    routing_entries = [
+        entry
+        for entry in distribution.entry_points
+        if entry.group == "paper_data_suite.modules"
+    ]
+    assert [(entry.name, entry.value) for entry in routing_entries] == [
+        ("quillan", "quillan.pds_module:get_module_profile")
+    ]
+    routing_profile = routing_entries[0].load()()
+    assert routing_profile.module_id == "quillan"
+    publication_entries = [
+        entry
+        for entry in distribution.entry_points
+        if entry.group == "paper_data_suite.publication_producers"
+    ]
+    assert [(entry.name, entry.value) for entry in publication_entries] == [
+        (
+            "quillan",
+            "quillan.pds_publication:get_publication_producer_profile",
+        )
+    ]
+    publication_profile = validate_publication_producer_profile(
+        publication_entries[0].load()()
+    )
+    assert publication_profile == (
+        quillan.pds_publication.get_publication_producer_profile()
+    )
+    discovered = tuple(
+        profile
+        for profile in discover_publication_producer_profiles()
+        if profile.module_id == "quillan"
+    )
+    assert discovered == (publication_profile,)
+    registry = build_publication_producer_registry()
+    registry_profile = registry.get("quillan")
+    assert registry_profile is not None
+    assert registry_profile == publication_profile
+    assert not sentinel.exists()
+    _assert_no_academic_state(sentinel)
 
     modules = sorted(module.name for module in pkgutil.walk_packages(quillan.__path__, "quillan."))
     for module in modules:
@@ -530,7 +575,7 @@ def main() -> int:
     workflow = _run_full_workflow(workflow_workspace, work=work, env=env) if args.full_workflow else None
     if args.full_workflow:
         _assert_no_academic_state(workflow_workspace)
-    print(json.dumps({"version": distribution.version, "distribution_root": str(root), "origins": [str(path) for path in origins], "core_version": core_distribution.version, "core_origin": str(core_origin), "core_06_academic_modules": academic_module_origins, "module_count": len(modules), "module_profile": profile.module_id, "workspace_side_effects": False, "academic_registry_side_effects": False, "workflow": workflow}, indent=2, sort_keys=True))
+    print(json.dumps({"version": distribution.version, "distribution_root": str(root), "origins": [str(path) for path in origins], "core_version": core_distribution.version, "core_origin": str(core_origin), "core_06_academic_modules": academic_module_origins, "module_count": len(modules), "module_profile": routing_profile.module_id, "publication_profile": publication_profile.module_id, "publication_profiles_discovered": len(discovered), "publication_registry_profile": registry_profile.module_id, "workspace_side_effects": False, "academic_registry_side_effects": False, "workflow": workflow}, indent=2, sort_keys=True))
     return 0
 
 

--- a/tests/test_installed_acceptance_contract.py
+++ b/tests/test_installed_acceptance_contract.py
@@ -169,6 +169,16 @@ def test_installed_acceptance_probes_academic_work_and_manifest_help() -> None:
     assert ("manifest", "--help") in SIDE_EFFECT_FREE_HELP_COMMANDS
 
 
+def test_installed_acceptance_probes_publication_profile_and_core_discovery() -> None:
+    source = Path("scripts/run_installed_acceptance.py").read_text(encoding="utf-8")
+    assert "import quillan.pds_publication" in source
+    assert "paper_data_suite.publication_producers" in source
+    assert "validate_publication_producer_profile" in source
+    assert "discover_publication_producer_profiles" in source
+    assert "build_publication_producer_registry" in source
+    assert 'assert not sentinel.exists()' in source
+
+
 def test_no_academic_state_accepts_ordinary_workspace(tmp_path: Path) -> None:
     (tmp_path / "classes").mkdir()
     (tmp_path / "scans" / "source").mkdir(parents=True)

--- a/tests/test_pds_contract.py
+++ b/tests/test_pds_contract.py
@@ -17,7 +17,9 @@ from pds_core.routing_models import (
 )
 
 from quillan.pds_contract import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
     DISPATCHABLE_ROUTE_STATUSES,
+    QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION,
     QUILLAN_DISPLAY_NAME,
     QUILLAN_MODULE_ID,
     RESPONSE_PAGE_CONTRACT_VERSION,
@@ -29,8 +31,10 @@ from quillan.pds_contract import (
 import quillan.pds_contract as pds_contract
 
 PUBLIC_CONTRACT_CONSTANTS = {
+    "ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION",
     "DISPATCHABLE_ROUTE_STATUSES",
     "QUILLAN_DISPLAY_NAME",
+    "QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION",
     "QUILLAN_MODULE_ID",
     "RESPONSE_PAGE_CONTRACT_VERSION",
     "RESPONSE_PAGE_RECORD_KIND",
@@ -43,6 +47,11 @@ PUBLIC_CONTRACT_CONSTANTS = {
 def test_quillan_contract_has_approved_values() -> None:
     assert QUILLAN_MODULE_ID == "quillan"
     assert QUILLAN_DISPLAY_NAME == "Quillan"
+    assert QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION == "quillan_academic_work_v1"
+    assert (
+        ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION
+        == "quillan_academic_result_manifest_v1"
+    )
     assert RESPONSE_PAGE_RECORD_KIND == "response_page"
     assert RESPONSE_PAGE_CONTRACT_VERSION == "1"
     assert SUPPORTED_CORE_ROUTING_CONTRACT_VERSIONS == frozenset(

--- a/tests/test_publication_producer_profile.py
+++ b/tests/test_publication_producer_profile.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import inspect
+import json
+import subprocess
+import sys
+import tomllib
+from dataclasses import FrozenInstanceError, replace
+from datetime import UTC, datetime
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+from pds_core.academic_work_registrations import AcademicWorkRegistration
+from pds_core.module_profiles import ModuleProfile
+from pds_core.publication_compatibility import (
+    PUBLICATION_PRODUCER_ENTRY_POINT_GROUP,
+    PublicationProducerProfile,
+    PublicationProducerProfileError,
+    build_publication_producer_registry,
+    discover_publication_producer_profiles,
+    evaluate_publication_compatibility,
+    validate_publication_producer_profile,
+)
+from pds_core.publication_records import (
+    PublicationCapability,
+    PublicationRecord,
+    PublicationRecordValidationError,
+)
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+
+from quillan.pds_module import get_module_profile
+from quillan.pds_publication import get_publication_producer_profile
+
+_SUPPORTED_CAPABILITIES = frozenset({"standards_ratings"})
+_UNSUPPORTED_CAPABILITIES = frozenset(
+    {
+        "points",
+        "question_evidence",
+        "multiple_attempts",
+        "criterion_scores",
+        "moderated_scores",
+        "intervention_history",
+        "intervention_status",
+        "intervention_outcomes",
+    }
+)
+_INTERVENTION_CAPABILITIES = frozenset(
+    {"intervention_history", "intervention_status", "intervention_outcomes"}
+)
+_NOW = datetime(2026, 8, 13, 12, tzinfo=UTC)
+
+
+def _publication(
+    *,
+    capabilities: tuple[PublicationCapability, ...] = ("standards_ratings",),
+) -> PublicationRecord:
+    return PublicationRecord(
+        schema_version="1",
+        record_type="publication_record",
+        publication_id="pub_" + "1" * 32,
+        work=ModuleWorkRef("quillan", "class1", "assignment1"),
+        source_record=None,
+        publication_kind="academic_result_set",
+        capabilities=capabilities,
+        record_set_id="academic_results",
+        record_set_revision=1,
+        manifest_contract_version="quillan_academic_result_manifest_v1",
+        manifest_path=(
+            "classes/class1/modules/quillan/work/assignment1/"
+            "exports/manifests/academic_results/1.json"
+        ),
+        manifest_digest_algorithm="sha256",
+        manifest_digest="0" * 64,
+        published_at=_NOW,
+        academic_work_registration_revision=1,
+        supersedes_publication_id=None,
+    )
+
+
+def _registration(
+    publication: PublicationRecord,
+    *,
+    producer_contract_version: str = "quillan_academic_work_v1",
+    work: ModuleWorkRef | None = None,
+    registration_revision: int = 1,
+) -> AcademicWorkRegistration:
+    return AcademicWorkRegistration(
+        schema_version="1",
+        record_type="academic_work_registration",
+        work=publication.work if work is None else work,
+        registration_revision=registration_revision,
+        producer_contract_version=producer_contract_version,
+        title="Synthetic writing assignment",
+        work_kind="assignment",
+        academic_intent="summative",
+        lifecycle="active",
+        created_at=_NOW,
+        updated_at=_NOW,
+        source_records=(
+            ModuleRecordRef("quillan", "assignment", "assignment1", "2"),
+        ),
+    )
+
+
+def test_provider_returns_exact_validated_immutable_profile() -> None:
+    assert tuple(inspect.signature(get_publication_producer_profile).parameters) == ()
+    profile = get_publication_producer_profile()
+    assert isinstance(profile, PublicationProducerProfile)
+    assert validate_publication_producer_profile(profile) == profile
+    assert get_publication_producer_profile() == profile
+    assert profile.module_id == "quillan"
+    assert profile.display_name == "Quillan"
+    assert profile.supported_core_publication_schema_versions == frozenset({"1"})
+    assert profile.supported_academic_work_contract_versions == frozenset(
+        {"quillan_academic_work_v1"}
+    )
+    assert len(profile.publication_contracts) == 1
+    support = profile.publication_contracts[0]
+    assert support.publication_kind == "academic_result_set"
+    assert support.manifest_contract_versions == frozenset(
+        {"quillan_academic_result_manifest_v1"}
+    )
+    assert support.supported_capabilities == _SUPPORTED_CAPABILITIES
+    assert support.source_record_contracts == ()
+    assert support.allows_missing_source_record is True
+    with pytest.raises((FrozenInstanceError, AttributeError)):
+        profile.module_id = "other"  # type: ignore[misc]
+    with pytest.raises(AttributeError):
+        profile.supported_core_publication_schema_versions.add("2")  # type: ignore[attr-defined]
+    with pytest.raises((FrozenInstanceError, AttributeError)):
+        support.publication_kind = "intervention_record_set"  # type: ignore[misc]
+    with pytest.raises(AttributeError):
+        support.supported_capabilities.add("points")  # type: ignore[attr-defined]
+
+
+def test_extracted_constants_preserve_previous_public_imports() -> None:
+    from quillan.academic_result_manifest import (
+        ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION as manifest_version,
+    )
+    from quillan.academic_work_registration import (
+        QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION as work_version,
+    )
+    from quillan.pds_contract import (
+        ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+        QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION,
+    )
+
+    assert manifest_version == ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION
+    assert work_version == QUILLAN_ACADEMIC_WORK_CONTRACT_VERSION
+
+
+def test_pyproject_declares_two_exact_independent_entry_points() -> None:
+    project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    groups = project["project"]["entry-points"]
+    assert groups["paper_data_suite.modules"] == {
+        "quillan": "quillan.pds_module:get_module_profile"
+    }
+    assert groups[PUBLICATION_PRODUCER_ENTRY_POINT_GROUP] == {
+        "quillan": "quillan.pds_publication:get_publication_producer_profile"
+    }
+
+
+def test_installed_entry_point_discovery_and_registry_are_exact() -> None:
+    points = tuple(
+        metadata.entry_points().select(
+            group=PUBLICATION_PRODUCER_ENTRY_POINT_GROUP,
+            name="quillan",
+        )
+    )
+    assert len(points) == 1
+    point = points[0]
+    assert point.value == "quillan.pds_publication:get_publication_producer_profile"
+    provider = point.load()
+    assert tuple(inspect.signature(provider).parameters) == ()
+    assert provider() == get_publication_producer_profile()
+    profiles = tuple(
+        profile
+        for profile in discover_publication_producer_profiles()
+        if profile.module_id == "quillan"
+    )
+    assert profiles == (get_publication_producer_profile(),)
+    assert (
+        build_publication_producer_registry().get("quillan")
+        == get_publication_producer_profile()
+    )
+
+
+def test_routing_and_publication_profiles_remain_independent() -> None:
+    routing = get_module_profile()
+    publication = get_publication_producer_profile()
+    assert id(get_module_profile) != id(get_publication_producer_profile)
+    assert isinstance(routing, ModuleProfile)
+    assert isinstance(publication, PublicationProducerProfile)
+    assert routing.module_id == publication.module_id == "quillan"
+    assert routing.display_name == publication.display_name == "Quillan"
+    assert callable(routing.route_handler)
+    assert callable(routing.registration_validator)
+    assert not hasattr(publication, "route_handler")
+    assert not hasattr(publication, "registration_validator")
+    assert not hasattr(routing, "publication_contracts")
+
+
+def test_profile_exposes_no_reader_parser_generator_or_operation_callbacks() -> None:
+    names = set(dir(get_publication_producer_profile()))
+    assert names.isdisjoint(
+        {
+            "manifest_parser",
+            "manifest_reader",
+            "manifest_validator",
+            "manifest_generator",
+            "publication_callback",
+            "supersession_callback",
+            "withdrawal_callback",
+            "route_handler",
+            "registration_validator",
+            "academic_work_registration_callback",
+            "cli_callback",
+            "menu_callback",
+        }
+    )
+
+
+def test_exact_publication_contract_is_compatible() -> None:
+    publication = _publication()
+    result = evaluate_publication_compatibility(
+        publication,
+        get_publication_producer_profile(),
+        _registration(publication),
+    )
+    assert result.compatible is True
+    assert result.codes == ()
+    assert publication.source_record is None
+    assert not Path(publication.manifest_path).exists()
+
+
+def test_missing_and_wrong_registration_contract_are_incompatible() -> None:
+    publication = _publication()
+    assert evaluate_publication_compatibility(
+        publication, get_publication_producer_profile()
+    ).codes == ("contracts.registration_version_incompatible",)
+    assert evaluate_publication_compatibility(
+        publication,
+        get_publication_producer_profile(),
+        _registration(publication, producer_contract_version="other_contract_v1"),
+    ).codes == ("contracts.registration_version_incompatible",)
+
+
+def test_registration_relationship_errors_are_invalid_evaluation_input() -> None:
+    publication = _publication()
+    with pytest.raises(PublicationProducerProfileError, match="work does not match"):
+        evaluate_publication_compatibility(
+            publication,
+            get_publication_producer_profile(),
+            _registration(
+                publication,
+                work=ModuleWorkRef("quillan", "class1", "other_assignment"),
+            ),
+        )
+    with pytest.raises(PublicationProducerProfileError, match="revision does not match"):
+        evaluate_publication_compatibility(
+            publication,
+            get_publication_producer_profile(),
+            _registration(publication, registration_revision=2),
+        )
+
+
+def test_schema_manifest_kind_source_and_module_mismatches_are_rejected() -> None:
+    publication = _publication()
+    registration = _registration(publication)
+    profile = get_publication_producer_profile()
+    unsupported_schema = replace(
+        profile, supported_core_publication_schema_versions=frozenset({"2"})
+    )
+    assert evaluate_publication_compatibility(
+        publication, unsupported_schema, registration
+    ).codes == ("contracts.publication_schema_incompatible",)
+    assert evaluate_publication_compatibility(
+        replace(publication, manifest_contract_version="fictional_manifest_v1"),
+        profile,
+        registration,
+    ).codes == ("contracts.manifest_version_incompatible",)
+    intervention = replace(
+        publication,
+        publication_kind="intervention_record_set",
+        capabilities=("intervention_status",),
+        academic_work_registration_revision=None,
+    )
+    assert evaluate_publication_compatibility(intervention, profile).codes == (
+        "contracts.publication_kind_incompatible",
+    )
+    for source in (
+        ModuleRecordRef("quillan", "assignment", "assignment1", "2"),
+        ModuleRecordRef("quillan", "review", "review1", "2"),
+    ):
+        assert evaluate_publication_compatibility(
+            replace(publication, source_record=source), profile, registration
+        ).codes == ("contracts.source_record_kind_incompatible",)
+    with pytest.raises(
+        PublicationRecordValidationError,
+        match="source_record.module_id must match work.module_id",
+    ):
+        replace(
+            publication,
+            source_record=ModuleRecordRef(
+                "other", "assignment", "assignment1", "2"
+            ),
+        )
+    assert evaluate_publication_compatibility(
+        publication, replace(profile, module_id="other"), registration
+    ).codes == ("contracts.profile_module_mismatch",)
+
+
+@pytest.mark.parametrize(
+    "capability", sorted(_UNSUPPORTED_CAPABILITIES - _INTERVENTION_CAPABILITIES)
+)
+def test_unsupported_capabilities_are_incompatible(
+    capability: PublicationCapability,
+) -> None:
+    publication = _publication(capabilities=(capability,))
+    result = evaluate_publication_compatibility(
+        publication,
+        get_publication_producer_profile(),
+        _registration(publication),
+    )
+    assert result.codes == ("contracts.capability_incompatible",)
+
+
+@pytest.mark.parametrize("capability", sorted(_INTERVENTION_CAPABILITIES))
+def test_core_rejects_intervention_capabilities_on_academic_results(
+    capability: PublicationCapability,
+) -> None:
+    with pytest.raises(
+        PublicationRecordValidationError,
+        match="academic-result publications cannot claim intervention capabilities",
+    ):
+        _publication(capabilities=(capability,))
+
+
+def test_profile_advertises_no_planned_or_fictional_contracts() -> None:
+    profile = get_publication_producer_profile()
+    support = profile.publication_contracts[0]
+    assert support.supported_capabilities.isdisjoint(_UNSUPPORTED_CAPABILITIES)
+    assert profile.supported_core_publication_schema_versions == frozenset({"1"})
+    assert profile.supported_academic_work_contract_versions == frozenset(
+        {"quillan_academic_work_v1"}
+    )
+    assert support.manifest_contract_versions == frozenset(
+        {"quillan_academic_result_manifest_v1"}
+    )
+
+
+def test_isolated_discovery_creates_no_state_or_workflow_imports(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "nonexistent_workspace"
+    script = """
+import json
+import os
+import pathlib
+import sys
+from pds_core.publication_compatibility import (
+    build_publication_producer_registry,
+    discover_publication_producer_profiles,
+)
+from quillan.pds_publication import get_publication_producer_profile
+
+workspace = pathlib.Path(os.environ["PDS_WORKSPACE_ROOT"])
+direct = get_publication_producer_profile()
+discovered = [p for p in discover_publication_producer_profiles() if p.module_id == "quillan"]
+registry = build_publication_producer_registry()
+blocked = ("scoreform", "concord", "portia", "pds_meridian", "vitrine")
+workflow_modules = (
+    "quillan.academic_result_manifest",
+    "quillan.academic_result_manifest_generation",
+    "quillan.academic_work_registration",
+    "quillan.cli",
+    "quillan.route_handler",
+)
+print(json.dumps({
+    "direct": direct.module_id,
+    "discovered": len(discovered),
+    "registry": registry.get("quillan").module_id,
+    "workspace_exists": workspace.exists(),
+    "blocked_imports": sorted(name for name in sys.modules if name.split(".")[0] in blocked),
+    "workflow_imports": sorted(name for name in workflow_modules if name in sys.modules),
+}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", script],
+        cwd=Path.cwd(),
+        env={"PDS_WORKSPACE_ROOT": str(workspace)},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == {
+        "direct": "quillan",
+        "discovered": 1,
+        "registry": "quillan",
+        "workspace_exists": False,
+        "blocked_imports": [],
+        "workflow_imports": [],
+    }
+    assert not workspace.exists()

--- a/tests/test_release_artifact_inspection.py
+++ b/tests/test_release_artifact_inspection.py
@@ -8,7 +8,11 @@ import zipfile
 
 import pytest
 
-from scripts.inspect_release_artifacts import inspect_sdist, inspect_wheel
+from scripts.inspect_release_artifacts import (
+    inspect_sdist,
+    inspect_wheel,
+    validate_entry_points_text,
+)
 
 
 REMOVED_MODULES = (
@@ -44,13 +48,16 @@ def _wheel(
 ) -> Path:
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr("quillan/_version.py", '__version__ = "0.8.9"\n')
+        archive.writestr("quillan/pds_publication.py", "")
         archive.writestr(extra_name, "")
         archive.writestr("quillan-0.8.9.dist-info/METADATA", metadata)
         archive.writestr(
             "quillan-0.8.9.dist-info/entry_points.txt",
             "[console_scripts]\nquillan = quillan.cli:main\n"
             "[paper_data_suite.modules]\n"
-            "quillan = quillan.pds_module:get_module_profile\n",
+            "quillan = quillan.pds_module:get_module_profile\n"
+            "[paper_data_suite.publication_producers]\n"
+            "quillan = quillan.pds_publication:get_publication_producer_profile\n",
         )
         archive.writestr("quillan-0.8.9.dist-info/licenses/LICENSE", "MIT\n")
     return path
@@ -71,6 +78,7 @@ def _sdist(
     (package / "quillan" / "_version.py").write_text(
         '__version__ = "0.8.9"\n', encoding="utf-8"
     )
+    (package / "quillan" / "pds_publication.py").write_text("", encoding="utf-8")
     target = package.joinpath(*extra_name.split("/"))
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text("", encoding="utf-8")
@@ -96,6 +104,40 @@ def test_sdist_rejects_each_removed_module(tmp_path: Path, removed: str) -> None
 def test_ordinary_current_package_paths_are_accepted(tmp_path: Path) -> None:
     assert inspect_wheel(_wheel(tmp_path / "current.whl"))["version"] == "0.8.9"
     assert inspect_sdist(_sdist(tmp_path / "current.tar.gz"))["version"] == "0.8.9"
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "[paper_data_suite.modules]\nquillan = quillan.pds_module:get_module_profile\n",
+        """[paper_data_suite.modules]
+quillan = quillan.pds_module:get_module_profile
+[paper_data_suite.publication_producers]
+other = quillan.pds_publication:get_publication_producer_profile
+""",
+        """[paper_data_suite.modules]
+quillan = quillan.pds_module:get_module_profile
+[paper_data_suite.publication_producers]
+quillan = quillan.pds_publication:wrong
+""",
+        """[paper_data_suite.modules]
+quillan = quillan.pds_publication:get_publication_producer_profile
+[paper_data_suite.publication_producers]
+quillan = quillan.pds_module:get_module_profile
+""",
+        """[paper_data_suite.modules]
+quillan = quillan.pds_module:get_module_profile
+[paper_data_suite.publication_producers]
+quillan = quillan.pds_publication:get_publication_producer_profile
+alias = quillan.pds_publication:get_publication_producer_profile
+""",
+    ),
+)
+def test_entry_point_contract_rejects_missing_wrong_swapped_or_alias_entries(
+    text: str,
+) -> None:
+    with pytest.raises(AssertionError):
+        validate_entry_points_text(text)
 
 
 def test_wheel_rejects_bundled_core_source(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements #362 by registering Quillan as an installed Core 0.6 publication producer.

- adds the independent `paper_data_suite.publication_producers` entry point
- declares the exact metadata-only Quillan `PublicationProducerProfile`
- supports Core Publication Record schema `1`
- supports `quillan_academic_work_v1`
- supports `academic_result_set`
- supports `quillan_academic_result_manifest_v1`
- advertises only `standards_ratings`
- requires Publication Record `source_record=None`
- preserves independent routing-profile discovery
- extends installed discovery and release-artifact validation
- documents publication-profile compatibility and responsibility boundaries

## Validation

- focused profile tests: `73 passed`
- full pytest: `2229 passed, 19 skipped`
- Ruff: PASS
- strict mypy: PASS — 267 files
- compileall: PASS
- `pip check`: PASS
- documentation integrity: PASS
- `run_tests.ps1`: PASS
- released Core 0.6.0 wheel authentication: PASS
- editable/noneditable install validation: PASS
- installed producer discovery/registry validation: PASS
- wheel/sdist artifact inspection: PASS
- automated release-candidate validation: PASS

Closes #362