### PR TITLE
feat: add recent class and assignment context

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -2039,3 +2039,10 @@ configuration. The teacher reviews the complete preset and still receives the
 normal final assignment preview/save boundary.
 
 See [Reusable Review-Configuration Presets](review_configuration_presets.md).
+
+## Interactive session context boundary
+
+Recent class/assignment context is an interactive-menu convenience only. Direct CLI
+commands remain stateless and continue to require the explicit identifiers defined by
+their existing arguments. Issue #382 adds no `--recent`-style argument, no persistent
+context record, and no CLI inventory entry. See `teacher_session_context.md`.

--- a/docs/teacher_session_context.md
+++ b/docs/teacher_session_context.md
@@ -1,0 +1,82 @@
+# Teacher session context
+
+Issue: #382 — recent class/assignment context and active-context headers
+
+## Scope
+
+Quillan's interactive teacher menu keeps a small, process-local navigation context so
+routine review work can remain inside one class and assignment. The context contains
+only the resolved workspace root, exact `class_id`, and exact `assignment_id`.
+It never contains a student identity, student writing, review content, ratings,
+feedback, or derived judgments.
+
+The context is convenience state, not an authoritative record. It is never serialized,
+written to the Paper Data Suite workspace, registered with Core, or exposed as a new
+CLI contract. Direct CLI commands remain stateless and continue to require their
+existing explicit identifiers.
+
+## Identity and validation rules
+
+Assignment context always implies class context. Changing the class clears the prior
+assignment unless a new exact class/assignment pair is committed atomically. A change
+in the canonically resolved workspace clears both class and assignment context.
+
+Remembered identifiers are revalidated before assignment-local review work is entered.
+Quillan uses canonical roster-backed class discovery and canonical assignment discovery,
+matching only exact `class_id` and `assignment_id` values. Assignment titles are display
+metadata only and are never used as a fallback identity. If a remembered class or
+assignment is removed, malformed, moved to another class, or otherwise no longer
+canonical, Quillan clears the stale portion of context and asks the teacher to select
+again rather than substituting another record.
+
+## Teacher-facing behavior
+
+The first assignment-review entry in a fresh menu session still asks for class and
+assignment. A valid active assignment can then be reused without repeating either
+selector. If the assignment is cleared while the class remains active, review entry
+asks only for the assignment in that class.
+
+The Review Student Work menu exposes `C. Manage active context`, with explicit actions
+to:
+
+1. switch assignment within the current class;
+2. switch class and assignment as one committed pair;
+3. clear only the assignment while retaining the class; and
+4. clear class and assignment context.
+
+Canceling a switch preserves the previous context. Back, Main Menu, refresh actions,
+and ordinary workflow completion also preserve context. Quitting Quillan ends the
+session and therefore discards it.
+
+Teacher-facing assignment-local screens render a bounded `Active context` block with
+the exact class and assignment IDs. A current assignment title is shown when canonical
+lookup succeeds; the exact assignment ID remains visible even when title lookup is
+unavailable.
+
+## Workspace behavior
+
+The session stores the canonical resolved workspace path only to detect workspace
+changes. Rebinding to the same canonical path preserves class/assignment context.
+Rebinding to a different canonical path clears it. Workspace files are never changed
+by this comparison.
+
+## Selection ownership boundaries
+
+Only selections that establish an operating review target update active context.
+Source-only/reference-only selection remains independent. In particular:
+
+- **Copy Writing Assignment** continues to ask for its source assignment explicitly;
+- **Save Review Preset from Assignment** continues to ask for its source assignment
+  explicitly;
+- diagnostic/reference-only pickers do not replace active review context; and
+- scan routing does not guess context from routed artifacts.
+
+After scan intake, an explicit **Review student work** action for one exact routed
+class/assignment target may activate that exact pair before entering review. Merely
+routing scans—or displaying one or more affected targets—does not change context.
+
+## Out of scope
+
+This issue does not add a deterministic work queue, next/previous-student navigation,
+`Continue Review` guidance, compact-review redesign, automatic publication, automatic
+scoring, or automatic teacher judgments. Those remain separate Phase 1 work items.

--- a/docs/workspace_lifecycle.md
+++ b/docs/workspace_lifecycle.md
@@ -360,3 +360,11 @@ Assignment creation may use only an explicitly selected current valid preset and
 rechecks the exact reviewed preset before saving. After an assignment is saved,
 its materialized schema-v2 configuration is authoritative and does not depend on
 the preset remaining present.
+
+## Interactive teacher session context
+
+The interactive Quillan menu may retain the current exact class and assignment for
+the life of one process. This state is ephemeral and is not part of the workspace
+contract. It is never serialized. If the canonically resolved workspace root changes,
+Quillan clears class and assignment context before it can be reused. Rebinding to the
+same canonical root preserves it. See `teacher_session_context.md`.

--- a/quillan/assignment_picker.py
+++ b/quillan/assignment_picker.py
@@ -26,8 +26,8 @@ class AssignmentChoice:
     path: Path
 
 
-def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
-    """Let a teacher choose a roster class and its canonical assignment."""
+def prompt_class_choice(workspace_root: Path) -> str | None:
+    """Let a teacher choose one exact roster-backed class."""
     folders = list_class_folders(workspace_root, require_roster=True)
     if not folders:
         print("No classes found in the current workspace.")
@@ -45,16 +45,20 @@ def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
             print("Class selection canceled.")
             return None
         if selection.isdigit() and 1 <= int(selection) <= len(folders):
