### PR TITLE
feat: expose consumer-neutral Quillan manifest and artifact reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Installed publication compatibility is documented in
 Core publication, supersession, withdrawal, republication, and catalog
 reconciliation are documented in
 [Academic Result Publication Lifecycle](docs/academic_result_publication.md).
+Consumer-neutral manifest reading and separately authorized student-work/feedback
+artifact resolution are documented in
+[Academic Result Reader and Authorized Artifacts](docs/academic_result_reader.md).
 
 > **Storage contract:** Quillan assignment, submission, review, feedback, and
 > assignment-report services use only
@@ -85,6 +88,8 @@ Quillan currently supports:
 * explicit immutable Academic Result manifest generation and byte-exact replay;
 * explicit Core Academic Result publication, supersession, withdrawal, republication,
   and catalog reconciliation;
+* a pure consumer-neutral Academic Result manifest reader with exact native lookup;
+* separately authorization-gated selected student-work and feedback artifact lookup;
 * Focus Standard feedback composition;
 * reusable Focus Standard comments in `shared/focus_standard_comments/`;
 * student feedback export to Markdown, PDF, or both;

--- a/docs/academic_result_manifest_v1.md
+++ b/docs/academic_result_manifest_v1.md
@@ -25,7 +25,10 @@ revision, correction, and withdrawal behavior is defined by
 assignment eligibility and Core registration are defined by
 [Quillan Academic Work Registration](academic_work_registration.md); the installed
 [Publication Producer Profile](publication_producer_profile.md) declares metadata
-compatibility; and publication and reader integration remain #363–#364.
+compatibility; explicit Core publication lifecycle is documented in
+[Academic Result Publication Lifecycle](academic_result_publication.md); and exact
+consumer-neutral reading plus separately authorized artifact resolution are documented
+in [Academic Result Reader and Authorized Artifacts](academic_result_reader.md).
 
 ## Exact schema
 

--- a/docs/academic_result_publication.md
+++ b/docs/academic_result_publication.md
@@ -49,6 +49,13 @@ authorities.
 `quillan.pds_publication` remains metadata-only. It contains no publication,
 supersession, withdrawal, catalog, CLI, menu, reader, or authorization callback.
 
+After a consumer has selected and authorized a canonical Core publication and Core has
+verified the exact producer manifest path and SHA-256, the immutable bytes may be
+parsed through `quillan.academic_result_reader`. Separately authorized student-work or
+feedback lookup is handled by `quillan.academic_result_artifacts`; neither reader
+selects Core publications or queries the academic catalog. See
+[Academic Result Reader and Authorized Artifacts](academic_result_reader.md).
+
 ## Producer head selection
 
 Initial publication and ordinary supersession require the caller-selected manifest

--- a/docs/academic_result_reader.md
+++ b/docs/academic_result_reader.md
@@ -1,0 +1,298 @@
+# Quillan Academic Result Reader and Authorized Artifacts
+
+## Purpose
+
+Quillan exposes two deliberately separate consumer-neutral integration boundaries:
+
+```text
+quillan.academic_result_reader
+quillan.academic_result_artifacts
+```
+
+The reader interprets already-authorized immutable
+`quillan_academic_result_manifest_v1` bytes and models. It performs no workspace,
+filesystem, Core registry/catalog, publication-selection, or authorization I/O.
+
+The artifact module performs the separate operation of resolving exact Quillan-owned
+student-work or feedback artifacts after an external application/deployment
+authorization decision.
+
+The split is normative:
+
+```text
+Core-authorized and Core-verified immutable manifest bytes
+-> pure Quillan manifest reader
+-> exact producer-native models
+-> consumer policy
+
+separately authorized artifact request
+-> external authorization gate
+-> exact manifest-bound native-source verification
+-> exact producer artifact
+```
+
+Neither boundary calculates Grades, proficiency/mastery, or portfolio policy.
+
+## Ownership
+
+Quillan owns Academic Result Manifest v1 parsing and validation; native
+assignment/submission/review semantics; exact student, source, review-unit,
+observation, rating, feedback, and selected-PDS2 evidence-reference lookup; native
+source verification needed for artifact access; selected-evidence eligibility;
+feedback-export relationship checks; and the producer privacy floor.
+
+Core owns Publication Records and Withdrawals, Academic Work Registration,
+publication-series state, publication selection, manifest path containment and
+Publication Record SHA-256 verification, compatibility metadata, and the rebuildable
+academic catalog.
+
+The application/deployment owns actor identity, purpose, manifest/result
+authorization, artifact authorization, recipient/disclosure authorization, filesystem
+permissions, and deployment trust.
+
+Meridian owns grading/reporting policy after authorized producer parsing. Vitrine owns
+portfolio Candidate/Selection/Profile/disclosure policy after authorized producer
+parsing. Quillan imports neither consumer.
+
+## Pure manifest reader
+
+Stable imports come from `quillan.academic_result_reader`.
+
+`read_academic_result_manifest(value)` accepts only exact immutable `bytes`. It
+delegates decoding and whole-manifest validation to the authoritative
+`quillan.academic_result_manifest` contract, canonicalizes the model with the
+authoritative serializer, and requires byte-for-byte equality with the caller input.
+
+Equivalent but noncanonical JSON fails closed, including alternate whitespace, key
+order, missing final newline, and trailing whitespace. Core's Publication Record
+digest remains a separate prior verification step; the reader does not replace Core
+publication-envelope integrity.
+
+`validate_academic_result_manifest(manifest)` accepts the exact immutable public model,
+delegates to the authoritative validator, returns the same model, and performs no I/O.
+
+Public reader failures are:
+
+```text
+QuillanAcademicResultReaderError
+  QuillanAcademicResultReaderValidationError
+    QuillanAcademicResultReaderDecodeError
+  QuillanAcademicResultReaderNotFoundError
+```
+
+Decode and not-found messages are bounded and do not echo manifest payloads or hidden
+student content.
+
+## Exact lookup semantics
+
+The reader exposes exact producer-native lookup only:
+
+```python
+lookup_academic_result_student(...)
+lookup_academic_result_source(...)
+lookup_academic_result_review_unit(...)
+lookup_academic_result_observation(...)
+lookup_academic_result_overall_rating(...)
+lookup_academic_result_standard_feedback(...)
+lookup_academic_result_evidence_reference(...)
+```
+
+Source names are exactly `assignment`, `submission`, and `review`. Assignment lookup
+takes no student ID; student sources require an exact represented student. These are
+metadata lookups only and never open native records.
+
+Review units resolve only by exact `unit_id`; observations only by exact
+`observation_id`; overall ratings and standard feedback only by exact native
+`standard_id`. Focus Standard IDs are bounded native text, not path-safe identifiers,
+and are never normalized into another module's scale.
+
+A present native minimum rating remains a real rating. An absent rating remains absent.
+Non-applicable observations and applicable observations without evidence retain their
+native null states and are never converted to numeric scores.
+
+`PublishedText` remains exactly `absent`, `withheld`, or `included`. The reader cannot
+recover withheld native text.
+
+Evidence-reference lookup searches only selected PDS2 provenance already represented
+in the manifest. It never derives a routed path, retained-source path, source filename,
+candidate evidence, duplicate evidence, excluded evidence, or replacement history.
+
+## Artifact kinds and authorization
+
+Stable artifact imports come from `quillan.academic_result_artifacts`.
+
+Supported kinds are closed:
+
+```text
+student_work
+feedback_pdf
+feedback_markdown
+```
+
+There is no arbitrary-path, generic-file, or generic-native-record API.
+
+Artifact access requires an externally supplied authorization gate. Decision states are
+exactly:
+
+```text
+allowed
+denied
+unresolved
+```
+
+The authorization request contains only bounded manifest-derived identity:
+
+```text
+work
+record_set_id
+record_set_revision
+student_id
+artifact_kind
+purpose
+```
+
+It contains no artifact path.
+
+Quillan calls the gate before canonicalizing or inspecting the workspace and before
+checking source or artifact existence. `denied` and `unresolved` therefore cannot leak
+whether a submission source, selected-evidence file, or feedback export exists.
+
+Quillan defines no teacher/admin/student role matrix here. Authorization policy remains
+deployment-owned.
+
+## Historical source integrity
+
+Artifact resolution is permitted only against the exact native source bytes bound into
+the immutable manifest. For each required source Quillan derives the exact canonical
+work descendant, requires agreement with the manifest source path, rejects link-like
+path components, reads an ordinary regular file, checks exact SHA-256, validates the
+existing native schema, and requires exact class/assignment/student identity.
+
+Quillan does not reconstruct historical source bytes and does not use newer native
+state under an older manifest. If the canonical native record changed after
+publication, artifact resolution fails closed even though the immutable manifest and
+Core Publication Record remain historically valid.
+
+## Selected PDS2 student work
+
+`student_work` is available only for `pds2_response_pages` results with represented
+public selected-evidence provenance.
+
+After authorization and exact `submission.json` verification, Quillan independently
+requires:
+
+```text
+page.selected_evidence_id == evidence.evidence_id
+evidence.evidence_role == selected
+```
+
+and exact agreement of:
+
+```text
+page_id
+evidence_id
+observation_id
+route_id
+issuance_id
+generation_id
+artifact_id
+source_page_number
+source_scan_id
+source_sha256
+routed_evidence_sha256
+```
+
+Only then may Quillan use the private native `routed_evidence_path`. The routed file
+must remain inside the exact work root, contain no link-like path component, use a
+supported image format, and hash exactly to public `routed_evidence_sha256`.
+
+Returned artifacts preserve manifest evidence-reference order. Candidate, unselected
+duplicate, excluded, unrelated replacement evidence, retained full scans,
+`retained_source_path`, `source_filename`, QR/route payloads, and another student's
+evidence are never returned.
+
+For `plain_paper_manual`, student work is explicitly unavailable; no digital artifact
+is fabricated.
+
+## Feedback PDF and Markdown
+
+Feedback reads are format-exact. PDF never falls back to Markdown and Markdown never
+falls back to PDF.
+
+After authorization Quillan requires the exact manifest-bound `review.json` source,
+schema-2 validation, exact identity, existing metadata under the requested
+`review.json.exports` field, the exact canonical feedback path, and:
+
+```text
+source_review_updated_at == review.updated_at
+```
+
+Artifact existence alone is insufficient.
+
+Markdown-only export now records the existing schema-2
+`exports.feedback_markdown` metadata, matching the persistence model already used by
+PDF and companion Markdown export. This is a consistency fix, not a schema change.
+
+The SHA-256 returned for feedback is the digest of the exact artifact bytes observed
+and returned by that read. It is not the Core Publication Record manifest digest and
+does not claim the derived feedback file was independently immutable since
+publication.
+
+Feedback reads do not regenerate artifacts and do not return `review.json`. Private
+notes, unselected comments, withheld rationales, reusable-comment provenance, and
+arbitrary module details remain outside the result.
+
+## Authorized artifact result
+
+`AuthorizedAcademicResultArtifact` is frozen and slotted and returns immutable bytes
+plus bounded metadata:
+
+```text
+artifact_kind
+work
+record_set_revision
+student_id
+workspace-relative artifact path
+media_type
+sha256
+byte_size
+data
+```
+
+Student work may also carry the exact public `EvidenceReference`. Feedback may carry
+safe `generated_at` and `source_review_updated_at` metadata. Absolute workspace paths
+and private native source locators are not returned.
+
+## Core-backed consumer sequence
+
+```text
+discover candidate publication through Core
+-> reload canonical Core publication state
+-> evaluate producer compatibility
+-> establish manifest/result authorization
+-> Core verifies exact manifest path and Publication Record SHA-256
+-> pass exact immutable bytes to quillan.academic_result_reader
+-> apply consumer-owned policy
+
+if a producer artifact is separately required:
+-> establish artifact authorization through deployment policy
+-> call quillan.academic_result_artifacts
+-> Quillan verifies exact historical native-source relationship
+-> receive bounded immutable artifact bytes
+```
+
+Manifest authorization, feedback authorization, student-work authorization, and
+underlying-source authorization remain distinct.
+
+## Packaging and side effects
+
+Both public modules ship in the Quillan wheel. Import and pure manifest reading create
+no workspace, registry, catalog, publication, withdrawal, or Academic Work
+Registration state. The artifact module performs no workspace/source/artifact I/O
+until the request is valid and the external gate returns `allowed`.
+
+There is no CLI or teacher-menu artifact reader. These modules are integration/library
+boundaries for authorized consumers.
+
+Issue #365 owns the complete clean-wheel producer-to-Core end-to-end acceptance flow.
+Issue #366 owns final compatibility/release authorization.

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -45,6 +45,14 @@ the full supersession chain, treats withdrawal as a separate immutable Core reco
 uses explicit republication after a withdrawn head, and fully rebuilds/reconciles the
 derived Core academic catalog after successful or replayed lifecycle writes.
 
+Consumer-neutral exact manifest reading and separately authorization-gated producer
+artifact lookup are defined in
+[Academic Result Reader and Authorized Artifacts](academic_result_reader.md). The pure
+reader performs no workspace or Core publication I/O. Artifact resolution verifies
+exact manifest-bound native source bytes before exposing only authoritative selected
+PDS2 student work or exact metadata-backed feedback PDF/Markdown bytes. Manifest,
+student-work, feedback, and underlying-source authorization remain distinct.
+
 Quillan-owned assignment records and all dependent submission, review, and export
 records are rooted exclusively beneath
 `classes/<class_id>/modules/quillan/work/<assignment_id>/`. Contextual loaders

--- a/docs/development_plan.md
+++ b/docs/development_plan.md
@@ -5,7 +5,7 @@ Academic Result Manifest v1, privacy projection, revision policy, Core 0.6
 compatibility, explicit Academic Work Registration, explicit immutable workspace
 manifest generation/replay, installed publication-producer compatibility, and
 explicit Core publication/supersession/withdrawal/republication with full catalog
-reconciliation. Consumer-neutral reading remains #364.
+reconciliation, and consumer-neutral manifest/artifact reading through #364.
 
 Classification: **active authority** for the v0.8.9 release candidate.
 
@@ -32,7 +32,9 @@ intake, Core routing review, Quillan post-dispatch review, digital and plain-pap
 submissions, teacher-controlled page management and standards-based review,
 feedback export, three assignment-local reports, dashboard schema version 2,
 student review status schema version 1, explicit immutable Academic Result
-manifest generation/replay, direct CLI commands, and the compact teacher menu.
+manifest generation/replay, a pure installed manifest reader, separately authorized
+selected student-work/feedback artifact resolution, direct CLI commands, and the
+compact teacher menu.
 
 ## Product boundaries
 
@@ -49,14 +51,13 @@ Python versions are CPython 3.11 through 3.14. Runtime Core compatibility is
 Quillan supports explicit Academic Work Registration for eligible managed
 assignments through Core under `quillan_academic_work_v1`; ordinary assignment,
 PDS2, review, feedback, and reporting workflows never register work implicitly.
-Registration itself does not generate manifests. A separate explicit #361
-workflow now validates native state and creates/replays immutable producer-owned
-Academic Result manifest revisions under
-`exports/manifests/academic_results/`. That workflow does not publish through
-Core, create Publication Records or withdrawals, rebuild the academic catalog,
-assign Academic Period membership, calculate proficiency or Grades, or create
-portfolio Candidates. #362–#365 own the remaining producer integration;
-#366 owns the final release audit.
+Registration itself does not generate manifests. The explicit #361 workflow
+validates native state and creates/replays immutable producer-owned Academic Result
+manifest revisions under `exports/manifests/academic_results/`. #363 owns explicit
+Core publication lifecycle and #364 owns consumer-neutral parsing plus separately
+authorized producer artifact lookup. These boundaries do not assign Academic Period
+membership, calculate proficiency or Grades, or create portfolio Candidates. #365
+owns installed end-to-end producer acceptance; #366 owns the final release audit.
 
 ## Core 0.6 academic-publication milestone status
 
@@ -65,8 +66,8 @@ portfolio Candidates. #362–#365 own the remaining producer integration;
 #360 Academic Work Registration                complete
 #361 immutable manifest generation/validation complete
 #362 publication producer profile              complete
-#363 publication lifecycle                     remaining
-#364 consumer-neutral reader                   remaining
+#363 publication lifecycle                     complete
+#364 consumer-neutral reader                   complete
 #365 installed end-to-end producer acceptance  remaining
 #366 release audit/version closeout             remaining
 ```

--- a/docs/publication_projection_policy_v1.md
+++ b/docs/publication_projection_policy_v1.md
@@ -431,9 +431,10 @@ because one student appears in them.
 
 ### Structured feedback
 
-A future structured feedback reader may return only content approved by this policy.
-It must not return complete `review.json`, unselected comments, withheld rationales,
-private notes, or arbitrary requirement history.
+The public consumer-neutral reader returns only manifest content already approved by
+this policy. It does not open `review.json` and cannot recover unselected comments,
+withheld rationales, private notes, or arbitrary requirement history. See
+[Academic Result Reader and Authorized Artifacts](academic_result_reader.md).
 
 ### Feedback PDF and Markdown
 
@@ -441,18 +442,21 @@ The existing PDF and Markdown exports are derived student-facing artifacts, not
 canonical review state. Their existence or metadata in `review.json.exports` does
 not grant publication or access permission.
 
-A later artifact reader may expose an exact feedback export only after verifying its
-relationship, source/projection provenance, applicable historical state, and
-separate artifact-access authorization.
+The authorized artifact reader exposes an exact feedback export only after verifying
+its manifest-bound review source, exact export metadata relationship, applicable
+historical state, canonical path, and separate artifact-access authorization. Its
+observed artifact SHA-256 is not the Core Publication Record manifest digest.
 
 ### Original student work
 
-A later student-work artifact projection may resolve only producer-confirmed selected
-evidence. It must not fall back to candidate evidence, duplicate alternatives,
-excluded evidence, unrelated replacement history, complete retained scans, another
-student's pages, or arbitrary source bytes.
+The authorized student-work artifact reader resolves only producer-confirmed selected
+PDS2 evidence after exact manifest-bound submission-source verification. It does not
+fall back to candidate evidence, duplicate alternatives, excluded evidence, unrelated
+replacement history, complete retained scans, another student's pages, or arbitrary
+source bytes. Plain paper receives no fabricated digital artifact.
 
-Artifact resolution belongs to #364, not this policy module.
+Artifact resolution is implemented by `quillan.academic_result_artifacts`; this
+policy module remains pure and does no artifact I/O.
 
 ## Discovery is not authorization
 

--- a/quillan/academic_result_artifacts.py
+++ b/quillan/academic_result_artifacts.py
@@ -1,0 +1,759 @@
+"""Authorization-gated Quillan Academic Result artifact resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Final, Literal, Protocol, TypeAlias, cast
+
+from quillan._path_safety import is_link_like
+from quillan.academic_result_manifest import (
+    AcademicResultManifest,
+    EvidenceReference,
+    WorkReference,
+)
+from quillan.academic_result_reader import (
+    QuillanAcademicResultReaderError,
+    lookup_academic_result_student,
+    validate_academic_result_manifest,
+)
+from quillan.record_context import (
+    QuillanRecordContextError,
+    canonical_workspace_root,
+)
+from quillan.review_record import ReviewRecordError, validate_review_record
+from quillan.submission_manifest import (
+    SubmissionManifestError,
+    validate_submission_manifest,
+)
+from quillan.work_paths import (
+    QuillanWorkPathError,
+    feedback_markdown_path,
+    feedback_pdf_path,
+    quillan_work_paths,
+    quillan_work_ref,
+    review_record_path,
+    routed_evidence_path,
+    submission_manifest_path,
+)
+
+AcademicResultArtifactKind: TypeAlias = Literal[
+    "student_work",
+    "feedback_pdf",
+    "feedback_markdown",
+]
+ArtifactAuthorizationStatus: TypeAlias = Literal["allowed", "denied", "unresolved"]
+
+_ALLOWED_ARTIFACT_KINDS: Final[frozenset[str]] = frozenset(
+    {"student_work", "feedback_pdf", "feedback_markdown"}
+)
+_ALLOWED_AUTHORIZATION_STATES: Final[frozenset[str]] = frozenset(
+    {"allowed", "denied", "unresolved"}
+)
+_MAX_PURPOSE = 500
+_SHA256 = frozenset("0123456789abcdef")
+
+
+class QuillanAcademicResultArtifactError(Exception):
+    """Base failure for authorized Academic Result artifact access."""
+
+
+class QuillanAcademicResultArtifactValidationError(
+    QuillanAcademicResultArtifactError, ValueError
+):
+    """Artifact request or public input is invalid."""
+
+
+class QuillanAcademicResultArtifactAuthorizationError(
+    QuillanAcademicResultArtifactError, PermissionError
+):
+    """Artifact authorization was denied, unresolved, or invalid."""
+
+
+class QuillanAcademicResultArtifactUnavailableError(
+    QuillanAcademicResultArtifactError, LookupError
+):
+    """The authorized exact artifact has no available producer representation."""
+
+
+class QuillanAcademicResultArtifactIntegrityError(
+    QuillanAcademicResultArtifactError
+):
+    """Producer source or artifact state contradicts the manifest."""
+
+
+class QuillanAcademicResultArtifactReadError(
+    QuillanAcademicResultArtifactError, OSError
+):
+    """An otherwise valid authorized source or artifact could not be read."""
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultArtifactAuthorizationRequest:
+    """Privacy-bounded exact request supplied to deployment authorization."""
+
+    work: WorkReference
+    record_set_id: str
+    record_set_revision: int
+    student_id: str
+    artifact_kind: AcademicResultArtifactKind
+    purpose: str
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultArtifactAuthorizationDecision:
+    """Deployment-owned authorization result; absence of allow is not permission."""
+
+    status: ArtifactAuthorizationStatus
+
+    def __post_init__(self) -> None:
+        if self.status not in _ALLOWED_AUTHORIZATION_STATES:
+            raise QuillanAcademicResultArtifactValidationError(
+                "Authorization decision status is invalid."
+            )
+
+
+class AcademicResultArtifactAuthorizationGate(Protocol):
+    """External authorization boundary supplied by the deployment/application."""
+
+    def authorize(
+        self,
+        request: AcademicResultArtifactAuthorizationRequest,
+    ) -> AcademicResultArtifactAuthorizationDecision:
+        """Return an explicit allowed, denied, or unresolved decision."""
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizedAcademicResultArtifact:
+    """One immutable exact artifact returned after authorization and verification."""
+
+    artifact_kind: AcademicResultArtifactKind
+    work: WorkReference
+    record_set_revision: int
+    student_id: str
+    relative_path: str
+    media_type: str
+    sha256: str
+    byte_size: int
+    data: bytes
+    evidence_reference: EvidenceReference | None = None
+    generated_at: str | None = None
+    source_review_updated_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.artifact_kind not in _ALLOWED_ARTIFACT_KINDS:
+            raise QuillanAcademicResultArtifactValidationError(
+                "Authorized artifact kind is invalid."
+            )
+        if type(self.data) is not bytes:
+            raise QuillanAcademicResultArtifactValidationError(
+                "Authorized artifact data must be immutable bytes."
+            )
+        if self.byte_size != len(self.data):
+            raise QuillanAcademicResultArtifactValidationError(
+                "Authorized artifact byte_size disagrees with data."
+            )
+        if (
+            len(self.sha256) != 64
+            or any(character not in _SHA256 for character in self.sha256)
+            or hashlib.sha256(self.data).hexdigest() != self.sha256
+        ):
+            raise QuillanAcademicResultArtifactValidationError(
+                "Authorized artifact SHA-256 disagrees with data."
+            )
+        _workspace_relative_posix(self.relative_path, "relative_path")
+
+
+class _DuplicateJsonKey(ValueError):
+    pass
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKey("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _reject_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON value {value}")
+
+
+def _strict_json_object(
+    value: bytes,
+    *,
+    source_name: Literal["submission", "review"],
+) -> dict[str, object]:
+    try:
+        decoded = json.loads(
+            value.decode("utf-8"),
+            object_pairs_hook=_pairs,
+            parse_constant=_reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKey, ValueError) as error:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            f"Manifest-bound {source_name} source is not valid strict JSON."
+        ) from error
+    if not isinstance(decoded, dict) or any(not isinstance(key, str) for key in decoded):
+        raise QuillanAcademicResultArtifactIntegrityError(
+            f"Manifest-bound {source_name} source is not one JSON object."
+        )
+    return cast(dict[str, object], decoded)
+
+
+def _purpose(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > _MAX_PURPOSE
+        or "\x00" in value
+    ):
+        raise QuillanAcademicResultArtifactValidationError(
+            f"purpose must be nonempty bounded text of at most {_MAX_PURPOSE} characters."
+        )
+    return value
+
+
+def _artifact_kind(value: object) -> AcademicResultArtifactKind:
+    if not isinstance(value, str) or value not in _ALLOWED_ARTIFACT_KINDS:
+        raise QuillanAcademicResultArtifactValidationError(
+            "artifact_kind must be student_work, feedback_pdf, or feedback_markdown."
+        )
+    return cast(AcademicResultArtifactKind, value)
+
+
+def _authorize(
+    gate: AcademicResultArtifactAuthorizationGate,
+    request: AcademicResultArtifactAuthorizationRequest,
+) -> None:
+    authorize = getattr(gate, "authorize", None)
+    if not callable(authorize):
+        raise QuillanAcademicResultArtifactAuthorizationError(
+            "Artifact authorization gate is unavailable."
+        )
+    try:
+        decision = authorize(request)
+    except Exception as error:
+        raise QuillanAcademicResultArtifactAuthorizationError(
+            "Artifact authorization could not be established."
+        ) from error
+    if type(decision) is not AcademicResultArtifactAuthorizationDecision:
+        raise QuillanAcademicResultArtifactAuthorizationError(
+            "Artifact authorization decision is invalid."
+        )
+    if decision.status != "allowed":
+        raise QuillanAcademicResultArtifactAuthorizationError(
+            "Artifact access is not authorized."
+        )
+
+
+def _workspace_relative_posix(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            f"{field} must be canonical workspace-relative POSIX text."
+        )
+    posix = PurePosixPath(value)
+    windows = PureWindowsPath(value)
+    if (
+        posix.is_absolute()
+        or windows.is_absolute()
+        or windows.drive
+        or value != posix.as_posix()
+        or any(part in {"", ".", ".."} for part in posix.parts)
+    ):
+        raise QuillanAcademicResultArtifactIntegrityError(
+            f"{field} must be canonical workspace-relative POSIX text."
+        )
+    return value
+
+
+def _require_non_link_path_chain(workspace_root: Path, path: Path) -> None:
+    try:
+        relative = path.relative_to(workspace_root)
+    except ValueError as error:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Authorized producer path escapes the workspace."
+        ) from error
+    current = workspace_root
+    for component in relative.parts:
+        current = current / component
+        if os.path.lexists(current) and is_link_like(current):
+            raise QuillanAcademicResultArtifactIntegrityError(
+                "Authorized producer path contains a link-like component."
+            )
+
+
+def _read_regular_file(
+    path: Path,
+    *,
+    workspace_root: Path,
+    missing_message: str,
+) -> bytes:
+    try:
+        _require_non_link_path_chain(workspace_root, path)
+        if not os.path.lexists(path):
+            raise QuillanAcademicResultArtifactUnavailableError(missing_message)
+        if not path.is_file():
+            raise QuillanAcademicResultArtifactIntegrityError(
+                "Authorized producer artifact path is not an ordinary regular file."
+            )
+        return path.read_bytes()
+    except QuillanAcademicResultArtifactError:
+        raise
+    except OSError as error:
+        raise QuillanAcademicResultArtifactReadError(
+            "Authorized producer artifact could not be read."
+        ) from error
+
+
+def _load_bound_submission(
+    workspace_root: Path,
+    manifest: AcademicResultManifest,
+    student_id: str,
+) -> dict[str, object]:
+    student = lookup_academic_result_student(manifest, student_id)
+    work_ref = quillan_work_ref(manifest.work.class_id, manifest.work.work_id)
+    paths = quillan_work_paths(
+        workspace_root, manifest.work.class_id, manifest.work.work_id
+    )
+    snapshot = student.source_snapshot.submission
+    expected_source = f"submissions/{student_id}/submission.json"
+    if snapshot.relative_path != expected_source:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest submission source path is not canonical for the represented student."
+        )
+    exact_path = paths.work_root.joinpath(*PurePosixPath(snapshot.relative_path).parts)
+    canonical_path = submission_manifest_path(workspace_root, work_ref, student_id)
+    if exact_path != canonical_path:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest submission source path disagrees with Quillan canonical storage."
+        )
+    raw = _read_regular_file(
+        exact_path,
+        workspace_root=workspace_root,
+        missing_message="Manifest-bound submission source is unavailable.",
+    )
+    if hashlib.sha256(raw).hexdigest() != snapshot.sha256:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest-bound submission source bytes have changed."
+        )
+    source = _strict_json_object(raw, source_name="submission")
+    try:
+        validate_submission_manifest(source)
+    except (SubmissionManifestError, TypeError, ValueError) as error:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest-bound submission source violates the Quillan submission contract."
+        ) from error
+    expected_identity = (
+        manifest.work.class_id,
+        manifest.work.work_id,
+        student_id,
+    )
+    if (
+        source.get("class_id"),
+        source.get("assignment_id"),
+        source.get("student_id"),
+    ) != expected_identity:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest-bound submission identity disagrees with the requested result."
+        )
+    return source
+
+
+def _load_bound_review(
+    workspace_root: Path,
+    manifest: AcademicResultManifest,
+    student_id: str,
+) -> dict[str, object]:
+    student = lookup_academic_result_student(manifest, student_id)
+    work_ref = quillan_work_ref(manifest.work.class_id, manifest.work.work_id)
+    paths = quillan_work_paths(
+        workspace_root, manifest.work.class_id, manifest.work.work_id
+    )
+    snapshot = student.source_snapshot.review
+    expected_source = f"submissions/{student_id}/review.json"
+    if snapshot.relative_path != expected_source:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest review source path is not canonical for the represented student."
+        )
+    exact_path = paths.work_root.joinpath(*PurePosixPath(snapshot.relative_path).parts)
+    canonical_path = review_record_path(workspace_root, work_ref, student_id)
+    if exact_path != canonical_path:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest review source path disagrees with Quillan canonical storage."
+        )
+    raw = _read_regular_file(
+        exact_path,
+        workspace_root=workspace_root,
+        missing_message="Manifest-bound review source is unavailable.",
+    )
+    if hashlib.sha256(raw).hexdigest() != snapshot.sha256:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest-bound review source bytes have changed."
+        )
+    source = _strict_json_object(raw, source_name="review")
+    try:
+        validate_review_record(source)
+    except (ReviewRecordError, TypeError, ValueError) as error:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest-bound review source violates the Quillan review contract."
+        ) from error
+    expected_identity = (
+        manifest.work.class_id,
+        manifest.work.work_id,
+        student_id,
+    )
+    if (
+        source.get("class_id"),
+        source.get("assignment_id"),
+        source.get("student_id"),
+    ) != expected_identity:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest-bound review identity disagrees with the requested result."
+        )
+    return source
+
+
+def _as_mapping(value: object, context: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise QuillanAcademicResultArtifactIntegrityError(
+            f"{context} is not an object."
+        )
+    return cast(Mapping[str, object], value)
+
+
+def _as_list(value: object, context: str) -> list[object]:
+    if not isinstance(value, list):
+        raise QuillanAcademicResultArtifactIntegrityError(
+            f"{context} is not an array."
+        )
+    return cast(list[object], value)
+
+
+def _native_selected_evidence(
+    submission: Mapping[str, object],
+    reference: EvidenceReference,
+) -> tuple[Mapping[str, object], int]:
+    matches: list[tuple[Mapping[str, object], Mapping[str, object], int]] = []
+    for page_value in _as_list(submission.get("pages"), "submission.pages"):
+        page = _as_mapping(page_value, "submission page")
+        page_number = page.get("page_number")
+        if isinstance(page_number, bool) or not isinstance(page_number, int):
+            raise QuillanAcademicResultArtifactIntegrityError(
+                "Submission page_number is invalid."
+            )
+        for evidence_value in _as_list(page.get("evidence"), "submission page evidence"):
+            evidence = _as_mapping(evidence_value, "submission evidence")
+            if evidence.get("evidence_id") == reference.evidence_id:
+                matches.append((page, evidence, page_number))
+    if len(matches) != 1:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest evidence reference does not resolve to one native evidence row."
+        )
+    page, evidence, page_number = matches[0]
+    if page.get("selected_evidence_id") != reference.evidence_id:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest evidence is no longer the authoritative selected page evidence."
+        )
+    if evidence.get("evidence_role") != "selected":
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest evidence does not have the native selected evidence role."
+        )
+    details = _as_mapping(evidence.get("module_details"), "evidence.module_details")
+    retained = _as_mapping(evidence.get("retained_source"), "evidence.retained_source")
+    expected_pairs = (
+        (details.get("page_id"), reference.page_id),
+        (evidence.get("evidence_id"), reference.evidence_id),
+        (details.get("observation_id"), reference.observation_id),
+        (details.get("route_id"), reference.route_id),
+        (details.get("issuance_id"), reference.issuance_id),
+        (details.get("generation_id"), reference.generation_id),
+        (details.get("artifact_id"), reference.artifact_id),
+        (retained.get("source_page_number"), reference.source_page_number),
+        (retained.get("source_scan_id"), reference.source_scan_id),
+        (retained.get("source_sha256"), reference.source_sha256),
+        (details.get("routed_evidence_sha256"), reference.routed_evidence_sha256),
+    )
+    if any(actual != expected for actual, expected in expected_pairs):
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Manifest evidence provenance disagrees with the exact native selected evidence."
+        )
+    logical_page = details.get("logical_page")
+    if logical_page != page_number:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Selected evidence logical page disagrees with its submission page."
+        )
+    return evidence, page_number
+
+
+def _artifact_path(
+    root: Path,
+    manifest: AcademicResultManifest,
+    student_id: str,
+    reference: EvidenceReference,
+    evidence: Mapping[str, object],
+    page_number: int,
+) -> tuple[Path, str]:
+    relative = _workspace_relative_posix(
+        evidence.get("routed_evidence_path"), "routed_evidence_path"
+    )
+    path = root.joinpath(*PurePosixPath(relative).parts)
+    work_ref = quillan_work_ref(manifest.work.class_id, manifest.work.work_id)
+    paths = quillan_work_paths(
+        root, manifest.work.class_id, manifest.work.work_id
+    )
+    try:
+        path.relative_to(paths.work_root)
+    except ValueError as error:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Authorized routed evidence does not remain inside the exact Quillan work root."
+        ) from error
+    try:
+        canonical = routed_evidence_path(
+            root,
+            work_ref,
+            reference.issuance_id,
+            student_id,
+            page_number,
+            reference.observation_id,
+            path.suffix,
+        )
+    except (QuillanWorkPathError, TypeError, ValueError) as error:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Authorized routed evidence path cannot be derived canonically."
+        ) from error
+    if path != canonical:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Authorized routed evidence path is not the exact canonical Quillan "
+            "selected-evidence path."
+        )
+    return path, relative
+
+
+def _media_type(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".png":
+        return "image/png"
+    if suffix in {".jpg", ".jpeg"}:
+        return "image/jpeg"
+    if suffix in {".tif", ".tiff"}:
+        return "image/tiff"
+    raise QuillanAcademicResultArtifactIntegrityError(
+        "Authorized routed evidence has an unsupported media type."
+    )
+
+
+def _read_student_work(
+    workspace_root: Path,
+    manifest: AcademicResultManifest,
+    student_id: str,
+) -> tuple[AuthorizedAcademicResultArtifact, ...]:
+    student = lookup_academic_result_student(manifest, student_id)
+    provenance = student.submission.digital_provenance
+    if student.submission.entry_method != "pds2_response_pages" or provenance is None:
+        raise QuillanAcademicResultArtifactUnavailableError(
+            "Requested student work has no software-readable Quillan artifact."
+        )
+    if not provenance.evidence_references:
+        raise QuillanAcademicResultArtifactUnavailableError(
+            "Requested student work has no represented selected evidence artifact."
+        )
+    native = _load_bound_submission(workspace_root, manifest, student_id)
+    results: list[AuthorizedAcademicResultArtifact] = []
+    for reference in provenance.evidence_references:
+        evidence, page_number = _native_selected_evidence(native, reference)
+        artifact_path, relative = _artifact_path(
+            workspace_root,
+            manifest,
+            student_id,
+            reference,
+            evidence,
+            page_number,
+        )
+        data = _read_regular_file(
+            artifact_path,
+            workspace_root=workspace_root,
+            missing_message="Authorized selected student-work artifact is unavailable.",
+        )
+        digest = hashlib.sha256(data).hexdigest()
+        if digest != reference.routed_evidence_sha256:
+            raise QuillanAcademicResultArtifactIntegrityError(
+                "Authorized routed-evidence bytes disagree with manifest provenance."
+            )
+        results.append(
+            AuthorizedAcademicResultArtifact(
+                artifact_kind="student_work",
+                work=manifest.work,
+                record_set_revision=manifest.record_set.revision,
+                student_id=student_id,
+                relative_path=relative,
+                media_type=_media_type(artifact_path),
+                sha256=digest,
+                byte_size=len(data),
+                data=data,
+                evidence_reference=reference,
+            )
+        )
+    return tuple(results)
+
+
+def _feedback_target(
+    workspace_root: Path,
+    manifest: AcademicResultManifest,
+    student_id: str,
+    artifact_kind: AcademicResultArtifactKind,
+) -> tuple[Path, str, str]:
+    work_ref = quillan_work_ref(manifest.work.class_id, manifest.work.work_id)
+    if artifact_kind == "feedback_pdf":
+        path = feedback_pdf_path(workspace_root, work_ref, student_id)
+        return path, "feedback_pdf", "application/pdf"
+    if artifact_kind == "feedback_markdown":
+        path = feedback_markdown_path(workspace_root, work_ref, student_id)
+        return path, "feedback_markdown", "text/markdown; charset=utf-8"
+    raise QuillanAcademicResultArtifactValidationError(
+        "Feedback artifact kind is invalid."
+    )
+
+
+def _metadata_text(
+    metadata: Mapping[str, object],
+    field: str,
+) -> str:
+    value = metadata.get(field)
+    if not isinstance(value, str) or not value:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Feedback export metadata is invalid."
+        )
+    return value
+
+
+def _read_feedback_artifact(
+    workspace_root: Path,
+    manifest: AcademicResultManifest,
+    student_id: str,
+    artifact_kind: AcademicResultArtifactKind,
+) -> tuple[AuthorizedAcademicResultArtifact, ...]:
+    review = _load_bound_review(workspace_root, manifest, student_id)
+    exports = _as_mapping(review.get("exports"), "review.exports")
+    path, field, media_type = _feedback_target(
+        workspace_root, manifest, student_id, artifact_kind
+    )
+    raw_metadata = exports.get(field)
+    if raw_metadata is None:
+        raise QuillanAcademicResultArtifactUnavailableError(
+            "Requested authorized feedback artifact has no exact export metadata."
+        )
+    metadata = _as_mapping(raw_metadata, f"review.exports.{field}")
+    actual_relative = _workspace_relative_posix(
+        metadata.get("path"), f"review.exports.{field}.path"
+    )
+    expected_relative = path.relative_to(workspace_root).as_posix()
+    if actual_relative != expected_relative:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Feedback export metadata path is not the exact canonical Quillan path."
+        )
+    generated_at = _metadata_text(metadata, "generated_at")
+    source_review_updated_at = _metadata_text(
+        metadata, "source_review_updated_at"
+    )
+    review_updated_at = review.get("updated_at")
+    if (
+        not isinstance(review_updated_at, str)
+        or source_review_updated_at != review_updated_at
+    ):
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Feedback export metadata does not describe the exact manifest-bound review state."
+        )
+    data = _read_regular_file(
+        path,
+        workspace_root=workspace_root,
+        missing_message="Authorized feedback artifact is unavailable.",
+    )
+    digest = hashlib.sha256(data).hexdigest()
+    return (
+        AuthorizedAcademicResultArtifact(
+            artifact_kind=artifact_kind,
+            work=manifest.work,
+            record_set_revision=manifest.record_set.revision,
+            student_id=student_id,
+            relative_path=expected_relative,
+            media_type=media_type,
+            sha256=digest,
+            byte_size=len(data),
+            data=data,
+            generated_at=generated_at,
+            source_review_updated_at=source_review_updated_at,
+        ),
+    )
+
+
+def read_authorized_academic_result_artifacts(
+    workspace_root: str | Path,
+    manifest: AcademicResultManifest,
+    student_id: str,
+    artifact_kind: AcademicResultArtifactKind,
+    *,
+    purpose: str,
+    authorization_gate: AcademicResultArtifactAuthorizationGate,
+) -> tuple[AuthorizedAcademicResultArtifact, ...]:
+    """Return exact producer artifacts only after an external authorization decision."""
+    try:
+        checked = validate_academic_result_manifest(manifest)
+        student = lookup_academic_result_student(checked, student_id)
+    except QuillanAcademicResultReaderError as error:
+        raise QuillanAcademicResultArtifactValidationError(
+            "Artifact manifest or student request is invalid."
+        ) from error
+    kind = _artifact_kind(artifact_kind)
+    bounded_purpose = _purpose(purpose)
+    request = AcademicResultArtifactAuthorizationRequest(
+        work=checked.work,
+        record_set_id=checked.record_set.record_set_id,
+        record_set_revision=checked.record_set.revision,
+        student_id=student.student_id,
+        artifact_kind=kind,
+        purpose=bounded_purpose,
+    )
+    _authorize(authorization_gate, request)
+
+    try:
+        root = canonical_workspace_root(workspace_root)
+    except QuillanRecordContextError as error:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Authorized artifact workspace is invalid."
+        ) from error
+    except OSError as error:
+        raise QuillanAcademicResultArtifactReadError(
+            "Authorized artifact workspace could not be inspected."
+        ) from error
+    try:
+        if kind == "student_work":
+            return _read_student_work(root, checked, student.student_id)
+        return _read_feedback_artifact(root, checked, student.student_id, kind)
+    except (QuillanWorkPathError, ValueError) as error:
+        raise QuillanAcademicResultArtifactIntegrityError(
+            "Authorized Quillan artifact path is invalid."
+        ) from error
+
+
+__all__ = (
+    "AcademicResultArtifactAuthorizationDecision",
+    "AcademicResultArtifactAuthorizationGate",
+    "AcademicResultArtifactAuthorizationRequest",
+    "AcademicResultArtifactKind",
+    "ArtifactAuthorizationStatus",
+    "AuthorizedAcademicResultArtifact",
+    "QuillanAcademicResultArtifactAuthorizationError",
+    "QuillanAcademicResultArtifactError",
+    "QuillanAcademicResultArtifactIntegrityError",
+    "QuillanAcademicResultArtifactReadError",
+    "QuillanAcademicResultArtifactUnavailableError",
+    "QuillanAcademicResultArtifactValidationError",
+    "read_authorized_academic_result_artifacts",
+)

--- a/quillan/academic_result_reader.py
+++ b/quillan/academic_result_reader.py
@@ -1,0 +1,282 @@
+"""Consumer-neutral reader for Quillan Academic Result Manifest v1."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal, TypeAlias
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from quillan.academic_result_manifest import (
+    AcademicResultManifest,
+    EvidenceReference,
+    OverallStandardRating,
+    QuillanAcademicResultManifestDecodeError,
+    QuillanAcademicResultManifestValidationError,
+    ReviewUnit,
+    SourceRecordSnapshot,
+    StandardFeedback,
+    StandardObservation,
+    StudentResult,
+    manifest_from_json_bytes,
+    manifest_to_canonical_json_bytes,
+    validate_manifest,
+)
+
+AcademicResultSourceName: TypeAlias = Literal["assignment", "submission", "review"]
+
+_PDS2_EVIDENCE_ID = re.compile(r"^obs_[0-9a-f]{32}$")
+_NATIVE_ID_LIMIT = 500
+
+
+class QuillanAcademicResultReaderError(Exception):
+    """Base failure for public Quillan manifest reading and exact lookup."""
+
+
+class QuillanAcademicResultReaderValidationError(
+    QuillanAcademicResultReaderError, ValueError
+):
+    """Reader input violates the public consumer-neutral contract."""
+
+
+class QuillanAcademicResultReaderDecodeError(
+    QuillanAcademicResultReaderValidationError
+):
+    """Immutable bytes are not an exact valid Quillan academic-result manifest."""
+
+
+class QuillanAcademicResultReaderNotFoundError(
+    QuillanAcademicResultReaderError, LookupError
+):
+    """An exact validated lookup is absent from the supplied manifest."""
+
+
+def _validated_manifest(manifest: AcademicResultManifest) -> AcademicResultManifest:
+    if type(manifest) is not AcademicResultManifest:
+        raise QuillanAcademicResultReaderValidationError(
+            "manifest must be an AcademicResultManifest."
+        )
+    try:
+        return validate_manifest(manifest)
+    except QuillanAcademicResultManifestValidationError as error:
+        raise QuillanAcademicResultReaderValidationError(
+            "Academic-result manifest model is invalid."
+        ) from error
+
+
+def _safe_student_id(value: object) -> str:
+    if not isinstance(value, str):
+        raise QuillanAcademicResultReaderValidationError(
+            "student_id must be a safe identifier."
+        )
+    try:
+        return validate_identifier(value, "student_id")
+    except (IdentifierValidationError, TypeError, ValueError) as error:
+        raise QuillanAcademicResultReaderValidationError(
+            "student_id must be a safe identifier."
+        ) from error
+
+
+def _native_lookup_id(value: object, field_name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > _NATIVE_ID_LIMIT
+        or "\x00" in value
+    ):
+        raise QuillanAcademicResultReaderValidationError(
+            f"{field_name} must be bounded nonempty native identifier text."
+        )
+    return value
+
+
+def _evidence_id(value: object) -> str:
+    if not isinstance(value, str) or _PDS2_EVIDENCE_ID.fullmatch(value) is None:
+        raise QuillanAcademicResultReaderValidationError(
+            "evidence_id must be an exact Quillan PDS2 evidence identifier."
+        )
+    return value
+
+
+def read_academic_result_manifest(value: bytes) -> AcademicResultManifest:
+    """Decode, validate, and require exact canonical Quillan manifest bytes."""
+    if type(value) is not bytes:
+        raise QuillanAcademicResultReaderValidationError(
+            "Academic-result manifest input must be immutable bytes."
+        )
+    try:
+        manifest = manifest_from_json_bytes(value)
+    except QuillanAcademicResultManifestDecodeError as error:
+        raise QuillanAcademicResultReaderDecodeError(
+            "Academic-result manifest bytes are invalid."
+        ) from error
+    try:
+        canonical = manifest_to_canonical_json_bytes(manifest)
+    except QuillanAcademicResultManifestValidationError as error:
+        raise QuillanAcademicResultReaderValidationError(
+            "Academic-result manifest could not be validated canonically."
+        ) from error
+    if canonical != value:
+        raise QuillanAcademicResultReaderValidationError(
+            "Academic-result manifest bytes are not canonical."
+        )
+    return manifest
+
+
+def validate_academic_result_manifest(
+    manifest: AcademicResultManifest,
+) -> AcademicResultManifest:
+    """Validate one existing immutable manifest model without I/O."""
+    return _validated_manifest(manifest)
+
+
+def lookup_academic_result_student(
+    manifest: AcademicResultManifest,
+    student_id: str,
+) -> StudentResult:
+    """Return one exact represented student without fabricating absence state."""
+    checked = _validated_manifest(manifest)
+    target = _safe_student_id(student_id)
+    for student in checked.students:
+        if student.student_id == target:
+            return student
+    raise QuillanAcademicResultReaderNotFoundError(
+        "Requested student is not represented in this manifest."
+    )
+
+
+def lookup_academic_result_source(
+    manifest: AcademicResultManifest,
+    source: AcademicResultSourceName,
+    *,
+    student_id: str | None = None,
+) -> SourceRecordSnapshot:
+    """Return one exact embedded source snapshot without opening native state."""
+    checked = _validated_manifest(manifest)
+    if source == "assignment":
+        if student_id is not None:
+            raise QuillanAcademicResultReaderValidationError(
+                "Assignment source lookup must not include student_id."
+            )
+        return checked.source_snapshot
+    if source not in {"submission", "review"}:
+        raise QuillanAcademicResultReaderValidationError(
+            "source must be assignment, submission, or review."
+        )
+    if student_id is None:
+        raise QuillanAcademicResultReaderValidationError(
+            "Student source lookup requires student_id."
+        )
+    student = lookup_academic_result_student(checked, student_id)
+    if source == "submission":
+        return student.source_snapshot.submission
+    return student.source_snapshot.review
+
+
+def lookup_academic_result_review_unit(
+    manifest: AcademicResultManifest,
+    student_id: str,
+    unit_id: str,
+) -> ReviewUnit:
+    """Return one exact native review unit by its producer-owned unit_id."""
+    student = lookup_academic_result_student(manifest, student_id)
+    target = _native_lookup_id(unit_id, "unit_id")
+    for unit in student.review.review_units:
+        if unit.unit_id == target:
+            return unit
+    raise QuillanAcademicResultReaderNotFoundError(
+        "Requested review unit is not represented for this student."
+    )
+
+
+def lookup_academic_result_observation(
+    manifest: AcademicResultManifest,
+    student_id: str,
+    observation_id: str,
+) -> StandardObservation:
+    """Return one exact native standard observation without score inference."""
+    student = lookup_academic_result_student(manifest, student_id)
+    target = _native_lookup_id(observation_id, "observation_id")
+    for unit in student.review.review_units:
+        for observation in unit.standard_observations:
+            if observation.observation_id == target:
+                return observation
+    raise QuillanAcademicResultReaderNotFoundError(
+        "Requested observation is not represented for this student."
+    )
+
+
+def lookup_academic_result_overall_rating(
+    manifest: AcademicResultManifest,
+    student_id: str,
+    standard_id: str,
+) -> OverallStandardRating:
+    """Return one exact teacher-entered overall Focus Standard rating."""
+    student = lookup_academic_result_student(manifest, student_id)
+    target = _native_lookup_id(standard_id, "standard_id")
+    for rating in student.review.overall_standard_ratings:
+        if rating.standard_id == target:
+            return rating
+    raise QuillanAcademicResultReaderNotFoundError(
+        "Requested overall standard rating is not represented for this student."
+    )
+
+
+def lookup_academic_result_standard_feedback(
+    manifest: AcademicResultManifest,
+    student_id: str,
+    standard_id: str,
+) -> StandardFeedback:
+    """Return one exact public standard-feedback composition record."""
+    student = lookup_academic_result_student(manifest, student_id)
+    target = _native_lookup_id(standard_id, "standard_id")
+    for feedback in student.review.feedback.standard_feedback:
+        if feedback.standard_id == target:
+            return feedback
+    raise QuillanAcademicResultReaderNotFoundError(
+        "Requested standard feedback is not represented for this student."
+    )
+
+
+def lookup_academic_result_evidence_reference(
+    manifest: AcademicResultManifest,
+    student_id: str,
+    evidence_id: str,
+) -> EvidenceReference:
+    """Return one exact public selected-evidence provenance reference."""
+    student = lookup_academic_result_student(manifest, student_id)
+    target = _evidence_id(evidence_id)
+    provenance = student.submission.digital_provenance
+    if provenance is not None:
+        for reference in provenance.evidence_references:
+            if reference.evidence_id == target:
+                return reference
+    raise QuillanAcademicResultReaderNotFoundError(
+        "Requested evidence reference is not represented for this student."
+    )
+
+
+__all__ = (
+    "AcademicResultManifest",
+    "AcademicResultSourceName",
+    "EvidenceReference",
+    "OverallStandardRating",
+    "QuillanAcademicResultReaderDecodeError",
+    "QuillanAcademicResultReaderError",
+    "QuillanAcademicResultReaderNotFoundError",
+    "QuillanAcademicResultReaderValidationError",
+    "ReviewUnit",
+    "SourceRecordSnapshot",
+    "StandardFeedback",
+    "StandardObservation",
+    "StudentResult",
+    "lookup_academic_result_evidence_reference",
+    "lookup_academic_result_observation",
+    "lookup_academic_result_overall_rating",
+    "lookup_academic_result_review_unit",
+    "lookup_academic_result_source",
+    "lookup_academic_result_standard_feedback",
+    "lookup_academic_result_student",
+    "read_academic_result_manifest",
+    "validate_academic_result_manifest",
+)

--- a/quillan/feedback_export.py
+++ b/quillan/feedback_export.py
@@ -187,6 +187,12 @@ def export_student_feedback(
         )
 
     _write_feedback(output_path, markdown, overwrite=overwrite)
+    _update_export_metadata(
+        context,
+        created_at=normalized_created_at,
+        feedback_pdf_path=None,
+        feedback_markdown_path=output_path,
+    )
     return ExportedFeedback(
         class_id=class_id,
         assignment_id=assignment_id,
@@ -923,19 +929,22 @@ def _update_export_metadata(
     context: dict[str, Any],
     *,
     created_at: str,
-    feedback_pdf_path: Path,
+    feedback_pdf_path: Path | None,
     feedback_markdown_path: Path | None,
 ) -> None:
+    if feedback_pdf_path is None and feedback_markdown_path is None:
+        raise FeedbackExportError("At least one feedback export path is required.")
     review = dict(context["review"])
     review["exports"] = dict(review["exports"])
-    review["exports"]["feedback_pdf"] = {
-        "path": _workspace_relative_path(
-            feedback_pdf_path, context["workspace_root"], "feedback PDF"
-        ),
-        "generated_at": created_at,
-        "source_review_updated_at": created_at,
-        "module_details": {},
-    }
+    if feedback_pdf_path is not None:
+        review["exports"]["feedback_pdf"] = {
+            "path": _workspace_relative_path(
+                feedback_pdf_path, context["workspace_root"], "feedback PDF"
+            ),
+            "generated_at": created_at,
+            "source_review_updated_at": created_at,
+            "module_details": {},
+        }
     if feedback_markdown_path is not None:
         review["exports"]["feedback_markdown"] = {
             "path": _workspace_relative_path(

--- a/scripts/run_installed_acceptance.py
+++ b/scripts/run_installed_acceptance.py
@@ -471,6 +471,160 @@ def _run_full_workflow(workspace: Path, *, work: Path, env: dict[str, str]) -> d
     }
 
 
+def _verify_installed_academic_result_reader() -> dict[str, object]:
+    # Exercise the installed public reader without source-checkout fixture access.
+    import quillan.academic_result_artifacts as artifacts
+    import quillan.academic_result_reader as reader
+    from quillan.academic_result_manifest import (
+        manifest_from_mapping,
+        manifest_to_canonical_json_bytes,
+    )
+
+    raw = {
+        "record_type": "quillan_academic_result_manifest",
+        "contract_version": "quillan_academic_result_manifest_v1",
+        "producer_module_id": "quillan",
+        "generated_at": "2026-08-14T20:00:00Z",
+        "record_set": {"record_set_id": "installed_results", "revision": 1},
+        "work": {
+            "module_id": "quillan",
+            "class_id": "installed_class",
+            "work_id": "installed_assignment",
+        },
+        "source_snapshot": {
+            "relative_path": "assignment.json",
+            "sha256": "0" * 64,
+            "contract_version": "2",
+        },
+        "assignment": {
+            "assignment_id": "installed_assignment",
+            "title": "Installed Reader",
+            "writing_type": "argument",
+            "student_prompt": "Write.",
+            "standards_profile_id": "installed_profile",
+            "focus_standard_ids": ["synthetic:W.1"],
+            "review_unit": {
+                "type": "paragraph",
+                "singular_label": "Paragraph",
+                "plural_label": "Paragraphs",
+            },
+            "rating_scale": {
+                "scale_id": "installed_scale",
+                "levels": [
+                    {
+                        "value": 0,
+                        "label": "Beginning",
+                        "description": "Beginning evidence.",
+                    },
+                    {
+                        "value": 2,
+                        "label": "Secure",
+                        "description": "Secure evidence.",
+                    },
+                ],
+            },
+            "basic_requirements": {
+                "paragraphs_min": None,
+                "paragraphs_max": None,
+                "word_count_min": None,
+                "word_count_max": None,
+                "required_elements": [],
+            },
+            "minimum_requirement_policy": {
+                "allow_return_without_full_review": True
+            },
+        },
+        "students": [
+            {
+                "student_id": "student_installed",
+                "source_snapshot": {
+                    "submission": {
+                        "relative_path": "submissions/student_installed/submission.json",
+                        "sha256": "1" * 64,
+                        "contract_version": "1",
+                    },
+                    "review": {
+                        "relative_path": "submissions/student_installed/review.json",
+                        "sha256": "2" * 64,
+                        "contract_version": "2",
+                    },
+                },
+                "submission": {
+                    "class_id": "installed_class",
+                    "assignment_id": "installed_assignment",
+                    "student_id": "student_installed",
+                    "submission_state": "reviewed",
+                    "entry_method": "plain_paper_manual",
+                    "expected_pages": None,
+                    "digital_provenance": None,
+                },
+                "review": {
+                    "class_id": "installed_class",
+                    "assignment_id": "installed_assignment",
+                    "student_id": "student_installed",
+                    "review_state": "ratings_complete",
+                    "minimum_requirement_outcome": {
+                        "status": "met",
+                        "returned_without_full_review": False,
+                        "teacher_note": {
+                            "disposition": "absent",
+                            "text": None,
+                        },
+                        "updated_at": "2026-08-14T19:00:00Z",
+                    },
+                    "review_units": [],
+                    "overall_standard_ratings": [
+                        {
+                            "standard_id": "synthetic:W.1",
+                            "rating": 0,
+                            "rationale": {
+                                "disposition": "withheld",
+                                "text": None,
+                            },
+                            "include_in_feedback": False,
+                            "updated_at": "2026-08-14T19:30:00Z",
+                        }
+                    ],
+                    "feedback": {
+                        "include_review_unit_observations": False,
+                        "include_overall_standard_ratings": True,
+                        "standard_feedback": [],
+                    },
+                },
+            }
+        ],
+    }
+    canonical = manifest_to_canonical_json_bytes(manifest_from_mapping(raw))
+    parsed = reader.read_academic_result_manifest(canonical)
+    assert reader.validate_academic_result_manifest(parsed) is parsed
+    student = reader.lookup_academic_result_student(parsed, "student_installed")
+    assert student is parsed.students[0]
+    assignment_source = reader.lookup_academic_result_source(parsed, "assignment")
+    assert assignment_source is parsed.source_snapshot
+    rating = reader.lookup_academic_result_overall_rating(
+        parsed, "student_installed", "synthetic:W.1"
+    )
+    assert rating.rating == 0
+    try:
+        reader.read_academic_result_manifest(canonical + b" ")
+    except reader.QuillanAcademicResultReaderValidationError:
+        pass
+    else:
+        raise AssertionError("Installed reader accepted noncanonical manifest bytes.")
+    artifact_kinds = str(artifacts.AcademicResultArtifactKind)
+    assert "student_work" in artifact_kinds
+    assert "feedback_pdf" in artifact_kinds
+    assert "feedback_markdown" in artifact_kinds
+    return {
+        "canonical_bytes": len(canonical),
+        "student_lookup": student.student_id,
+        "assignment_source": assignment_source.relative_path,
+        "native_rating": rating.rating,
+        "noncanonical_rejected": True,
+        "artifact_module": "quillan.academic_result_artifacts",
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--work", type=Path, required=True)
@@ -491,6 +645,8 @@ def main() -> int:
     assert core_distribution.version == "0.6.0"
     root = Path(str(distribution.locate_file(""))).resolve()
     import quillan
+    import quillan.academic_result_artifacts
+    import quillan.academic_result_reader
     import quillan.pds_module
     import quillan.pds_publication
     import pds_core
@@ -512,6 +668,8 @@ def main() -> int:
 
     origins = [
         Path(quillan.__file__).resolve(),
+        Path(quillan.academic_result_artifacts.__file__).resolve(),
+        Path(quillan.academic_result_reader.__file__).resolve(),
         Path(quillan.pds_module.__file__).resolve(),
         Path(quillan.pds_publication.__file__).resolve(),
     ]
@@ -555,6 +713,9 @@ def main() -> int:
     assert registry_profile == publication_profile
     assert not sentinel.exists()
     _assert_no_academic_state(sentinel)
+    reader_probe = _verify_installed_academic_result_reader()
+    assert not sentinel.exists()
+    _assert_no_academic_state(sentinel)
 
     modules = sorted(module.name for module in pkgutil.walk_packages(quillan.__path__, "quillan."))
     for module in modules:
@@ -576,7 +737,7 @@ def main() -> int:
     workflow = _run_full_workflow(workflow_workspace, work=work, env=env) if args.full_workflow else None
     if args.full_workflow:
         _assert_no_academic_state(workflow_workspace)
-    print(json.dumps({"version": distribution.version, "distribution_root": str(root), "origins": [str(path) for path in origins], "core_version": core_distribution.version, "core_origin": str(core_origin), "core_06_academic_modules": academic_module_origins, "module_count": len(modules), "module_profile": routing_profile.module_id, "publication_profile": publication_profile.module_id, "publication_profiles_discovered": len(discovered), "publication_registry_profile": registry_profile.module_id, "workspace_side_effects": False, "academic_registry_side_effects": False, "workflow": workflow}, indent=2, sort_keys=True))
+    print(json.dumps({"version": distribution.version, "distribution_root": str(root), "origins": [str(path) for path in origins], "core_version": core_distribution.version, "core_origin": str(core_origin), "core_06_academic_modules": academic_module_origins, "module_count": len(modules), "module_profile": routing_profile.module_id, "publication_profile": publication_profile.module_id, "publication_profiles_discovered": len(discovered), "publication_registry_profile": registry_profile.module_id, "academic_result_reader": reader_probe, "workspace_side_effects": False, "academic_registry_side_effects": False, "workflow": workflow}, indent=2, sort_keys=True))
     return 0
 
 

--- a/tests/test_academic_result_artifacts.py
+++ b/tests/test_academic_result_artifacts.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import quillan.academic_result_artifacts as artifacts_module
+from quillan._path_safety import is_link_like as shared_is_link_like
+from quillan.academic_result_artifacts import (
+    AcademicResultArtifactAuthorizationDecision,
+    AcademicResultArtifactAuthorizationRequest,
+    AuthorizedAcademicResultArtifact,
+    QuillanAcademicResultArtifactAuthorizationError,
+    QuillanAcademicResultArtifactIntegrityError,
+    QuillanAcademicResultArtifactUnavailableError,
+    QuillanAcademicResultArtifactValidationError,
+    read_authorized_academic_result_artifacts,
+)
+from quillan.academic_result_manifest import (
+    AcademicResultManifest,
+    StudentSourceSnapshot,
+)
+from quillan.academic_result_manifest_generation import (
+    build_academic_result_manifest,
+    load_academic_result_manifest_generation_context,
+)
+from quillan.work_paths import quillan_work_ref
+from tests.test_academic_result_manifest_generation import _prepare_pds2_pair
+
+EXPECTED_PUBLIC = {
+    "AcademicResultArtifactAuthorizationDecision",
+    "AcademicResultArtifactAuthorizationGate",
+    "AcademicResultArtifactAuthorizationRequest",
+    "AcademicResultArtifactKind",
+    "ArtifactAuthorizationStatus",
+    "AuthorizedAcademicResultArtifact",
+    "QuillanAcademicResultArtifactAuthorizationError",
+    "QuillanAcademicResultArtifactError",
+    "QuillanAcademicResultArtifactIntegrityError",
+    "QuillanAcademicResultArtifactReadError",
+    "QuillanAcademicResultArtifactUnavailableError",
+    "QuillanAcademicResultArtifactValidationError",
+    "read_authorized_academic_result_artifacts",
+}
+
+
+class Gate:
+    def __init__(self, status: str) -> None:
+        self.status = status
+        self.requests: list[AcademicResultArtifactAuthorizationRequest] = []
+
+    def authorize(
+        self, request: AcademicResultArtifactAuthorizationRequest
+    ) -> AcademicResultArtifactAuthorizationDecision:
+        self.requests.append(request)
+        return AcademicResultArtifactAuthorizationDecision(
+            cast(object, self.status)  # type: ignore[arg-type]
+        )
+
+
+class RaisingGate:
+    def authorize(
+        self, request: AcademicResultArtifactAuthorizationRequest
+    ) -> AcademicResultArtifactAuthorizationDecision:
+        del request
+        raise RuntimeError("private authorization backend detail")
+
+
+def _manifest_and_paths(
+    tmp_path: Path,
+) -> tuple[AcademicResultManifest, str, str, str, Path, Path]:
+    class_id, assignment_id, student_id, retained, routed = _prepare_pds2_pair(
+        tmp_path
+    )
+    context = load_academic_result_manifest_generation_context(
+        tmp_path, quillan_work_ref(class_id, assignment_id)
+    )
+    manifest = build_academic_result_manifest(
+        context,
+        record_set_revision=7,
+        generated_at=datetime(2026, 8, 14, 20, 0, tzinfo=timezone.utc),
+    )
+    return manifest, class_id, assignment_id, student_id, retained, routed
+
+
+def _submission_path(
+    tmp_path: Path, class_id: str, assignment_id: str, student_id: str
+) -> Path:
+    return (
+        tmp_path
+        / "classes"
+        / class_id
+        / "modules"
+        / "quillan"
+        / "work"
+        / assignment_id
+        / "submissions"
+        / student_id
+        / "submission.json"
+    )
+
+
+def _manifest_with_current_submission_digest(
+    manifest: AcademicResultManifest,
+    submission_path: Path,
+) -> AcademicResultManifest:
+    digest = hashlib.sha256(submission_path.read_bytes()).hexdigest()
+    student = manifest.students[0]
+    source = replace(student.source_snapshot.submission, sha256=digest)
+    sources = StudentSourceSnapshot(source, student.source_snapshot.review)
+    replaced_student = replace(student, source_snapshot=sources)
+    return replace(manifest, students=(replaced_student,))
+
+
+def test_artifact_module_exports_exact_initial_surface() -> None:
+    assert set(artifacts_module.__all__) == EXPECTED_PUBLIC
+
+
+@pytest.mark.parametrize("status", ["denied", "unresolved"])
+def test_denied_or_unresolved_authorization_precedes_any_workspace_access(
+    tmp_path: Path,
+    status: str,
+) -> None:
+    manifest, _, _, student_id, _, _ = _manifest_and_paths(tmp_path)
+    gate = Gate(status)
+    missing_workspace = tmp_path / "does-not-exist"
+    with pytest.raises(
+        QuillanAcademicResultArtifactAuthorizationError,
+        match="not authorized",
+    ):
+        read_authorized_academic_result_artifacts(
+            missing_workspace,
+            manifest,
+            student_id,
+            "student_work",
+            purpose="portfolio candidate evaluation",
+            authorization_gate=gate,
+        )
+    assert len(gate.requests) == 1
+    request = gate.requests[0]
+    assert request.work is manifest.work
+    assert request.record_set_id == manifest.record_set.record_set_id
+    assert request.record_set_revision == 7
+    assert request.student_id == student_id
+    assert request.artifact_kind == "student_work"
+
+
+def test_authorization_backend_exception_is_bounded() -> None:
+    fixture = Path(
+        "tests/fixtures/publication/quillan_academic_result_manifest_v1.json"
+    ).read_bytes()
+    from quillan.academic_result_reader import read_academic_result_manifest
+
+    manifest = read_academic_result_manifest(fixture)
+    with pytest.raises(
+        QuillanAcademicResultArtifactAuthorizationError
+    ) as caught:
+        read_authorized_academic_result_artifacts(
+            Path("definitely-missing"),
+            manifest,
+            "student_001",
+            "student_work",
+            purpose="consumer read",
+            authorization_gate=RaisingGate(),
+        )
+    assert "private authorization backend detail" not in str(caught.value)
+
+
+@pytest.mark.parametrize("purpose", ["", "   ", "\x00", "x" * 501])
+def test_invalid_purpose_fails_before_authorization(
+    tmp_path: Path, purpose: str
+) -> None:
+    manifest, _, _, student_id, _, _ = _manifest_and_paths(tmp_path)
+    gate = Gate("allowed")
+    with pytest.raises(QuillanAcademicResultArtifactValidationError):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            student_id,
+            "student_work",
+            purpose=purpose,
+            authorization_gate=gate,
+        )
+    assert gate.requests == []
+
+
+def test_invalid_artifact_kind_fails_before_authorization(tmp_path: Path) -> None:
+    manifest, _, _, student_id, _, _ = _manifest_and_paths(tmp_path)
+    gate = Gate("allowed")
+    with pytest.raises(QuillanAcademicResultArtifactValidationError):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            student_id,
+            "arbitrary_path",  # type: ignore[arg-type]
+            purpose="consumer read",
+            authorization_gate=gate,
+        )
+    assert gate.requests == []
+
+
+def test_authorized_selected_pds2_student_work_returns_exact_routed_bytes(
+    tmp_path: Path,
+) -> None:
+    manifest, _, _, student_id, retained, routed = _manifest_and_paths(tmp_path)
+    gate = Gate("allowed")
+
+    result = read_authorized_academic_result_artifacts(
+        tmp_path,
+        manifest,
+        student_id,
+        "student_work",
+        purpose="authorized source projection",
+        authorization_gate=gate,
+    )
+
+    assert len(result) == 1
+    artifact = result[0]
+    assert isinstance(artifact, AuthorizedAcademicResultArtifact)
+    assert artifact.artifact_kind == "student_work"
+    assert artifact.work is manifest.work
+    assert artifact.record_set_revision == 7
+    assert artifact.student_id == student_id
+    assert artifact.data == routed.read_bytes()
+    assert artifact.relative_path == routed.relative_to(tmp_path).as_posix()
+    assert artifact.relative_path != retained.relative_to(tmp_path).as_posix()
+    assert artifact.byte_size == len(artifact.data)
+    assert artifact.sha256 == hashlib.sha256(artifact.data).hexdigest()
+    assert artifact.evidence_reference is (
+        manifest.students[0].submission.digital_provenance.evidence_references[0]  # type: ignore[union-attr]
+    )
+    assert not Path(artifact.relative_path).is_absolute()
+    assert str(retained) not in artifact.relative_path
+
+
+def test_plain_paper_student_work_is_unavailable_after_authorization() -> None:
+    from quillan.academic_result_reader import read_academic_result_manifest
+
+    raw = Path(
+        "tests/fixtures/publication/quillan_academic_result_manifest_v1.json"
+    ).read_bytes()
+    manifest = read_academic_result_manifest(raw)
+    gate = Gate("allowed")
+    with pytest.raises(
+        QuillanAcademicResultArtifactUnavailableError,
+        match="software-readable",
+    ):
+        read_authorized_academic_result_artifacts(
+            Path("."),
+            manifest,
+            "student_002",
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=gate,
+        )
+    assert len(gate.requests) == 1
+
+
+def test_changed_submission_bytes_fail_manifest_bound_integrity(
+    tmp_path: Path,
+) -> None:
+    manifest, class_id, assignment_id, student_id, _, _ = _manifest_and_paths(
+        tmp_path
+    )
+    submission = _submission_path(tmp_path, class_id, assignment_id, student_id)
+    submission.write_bytes(submission.read_bytes() + b"\n")
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="source bytes have changed",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            student_id,
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=Gate("allowed"),
+        )
+
+
+def test_another_students_routed_artifact_cannot_resolve_even_with_matching_bytes(
+    tmp_path: Path,
+) -> None:
+    manifest, class_id, assignment_id, student_id, _, routed = _manifest_and_paths(
+        tmp_path
+    )
+    other_student_path = routed.with_name(
+        routed.name.replace(f"response_{student_id}_", "response_99999_", 1)
+    )
+    assert other_student_path != routed
+    other_student_path.write_bytes(routed.read_bytes())
+
+    submission = _submission_path(tmp_path, class_id, assignment_id, student_id)
+    data = json.loads(submission.read_text(encoding="utf-8"))
+    data["pages"][0]["evidence"][0]["routed_evidence_path"] = (
+        other_student_path.relative_to(tmp_path).as_posix()
+    )
+    submission.write_text(
+        json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    altered_manifest = _manifest_with_current_submission_digest(manifest, submission)
+
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="exact canonical Quillan selected-evidence path",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            altered_manifest,
+            student_id,
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=Gate("allowed"),
+        )
+
+
+def test_changed_routed_bytes_fail_manifest_provenance(
+    tmp_path: Path,
+) -> None:
+    manifest, _, _, student_id, _, routed = _manifest_and_paths(tmp_path)
+    routed.write_bytes(routed.read_bytes() + b"tampered")
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="routed-evidence bytes",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            student_id,
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=Gate("allowed"),
+        )
+
+
+def test_native_selection_is_independently_rechecked_after_source_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, class_id, assignment_id, student_id, _, _ = _manifest_and_paths(
+        tmp_path
+    )
+    submission = _submission_path(tmp_path, class_id, assignment_id, student_id)
+    data = json.loads(submission.read_text(encoding="utf-8"))
+    data["pages"][0]["selected_evidence_id"] = None
+    submission.write_text(
+        json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    altered_manifest = _manifest_with_current_submission_digest(manifest, submission)
+
+    # Prove the artifact resolver owns an independent selected-evidence check even
+    # if a future regression in the native schema validator were to admit this state.
+    monkeypatch.setattr(
+        artifacts_module,
+        "validate_submission_manifest",
+        lambda _value: None,
+    )
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="authoritative selected",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            altered_manifest,
+            student_id,
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=Gate("allowed"),
+        )
+
+
+def test_native_selected_role_is_independently_rechecked_after_source_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, class_id, assignment_id, student_id, _, _ = _manifest_and_paths(
+        tmp_path
+    )
+    submission = _submission_path(tmp_path, class_id, assignment_id, student_id)
+    data = json.loads(submission.read_text(encoding="utf-8"))
+    data["pages"][0]["evidence"][0]["evidence_role"] = "candidate"
+    submission.write_text(
+        json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    altered_manifest = _manifest_with_current_submission_digest(manifest, submission)
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "validate_submission_manifest",
+        lambda _value: None,
+    )
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="selected evidence role",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            altered_manifest,
+            student_id,
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=Gate("allowed"),
+        )
+
+
+def test_native_provenance_identity_is_rechecked_even_with_matching_source_digest(
+    tmp_path: Path,
+) -> None:
+    manifest, class_id, assignment_id, student_id, _, _ = _manifest_and_paths(
+        tmp_path
+    )
+    submission = _submission_path(tmp_path, class_id, assignment_id, student_id)
+    data = json.loads(submission.read_text(encoding="utf-8"))
+    data["pages"][0]["evidence"][0]["module_details"]["route_id"] = (
+        "rt_ffffffffffffffffffffffffffffffff"
+    )
+    submission.write_text(
+        json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    altered_manifest = _manifest_with_current_submission_digest(manifest, submission)
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="provenance disagrees",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            altered_manifest,
+            student_id,
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=Gate("allowed"),
+        )
+
+
+def test_link_like_routed_artifact_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest, _, _, student_id, _, routed = _manifest_and_paths(tmp_path)
+    def link_only(path: Path) -> bool:
+        return path == routed or shared_is_link_like(path)
+
+    monkeypatch.setattr(
+        "quillan.academic_result_artifacts.is_link_like",
+        link_only,
+    )
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="link-like component",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            student_id,
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=Gate("allowed"),
+        )
+
+
+def test_link_like_parent_component_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest, _, _, student_id, _, routed = _manifest_and_paths(tmp_path)
+    linked_parent = routed.parent
+
+    def parent_link(path: Path) -> bool:
+        return path == linked_parent or shared_is_link_like(path)
+
+    monkeypatch.setattr(
+        "quillan.academic_result_artifacts.is_link_like",
+        parent_link,
+    )
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="link-like component",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            student_id,
+            "student_work",
+            purpose="authorized source projection",
+            authorization_gate=Gate("allowed"),
+        )
+
+
+def test_result_exposes_no_absolute_or_retained_source_path(tmp_path: Path) -> None:
+    manifest, _, _, student_id, retained, _ = _manifest_and_paths(tmp_path)
+    artifact = read_authorized_academic_result_artifacts(
+        tmp_path,
+        manifest,
+        student_id,
+        "student_work",
+        purpose="authorized source projection",
+        authorization_gate=Gate("allowed"),
+    )[0]
+    rendered = repr(artifact)
+    assert str(tmp_path) not in rendered
+    assert str(retained) not in rendered
+    assert "retained_source_path" not in rendered
+    assert "source_filename" not in rendered
+
+
+@pytest.mark.parametrize("artifact_kind", ["feedback_pdf", "feedback_markdown"])
+def test_feedback_kinds_require_authorization_before_workspace_access(
+    tmp_path: Path,
+    artifact_kind: str,
+) -> None:
+    manifest, _, _, student_id, _, _ = _manifest_and_paths(tmp_path)
+    denied = Gate("denied")
+    missing_workspace = tmp_path / "missing-workspace"
+    with pytest.raises(QuillanAcademicResultArtifactAuthorizationError):
+        read_authorized_academic_result_artifacts(
+            missing_workspace,
+            manifest,
+            student_id,
+            artifact_kind,  # type: ignore[arg-type]
+            purpose="consumer feedback read",
+            authorization_gate=denied,
+        )
+    assert len(denied.requests) == 1
+
+
+def test_artifact_source_has_no_consumer_or_core_publication_policy_dependency() -> None:
+    source = Path("quillan/academic_result_artifacts.py").read_text(encoding="utf-8")
+    lowered = source.lower()
+    for forbidden in (
+        "import meridian",
+        "from meridian",
+        "import vitrine",
+        "from vitrine",
+        "import scoreform",
+        "from scoreform",
+        "import concord",
+        "from concord",
+        "academic_catalog",
+        "publication_storage",
+        "registry_services",
+        "query_publication_catalog",
+        "grade_item",
+        "portfolio_candidate",
+        "portfolio_selection",
+    ):
+        assert forbidden not in lowered

--- a/tests/test_academic_result_feedback_artifacts.py
+++ b/tests/test_academic_result_feedback_artifacts.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from quillan._path_safety import is_link_like as shared_is_link_like
+from quillan.academic_result_artifacts import (
+    AcademicResultArtifactAuthorizationDecision,
+    AcademicResultArtifactAuthorizationRequest,
+    AuthorizedAcademicResultArtifact,
+    QuillanAcademicResultArtifactIntegrityError,
+    QuillanAcademicResultArtifactUnavailableError,
+    read_authorized_academic_result_artifacts,
+)
+from quillan.academic_result_manifest import (
+    AcademicResultManifest,
+    StudentSourceSnapshot,
+)
+from quillan.academic_result_manifest_generation import (
+    build_academic_result_manifest,
+    load_academic_result_manifest_generation_context,
+)
+from quillan.feedback_export import (
+    export_student_feedback,
+    export_student_feedback_pdf,
+)
+from quillan.work_paths import (
+    feedback_markdown_path,
+    feedback_pdf_path,
+    quillan_work_ref,
+    review_record_path,
+)
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID, STUDENT_ID
+from tests.test_academic_result_manifest_generation import _prepare_plain_pair
+
+EXPORT_TIME = "2026-08-14T21:30:00+00:00"
+
+
+class AllowGate:
+    def __init__(self) -> None:
+        self.requests: list[AcademicResultArtifactAuthorizationRequest] = []
+
+    def authorize(
+        self,
+        request: AcademicResultArtifactAuthorizationRequest,
+    ) -> AcademicResultArtifactAuthorizationDecision:
+        self.requests.append(request)
+        return AcademicResultArtifactAuthorizationDecision("allowed")
+
+
+def _build_current_manifest(tmp_path: Path, revision: int = 9) -> AcademicResultManifest:
+    context = load_academic_result_manifest_generation_context(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+    )
+    return build_academic_result_manifest(
+        context,
+        record_set_revision=revision,
+        generated_at=datetime(2026, 8, 14, 22, 0, tzinfo=timezone.utc),
+    )
+
+
+def _manifest_with_current_review_digest(
+    manifest: AcademicResultManifest,
+    review_path: Path,
+) -> AcademicResultManifest:
+    digest = hashlib.sha256(review_path.read_bytes()).hexdigest()
+    student = manifest.students[0]
+    review_source = replace(student.source_snapshot.review, sha256=digest)
+    sources = StudentSourceSnapshot(
+        student.source_snapshot.submission,
+        review_source,
+    )
+    replaced_student = replace(student, source_snapshot=sources)
+    return replace(manifest, students=(replaced_student,))
+
+
+def test_authorized_pdf_feedback_reads_exact_metadata_backed_bytes(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    exported = export_student_feedback_pdf(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    manifest = _build_current_manifest(tmp_path)
+    gate = AllowGate()
+
+    result = read_authorized_academic_result_artifacts(
+        tmp_path,
+        manifest,
+        STUDENT_ID,
+        "feedback_pdf",
+        purpose="authorized feedback display",
+        authorization_gate=gate,
+    )
+
+    assert len(result) == 1
+    artifact = result[0]
+    assert isinstance(artifact, AuthorizedAcademicResultArtifact)
+    assert artifact.data == exported.feedback_pdf_path.read_bytes()
+    assert artifact.media_type == "application/pdf"
+    assert artifact.relative_path == exported.feedback_pdf_path.relative_to(
+        tmp_path
+    ).as_posix()
+    assert artifact.sha256 == hashlib.sha256(artifact.data).hexdigest()
+    assert artifact.byte_size == len(artifact.data)
+    assert artifact.evidence_reference is None
+    assert artifact.generated_at == EXPORT_TIME
+    assert artifact.source_review_updated_at == EXPORT_TIME
+    assert len(gate.requests) == 1
+
+
+def test_markdown_only_export_persists_metadata_and_resolves_exact_bytes(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    exported = export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    review_path = review_record_path(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        STUDENT_ID,
+    )
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    metadata = review["exports"]["feedback_markdown"]
+    assert metadata == {
+        "path": exported.feedback_path.relative_to(tmp_path).as_posix(),
+        "generated_at": EXPORT_TIME,
+        "source_review_updated_at": EXPORT_TIME,
+        "module_details": {},
+    }
+    assert review["exports"]["feedback_pdf"] is None
+    assert review["updated_at"] == EXPORT_TIME
+    assert review["review_state"] == "exported"
+
+    manifest = _build_current_manifest(tmp_path)
+    artifact = read_authorized_academic_result_artifacts(
+        tmp_path,
+        manifest,
+        STUDENT_ID,
+        "feedback_markdown",
+        purpose="authorized feedback display",
+        authorization_gate=AllowGate(),
+    )[0]
+    assert artifact.data == exported.feedback_path.read_bytes()
+    assert artifact.media_type == "text/markdown; charset=utf-8"
+    assert artifact.relative_path == exported.feedback_path.relative_to(
+        tmp_path
+    ).as_posix()
+    assert artifact.generated_at == EXPORT_TIME
+    assert artifact.source_review_updated_at == EXPORT_TIME
+
+
+def test_feedback_format_never_falls_back_to_other_export(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    exported = export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    assert exported.feedback_path.is_file()
+    assert not feedback_pdf_path(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        STUDENT_ID,
+    ).exists()
+    manifest = _build_current_manifest(tmp_path)
+
+    with pytest.raises(
+        QuillanAcademicResultArtifactUnavailableError,
+        match="no exact export metadata",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            STUDENT_ID,
+            "feedback_pdf",
+            purpose="authorized feedback display",
+            authorization_gate=AllowGate(),
+        )
+
+
+def test_feedback_file_presence_without_export_metadata_is_not_access(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    path = feedback_pdf_path(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        STUDENT_ID,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"%PDF-1.4 synthetic")
+    manifest = _build_current_manifest(tmp_path)
+
+    with pytest.raises(
+        QuillanAcademicResultArtifactUnavailableError,
+        match="no exact export metadata",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            STUDENT_ID,
+            "feedback_pdf",
+            purpose="authorized feedback display",
+            authorization_gate=AllowGate(),
+        )
+
+
+def test_review_change_after_manifest_blocks_feedback_resolution(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    manifest = _build_current_manifest(tmp_path)
+    review_path = review_record_path(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        STUDENT_ID,
+    )
+    review_path.write_bytes(review_path.read_bytes() + b"\n")
+
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="review source bytes have changed",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            STUDENT_ID,
+            "feedback_markdown",
+            purpose="authorized feedback display",
+            authorization_gate=AllowGate(),
+        )
+
+
+def test_feedback_metadata_path_must_be_exact_canonical_path(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    manifest = _build_current_manifest(tmp_path)
+    review_path = review_record_path(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        STUDENT_ID,
+    )
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    review["exports"]["feedback_markdown"]["path"] = (
+        f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
+        f"submissions/{STUDENT_ID}/exports/not-feedback.md"
+    )
+    review_path.write_text(
+        json.dumps(review, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    altered = _manifest_with_current_review_digest(manifest, review_path)
+
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="exact canonical",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            altered,
+            STUDENT_ID,
+            "feedback_markdown",
+            purpose="authorized feedback display",
+            authorization_gate=AllowGate(),
+        )
+
+
+def test_feedback_metadata_must_match_exact_review_updated_at(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    manifest = _build_current_manifest(tmp_path)
+    review_path = review_record_path(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        STUDENT_ID,
+    )
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    review["exports"]["feedback_markdown"]["source_review_updated_at"] = (
+        "2026-08-14T21:29:59+00:00"
+    )
+    review_path.write_text(
+        json.dumps(review, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    altered = _manifest_with_current_review_digest(manifest, review_path)
+
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="exact manifest-bound review state",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            altered,
+            STUDENT_ID,
+            "feedback_markdown",
+            purpose="authorized feedback display",
+            authorization_gate=AllowGate(),
+        )
+
+
+def test_link_like_feedback_parent_component_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    exported = export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    manifest = _build_current_manifest(tmp_path)
+    linked_parent = exported.feedback_path.parent
+
+    def parent_link(path: Path) -> bool:
+        return path == linked_parent or shared_is_link_like(path)
+
+    monkeypatch.setattr(
+        "quillan.academic_result_artifacts.is_link_like",
+        parent_link,
+    )
+    with pytest.raises(
+        QuillanAcademicResultArtifactIntegrityError,
+        match="link-like component",
+    ):
+        read_authorized_academic_result_artifacts(
+            tmp_path,
+            manifest,
+            STUDENT_ID,
+            "feedback_markdown",
+            purpose="authorized feedback display",
+            authorization_gate=AllowGate(),
+        )
+
+
+def test_feedback_result_does_not_expose_review_body_or_absolute_paths(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    exported = export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    manifest = _build_current_manifest(tmp_path)
+    artifact = read_authorized_academic_result_artifacts(
+        tmp_path,
+        manifest,
+        STUDENT_ID,
+        "feedback_markdown",
+        purpose="authorized feedback display",
+        authorization_gate=AllowGate(),
+    )[0]
+    rendered = repr(artifact)
+    assert str(tmp_path) not in rendered
+    assert "private_notes" not in rendered
+    assert "review.json" not in rendered
+    assert artifact.relative_path == feedback_markdown_path(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        STUDENT_ID,
+    ).relative_to(tmp_path).as_posix()
+    assert artifact.data == exported.feedback_path.read_bytes()
+
+
+def test_feedback_artifact_reader_does_not_mutate_review_or_artifact(
+    tmp_path: Path,
+) -> None:
+    _prepare_plain_pair(tmp_path)
+    exported = export_student_feedback(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        STUDENT_ID,
+        created_at=EXPORT_TIME,
+    )
+    manifest = _build_current_manifest(tmp_path)
+    review_path = review_record_path(
+        tmp_path,
+        quillan_work_ref(CLASS_ID, ASSIGNMENT_ID),
+        STUDENT_ID,
+    )
+    before_review = review_path.read_bytes()
+    before_artifact = exported.feedback_path.read_bytes()
+
+    read_authorized_academic_result_artifacts(
+        tmp_path,
+        manifest,
+        STUDENT_ID,
+        "feedback_markdown",
+        purpose="authorized feedback display",
+        authorization_gate=AllowGate(),
+    )
+
+    assert review_path.read_bytes() == before_review
+    assert exported.feedback_path.read_bytes() == before_artifact

--- a/tests/test_academic_result_reader.py
+++ b/tests/test_academic_result_reader.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+import quillan.academic_result_reader as reader_module
+from quillan.academic_result_manifest import (
+    AcademicResultManifest,
+    EvidenceReference,
+    OverallStandardRating,
+    ReviewUnit,
+    SourceRecordSnapshot,
+    StandardFeedback,
+    StandardObservation,
+    StudentResult,
+    manifest_from_json_bytes,
+)
+from quillan.academic_result_reader import (
+    QuillanAcademicResultReaderDecodeError,
+    QuillanAcademicResultReaderNotFoundError,
+    QuillanAcademicResultReaderValidationError,
+    lookup_academic_result_evidence_reference,
+    lookup_academic_result_observation,
+    lookup_academic_result_overall_rating,
+    lookup_academic_result_review_unit,
+    lookup_academic_result_source,
+    lookup_academic_result_standard_feedback,
+    lookup_academic_result_student,
+    read_academic_result_manifest,
+    validate_academic_result_manifest,
+)
+
+FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "publication"
+    / "quillan_academic_result_manifest_v1.json"
+)
+
+EXPECTED_PUBLIC = {
+    "AcademicResultManifest",
+    "AcademicResultSourceName",
+    "EvidenceReference",
+    "OverallStandardRating",
+    "QuillanAcademicResultReaderDecodeError",
+    "QuillanAcademicResultReaderError",
+    "QuillanAcademicResultReaderNotFoundError",
+    "QuillanAcademicResultReaderValidationError",
+    "ReviewUnit",
+    "SourceRecordSnapshot",
+    "StandardFeedback",
+    "StandardObservation",
+    "StudentResult",
+    "lookup_academic_result_evidence_reference",
+    "lookup_academic_result_observation",
+    "lookup_academic_result_overall_rating",
+    "lookup_academic_result_review_unit",
+    "lookup_academic_result_source",
+    "lookup_academic_result_standard_feedback",
+    "lookup_academic_result_student",
+    "read_academic_result_manifest",
+    "validate_academic_result_manifest",
+}
+
+
+def fixture_bytes() -> bytes:
+    return FIXTURE.read_bytes()
+
+
+def fixture_manifest() -> AcademicResultManifest:
+    return read_academic_result_manifest(fixture_bytes())
+
+
+def test_public_reader_exports_exact_stable_surface() -> None:
+    assert set(reader_module.__all__) == EXPECTED_PUBLIC
+    assert reader_module.AcademicResultManifest is AcademicResultManifest
+
+
+def test_canonical_fixture_reads_through_existing_contract() -> None:
+    raw = fixture_bytes()
+    assert read_academic_result_manifest(raw) == manifest_from_json_bytes(raw)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda raw: json.dumps(
+            json.loads(raw),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8"),
+        lambda raw: (
+            json.dumps(
+                dict(reversed(list(json.loads(raw).items()))),
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n"
+        ).encode("utf-8"),
+        lambda raw: raw.removesuffix(b"\n"),
+        lambda raw: raw + b" ",
+        lambda raw: raw.replace(
+            b"2026-01-15T17:00:00Z",
+            b"2026-01-15T17:00:00+00:00",
+            1,
+        ),
+    ],
+    ids=[
+        "minified",
+        "top-level-key-order",
+        "missing-final-newline",
+        "trailing-space",
+        "timestamp-rendering",
+    ],
+)
+def test_semantically_valid_noncanonical_bytes_fail_closed(
+    mutation: Callable[[bytes], bytes],
+) -> None:
+    with pytest.raises(
+        QuillanAcademicResultReaderValidationError, match="not canonical"
+    ):
+        read_academic_result_manifest(mutation(fixture_bytes()))
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"not json",
+        b"\xff",
+        b'{"record_type":"a","record_type":"b"}',
+        b'{"number":NaN}',
+    ],
+)
+def test_decode_failures_are_normalized_without_payload_leak(raw: bytes) -> None:
+    with pytest.raises(
+        QuillanAcademicResultReaderDecodeError, match="bytes are invalid"
+    ) as caught:
+        read_academic_result_manifest(raw)
+    assert str(caught.value) == "Academic-result manifest bytes are invalid."
+
+
+def test_reader_requires_exact_immutable_bytes_type() -> None:
+    with pytest.raises(
+        QuillanAcademicResultReaderValidationError, match="immutable bytes"
+    ):
+        read_academic_result_manifest("not bytes")  # type: ignore[arg-type]
+    with pytest.raises(
+        QuillanAcademicResultReaderValidationError, match="immutable bytes"
+    ):
+        read_academic_result_manifest(bytearray(fixture_bytes()))  # type: ignore[arg-type]
+
+
+def test_invalid_semantic_manifest_is_wrapped_without_sensitive_value() -> None:
+    data = json.loads(fixture_bytes())
+    data["students"][0]["submission"]["student_id"] = "student_secret"
+    raw = (
+        json.dumps(
+            data,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+    with pytest.raises(QuillanAcademicResultReaderDecodeError) as caught:
+        read_academic_result_manifest(raw)
+    assert "student_secret" not in str(caught.value)
+    assert "student_001" not in str(caught.value)
+
+
+def test_existing_manifest_model_validates_without_mutation() -> None:
+    manifest = fixture_manifest()
+    assert validate_academic_result_manifest(manifest) is manifest
+    with pytest.raises(QuillanAcademicResultReaderValidationError):
+        validate_academic_result_manifest(object())  # type: ignore[arg-type]
+
+
+def test_source_lookup_returns_exact_embedded_snapshots_without_io(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = fixture_manifest()
+
+    def forbidden_open(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("source lookup must not open native files")
+
+    monkeypatch.setattr(builtins, "open", forbidden_open)
+    assignment = lookup_academic_result_source(manifest, "assignment")
+    submission = lookup_academic_result_source(
+        manifest, "submission", student_id="student_001"
+    )
+    review = lookup_academic_result_source(
+        manifest, "review", student_id="student_001"
+    )
+    assert isinstance(assignment, SourceRecordSnapshot)
+    assert assignment is manifest.source_snapshot
+    assert submission is manifest.students[0].source_snapshot.submission
+    assert review is manifest.students[0].source_snapshot.review
+
+
+def test_source_lookup_rejects_unknown_or_incomplete_combinations() -> None:
+    manifest = fixture_manifest()
+    with pytest.raises(QuillanAcademicResultReaderValidationError, match="source must"):
+        lookup_academic_result_source(manifest, "native_file")  # type: ignore[arg-type]
+    with pytest.raises(QuillanAcademicResultReaderValidationError):
+        lookup_academic_result_source(
+            manifest, "assignment", student_id="student_001"
+        )
+    with pytest.raises(QuillanAcademicResultReaderValidationError):
+        lookup_academic_result_source(manifest, "submission")
+    with pytest.raises(QuillanAcademicResultReaderValidationError):
+        lookup_academic_result_source(manifest, "review")
+
+
+def test_student_lookup_returns_exact_student() -> None:
+    manifest = fixture_manifest()
+    student = lookup_academic_result_student(manifest, "student_001")
+    assert isinstance(student, StudentResult)
+    assert student is manifest.students[0]
+
+
+def test_student_lookup_absence_and_invalid_id_are_privacy_safe() -> None:
+    manifest = fixture_manifest()
+    secret = "student_secret"
+    with pytest.raises(QuillanAcademicResultReaderNotFoundError) as caught:
+        lookup_academic_result_student(manifest, secret)
+    assert secret not in str(caught.value)
+    with pytest.raises(QuillanAcademicResultReaderValidationError):
+        lookup_academic_result_student(manifest, "../unsafe")
+
+
+def test_review_unit_lookup_is_exact_by_unit_id() -> None:
+    manifest = fixture_manifest()
+    unit = lookup_academic_result_review_unit(
+        manifest, "student_001", "paragraph_2"
+    )
+    assert isinstance(unit, ReviewUnit)
+    assert unit is manifest.students[0].review.review_units[1]
+    assert unit.sequence == 2
+    with pytest.raises(QuillanAcademicResultReaderNotFoundError):
+        lookup_academic_result_review_unit(manifest, "student_001", "Paragraph 2")
+    with pytest.raises(QuillanAcademicResultReaderValidationError):
+        lookup_academic_result_review_unit(manifest, "student_001", "")
+
+
+def test_observation_lookup_preserves_non_score_states_exactly() -> None:
+    manifest = fixture_manifest()
+    non_applicable = lookup_academic_result_observation(
+        manifest, "student_001", "observation_0002"
+    )
+    no_evidence = lookup_academic_result_observation(
+        manifest, "student_001", "observation_0003"
+    )
+    assert isinstance(non_applicable, StandardObservation)
+    assert (non_applicable.applicable, non_applicable.evidence_present, non_applicable.rating) == (
+        False,
+        None,
+        None,
+    )
+    assert (no_evidence.applicable, no_evidence.evidence_present, no_evidence.rating) == (
+        True,
+        False,
+        None,
+    )
+    with pytest.raises(QuillanAcademicResultReaderNotFoundError):
+        lookup_academic_result_observation(
+            manifest, "student_001", "observation_missing"
+        )
+
+
+def test_overall_rating_lookup_preserves_native_lowest_rating_and_absence() -> None:
+    manifest = fixture_manifest()
+    standard = "njsls-ela:RL.CR.9-10.1"
+    rating = lookup_academic_result_overall_rating(
+        manifest, "student_001", standard
+    )
+    assert isinstance(rating, OverallStandardRating)
+    assert rating is manifest.students[0].review.overall_standard_ratings[0]
+    assert rating.standard_id == standard
+    assert rating.rating == 0
+    with pytest.raises(QuillanAcademicResultReaderNotFoundError):
+        lookup_academic_result_overall_rating(
+            manifest,
+            "student_001",
+            "njsls-ela:W.AW.9-10.1",
+        )
+
+
+def test_standard_id_lookup_preserves_exact_native_text() -> None:
+    manifest = fixture_manifest()
+    with pytest.raises(QuillanAcademicResultReaderNotFoundError):
+        lookup_academic_result_overall_rating(
+            manifest,
+            "student_001",
+            "NJSLS-ELA:RL.CR.9-10.1",
+        )
+    with pytest.raises(QuillanAcademicResultReaderValidationError):
+        lookup_academic_result_overall_rating(manifest, "student_001", "\x00")
+
+
+def test_standard_feedback_returns_public_composition_without_recovering_withheld_text() -> None:
+    manifest = fixture_manifest()
+    feedback = lookup_academic_result_standard_feedback(
+        manifest,
+        "student_001",
+        "njsls-ela:RL.CR.9-10.1",
+    )
+    assert isinstance(feedback, StandardFeedback)
+    assert feedback is manifest.students[0].review.feedback.standard_feedback[0]
+    assert feedback.comments[0].text.disposition == "included"
+    assert feedback.comments[0].text.text == "Clarify the central idea."
+    overall = lookup_academic_result_overall_rating(
+        manifest,
+        "student_001",
+        "njsls-ela:RL.CR.9-10.1",
+    )
+    assert overall.rationale.disposition == "withheld"
+    assert overall.rationale.text is None
+    assert manifest.students[0].review.minimum_requirement_outcome.teacher_note.disposition == (
+        "withheld"
+    )
+    assert manifest.students[0].review.minimum_requirement_outcome.teacher_note.text is None
+
+
+def test_evidence_reference_lookup_returns_only_public_selected_provenance() -> None:
+    manifest = fixture_manifest()
+    evidence_id = "obs_00000000000000000000000000000001"
+    reference = lookup_academic_result_evidence_reference(
+        manifest, "student_001", evidence_id
+    )
+    assert isinstance(reference, EvidenceReference)
+    assert (
+        reference
+        is manifest.students[0].submission.digital_provenance.evidence_references[0]  # type: ignore[union-attr]
+    )
+    assert reference.evidence_id == evidence_id
+    assert reference.routed_evidence_sha256 == "4" * 64
+    assert not hasattr(reference, "routed_evidence_path")
+    assert not hasattr(reference, "retained_source_path")
+    assert not hasattr(reference, "source_filename")
+
+
+def test_plain_paper_has_no_fabricated_evidence_reference() -> None:
+    manifest = fixture_manifest()
+    with pytest.raises(QuillanAcademicResultReaderNotFoundError):
+        lookup_academic_result_evidence_reference(
+            manifest,
+            "student_002",
+            "obs_00000000000000000000000000000001",
+        )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "observation_0001",
+        "obs_ABCDEF00000000000000000000000000",
+        "obs_0000000000000000000000000000000",
+    ],
+)
+def test_evidence_lookup_rejects_invalid_pds2_identifier(value: str) -> None:
+    manifest = fixture_manifest()
+    with pytest.raises(QuillanAcademicResultReaderValidationError):
+        lookup_academic_result_evidence_reference(
+            manifest,
+            "student_001",
+            value,
+        )
+
+
+def test_reader_source_has_no_consumer_workspace_publication_or_io_boundary() -> None:
+    source = Path("quillan/academic_result_reader.py").read_text(encoding="utf-8")
+    lowered = source.lower()
+    for forbidden in (
+        "import meridian",
+        "from meridian",
+        "import vitrine",
+        "from vitrine",
+        "import scoreform",
+        "from scoreform",
+        "import concord",
+        "from concord",
+        "import portia",
+        "from portia",
+        "academic_result_manifest_generation",
+        "academic_result_publication",
+        "feedback_export",
+        "record_context",
+        "publication_storage",
+        "academic_catalog",
+        "registry_services",
+    ):
+        assert forbidden not in lowered
+    assert "open(" not in source
+    assert "Path(" not in source
+
+
+def test_reader_public_functions_do_not_print_or_write(capsys: pytest.CaptureFixture[str]) -> None:
+    manifest = fixture_manifest()
+    lookup_academic_result_source(manifest, "assignment")
+    lookup_academic_result_student(manifest, "student_001")
+    lookup_academic_result_review_unit(manifest, "student_001", "paragraph_1")
+    lookup_academic_result_observation(
+        manifest, "student_001", "observation_0001"
+    )
+    lookup_academic_result_overall_rating(
+        manifest, "student_001", "njsls-ela:RL.CR.9-10.1"
+    )
+    lookup_academic_result_standard_feedback(
+        manifest, "student_001", "njsls-ela:RL.CR.9-10.1"
+    )
+    lookup_academic_result_evidence_reference(
+        manifest,
+        "student_001",
+        "obs_00000000000000000000000000000001",
+    )
+    assert capsys.readouterr() == ("", "")

--- a/tests/test_academic_result_reader_boundaries.py
+++ b/tests/test_academic_result_reader_boundaries.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import quillan.academic_result_artifacts as artifacts
+import quillan.academic_result_reader as reader
+
+
+def test_pure_reader_source_has_only_contract_dependencies() -> None:
+    source = Path("quillan/academic_result_reader.py").read_text(encoding="utf-8")
+    lowered = source.lower()
+    for forbidden in (
+        "pathlib",
+        "import os",
+        "importlib",
+        "subprocess",
+        "socket",
+        "requests",
+        "academic_result_manifest_generation",
+        "academic_result_publication",
+        "feedback_export",
+        "record_context",
+        "publication_storage",
+        "registry_services",
+        "academic_catalog",
+        "meridian",
+        "vitrine",
+        "scoreform",
+        "concord",
+        "portia",
+    ):
+        assert forbidden not in lowered
+    assert "open(" not in source
+    assert "read_bytes(" not in source
+    assert "write_bytes(" not in source
+    assert "write_text(" not in source
+
+
+def test_artifact_module_has_no_core_publication_or_consumer_policy_dependency() -> None:
+    source = Path("quillan/academic_result_artifacts.py").read_text(encoding="utf-8")
+    lowered = source.lower()
+    for forbidden in (
+        "publication_storage",
+        "registry_services",
+        "academic_catalog",
+        "query_publication_catalog",
+        "publish_manifest_revision",
+        "supersede_manifest_revision",
+        "withdraw_publication",
+        "meridian",
+        "vitrine",
+        "scoreform",
+        "concord",
+        "portia",
+    ):
+        assert forbidden not in lowered
+
+
+def test_artifact_public_request_has_no_path_or_role_authorization_surface() -> None:
+    fields = artifacts.AcademicResultArtifactAuthorizationRequest.__dataclass_fields__
+    assert tuple(fields) == (
+        "work",
+        "record_set_id",
+        "record_set_revision",
+        "student_id",
+        "artifact_kind",
+        "purpose",
+    )
+    assert not {
+        "path",
+        "url",
+        "role",
+        "actor",
+        "teacher",
+        "admin",
+        "include_private",
+    }.intersection(fields)
+
+
+def test_artifact_kinds_are_closed_and_no_generic_reader_is_exported() -> None:
+    public = set(artifacts.__all__)
+    assert "read_authorized_academic_result_artifacts" in public
+    assert not {
+        "read_artifact",
+        "read_file",
+        "open_source",
+        "read_native_record",
+        "read_any_artifact",
+    }.intersection(public)
+    rendered = str(artifacts.AcademicResultArtifactKind)
+    assert "student_work" in rendered
+    assert "feedback_pdf" in rendered
+    assert "feedback_markdown" in rendered
+
+
+def test_reader_public_surface_contains_no_consumer_selection_policy() -> None:
+    forbidden = (
+        "grade",
+        "proficiency",
+        "mastery",
+        "best",
+        "latest",
+        "official",
+        "portfolio",
+        "showcase",
+        "graduation",
+    )
+    for name in reader.__all__:
+        assert not any(fragment in name.lower() for fragment in forbidden)
+
+
+def test_artifact_public_function_accepts_identity_not_arbitrary_path() -> None:
+    signature = inspect.signature(
+        artifacts.read_authorized_academic_result_artifacts
+    )
+    assert tuple(signature.parameters) == (
+        "workspace_root",
+        "manifest",
+        "student_id",
+        "artifact_kind",
+        "purpose",
+        "authorization_gate",
+    )
+    assert "path" not in signature.parameters
+    assert "publication_id" not in signature.parameters
+    assert "source_record" not in signature.parameters
+
+
+def test_reader_and_artifact_modules_define_explicit_public_surfaces() -> None:
+    assert type(reader.__all__) is tuple
+    assert type(artifacts.__all__) is tuple
+    assert len(reader.__all__) == len(set(reader.__all__))
+    assert len(artifacts.__all__) == len(set(artifacts.__all__))

--- a/tests/test_cli_feedback_export.py
+++ b/tests/test_cli_feedback_export.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -67,7 +68,6 @@ def test_cli_exports_feedback_and_prints_summary(
         }
     )
     review_path = _write_review(tmp_path, review)
-    review_before = review_path.read_bytes()
     monkeypatch.setattr(cli_exports, "resolve_workspace_root", lambda: tmp_path)
 
     assert main(
@@ -95,7 +95,12 @@ def test_cli_exports_feedback_and_prints_summary(
     assert "### synthetic:W.A" in content
     assert "Rating: 3" in content
     assert "Rationale:\nUses evidence." in content
-    assert review_path.read_bytes() == review_before
+    review_after = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review_after["review_state"] == "exported"
+    metadata = review_after["exports"]["feedback_markdown"]
+    assert metadata["path"] == relative
+    assert metadata["generated_at"] == review_after["updated_at"]
+    assert metadata["source_review_updated_at"] == review_after["updated_at"]
 
 
 def test_cli_missing_review_returns_one(
@@ -158,10 +163,16 @@ def test_cli_overwrite_flag_controls_replacement(
 
     assert main(command) == 1
     assert output_path.read_text(encoding="utf-8") == "manual edit"
+    assert review_path.read_bytes() == review_before
     assert main([*command, "--overwrite"]) == 0
 
     output = (lambda captured: captured.out + captured.err)(capsys.readouterr())
     assert "Use --overwrite" in output
     assert "Overwrote existing: yes" in output
     assert output_path.read_text(encoding="utf-8").startswith("# Feedback")
-    assert review_path.read_bytes() == review_before
+    review_after = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review_after["review_state"] == "exported"
+    metadata = review_after["exports"]["feedback_markdown"]
+    assert metadata["path"] == output_path.relative_to(tmp_path).as_posix()
+    assert metadata["generated_at"] == review_after["updated_at"]
+    assert metadata["source_review_updated_at"] == review_after["updated_at"]

--- a/tests/test_feedback_export.py
+++ b/tests/test_feedback_export.py
@@ -111,7 +111,7 @@ def _write_standards_library(root: Path) -> None:
     )
 
 
-def test_exports_ordered_student_content_without_mutating_sources(
+def test_exports_ordered_student_content_and_records_markdown_metadata(
     tmp_path: Path,
 ) -> None:
     manifest_path = _write_manifest(tmp_path)
@@ -207,7 +207,6 @@ def test_exports_ordered_student_content_without_mutating_sources(
     retained_path.write_bytes(b"source")
     originals = {
         manifest_path: manifest_path.read_bytes(),
-        review_path: review_path.read_bytes(),
         evidence_path: evidence_path.read_bytes(),
         retained_path: retained_path.read_bytes(),
     }
@@ -263,6 +262,16 @@ def test_exports_ordered_student_content_without_mutating_sources(
         assert private_text not in content
     for path, original in originals.items():
         assert path.read_bytes() == original
+    review_after = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review_after["review_state"] == "exported"
+    assert review_after["updated_at"] == TIMESTAMP
+    assert review_after["exports"]["feedback_pdf"] is None
+    assert review_after["exports"]["feedback_markdown"] == {
+        "path": expected_path.relative_to(tmp_path).as_posix(),
+        "generated_at": TIMESTAMP,
+        "source_review_updated_at": TIMESTAMP,
+        "module_details": {},
+    }
 
 
 def test_empty_scores_and_comments_have_clear_messages(tmp_path: Path) -> None:
@@ -509,10 +518,10 @@ def test_identity_mismatch_is_rejected(
 def test_overwrite_policy(tmp_path: Path) -> None:
     _write_manifest(tmp_path)
     review_path = _write_review(tmp_path, _review())
-    original_review = review_path.read_bytes()
     first = export_student_feedback(
         tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
     )
+    review_after_first = review_path.read_bytes()
     first.feedback_path.write_text("manually edited", encoding="utf-8")
 
     with pytest.raises(FeedbackExportError, match="--overwrite"):
@@ -520,6 +529,7 @@ def test_overwrite_policy(tmp_path: Path) -> None:
             tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID, created_at=TIMESTAMP
         )
     assert first.feedback_path.read_text(encoding="utf-8") == "manually edited"
+    assert review_path.read_bytes() == review_after_first
 
     second = export_student_feedback(
         tmp_path,
@@ -531,7 +541,9 @@ def test_overwrite_policy(tmp_path: Path) -> None:
     )
     assert second.overwrote_existing is True
     assert second.feedback_path.read_text(encoding="utf-8").startswith("# Feedback")
-    assert review_path.read_bytes() == original_review
+    review_after_second = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review_after_second["exports"]["feedback_markdown"]["generated_at"] == TIMESTAMP
+    assert review_after_second["updated_at"] == TIMESTAMP
 
 
 @pytest.mark.parametrize(

--- a/tests/test_installed_acceptance_contract.py
+++ b/tests/test_installed_acceptance_contract.py
@@ -13,6 +13,7 @@ from scripts.run_installed_acceptance import (
     SIDE_EFFECT_FREE_HELP_COMMANDS,
     _assert_no_academic_state,
     _compare_retained_source_inventories,
+    _verify_installed_academic_result_reader,
     _retained_source_inventory,
     _verify_digital_durable_state,
     _verify_plain_paper_absence,
@@ -178,6 +179,32 @@ def test_installed_acceptance_probes_publication_profile_and_core_discovery() ->
     assert "discover_publication_producer_profiles" in source
     assert "build_publication_producer_registry" in source
     assert 'assert not sentinel.exists()' in source
+
+
+def test_installed_acceptance_probes_public_reader_and_artifact_modules() -> None:
+    source = Path("scripts/run_installed_acceptance.py").read_text(encoding="utf-8")
+    assert "import quillan.academic_result_reader" in source
+    assert "import quillan.academic_result_artifacts" in source
+    assert "_verify_installed_academic_result_reader()" in source
+    assert "read_academic_result_manifest(canonical)" in source
+    assert "lookup_academic_result_student" in source
+    assert "lookup_academic_result_source" in source
+    assert "lookup_academic_result_overall_rating" in source
+    assert 'canonical + b" "' in source
+    assert "tests/fixtures" not in source
+
+
+def test_installed_reader_probe_is_side_effect_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sentinel = tmp_path / "must-not-exist"
+    monkeypatch.setenv("PDS_WORKSPACE_ROOT", str(sentinel))
+    result = _verify_installed_academic_result_reader()
+    assert result["student_lookup"] == "student_installed"
+    assert result["assignment_source"] == "assignment.json"
+    assert result["native_rating"] == 0
+    assert result["noncanonical_rejected"] is True
+    assert not sentinel.exists()
 
 
 def test_no_academic_state_accepts_ordinary_workspace(tmp_path: Path) -> None:

--- a/tests/test_menu_export_actions.py
+++ b/tests/test_menu_export_actions.py
@@ -447,7 +447,6 @@ def test_menu_export_student_feedback_creates_feedback_file(
         ASSIGNMENT_ID,
         STUDENT_ID,
     )
-    review_before = review_path.read_bytes()
 
     recorder = MenuScreenRecorder(
         _enter_selected_student()
@@ -480,7 +479,12 @@ def test_menu_export_student_feedback_creates_feedback_file(
     assert "- Good work." in feedback_text
     assert "This should not appear in student feedback." not in feedback_text
     assert manifest_path.read_bytes() == manifest_before
-    assert review_path.read_bytes() == review_before
+    review_after = json.loads(review_path.read_text(encoding="utf-8"))
+    assert review_after["review_state"] == "exported"
+    metadata = review_after["exports"]["feedback_markdown"]
+    assert metadata["path"] == feedback_path.relative_to(workspace).as_posix()
+    assert metadata["generated_at"] == review_after["updated_at"]
+    assert metadata["source_review_updated_at"] == review_after["updated_at"]
 
 
 def test_menu_export_student_feedback_pdf_creates_pdf_and_updates_metadata(

--- a/tests/test_v080_end_to_end_smoke.py
+++ b/tests/test_v080_end_to_end_smoke.py
@@ -315,7 +315,7 @@ def test_v080_scan_review_export_end_to_end_smoke(
 
     class_summary_text = class_summary_path.read_text(encoding="utf-8")
     assert STUDENT_ID in class_summary_text
-    assert "not_started" in class_summary_text
+    assert "exported" in class_summary_text
 
     standards_summary_text = standards_summary_path.read_text(encoding="utf-8")
     assert "students_expected" in standards_summary_text


### PR DESCRIPTION
﻿## Summary

Expose Quillan's stable consumer-neutral Academic Result Manifest v1 reader and a separate authorization-gated resolver for Quillan-owned student-work and feedback artifacts.

This completes the #364 producer boundary:

verified immutable Quillan manifest bytes
-> pure Quillan manifest reader
-> validated immutable producer-native models
-> exact native lookup
-> downstream consumer policy

separately authorized artifact request
-> deployment-owned authorization gate
-> Quillan native source/provenance verification
-> exact authorized student-work or feedback artifact

## Public reader

Adds:

quillan/academic_result_reader.py

The reader:

- accepts exact immutable canonical manifest bytes;
- delegates decoding and whole-manifest validation to Quillan's existing Manifest v1 authority;
- rejects byte-equivalent but noncanonical JSON;
- exposes exact producer-native student, source, review-unit, observation, rating, feedback, and evidence-reference lookup;
- preserves native null/non-applicable/non-evidence semantics;
- performs no workspace, filesystem, Core registry/catalog, publication-selection, or authorization I/O.

## Authorized artifact resolver

Adds:

quillan/academic_result_artifacts.py

Supported artifact kinds are deliberately closed to:

student_work
feedback_pdf
feedback_markdown

Artifact access requires an external deployment-owned authorization decision before workspace/source/artifact inspection.

Student-work resolution re-verifies the exact manifest-bound native submission and selected-evidence relationship. Candidate, duplicate, excluded, replacement, retained-source, unrelated, or another student's evidence is not exposed.

Feedback resolution requires exact manifest-bound review state and format-specific export metadata. PDF and Markdown do not fall back to one another, and artifact reads do not regenerate feedback.

## Privacy/integrity hardening

The final audit identified and repaired a narrow cross-student routed-evidence risk: a corrupted-but-schema-valid submission.json could otherwise redirect selected evidence to another student's routed artifact inside the same assignment work root when the artifact bytes had the same SHA-256.

The resolver now requires the native path to equal Quillan's exact canonical selected-evidence path derived from the authorized student, issuance, logical page, observation, and extension.

An adversarial regression test proves that another student's routed artifact cannot resolve even when its bytes and digest match.

## Feedback-export consistency

Markdown-only export now records the existing schema-2 exports.feedback_markdown metadata, matching the persistence model already used by PDF and companion Markdown export.

This is a consistency fix, not a schema change.

## Validation

Focused #364 gate after the final routed-path repair:

87 passed
Ruff: PASS
mypy: PASS
git diff --check: PASS

Fresh release-candidate validation then rebuilt and tested both distributions against authenticated Core 0.6.0:

Automated release-candidate validation: PASS
Physical acceptance: PENDING OWNER
Release authorization: NOT GRANTED

Validated:

- source pytest, Ruff, mypy, documentation integrity, and diff-whitespace checks;
- wheel and sdist build plus Twine;
- exact Core 0.6.0 identity in clean environments;
- installed reader and artifact modules;
- full installed synthetic workflow from the wheel;
- installed acceptance from the sdist;
- no unauthorized registry/workspace side effects;
- byte-exact persistence of tested artifacts.

Fresh candidate hashes:

quillan-0.8.9-py3-none-any.whl
5ef7ece82e7c1bd2064ce6a1815d197a42cddeca763cd7e49477e1934c632440

quillan-0.8.9.tar.gz
762cf97f11c24e91efc44d8aea4f5c9da516f05a818d61d4c9927b09a73641e8

The product-release safeguard remains intentionally ungranted. #365 owns installed producer-to-Core end-to-end acceptance, and #366 owns final compatibility/release authorization.

## Scope

Exactly 20 files changed from the #363 merge base in one commit:

cbd2390

No Core dependency-range change, package-version change, manifest-schema change, Meridian grading policy, Vitrine portfolio policy, or sibling-repository change.

Closes #364