-            class_id = folders[int(selection) - 1].class_id
-            break
+            return folders[int(selection) - 1].class_id
         class_matches = [
             folder for folder in folders if folder.class_id == selection
         ]
         if class_matches:
-            class_id = class_matches[0].class_id
-            break
+            return class_matches[0].class_id
         print(f"Invalid class selection. {navigation_hint()}")
 
+
+def prompt_assignment_choice_for_class(
+    workspace_root: Path,
+    class_id: str,
+) -> AssignmentChoice | None:
+    """Let a teacher choose one canonical assignment in an exact class."""
     from quillan.menu import clear_screen, print_menu_header
 
     clear_screen()
@@ -88,6 +92,14 @@ def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
         if assignment_matches:
             return assignment_matches[0]
         print(f"Invalid assignment selection. {navigation_hint()}")
+
+
+def prompt_assignment_choice(workspace_root: Path) -> AssignmentChoice | None:
+    """Let a teacher choose a roster class and its canonical assignment."""
+    class_id = prompt_class_choice(workspace_root)
+    if class_id is None:
+        return None
+    return prompt_assignment_choice_for_class(workspace_root, class_id)
 
 
 def available_assignments(

--- a/quillan/menu.py
+++ b/quillan/menu.py
@@ -18,6 +18,7 @@ from quillan.intake_assembly import (
     IntakeAssemblyTarget,
     QuillanPostDispatchPersistenceResult,
 )
+from quillan.menu_context import MenuSessionContext, print_session_context
 from quillan.menu_navigation import (
     NavigationChoice,
     QuitQuillan,
@@ -252,6 +253,7 @@ def _print_post_route_action_header(
 def _launch_post_route_review(
     workspace_root: Path,
     target: IntakeAssemblyTarget,
+    session_context: MenuSessionContext | None = None,
 ) -> None:
     from quillan.review_menu import launch_assignment_review_actions
 
@@ -259,6 +261,7 @@ def _launch_post_route_review(
         workspace_root,
         target.class_id,
         target.assignment_id,
+        session_context=session_context,
     )
 
 
@@ -266,6 +269,7 @@ def _handle_single_post_route_target(
     workspace_root: Path,
     target: IntakeAssemblyTarget,
     status: PostRouteTargetStatus,
+    session_context: MenuSessionContext | None = None,
 ) -> bool:
     if status.status_error is not None:
         print("Submission status could not be loaded.")
@@ -315,7 +319,7 @@ def _handle_single_post_route_target(
             return True
         if choice == "3":
             _print_post_route_action_header("Review Student Work", target)
-            _launch_post_route_review(workspace_root, target)
+            _launch_post_route_review(workspace_root, target, session_context)
             return True
         print(f"Invalid selection. {navigation_hint()}")
         return True
@@ -340,7 +344,7 @@ def _handle_single_post_route_target(
             return True
         if choice == "2":
             _print_post_route_action_header("Review Student Work", target)
-            _launch_post_route_review(workspace_root, target)
+            _launch_post_route_review(workspace_root, target, session_context)
             return True
         if choice == "3":
             _print_post_route_action_header("Assemble Submissions", target)
@@ -379,6 +383,7 @@ def _handle_single_post_route_target(
 def handle_scan_post_route_menu(
     workspace_root: Path,
     workflow: QuillanPostDispatchPersistenceResult | Sequence[IntakeAssemblyTarget],
+    session_context: MenuSessionContext | None = None,
 ) -> None:
     """Show status-aware follow-up actions after scan intake routes evidence."""
     if isinstance(workflow, QuillanPostDispatchPersistenceResult):
@@ -479,6 +484,7 @@ def handle_scan_post_route_menu(
                 workspace_root,
                 targets[0],
                 statuses[0],
+                session_context,
             )
             if not should_redraw:
                 return
@@ -496,12 +502,15 @@ def handle_scan_post_route_menu(
                 workspace_root,
                 targets[index],
                 statuses[index],
+                session_context,
             )
             continue
         print(f"Invalid selection. {navigation_hint()}")
 
 
-def launch_scan_intake_workflow() -> None:
+def launch_scan_intake_workflow(
+    session_context: MenuSessionContext | None = None,
+) -> None:
     """Route scans from the shared inbox, with a power-user path fallback."""
     from quillan.cli_app.handlers import routing
 
@@ -582,14 +591,21 @@ def launch_scan_intake_workflow() -> None:
             print()
             pause_for_user()
             continue
-        handle_scan_post_route_menu(workspace_root, result)
+        if session_context is None:
+            handle_scan_post_route_menu(workspace_root, result)
+        else:
+            handle_scan_post_route_menu(
+                workspace_root, result, session_context
+            )
 
 
-def launch_review_student_work_menu() -> None:
+def launch_review_student_work_menu(
+    session_context: MenuSessionContext | None = None,
+) -> None:
     """Launch the teacher-facing review navigation workflow."""
     from quillan.review_menu import launch_review_student_work_menu as launch
 
-    launch()
+    launch(session_context)
 
 
 def launch_workspace_menu(
@@ -597,6 +613,7 @@ def launch_workspace_menu(
     workspace_set: WorkspaceSetHandler,
     workspace_validate: WorkspaceActionHandler,
     workspace_reset: WorkspaceActionHandler,
+    session_context: MenuSessionContext | None = None,
 ) -> None:
     """Launch the shared Paper Data Suite workspace settings submenu."""
     while True:
@@ -627,7 +644,9 @@ def launch_workspace_menu(
             ).strip()
             print()
             if path:
-                workspace_set(path)
+                result = workspace_set(path)
+                if result == 0:
+                    _rebind_session_workspace(session_context)
             else:
                 print("Workspace selection canceled. No preference was changed.")
             print()
@@ -641,7 +660,9 @@ def launch_workspace_menu(
         elif choice == "4":
             clear_screen()
             print_menu_header("Reset Workspace Preference")
-            workspace_reset()
+            result = workspace_reset()
+            if result == 0:
+                _rebind_session_workspace(session_context)
             print()
             pause_for_user()
         elif navigation is NavigationChoice.BACK:
@@ -652,17 +673,42 @@ def launch_workspace_menu(
             pause_for_user()
 
 
+
+def _rebind_session_workspace(
+    session_context: MenuSessionContext | None,
+) -> None:
+    if session_context is None:
+        return
+    from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+    had_active_context = session_context.class_id is not None
+    try:
+        workspace_root = resolve_workspace_root()
+    except WorkspaceRootError:
+        return
+    if session_context.bind_workspace(workspace_root) and had_active_context:
+        print()
+        print(
+            "Active class/assignment context was cleared because the "
+            "resolved workspace changed."
+        )
+
+
 def launch_menu(
     workspace_show: WorkspaceShowHandler,
     workspace_set: WorkspaceSetHandler,
     workspace_validate: WorkspaceActionHandler,
     workspace_reset: WorkspaceActionHandler,
+    session_context: MenuSessionContext | None = None,
 ) -> int:
     """Launch the Quillan teacher-facing menu skeleton."""
+    context = session_context if session_context is not None else MenuSessionContext()
     try:
         while True:
             clear_screen()
             print_menu_header()
+            _rebind_session_workspace(context)
+            print_session_context(context)
             print("1. Assignment Management")
             print("2. Review Student Work")
             print("3. Roster Management")
@@ -680,7 +726,7 @@ def launch_menu(
             if choice == "1":
                 launch_assignment_menu()
             elif choice == "2":
-                launch_review_student_work_menu()
+                launch_review_student_work_menu(context)
             elif choice == "3":
                 launch_roster_menu()
             elif choice == "4":
@@ -689,6 +735,7 @@ def launch_menu(
                     workspace_set,
                     workspace_validate,
                     workspace_reset,
+                    context,
                 )
             elif choice == "5":
                 clear_screen()
@@ -708,6 +755,7 @@ def launch_menu(
             workspace_set,
             workspace_validate,
             workspace_reset,
+            context,
         )
     except QuitQuillan:
         print("Goodbye.")

--- a/quillan/menu_context.py
+++ b/quillan/menu_context.py
@@ -1,0 +1,178 @@
+"""Session-local active class/assignment context for teacher menus."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pds_core.classes import list_class_folders
+
+from quillan.assignment_picker import AssignmentChoice, available_assignments
+
+
+@dataclass(frozen=True, slots=True)
+class ContextValidation:
+    """Result of revalidating a session context against the current workspace."""
+
+    assignment: AssignmentChoice | None
+    message: str | None = None
+
+
+@dataclass(slots=True)
+class MenuSessionContext:
+    """Ephemeral navigation context owned by one interactive Quillan session."""
+
+    workspace_root: Path | None = None
+    class_id: str | None = None
+    assignment_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.assignment_id is not None and self.class_id is None:
+            raise ValueError("assignment context requires class context")
+        if self.workspace_root is not None:
+            self.workspace_root = _canonical_workspace_root(self.workspace_root)
+
+    def bind_workspace(self, workspace_root: Path) -> bool:
+        """Bind to a canonical workspace and clear targets if the root changed."""
+        canonical = _canonical_workspace_root(workspace_root)
+        changed = self.workspace_root is not None and self.workspace_root != canonical
+        self.workspace_root = canonical
+        if changed:
+            self.class_id = None
+            self.assignment_id = None
+        return changed
+
+    def activate_class(self, class_id: str) -> None:
+        """Activate one exact class and clear any prior assignment."""
+        _require_identity(class_id, "class_id")
+        self.class_id = class_id
+        self.assignment_id = None
+
+    def activate_assignment(self, class_id: str, assignment_id: str) -> None:
+        """Atomically activate one exact class/assignment pair."""
+        _require_identity(class_id, "class_id")
+        _require_identity(assignment_id, "assignment_id")
+        self.class_id = class_id
+        self.assignment_id = assignment_id
+
+    def clear_assignment(self) -> None:
+        """Clear assignment context while retaining the active class."""
+        self.assignment_id = None
+
+    def clear_selection(self) -> None:
+        """Clear class and assignment context while retaining workspace binding."""
+        self.class_id = None
+        self.assignment_id = None
+
+
+def _canonical_workspace_root(workspace_root: Path) -> Path:
+    return workspace_root.expanduser().resolve(strict=False)
+
+
+def _require_identity(value: str, field: str) -> None:
+    if not value or value.strip() != value:
+        raise ValueError(f"{field} must be a non-empty exact identifier")
+
+
+def exact_assignment_choice(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> AssignmentChoice | None:
+    """Return only the exact canonical assignment identity, never a title match."""
+    return next(
+        (
+            choice
+            for choice in available_assignments(workspace_root, class_id)
+            if choice.assignment_id == assignment_id
+        ),
+        None,
+    )
+
+
+def revalidate_menu_context(
+    context: MenuSessionContext,
+    workspace_root: Path,
+) -> ContextValidation:
+    """Fail closed when remembered context is stale or belongs elsewhere."""
+    previous_class = context.class_id
+    previous_assignment = context.assignment_id
+    if context.bind_workspace(workspace_root):
+        return ContextValidation(
+            assignment=None,
+            message=(
+                "Active class/assignment context was cleared because the "
+                "resolved workspace changed."
+            ),
+        )
+
+    if context.class_id is None:
+        return ContextValidation(assignment=None)
+
+    class_ids = {
+        folder.class_id
+        for folder in list_class_folders(workspace_root, require_roster=True)
+    }
+    if context.class_id not in class_ids:
+        context.clear_selection()
+        return ContextValidation(
+            assignment=None,
+            message=(
+                "Active class context is no longer available in this workspace: "
+                f"{previous_class}. Select a class and assignment again."
+            ),
+        )
+
+    if context.assignment_id is None:
+        return ContextValidation(assignment=None)
+
+    choice = exact_assignment_choice(
+        workspace_root,
+        context.class_id,
+        context.assignment_id,
+    )
+    if choice is None:
+        context.clear_assignment()
+        return ContextValidation(
+            assignment=None,
+            message=(
+                "Active assignment context is no longer a valid canonical "
+                f"assignment for class {previous_class}: {previous_assignment}. "
+                "Select an assignment again."
+            ),
+        )
+    return ContextValidation(assignment=choice)
+
+
+def print_active_context(
+    workspace_root: Path | None,
+    class_id: str,
+    assignment_id: str | None = None,
+) -> None:
+    """Render an exact, bounded active-context block for teacher-facing screens."""
+    print("Active context")
+    print(f"Class: {class_id}")
+    if assignment_id is not None:
+        choice = (
+            None
+            if workspace_root is None
+            else exact_assignment_choice(workspace_root, class_id, assignment_id)
+        )
+        if choice is not None and choice.title is not None:
+            print(f"Assignment: {assignment_id} - {choice.title}")
+        elif choice is not None:
+            print(f"Assignment: {assignment_id}")
+        else:
+            print(f"Assignment: {assignment_id} - title unavailable")
+    print()
+
+
+def print_session_context(context: MenuSessionContext) -> None:
+    """Render session context when a class has been explicitly selected."""
+    if context.class_id is None:
+        return
+    print_active_context(
+        context.workspace_root,
+        context.class_id,
+        context.assignment_id,
+    )

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -14,7 +14,11 @@ from pds_core.standards_selection import (
 )
 from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
 
-from quillan.assignment_picker import prompt_assignment_choice
+from quillan.assignment_picker import (
+    AssignmentChoice,
+    prompt_assignment_choice,
+    prompt_assignment_choice_for_class,
+)
 from quillan.assignment_submission_assembly import assemble_assignment_submissions
 from quillan.class_summary_export import (
     ClassSummaryExportError,
@@ -144,6 +148,13 @@ from quillan.student_review_status import (
     build_student_review_status,
     student_review_status_to_dict,
 )
+from quillan.menu_context import (
+    MenuSessionContext,
+    exact_assignment_choice,
+    print_active_context,
+    print_session_context,
+    revalidate_menu_context,
+)
 from quillan.menu_navigation import (
     NavigationChoice,
     navigation_hint,
@@ -161,16 +172,21 @@ _BACK = object()
 _CANCEL = object()
 
 
-def launch_review_student_work_menu() -> int:
-    """Launch the read-only teacher review navigation workflow."""
+def launch_review_student_work_menu(
+    session_context: MenuSessionContext | None = None,
+) -> int:
+    """Launch the teacher-facing review navigation workflow."""
     from quillan.menu import clear_screen, pause_for_user, print_menu_header
 
+    context = session_context if session_context is not None else MenuSessionContext()
     try:
         while True:
             clear_screen()
             print_menu_header("Review Student Work")
+            print_session_context(context)
             print("1. Assignment Review Actions")
             print("2. Scan Intake / Route Paper Responses")
+            print("C. Manage active context")
             print("R. Resolve Scan Review Items")
             print_navigation_options()
             print()
@@ -182,13 +198,15 @@ def launch_review_student_work_menu() -> int:
                 return 0
             if choice == "1":
                 clear_screen()
-                _run_review_selection_workflow()
+                _run_review_selection_workflow(context)
                 print()
                 pause_for_user()
             elif choice == "2":
                 from quillan.menu import launch_scan_intake_workflow
 
-                launch_scan_intake_workflow()
+                launch_scan_intake_workflow(context)
+            elif choice.casefold() == "c":
+                _manage_active_context(context)
             elif choice.casefold() == "r":
                 workspace_root = _workspace_root()
                 if workspace_root is not None:
@@ -206,7 +224,28 @@ def launch_review_student_work_menu() -> int:
         return 0
 
 
-def _run_review_selection_workflow() -> int:
+def _select_review_assignment(
+    workspace_root: Path,
+    context: MenuSessionContext,
+) -> AssignmentChoice | None:
+    validation = revalidate_menu_context(context, workspace_root)
+    if validation.message is not None:
+        print(validation.message)
+        print()
+    if validation.assignment is not None:
+        return validation.assignment
+
+    assignment = (
+        prompt_assignment_choice_for_class(workspace_root, context.class_id)
+        if context.class_id is not None
+        else prompt_assignment_choice(workspace_root)
+    )
+    if assignment is not None:
+        context.activate_assignment(assignment.class_id, assignment.assignment_id)
+    return assignment
+
+
+def _run_review_selection_workflow(context: MenuSessionContext) -> int:
     from quillan.menu import print_menu_header
 
     print_menu_header("Review Student Work")
@@ -214,7 +253,7 @@ def _run_review_selection_workflow() -> int:
     if workspace_root is None:
         return 1
 
-    assignment = prompt_assignment_choice(workspace_root)
+    assignment = _select_review_assignment(workspace_root, context)
     if assignment is None:
         return 0
 
@@ -225,12 +264,93 @@ def _run_review_selection_workflow() -> int:
     )
 
 
+def _manage_active_context(context: MenuSessionContext) -> None:
+    from quillan.menu import clear_screen, pause_for_user, print_menu_header
+
+    workspace_root = _workspace_root()
+    if workspace_root is None:
+        return
+    validation = revalidate_menu_context(context, workspace_root)
+    if validation.message is not None:
+        print(validation.message)
+        print()
+        pause_for_user()
+
+    while True:
+        clear_screen()
+        print_menu_header("Manage Active Context")
+        print_session_context(context)
+        if context.class_id is None:
+            print("Active class: none")
+            print()
+        print("1. Switch assignment within current class")
+        print("2. Switch class and assignment")
+        print("3. Clear assignment; retain class")
+        print("4. Clear class and assignment")
+        print_navigation_options()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
+        if choice == "" or navigation is NavigationChoice.BACK:
+            return
+        if choice == "1":
+            if context.class_id is None:
+                print("No active class. Select class and assignment first.")
+                pause_for_user()
+                continue
+            assignment = prompt_assignment_choice_for_class(
+                workspace_root, context.class_id
+            )
+            if assignment is not None:
+                context.activate_assignment(
+                    assignment.class_id, assignment.assignment_id
+                )
+                print("Active assignment updated.")
+                pause_for_user()
+        elif choice == "2":
+            assignment = prompt_assignment_choice(workspace_root)
+            if assignment is not None:
+                context.activate_assignment(
+                    assignment.class_id, assignment.assignment_id
+                )
+                print("Active class and assignment updated.")
+                pause_for_user()
+        elif choice == "3":
+            if context.class_id is None:
+                print("No active class or assignment to change.")
+            else:
+                context.clear_assignment()
+                print("Active assignment cleared; active class retained.")
+            pause_for_user()
+        elif choice == "4":
+            context.clear_selection()
+            print("Active class and assignment cleared.")
+            pause_for_user()
+        else:
+            print(f"Invalid selection. {navigation_hint()}")
+            pause_for_user()
+
+
 def launch_assignment_review_actions(
     workspace_root: Path,
     class_id: str,
     assignment_id: str,
+    *,
+    session_context: MenuSessionContext | None = None,
 ) -> int:
-    """Launch review actions for a known class assignment."""
+    """Launch review actions for a known exact class assignment."""
+    if session_context is not None:
+        validation = revalidate_menu_context(session_context, workspace_root)
+        if validation.message is not None:
+            print(validation.message)
+        choice = exact_assignment_choice(workspace_root, class_id, assignment_id)
+        if choice is None:
+            print(
+                "Review target is not a valid canonical assignment: "
+                f"{class_id}/{assignment_id}."
+            )
+            return 1
+        session_context.activate_assignment(class_id, assignment_id)
     return _launch_assignment_review_actions(
         workspace_root,
         class_id,
@@ -291,9 +411,7 @@ def _prompt_student_id(
 
     clear_screen()
     print_menu_header("Select Student/Submission")
-    print(f"Class: {class_id}")
-    print(f"Assignment: {assignment_id}")
-    print()
+    print_active_context(workspace_root, class_id, assignment_id)
 
     status_items = (
         status.students
@@ -398,6 +516,7 @@ def _launch_selected_student_review(
     while True:
         clear_screen()
         print_menu_header("Selected Student Review")
+        print_active_context(workspace_root, class_id, assignment_id)
         _print_review_summary(
             workspace_root,
             class_id,
@@ -614,9 +733,11 @@ def _print_assignment_action_header(
 
     clear_screen()
     print_menu_header(title)
-    print(f"Class: {class_id}")
-    print(f"Assignment: {assignment_id}")
-    print()
+    try:
+        active_workspace = resolve_workspace_root()
+    except WorkspaceRootError:
+        active_workspace = None
+    print_active_context(active_workspace, class_id, assignment_id)
 
 
 def _print_review_action_header(
@@ -629,14 +750,15 @@ def _print_review_action_header(
 
     clear_screen()
     print_menu_header(title)
-    print(f"Class: {class_id}")
-    print(f"Assignment: {assignment_id}")
     try:
-        workspace_root = resolve_workspace_root()
+        workspace_root: Path | None = resolve_workspace_root()
     except WorkspaceRootError:
+        workspace_root = None
+    if workspace_root is None:
         student_label = student_id
     else:
         student_label = student_review_label(workspace_root, class_id, student_id)
+    print_active_context(workspace_root, class_id, assignment_id)
     print(f"Student: {student_label}")
     print()
 
@@ -3788,6 +3910,7 @@ def _launch_assignment_review_actions(
     while True:
         clear_screen()
         print_menu_header("Assignment Review Actions")
+        print_active_context(workspace_root, class_id, assignment_id)
 
         dashboard = _load_review_dashboard(
             workspace_root,
@@ -3830,6 +3953,7 @@ def _launch_assignment_review_actions(
         elif choice == "2":
             clear_screen()
             print_menu_header("Assignment Submission Status")
+            print_active_context(workspace_root, class_id, assignment_id)
             status = _load_submission_status(
                 workspace_root, class_id, assignment_id
             )
@@ -3851,6 +3975,7 @@ def _launch_assignment_review_actions(
         elif choice == "5":
             clear_screen()
             print_menu_header("Full Assignment Diagnostic Dashboard")
+            print_active_context(workspace_root, class_id, assignment_id)
             print(
                 format_assignment_review_dashboard(
                     dashboard, show_unused_duplicate_files=False
@@ -3912,9 +4037,7 @@ def _menu_export_assignment_reports(
     while True:
         clear_screen()
         print_menu_header("Assignment Reports")
-        print(f"Class: {class_id}")
-        print(f"Assignment: {assignment_id}")
-        print()
+        print_active_context(workspace_root, class_id, assignment_id)
         print("1. Comprehensive Class Summary")
         print("2. Focus Standard Summary")
         print("3. Student Performance Summary")
@@ -3926,12 +4049,15 @@ def _menu_export_assignment_reports(
         clear_screen()
         if choice == "1":
             print_menu_header("Export Comprehensive Class Summary")
+            print_active_context(workspace_root, class_id, assignment_id)
             _menu_export_class_summary(workspace_root, class_id, assignment_id)
         elif choice == "2":
             print_menu_header("Export Focus Standard Summary")
+            print_active_context(workspace_root, class_id, assignment_id)
             _menu_export_standards_summary(workspace_root, class_id, assignment_id)
         elif choice == "3":
             print_menu_header("Export Student Performance Summary")
+            print_active_context(workspace_root, class_id, assignment_id)
             _menu_export_student_performance_summary(
                 workspace_root, class_id, assignment_id
             )

--- a/tests/test_menu_context_issue382.py
+++ b/tests/test_menu_context_issue382.py
@@ -1,0 +1,489 @@
+"""Issue #382 tests for ephemeral teacher class/assignment context."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from quillan.assignment_picker import (
+    prompt_assignment_choice,
+    prompt_assignment_choice_for_class,
+)
+from quillan.menu_context import (
+    MenuSessionContext,
+    exact_assignment_choice,
+    print_session_context,
+    revalidate_menu_context,
+)
+import quillan.menu as menu
+import quillan.review_menu as review_menu
+from quillan.menu_navigation import ReturnToMainMenu
+from tests.menu_screen_recorder import MenuScreenRecorder
+
+
+CLASS_ID = "english12_p3_synthetic"
+OTHER_CLASS_ID = "english12_p4_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+OTHER_ASSIGNMENT_ID = "essay_02_synthetic"
+
+
+def _assignment(assignment_id: str, title: str) -> dict[str, object]:
+    return {
+        "schema_version": "2",
+        "module": "quillan",
+        "record_type": "assignment",
+        "assignment_id": assignment_id,
+        "title": title,
+        "class_ids": [CLASS_ID],
+        "writing_type": "argument",
+        "student_prompt": "Write a synthetic argument.",
+        "standards_profile_id": "synthetic_profile",
+        "focus_standard_ids": ["njsls-ela:W.1"],
+        "review_unit": {
+            "type": "paragraph",
+            "singular_label": "paragraph",
+            "plural_label": "paragraphs",
+        },
+        "rating_scale": {
+            "scale_id": "standards_2_level",
+            "levels": [
+                {
+                    "value": 1,
+                    "label": "Developing",
+                    "description": "Limited evidence.",
+                }
+            ],
+        },
+        "basic_requirements": {},
+        "minimum_requirement_policy": {
+            "allow_return_without_full_review": True,
+        },
+        "created_at": "2026-08-20T00:00:00+00:00",
+        "updated_at": "2026-08-20T00:00:00+00:00",
+        "module_details": {},
+    }
+
+
+def _write_class(root: Path, class_id: str) -> None:
+    class_dir = root / "classes" / class_id
+    class_dir.mkdir(parents=True, exist_ok=True)
+    with (class_dir / "roster.csv").open("w", encoding="utf-8", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(("class_id", "student_id", "last_name", "first_name", "period"))
+        writer.writerow((class_id, "student_001", "Student", "Synthetic", "3"))
+
+
+def _write_assignment(
+    root: Path,
+    class_id: str,
+    assignment_id: str,
+    title: str,
+) -> Path:
+    document = _assignment(assignment_id, title)
+    document["class_ids"] = [class_id]
+    path = (
+        root
+        / "classes"
+        / class_id
+        / "modules"
+        / "quillan"
+        / "work"
+        / assignment_id
+        / "assignment.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    _write_class(tmp_path, CLASS_ID)
+    _write_class(tmp_path, OTHER_CLASS_ID)
+    _write_assignment(tmp_path, CLASS_ID, ASSIGNMENT_ID, "Shared Title")
+    _write_assignment(tmp_path, CLASS_ID, OTHER_ASSIGNMENT_ID, "Shared Title")
+    return tmp_path
+
+
+def test_context_invariants_and_class_change() -> None:
+    with pytest.raises(ValueError, match="requires class"):
+        MenuSessionContext(assignment_id=ASSIGNMENT_ID)
+
+    context = MenuSessionContext()
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id == ASSIGNMENT_ID
+
+    context.activate_class(OTHER_CLASS_ID)
+    assert context.class_id == OTHER_CLASS_ID
+    assert context.assignment_id is None
+
+
+def test_workspace_binding_preserves_same_root_and_clears_changed_root(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    context = MenuSessionContext()
+
+    assert context.bind_workspace(first) is False
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    assert context.bind_workspace(first / ".") is False
+    assert context.assignment_id == ASSIGNMENT_ID
+
+    assert context.bind_workspace(second) is True
+    assert context.class_id is None
+    assert context.assignment_id is None
+
+
+def test_exact_assignment_identity_never_falls_back_to_matching_title(
+    workspace: Path,
+) -> None:
+    choice = exact_assignment_choice(workspace, CLASS_ID, ASSIGNMENT_ID)
+    assert choice is not None
+    assert choice.assignment_id == ASSIGNMENT_ID
+
+    choice.path.unlink()
+    assert exact_assignment_choice(workspace, CLASS_ID, ASSIGNMENT_ID) is None
+    other = exact_assignment_choice(workspace, CLASS_ID, OTHER_ASSIGNMENT_ID)
+    assert other is not None
+    assert other.title == "Shared Title"
+
+
+def test_stale_assignment_fails_closed_and_retains_valid_class(
+    workspace: Path,
+) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    choice = exact_assignment_choice(workspace, CLASS_ID, ASSIGNMENT_ID)
+    assert choice is not None
+    choice.path.unlink()
+
+    result = revalidate_menu_context(context, workspace)
+
+    assert result.assignment is None
+    assert result.message is not None
+    assert "no longer a valid canonical assignment" in result.message
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id is None
+
+
+def test_stale_class_fails_closed_and_clears_assignment(workspace: Path) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    (workspace / "classes" / CLASS_ID / "roster.csv").unlink()
+
+    result = revalidate_menu_context(context, workspace)
+
+    assert result.assignment is None
+    assert result.message is not None
+    assert context.class_id is None
+    assert context.assignment_id is None
+
+
+def test_assignment_in_class_picker_does_not_prompt_for_class(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts: list[str] = []
+    responses = iter(("1",))
+
+    def fake_input(prompt: str = "") -> str:
+        prompts.append(prompt)
+        return next(responses)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+
+    choice = prompt_assignment_choice_for_class(workspace, CLASS_ID)
+
+    assert choice is not None
+    assert choice.assignment_id == ASSIGNMENT_ID
+    assert prompts == ["Select assignment: "]
+
+
+def test_review_assignment_selection_reuses_active_context_without_prompts(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = MenuSessionContext()
+    prompts: list[str] = []
+    responses = iter(("1", "1"))
+
+    def fake_input(prompt: str = "") -> str:
+        prompts.append(prompt)
+        return next(responses)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+
+    first = review_menu._select_review_assignment(workspace, context)
+    assert first is not None
+    assert prompts == ["Select class: ", "Select assignment: "]
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id == ASSIGNMENT_ID
+
+    prompts.clear()
+    second = review_menu._select_review_assignment(workspace, context)
+    assert second is not None
+    assert second.assignment_id == ASSIGNMENT_ID
+    assert prompts == []
+
+
+def test_class_only_review_context_requires_only_assignment_prompt(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_class(CLASS_ID)
+    prompts: list[str] = []
+
+    def choose_first_assignment(prompt: str = "") -> str:
+        prompts.append(prompt)
+        return "1"
+
+    monkeypatch.setattr("builtins.input", choose_first_assignment)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+
+    choice = review_menu._select_review_assignment(workspace, context)
+
+    assert choice is not None
+    assert prompts == ["Select assignment: "]
+    assert context.assignment_id == ASSIGNMENT_ID
+
+
+def test_context_rendering_shows_exact_ids_and_current_title(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+
+    print_session_context(context)
+
+    output = capsys.readouterr().out
+    assert "Active context" in output
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID} - Shared Title" in output
+
+
+def test_context_reads_do_not_write_workspace(
+    workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    files_before = {
+        path.relative_to(workspace): path.read_bytes()
+        for path in workspace.rglob("*")
+        if path.is_file()
+    }
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+
+    assert revalidate_menu_context(context, workspace).assignment is not None
+    print_session_context(context)
+    capsys.readouterr()
+
+    files_after = {
+        path.relative_to(workspace): path.read_bytes()
+        for path in workspace.rglob("*")
+        if path.is_file()
+    }
+    assert files_after == files_before
+
+
+def test_known_review_handoff_updates_context_only_for_exact_valid_target(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = MenuSessionContext()
+    called: list[tuple[Path, str, str]] = []
+
+    def record_launch(root: Path, class_id: str, assignment_id: str) -> int:
+        called.append((root, class_id, assignment_id))
+        return 0
+
+    monkeypatch.setattr(
+        review_menu,
+        "_launch_assignment_review_actions",
+        record_launch,
+    )
+
+    result = review_menu.launch_assignment_review_actions(
+        workspace,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        session_context=context,
+    )
+
+    assert result == 0
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id == ASSIGNMENT_ID
+    assert called == [(workspace, CLASS_ID, ASSIGNMENT_ID)]
+
+
+def test_invalid_known_review_handoff_does_not_replace_existing_context(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    monkeypatch.setattr(
+        review_menu,
+        "_launch_assignment_review_actions",
+        lambda *_args: pytest.fail("invalid target must not launch review"),
+    )
+
+    result = review_menu.launch_assignment_review_actions(
+        workspace,
+        OTHER_CLASS_ID,
+        "missing_assignment",
+        session_context=context,
+    )
+
+    assert result == 1
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id == ASSIGNMENT_ID
+    assert "not a valid canonical assignment" in capsys.readouterr().out
+
+
+def test_context_switch_cancellation_preserves_previous_pair(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    responses = iter(("2", "b", "b"))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+    monkeypatch.setattr(review_menu, "_workspace_root", lambda: workspace)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+    monkeypatch.setattr("quillan.menu.pause_for_user", lambda: None)
+
+    review_menu._manage_active_context(context)
+
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id == ASSIGNMENT_ID
+
+
+def test_clear_assignment_retains_class_for_next_selection(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    responses = iter(("3", "b"))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+    monkeypatch.setattr(review_menu, "_workspace_root", lambda: workspace)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+    monkeypatch.setattr("quillan.menu.pause_for_user", lambda: None)
+
+    review_menu._manage_active_context(context)
+
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id is None
+
+
+
+def test_recorder_context_prompt_cost_matches_issue_382_targets(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = MenuSessionContext()
+    recorder = MenuScreenRecorder(["1", "1", "1", "1", "1"])
+    recorder.install(monkeypatch)
+
+    before = len(recorder.prompts)
+    assert review_menu._select_review_assignment(workspace, context) is not None
+    first_prompts = recorder.prompts[before:]
+    assert [item.prompt for item in first_prompts] == [
+        "Select class: ",
+        "Select assignment: ",
+    ]
+
+    before = len(recorder.prompts)
+    assert review_menu._select_review_assignment(workspace, context) is not None
+    assert recorder.prompts[before:] == []
+
+    context.clear_assignment()
+    before = len(recorder.prompts)
+    assert review_menu._select_review_assignment(workspace, context) is not None
+    assert [item.prompt for item in recorder.prompts[before:]] == [
+        "Select assignment: ",
+    ]
+
+    context.clear_selection()
+    before = len(recorder.prompts)
+    assert review_menu._select_review_assignment(workspace, context) is not None
+    assert [item.prompt for item in recorder.prompts[before:]] == [
+        "Select class: ",
+        "Select assignment: ",
+    ]
+
+
+def test_standalone_source_picker_does_not_mutate_active_session_context(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    responses = iter(("1", "2"))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+
+    source = prompt_assignment_choice(workspace)
+
+    assert source is not None
+    assert source.assignment_id == OTHER_ASSIGNMENT_ID
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id == ASSIGNMENT_ID
+
+
+def test_return_to_main_menu_reuses_same_session_context(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = MenuSessionContext()
+    context.bind_workspace(workspace)
+    context.activate_assignment(CLASS_ID, ASSIGNMENT_ID)
+    responses = iter(("2", "q"))
+    seen: list[MenuSessionContext] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+    monkeypatch.setattr(menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(
+        "pds_core.workspace.resolve_workspace_root", lambda: workspace
+    )
+
+    def return_to_main(received: MenuSessionContext | None = None) -> None:
+        assert received is context
+        seen.append(received)
+        raise ReturnToMainMenu
+
+    monkeypatch.setattr(menu, "launch_review_student_work_menu", return_to_main)
+
+    result = menu.launch_menu(
+        lambda: 0,
+        lambda _path: 0,
+        lambda: 0,
+        lambda: 0,
+        context,
+    )
+
+    assert result == 0
+    assert seen == [context]
+    assert context.class_id == CLASS_ID
+    assert context.assignment_id == ASSIGNMENT_ID


### PR DESCRIPTION
## Summary

Completes #382 by adding teacher-visible, session-local active class/assignment context to Quillan's interactive review workflow.

## What changed

- add an explicit `MenuSessionContext` for the current interactive Quillan process;
- retain exact `class_id` / `assignment_id` context across ordinary menu navigation;
- preserve active context across `B` and `M` navigation while discarding it on process exit;
- bind context to the resolved PDS workspace and clear class/assignment context when that workspace changes;
- revalidate remembered classes and assignments through canonical discovery before reuse;
- fail closed when remembered context becomes stale, malformed, deleted, or belongs to the wrong class;
- allow immediate reuse of a valid active assignment without repeating class/assignment selection;
- allow assignment-only selection when a valid active class remains;
- add explicit controls to:
  - switch assignment within the active class;
  - switch class and assignment;
  - clear only the assignment;
  - clear all class/assignment context;
- preserve prior context when a switch operation is canceled;
- add reusable active-context headers showing exact IDs and current assignment title when safely available;
- carry context into explicit post-scan review handoff without allowing scan routing itself to silently select an operating target;
- keep source-only assignment selections independent of active operating context;
- preserve direct CLI statelessness;
- document the session-context lifecycle and CLI boundary.

No persistent recent-context record, Core API, suite-level context protocol, grading behavior, or later review-queue/navigation work is introduced.

## Validation

```text
Focused #382/menu suite:
93 passed, 1 skipped

Full test suite:
2511 passed, 21 skipped

mypy:
Success: no issues found in 302 source files

ruff:
All checks passed

git diff --check:
clean
```

## Scope

This PR implements only #382.

Follow-up workflow improvements such as deterministic review queues, next/previous student navigation, Continue Review guidance, compact review redesign, batch export, summaries, publication guidance, and diagnostics remain assigned to their later Phase 1 tickets.

Closes #382