### PR TITLE
feat: add deterministic review work queue

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -103,6 +103,23 @@ not calculate a Grade.
 
 See [Academic Result Publication Lifecycle](academic_result_publication.md).
 
+## Direct Review Work Queue
+
+`quillan review-queue <class_id> <assignment_id> [--format text|json]`
+prints the deterministic roster-ordered work classification for one exact
+assignment. Text is the default. JSON emits schema version `1` with fixed
+category-count order, exact student IDs, bounded reason/warning codes, and
+unrostered diagnostic IDs kept outside the normal roster queue.
+
+The command is strictly read-only. It rebuilds from current canonical state on
+every invocation and does not persist queue state, assemble submissions, create
+reviews, infer teacher judgments, generate feedback, export artifacts, or choose a
+next student. Missing/invalid assignment state or an unavailable canonical roster
+is concise and nonzero. Invalid student records that can be isolated safely remain
+visible as `attention_required` queue items. See
+[`review_work_queue.md`](review_work_queue.md) for classification precedence and
+privacy boundaries.
+
 ## Direct Student Review Status
 
 `quillan review-status <class_id> <assignment_id> <student_id> [--format text|json]`
@@ -117,7 +134,8 @@ This command is strictly read-only and performs no automated judgment. It does
 not inspect evidence or student writing, assemble submissions, create reviews,
 mutate workflow, or generate exports. It excludes teacher-entered and student
 prose. Current Review Details remains the content-oriented teacher view;
-`review-dashboard` remains the assignment-wide overview.
+`review-dashboard` remains the assignment-wide diagnostic overview, while
+`review-queue` remains the roster-ordered mechanical work classification.
 
 ## Purpose and Status
 
@@ -317,6 +335,7 @@ quillan
 quillan --help
 quillan --version
 quillan review-dashboard <class_id> <assignment_id> [--format text|json]
+quillan review-queue <class_id> <assignment_id> [--format text|json]
 quillan review-status <class_id> <assignment_id> <student_id> [--format text|json]
 quillan review-workflow set-state <class_id> <assignment_id> <student_id> --state <state> --yes
 quillan assignment create <class_id> <assignment_id> --title <title> --writing-type <type> (--prompt <text> | --prompt-file <path>) --standards-profile-id <profile_id> --focus-standard-ids <id,...> [--review-unit-type <type>] [--review-unit-singular <label>] [--review-unit-plural <label>] [--rating-scale default] [--paragraphs-min N] [--paragraphs-max N] [--word-count-min N] [--word-count-max N] [--required-elements <items>] [--allow-return-without-full-review true|false] [--overwrite] [--yes | --dry-run]
@@ -1214,15 +1233,30 @@ menu provides:
 
 ```text
 1. Select student/submission
-2. Assemble routed submissions
-3. Export Comprehensive Class Summary
-4. Export Standards Summary
-5. Export Student Performance Summary
-6. Back
+2. View submission status
+3. Review scan problems
+4. Export reports
+5. View full diagnostic dashboard
+6. Refresh
+7. View review work queue
+B. Back
+M. Main Menu
+Q. Quit
 ```
 
-Selecting a student/submission lets the teacher pick a student by number. The
-selected-student view shows a compact current review summary with class,
+`View review work queue` rebuilds #383's deterministic roster-ordered queue from
+current canonical state. It shows the exact active class/assignment context,
+complete/needs-work counts, and one bounded mechanical category/reason for each
+roster student. `R. Refresh` rebuilds the queue without persisting it. Back and Main
+Menu preserve the #382 active class/assignment context; Quit ends the process. The
+queue screen does not select or open a student and adds no next/previous/continue
+behavior.
+
+Selecting a student/submission lets the teacher pick a student by number. Roster
+students retain concise submission details and also show the same canonical #383
+`work=` category used by the review queue; unrostered diagnostic records remain
+explicitly outside the normal roster queue. The selected-student view shows a compact
+current review summary with class,
 assignment, student, submission/evidence status, review state, and existing
 `review.json` counts when a valid review record is already present. Long file
 paths are reserved for detail/output actions.

--- a/docs/cli_contract_inventory.json
+++ b/docs/cli_contract_inventory.json
@@ -71,6 +71,51 @@
     {
       "path": [
         "quillan",
+        "review-queue"
+      ],
+      "aliases": [],
+      "short_help": "Show the deterministic roster-ordered review work queue.",
+      "description": "Classify each roster student from current canonical assignment, submission, review, and feedback-export state without writing files.",
+      "arguments": [
+        {
+          "names": [
+            "class_id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Class identifier.",
+          "mutex_group": null
+        },
+        {
+          "names": [
+            "assignment_id"
+          ],
+          "required": true,
+          "choices": [],
+          "default": null,
+          "help": "Assignment identifier.",
+          "mutex_group": null
+        },
+        {
+          "names": [
+            "--format"
+          ],
+          "required": false,
+          "choices": [
+            "text",
+            "json"
+          ],
+          "default": "text",
+          "help": "Standard-output representation (default: text).",
+          "mutex_group": null
+        }
+      ],
+      "mutex_groups": []
+    },
+    {
+      "path": [
+        "quillan",
         "review-status"
       ],
       "aliases": [],

--- a/docs/review_work_queue.md
+++ b/docs/review_work_queue.md
@@ -1,0 +1,129 @@
+# Deterministic review work queue
+
+Issue: #383 — deterministic review work queue
+
+## Boundary
+
+The Quillan review work queue is an immutable, read-only view of one exact
+class/assignment. It is rebuilt from current canonical workspace records whenever a
+caller asks for it. It is not persisted, cached in menu session context, or treated as
+authoritative review state.
+
+Core remains authoritative for the class roster and roster order. Quillan remains
+authoritative for assignment validity, submission/review state, minimum-requirement
+semantics, and feedback-export freshness.
+
+Queue construction does not create or modify assignment, submission, review, export,
+roster, routing, registry, preference, or publication records.
+
+## Population and order
+
+The normal queue contains every canonical roster student exactly once, in canonical
+roster order. Exact `student_id` is the durable identity; display names are
+supplemental labels only.
+
+Unrostered submissions or routed artifacts do not become queue members. They are
+reported separately as bounded diagnostic state. If the canonical roster cannot be
+loaded, queue construction fails rather than substituting submission-directory,
+display-name, timestamp, performance, or category order.
+
+## Categories and precedence
+
+The fixed queue categories are:
+
+```text
+no_submission
+needs_assembly
+minimum_requirements_pending
+observations_pending
+ratings_pending
+feedback_pending
+export_pending
+complete
+attention_required
+```
+
+Classification follows a deterministic earliest-gate policy:
+
+1. unsafe/invalid canonical record state -> `attention_required`;
+2. routed evidence without a valid submission -> `needs_assembly`;
+3. no valid submission and no pending routed evidence -> `no_submission`;
+4. configured minimum requirements without an explicit usable outcome ->
+   `minimum_requirements_pending`;
+5. explicit `returned_without_full_review` bypasses observations, ratings, and normal
+   feedback composition, then requires a current feedback export;
+6. otherwise explicit review workflow state determines observations, ratings, and
+   feedback stages in order;
+7. an export-capable review with no current supported feedback export ->
+   `export_pending`;
+8. an applicable completed review path with at least one current supported canonical
+   feedback export -> `complete`.
+
+The classifier never reads student writing to decide a category and never infers a
+teacher-entered minimum-requirement outcome, applicability decision, observation,
+rating, feedback decision, or completion decision.
+
+## Export freshness
+
+Queue completion uses the existing Quillan feedback-export status boundary. A current
+PDF or Markdown export is sufficient. A missing optional companion does not make an
+otherwise current export incomplete. Stale exports, missing artifacts referenced by
+metadata, or artifacts lacking usable canonical metadata remain `export_pending`.
+
+`review_state == exported` alone is not sufficient for `complete`.
+
+## Integrity handling
+
+`attention_required` is an exceptional fail-closed classification, not a workflow
+phase. It is used when invalid submissions/reviews, identity mismatches, orphan
+reviews, or inconsistent returned-work state prevent safe normal classification.
+
+The queue exposes bounded reason/warning codes, not student writing, feedback bodies,
+private notes, rating values, rationales, or teacher-note text.
+
+## Later integration
+
+This model deliberately does not implement:
+
+```text
+#384 next/previous/next-needing-review navigation
+#385 Continue Review routing
+#387 batch feedback export
+#388 redesigned class completion views
+#391 shared attention provider
+```
+
+Later work may consume roster order, exact student identity, category, counts, and
+reason codes from this read-only model without changing its no-write boundary.
+## Direct CLI
+
+The supported direct command is:
+
+```text
+quillan review-queue <class_id> <assignment_id> [--format text|json]
+```
+
+Text is the default. JSON emits `quillan_assignment_review_work_queue` schema
+version `1`. Both representations are rebuilt from current canonical state and write
+nothing. Workspace, assignment, or roster failures return nonzero; isolated invalid
+student records use the queue's bounded `attention_required` category.
+
+The command has no navigation, priority, mutation, assembly, continuation, or export
+options. Those remain later workflow concerns.
+## Teacher menu integration
+
+`Assignment Review Actions` exposes `View review work queue`. The screen rebuilds the
+queue from current canonical state on entry and on `R. Refresh`, shows the #382 exact
+active class/assignment header, then renders complete/needs-work counts and roster
+students in canonical roster order. `B. Back` and `M. Main Menu` retain the active
+class/assignment context; `Q. Quit` ends the process. Viewing and refreshing write no
+workspace files and do not cache queue state in `MenuSessionContext`.
+
+The existing `Select Student/Submission` screen remains the explicit student-selection
+path. It keeps concise submission/evidence detail and appends the same queue category
+as `work=<category>` for roster students. Unrostered diagnostic records remain
+selectable where the pre-existing dashboard exposes them, but they are labeled outside
+the normal roster queue rather than being silently promoted into it.
+
+This integration does not implement next/previous student navigation, automatic opening
+of a queue item, `Continue Review`, automatic assembly, or automatic export.

--- a/quillan/cli_app/handlers/review_queue.py
+++ b/quillan/cli_app/handlers/review_queue.py
@@ -1,0 +1,41 @@
+"""Direct deterministic assignment review work queue command handler."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from pds_core.workspace import WorkspaceRootError, resolve_workspace_root
+
+from quillan.review_work_queue import (
+    ReviewWorkQueueError,
+    assignment_review_work_queue_to_dict,
+    build_assignment_review_work_queue,
+    format_assignment_review_work_queue,
+)
+
+
+def handle_review_queue(args: argparse.Namespace) -> int:
+    """Print one deterministic read-only assignment review work queue."""
+    try:
+        queue = build_assignment_review_work_queue(
+            resolve_workspace_root(), args.class_id, args.assignment_id
+        )
+        output = (
+            json.dumps(
+                assignment_review_work_queue_to_dict(queue),
+                indent=2,
+                ensure_ascii=False,
+            )
+            if args.format == "json"
+            else format_assignment_review_work_queue(queue)
+        )
+    except (WorkspaceRootError, ReviewWorkQueueError, OSError, TypeError) as error:
+        print(
+            f"Error: could not build review work queue: {error}",
+            file=sys.stderr,
+        )
+        return 1
+    print(output)
+    return 0

--- a/quillan/cli_app/parser.py
+++ b/quillan/cli_app/parser.py
@@ -17,6 +17,7 @@ from quillan.cli_app.handlers.comments import (
     handle_comments_show,
 )
 from quillan.cli_app.handlers.dashboard import handle_review_dashboard
+from quillan.cli_app.handlers.review_queue import handle_review_queue
 from quillan.cli_app.handlers.review_status import handle_review_status
 from quillan.cli_app.handlers.review_workflow import handle_review_workflow_set_state
 from quillan.cli_app.handlers.exports import (
@@ -165,6 +166,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Standard-output representation (default: text).",
     )
     dashboard_parser.set_defaults(handler=handle_review_dashboard)
+
+    review_queue_parser = subparsers.add_parser(
+        "review-queue",
+        help="Show the deterministic roster-ordered review work queue.",
+        description=(
+            "Classify each roster student from current canonical assignment, "
+            "submission, review, and feedback-export state without writing files."
+        ),
+    )
+    _add_assignment_identity_arguments(review_queue_parser)
+    review_queue_parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Standard-output representation (default: text).",
+    )
+    review_queue_parser.set_defaults(handler=handle_review_queue)
 
     review_status_parser = subparsers.add_parser(
         "review-status",

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -110,6 +110,12 @@ from quillan.review_status_display import (
     review_progress_status,
     review_status_label,
 )
+from quillan.review_work_queue import (
+    CATEGORY_LABELS,
+    AssignmentReviewWorkQueue,
+    ReviewWorkQueueError,
+    build_assignment_review_work_queue,
+)
 from quillan.review_snapshot import current_review_details_text
 from quillan.review_targets import (
     ReviewTargetError,
@@ -396,6 +402,20 @@ def _load_review_dashboard(
         return None
 
 
+def _load_review_work_queue(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> AssignmentReviewWorkQueue | None:
+    try:
+        return build_assignment_review_work_queue(
+            workspace_root, class_id, assignment_id
+        )
+    except (ReviewWorkQueueError, OSError) as error:
+        print(f"Error: could not build review work queue: {error}")
+        return None
+
+
 def _prompt_student_id(
     workspace_root: Path,
     class_id: str,
@@ -413,6 +433,11 @@ def _prompt_student_id(
     print_menu_header("Select Student/Submission")
     print_active_context(workspace_root, class_id, assignment_id)
 
+    queue = _load_review_work_queue(workspace_root, class_id, assignment_id)
+    queue_by_student = (
+        {} if queue is None else {item.student_id: item for item in queue.items}
+    )
+
     status_items = (
         status.students
         if isinstance(status, AssignmentReviewDashboard)
@@ -422,9 +447,17 @@ def _prompt_student_id(
     student_labels = student_display_lookup(workspace_root, class_id)
     print("Select student/submission:")
     for index, student_id in enumerate(student_ids, start=1):
+        queue_item = queue_by_student.get(student_id)
+        if queue is None:
+            work_label = "queue unavailable"
+        elif queue_item is None:
+            work_label = "unrostered diagnostic"
+        else:
+            work_label = CATEGORY_LABELS[queue_item.category]
         print(
             f"{index}. {student_labels.get(student_id, student_id)}: "
-            f"{_student_status_label(status_by_student.get(student_id))}"
+            f"{_student_status_label(status_by_student.get(student_id))}; "
+            f"work={work_label}"
         )
     print_navigation_options()
     print()
@@ -3930,6 +3963,7 @@ def _launch_assignment_review_actions(
         print("4. Export reports")
         print("5. View full diagnostic dashboard")
         print("6. Refresh")
+        print("7. View review work queue")
         print_navigation_options()
         print()
 
@@ -3984,9 +4018,64 @@ def _launch_assignment_review_actions(
             input("Press Enter to continue...")
         elif choice == "6":
             continue
+        elif choice == "7":
+            _menu_review_work_queue(workspace_root, class_id, assignment_id)
         else:
             print("Invalid selection. Please choose a listed action.")
             input("Press Enter to continue...")
+
+
+def _menu_review_work_queue(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+) -> None:
+    from quillan.menu import clear_screen, print_menu_header
+
+    while True:
+        clear_screen()
+        print_menu_header("Review Work Queue")
+        print_active_context(workspace_root, class_id, assignment_id)
+
+        queue = _load_review_work_queue(workspace_root, class_id, assignment_id)
+        if queue is not None:
+            print(f"Complete: {queue.complete_count} / {queue.roster_count}")
+            print(f"Needs work: {queue.needs_work_count}")
+            print()
+            print("Students:")
+            if not queue.items:
+                print("- none")
+            for index, item in enumerate(queue.items, start=1):
+                identity = (
+                    f"{item.display_name} ({item.student_id})"
+                    if item.display_name != item.student_id
+                    else item.student_id
+                )
+                print(
+                    f"{index}. {identity} — {CATEGORY_LABELS[item.category]} "
+                    f"[{item.reason_code}]"
+                )
+            if queue.unrostered_student_ids:
+                print()
+                print(
+                    "Unrostered diagnostic records excluded: "
+                    f"{len(queue.unrostered_student_ids)}"
+                )
+            if queue.warnings:
+                print(f"Queue warnings: {len(queue.warnings)}")
+
+        print()
+        print("R. Refresh")
+        print_navigation_options()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_navigation_choice(choice)
+        if choice == "" or navigation is NavigationChoice.BACK:
+            return
+        if choice.casefold() == "r":
+            continue
+        print(f"Invalid selection. {navigation_hint()}")
+        input("Press Enter to continue...")
 
 
 def _print_compact_assignment_dashboard(

--- a/quillan/review_work_queue.py
+++ b/quillan/review_work_queue.py
@@ -1,0 +1,491 @@
+"""Deterministic read-only work queue for one Quillan assignment."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from quillan.assignment_summary_context import load_assignment
+from quillan.minimum_requirement_review import configured_requirements
+from quillan.review_dashboard import (
+    AssignmentReviewDashboard,
+    DashboardStudentStatus,
+    build_assignment_review_dashboard,
+)
+from quillan.review_status_display import review_progress_status
+
+WORK_QUEUE_SCHEMA_VERSION: Final = "1"
+WORK_QUEUE_RECORD_TYPE: Final = "quillan_assignment_review_work_queue"
+WORK_QUEUE_CATEGORIES: Final = (
+    "no_submission",
+    "needs_assembly",
+    "minimum_requirements_pending",
+    "observations_pending",
+    "ratings_pending",
+    "feedback_pending",
+    "export_pending",
+    "complete",
+    "attention_required",
+)
+
+CATEGORY_LABELS: Final = {
+    "no_submission": "no submission",
+    "needs_assembly": "needs assembly",
+    "minimum_requirements_pending": "minimum requirements pending",
+    "observations_pending": "observations pending",
+    "ratings_pending": "ratings pending",
+    "feedback_pending": "feedback pending",
+    "export_pending": "export pending",
+    "complete": "complete",
+    "attention_required": "attention required",
+}
+
+_VALID_MINIMUM_OUTCOMES: Final = {
+    "met",
+    "unmet_continue_review",
+    "returned_without_full_review",
+}
+_RETURNED_STATE: Final = "returned_without_full_review"
+
+
+class ReviewWorkQueueError(ValueError):
+    """Raised when a safe deterministic work queue cannot be derived."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewWorkQueueItem:
+    """One roster student's mechanically derived assignment-work state."""
+
+    class_id: str
+    assignment_id: str
+    student_id: str
+    display_name: str
+    category: str
+    reason_code: str
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AssignmentReviewWorkQueue:
+    """Immutable roster-ordered work queue for one exact assignment."""
+
+    class_id: str
+    assignment_id: str
+    assignment_title: str
+    items: tuple[ReviewWorkQueueItem, ...]
+    counts: tuple[tuple[str, int], ...]
+    unrostered_student_ids: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+    @property
+    def roster_count(self) -> int:
+        return len(self.items)
+
+    @property
+    def complete_count(self) -> int:
+        return dict(self.counts)["complete"]
+
+    @property
+    def needs_work_count(self) -> int:
+        return self.roster_count - self.complete_count
+
+
+def build_assignment_review_work_queue(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+) -> AssignmentReviewWorkQueue:
+    """Build a read-only roster queue from current canonical Quillan state."""
+    root = Path(workspace_root)
+    try:
+        dashboard = build_assignment_review_dashboard(root, class_id, assignment_id)
+        assignment = load_assignment(root, class_id, assignment_id)
+    except (OSError, ValueError) as error:
+        raise ReviewWorkQueueError(
+            f"Could not build review work queue: {error}"
+        ) from error
+
+    requirement_count = len(configured_requirements(assignment))
+    return derive_assignment_review_work_queue(
+        dashboard,
+        configured_requirement_count=requirement_count,
+    )
+
+
+def derive_assignment_review_work_queue(
+    dashboard: AssignmentReviewDashboard,
+    *,
+    configured_requirement_count: int,
+) -> AssignmentReviewWorkQueue:
+    """Derive queue classification from one already-built canonical dashboard."""
+    if configured_requirement_count < 0:
+        raise ReviewWorkQueueError(
+            "configured_requirement_count must be zero or greater"
+        )
+    if not dashboard.roster_available or dashboard.rostered_count is None:
+        raise ReviewWorkQueueError(
+            "Canonical class roster is unavailable; review queue ordering cannot "
+            "be derived safely."
+        )
+
+    items: list[ReviewWorkQueueItem] = []
+    unrostered_student_ids: list[str] = []
+    for student in dashboard.students:
+        if student.roster_status == "rostered":
+            items.append(
+                classify_review_work_queue_item(
+                    dashboard.class_id,
+                    dashboard.assignment_id,
+                    student,
+                    configured_requirement_count=configured_requirement_count,
+                )
+            )
+        elif student.roster_status == "unrostered":
+            unrostered_student_ids.append(student.student_id)
+        else:
+            raise ReviewWorkQueueError(
+                "Unexpected student roster state while a canonical roster is "
+                f"available: {student.roster_status!r}."
+            )
+
+    if len(items) != dashboard.rostered_count:
+        raise ReviewWorkQueueError(
+            "Roster/dashboard population mismatch: expected "
+            f"{dashboard.rostered_count} roster students, derived {len(items)}."
+        )
+
+    counts = Counter(item.category for item in items)
+    warnings = [
+        warning.code
+        for warning in dashboard.warnings
+        if warning.student_id is None
+    ]
+    if unrostered_student_ids:
+        warnings.append("unrostered_records_excluded")
+
+    return AssignmentReviewWorkQueue(
+        class_id=dashboard.class_id,
+        assignment_id=dashboard.assignment_id,
+        assignment_title=dashboard.assignment_title,
+        items=tuple(items),
+        counts=tuple(
+            (category, counts[category]) for category in WORK_QUEUE_CATEGORIES
+        ),
+        unrostered_student_ids=tuple(unrostered_student_ids),
+        warnings=_dedupe(warnings),
+    )
+
+
+def classify_review_work_queue_item(
+    class_id: str,
+    assignment_id: str,
+    student: DashboardStudentStatus,
+    *,
+    configured_requirement_count: int,
+) -> ReviewWorkQueueItem:
+    """Classify one dashboard student without inventing teacher judgment."""
+    if configured_requirement_count < 0:
+        raise ReviewWorkQueueError(
+            "configured_requirement_count must be zero or greater"
+        )
+
+    warnings = list(student.warnings)
+
+    if student.submission_status == "invalid":
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "attention_required",
+            "invalid_submission",
+            warnings,
+        )
+    if student.submission_status == "identity_mismatch":
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "attention_required",
+            "record_identity_mismatch",
+            warnings,
+        )
+    if student.review_status == "invalid":
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "attention_required",
+            "invalid_review",
+            warnings,
+        )
+    if student.review_status == "identity_mismatch":
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "attention_required",
+            "record_identity_mismatch",
+            warnings,
+        )
+    if student.review_status == "orphaned":
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "attention_required",
+            "orphan_review",
+            warnings,
+        )
+
+    if student.submission_status != "valid":
+        if student.submission_status not in {"missing"}:
+            return _item(
+                class_id,
+                assignment_id,
+                student,
+                "attention_required",
+                "submission_state_unavailable",
+                warnings,
+            )
+        if student.needs_assembly:
+            return _item(
+                class_id,
+                assignment_id,
+                student,
+                "needs_assembly",
+                "routed_evidence_needs_assembly",
+                warnings,
+            )
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "no_submission",
+            "submission_missing",
+            warnings,
+        )
+
+    if student.review_status not in {"valid", "missing"}:
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "attention_required",
+            "review_state_unavailable",
+            warnings,
+        )
+
+    outcome_returned = student.minimum_requirement_status == _RETURNED_STATE
+    flag_returned = student.returned_without_full_review
+    state_returned = student.review_state == _RETURNED_STATE
+    any_returned = outcome_returned or flag_returned or state_returned
+    all_returned = outcome_returned and flag_returned and state_returned
+    if any_returned and not all_returned:
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "attention_required",
+            "returned_state_inconsistent",
+            warnings,
+        )
+    if all_returned and configured_requirement_count == 0:
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "attention_required",
+            "returned_state_without_configured_requirements",
+            warnings,
+        )
+
+    if configured_requirement_count > 0 and (
+        student.minimum_requirement_status not in _VALID_MINIMUM_OUTCOMES
+    ):
+        if student.review_state not in {None, "not_started", "requirements_checked"}:
+            warnings.append("workflow_state_ahead_of_minimum_requirements")
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "minimum_requirements_pending",
+            "minimum_requirement_outcome_not_checked",
+            warnings,
+        )
+
+    if all_returned:
+        return _export_or_complete_item(
+            class_id,
+            assignment_id,
+            student,
+            warnings,
+        )
+
+    state = student.review_state or "not_started"
+    progress = review_progress_status({"review_state": state})
+    if not progress.observations_complete:
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "observations_pending",
+            "observations_not_complete",
+            warnings,
+        )
+    if not progress.ratings_complete:
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "ratings_pending",
+            "ratings_not_complete",
+            warnings,
+        )
+    if not progress.feedback_composed:
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "feedback_pending",
+            "feedback_not_composed",
+            warnings,
+        )
+
+    return _export_or_complete_item(
+        class_id,
+        assignment_id,
+        student,
+        warnings,
+    )
+
+
+def assignment_review_work_queue_to_dict(
+    queue: AssignmentReviewWorkQueue,
+) -> dict[str, object]:
+    """Serialize the emitted queue representation using deterministic key order."""
+    return {
+        "schema_version": WORK_QUEUE_SCHEMA_VERSION,
+        "record_type": WORK_QUEUE_RECORD_TYPE,
+        "class_id": queue.class_id,
+        "assignment_id": queue.assignment_id,
+        "assignment_title": queue.assignment_title,
+        "counts": dict(queue.counts),
+        "students": [
+            {
+                "student_id": item.student_id,
+                "display_name": item.display_name,
+                "category": item.category,
+                "reason_code": item.reason_code,
+                "warnings": list(item.warnings),
+            }
+            for item in queue.items
+        ],
+        "unrostered_student_ids": list(queue.unrostered_student_ids),
+        "warnings": list(queue.warnings),
+    }
+
+
+def format_assignment_review_work_queue(
+    queue: AssignmentReviewWorkQueue,
+) -> str:
+    """Render a concise deterministic teacher-facing queue."""
+    lines = [
+        "Review Work Queue",
+        "",
+        f"Class: {queue.class_id}",
+        f"Assignment: {queue.assignment_title} ({queue.assignment_id})",
+        "",
+        f"Complete: {queue.complete_count} / {queue.roster_count}",
+        f"Needs work: {queue.needs_work_count}",
+        "",
+        "Category counts:",
+    ]
+    lines.extend(
+        f"- {CATEGORY_LABELS[category]}: {count}"
+        for category, count in queue.counts
+    )
+    lines.extend(["", "Students:"])
+    if not queue.items:
+        lines.append("- none")
+    for index, item in enumerate(queue.items, start=1):
+        identity = (
+            f"{item.display_name} ({item.student_id})"
+            if item.display_name != item.student_id
+            else item.student_id
+        )
+        lines.append(
+            f"{index}. {identity} — {CATEGORY_LABELS[item.category]} "
+            f"[{item.reason_code}]"
+        )
+
+    if queue.unrostered_student_ids:
+        lines.extend(
+            [
+                "",
+                "Unrostered records excluded from queue:",
+                *(f"- {student_id}" for student_id in queue.unrostered_student_ids),
+            ]
+        )
+    if queue.warnings:
+        lines.extend(["", "Warnings:"])
+        lines.extend(f"- {warning}" for warning in queue.warnings)
+    return "\n".join(lines)
+
+
+def _export_or_complete_item(
+    class_id: str,
+    assignment_id: str,
+    student: DashboardStudentStatus,
+    warnings: list[str],
+) -> ReviewWorkQueueItem:
+    statuses = (student.feedback_pdf_status, student.feedback_markdown_status)
+    if "present" in statuses:
+        return _item(
+            class_id,
+            assignment_id,
+            student,
+            "complete",
+            "current_feedback_export_present",
+            warnings,
+        )
+    if "stale" in statuses:
+        reason = "feedback_export_stale"
+    elif "unknown" in statuses:
+        reason = "feedback_export_metadata_unknown"
+    else:
+        reason = "feedback_export_missing"
+    return _item(
+        class_id,
+        assignment_id,
+        student,
+        "export_pending",
+        reason,
+        warnings,
+    )
+
+
+def _item(
+    class_id: str,
+    assignment_id: str,
+    student: DashboardStudentStatus,
+    category: str,
+    reason_code: str,
+    warnings: list[str],
+) -> ReviewWorkQueueItem:
+    if category not in WORK_QUEUE_CATEGORIES:
+        raise ReviewWorkQueueError(f"Unknown work queue category: {category}")
+    return ReviewWorkQueueItem(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student.student_id,
+        display_name=student.display_name,
+        category=category,
+        reason_code=reason_code,
+        warnings=_dedupe(warnings),
+    )
+
+
+def _dedupe(values: list[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(values))

--- a/tests/test_cli_review_work_queue_issue383.py
+++ b/tests/test_cli_review_work_queue_issue383.py
@@ -1,0 +1,90 @@
+"""Issue #383 direct CLI tests for the deterministic review work queue."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quillan.cli import main
+import quillan.cli_app.handlers.review_queue as cli_review_queue
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID
+from tests.test_class_summary_export import _write_assignment, _write_roster
+
+
+def _snapshot(root: Path) -> dict[str, bytes | None]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes() if path.is_file() else None
+        for path in root.rglob("*")
+    }
+
+
+def test_cli_review_queue_text_and_json_are_deterministic_and_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_assignment(tmp_path)
+    _write_roster(tmp_path)
+    before = _snapshot(tmp_path)
+    monkeypatch.setattr(cli_review_queue, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(["review-queue", CLASS_ID, ASSIGNMENT_ID]) == 0
+    first_text = capsys.readouterr().out
+    assert "Review Work Queue" in first_text
+    assert "Avery Rivera (00100)" in first_text
+
+    assert main(["review-queue", CLASS_ID, ASSIGNMENT_ID]) == 0
+    assert capsys.readouterr().out == first_text
+
+    assert (
+        main(["review-queue", CLASS_ID, ASSIGNMENT_ID, "--format", "json"])
+        == 0
+    )
+    document = json.loads(capsys.readouterr().out)
+
+    assert document["schema_version"] == "1"
+    assert document["record_type"] == "quillan_assignment_review_work_queue"
+    assert document["class_id"] == CLASS_ID
+    assert document["assignment_id"] == ASSIGNMENT_ID
+    assert [student["student_id"] for student in document["students"]] == [
+        "00100",
+        "00200",
+        "00900",
+    ]
+    assert document["counts"]["no_submission"] == 3
+    assert sum(document["counts"].values()) == 3
+    assert _snapshot(tmp_path) == before
+
+
+def test_cli_review_queue_help_and_roster_failure_are_bounded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as help_exit:
+        main(["review-queue", "--help"])
+    assert help_exit.value.code == 0
+    help_output = capsys.readouterr().out
+    assert "--format" in help_output
+    assert "class_id" in help_output
+    assert "assignment_id" in help_output
+
+    _write_assignment(tmp_path)
+    before = _snapshot(tmp_path)
+    monkeypatch.setattr(cli_review_queue, "resolve_workspace_root", lambda: tmp_path)
+
+    assert main(["review-queue", CLASS_ID, ASSIGNMENT_ID]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Error: could not build review work queue" in captured.err
+    assert "roster is unavailable" in captured.err
+    assert _snapshot(tmp_path) == before
+
+
+def test_cli_review_queue_rejects_later_navigation_options() -> None:
+    for option in ("--next", "--previous", "--priority", "--continue"):
+        with pytest.raises(SystemExit) as exit_info:
+            main(["review-queue", CLASS_ID, ASSIGNMENT_ID, option])
+        assert exit_info.value.code == 2

--- a/tests/test_menu_review_work_queue_issue383.py
+++ b/tests/test_menu_review_work_queue_issue383.py
@@ -1,0 +1,151 @@
+"""Issue #383 menu integration tests for the deterministic review work queue."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quillan.menu_navigation import QuitQuillan, ReturnToMainMenu
+import quillan.review_menu as review_menu
+from tests.test_menu_review_student_work import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    STUDENT_ID,
+    SECOND_STUDENT_ID,
+    _write_workspace,
+)
+
+
+def _snapshot(root: Path) -> dict[str, bytes | None]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes() if path.is_file() else None
+        for path in root.rglob("*")
+    }
+
+
+def _inputs(monkeypatch: pytest.MonkeyPatch, responses: tuple[str, ...]) -> None:
+    iterator = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(iterator)
+        except StopIteration as error:
+            raise AssertionError("Menu requested more input than supplied.") from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def test_queue_screen_is_roster_ordered_refreshable_and_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_workspace(tmp_path)
+    before = _snapshot(tmp_path)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+    _inputs(monkeypatch, ("r", "b"))
+
+    review_menu._menu_review_work_queue(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+    output = capsys.readouterr().out
+    assert output.count("Review Work Queue") == 2
+    assert output.count("Active context") == 2
+    assert f"Class: {CLASS_ID}" in output
+    assert f"Assignment: {ASSIGNMENT_ID} - Synthetic Essay" in output
+    assert "Complete: 0 / 2" in output
+    assert "Needs work: 2" in output
+    first = f"1. Avery Rivera ({STUDENT_ID}) — minimum requirements pending"
+    second = f"2. Mina Patel ({SECOND_STUDENT_ID}) — no submission"
+    assert first in output
+    assert second in output
+    assert output.index(first) < output.index(second)
+    assert "R. Refresh" in output
+    assert "Next student" not in output
+    assert "Previous student" not in output
+    assert "Continue Review" not in output
+    assert _snapshot(tmp_path) == before
+
+
+def test_student_picker_uses_same_queue_category_without_losing_submission_detail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_workspace(tmp_path)
+    dashboard = review_menu._load_review_dashboard(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    assert dashboard is not None
+    before = _snapshot(tmp_path)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+    _inputs(monkeypatch, ("b",))
+
+    selected = review_menu._prompt_student_id(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        dashboard,
+    )
+
+    assert selected is None
+    output = capsys.readouterr().out
+    assert (
+        f"1. Avery Rivera ({STUDENT_ID}): "
+        "unreviewed; manifest exists; evidence files=1; "
+        "work=minimum requirements pending"
+    ) in output
+    assert (
+        f"2. Mina Patel ({SECOND_STUDENT_ID}): "
+        "no manifest; no routed evidence; work=no submission"
+    ) in output
+    assert _snapshot(tmp_path) == before
+
+
+def test_assignment_review_actions_add_queue_without_renumbering_existing_actions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+    _inputs(monkeypatch, ("7", "b", "b"))
+
+    assert review_menu._launch_assignment_review_actions(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    for expected in (
+        "1. Select student/submission",
+        "2. View submission status",
+        "3. Review scan problems",
+        "4. Export reports",
+        "5. View full diagnostic dashboard",
+        "6. Refresh",
+        "7. View review work queue",
+    ):
+        assert expected in output
+    assert "Review Work Queue" in output
+
+
+def test_queue_screen_main_menu_uses_existing_navigation_semantics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+    _inputs(monkeypatch, ("m",))
+
+    with pytest.raises(ReturnToMainMenu):
+        review_menu._menu_review_work_queue(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+
+def test_queue_screen_quit_uses_existing_navigation_semantics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+    _inputs(monkeypatch, ("q",))
+
+    with pytest.raises(QuitQuillan):
+        review_menu._menu_review_work_queue(tmp_path, CLASS_ID, ASSIGNMENT_ID)

--- a/tests/test_review_work_queue_issue383.py
+++ b/tests/test_review_work_queue_issue383.py
@@ -1,0 +1,382 @@
+"""Issue #383 tests for the deterministic assignment review work queue."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from quillan.review_dashboard import DashboardStudentStatus
+from quillan.review_work_queue import (
+    WORK_QUEUE_CATEGORIES,
+    ReviewWorkQueueError,
+    assignment_review_work_queue_to_dict,
+    build_assignment_review_work_queue,
+    classify_review_work_queue_item,
+    format_assignment_review_work_queue,
+)
+from tests.review_test_support import ASSIGNMENT_ID, CLASS_ID
+from tests.test_class_summary_export import (
+    _write_assignment,
+    _write_records,
+    _write_roster,
+)
+
+
+def _student(
+    *,
+    student_id: str = "00100",
+    display_name: str = "Avery Rivera",
+    needs_assembly: bool = False,
+    submission_status: str = "valid",
+    review_status: str = "valid",
+    review_state: str | None = "not_started",
+    minimum_status: str | None = "met",
+    returned: bool = False,
+    plain_paper: bool = False,
+    pdf_status: str = "missing",
+    markdown_status: str = "missing",
+    warnings: tuple[str, ...] = (),
+) -> DashboardStudentStatus:
+    return DashboardStudentStatus(
+        student_id=student_id,
+        display_name=display_name,
+        roster_status="rostered",
+        routed_evidence_present=needs_assembly,
+        needs_assembly=needs_assembly,
+        submission_status=submission_status,
+        submission_path=(
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
+            f"submissions/{student_id}/submission.json"
+        ),
+        submission_state=None if submission_status != "valid" else "unreviewed",
+        plain_paper=plain_paper,
+        evidence_file_count=0,
+        page_counts=(),
+        review_status=review_status,
+        review_path=(
+            f"classes/{CLASS_ID}/modules/quillan/work/{ASSIGNMENT_ID}/"
+            f"submissions/{student_id}/review.json"
+        ),
+        review_state=review_state,
+        minimum_requirement_status=minimum_status,
+        returned_without_full_review=returned,
+        feedback_pdf_status=pdf_status,
+        feedback_markdown_status=markdown_status,
+        warnings=warnings,
+    )
+
+
+def _category(
+    student: DashboardStudentStatus,
+    *,
+    configured_requirement_count: int = 1,
+) -> tuple[str, str, tuple[str, ...]]:
+    item = classify_review_work_queue_item(
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        student,
+        configured_requirement_count=configured_requirement_count,
+    )
+    return item.category, item.reason_code, item.warnings
+
+
+def _snapshot(root: Path) -> dict[str, bytes | None]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes() if path.is_file() else None
+        for path in root.rglob("*")
+    }
+
+
+def test_submission_preparation_categories_are_distinct() -> None:
+    no_submission = _student(
+        submission_status="missing",
+        review_status="unavailable",
+        review_state=None,
+        minimum_status=None,
+    )
+    needs_assembly = _student(
+        needs_assembly=True,
+        submission_status="missing",
+        review_status="unavailable",
+        review_state=None,
+        minimum_status=None,
+    )
+
+    assert _category(no_submission)[:2] == (
+        "no_submission",
+        "submission_missing",
+    )
+    assert _category(needs_assembly)[:2] == (
+        "needs_assembly",
+        "routed_evidence_needs_assembly",
+    )
+
+
+def test_minimum_requirement_gate_precedes_later_workflow_state() -> None:
+    student = _student(
+        review_state="ratings_complete",
+        minimum_status="not_checked",
+    )
+
+    category, reason, warnings = _category(student)
+
+    assert category == "minimum_requirements_pending"
+    assert reason == "minimum_requirement_outcome_not_checked"
+    assert "workflow_state_ahead_of_minimum_requirements" in warnings
+
+
+def test_assignment_without_minimum_requirements_skips_requirement_phase() -> None:
+    student = _student(
+        review_status="missing",
+        review_state=None,
+        minimum_status=None,
+    )
+
+    assert _category(student, configured_requirement_count=0)[:2] == (
+        "observations_pending",
+        "observations_not_complete",
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_category", "expected_reason"),
+    (
+        ("not_started", "observations_pending", "observations_not_complete"),
+        (
+            "requirements_checked",
+            "observations_pending",
+            "observations_not_complete",
+        ),
+        (
+            "observations_in_progress",
+            "observations_pending",
+            "observations_not_complete",
+        ),
+        ("observations_complete", "ratings_pending", "ratings_not_complete"),
+        ("ratings_complete", "feedback_pending", "feedback_not_composed"),
+        ("feedback_composed", "export_pending", "feedback_export_missing"),
+        ("ready_for_export", "export_pending", "feedback_export_missing"),
+        ("exported", "export_pending", "feedback_export_missing"),
+    ),
+)
+def test_explicit_review_state_drives_mechanical_stage(
+    state: str,
+    expected_category: str,
+    expected_reason: str,
+) -> None:
+    student = _student(review_state=state, minimum_status="met")
+
+    assert _category(student)[:2] == (expected_category, expected_reason)
+
+
+def test_plain_paper_valid_submission_enters_normal_review_classification() -> None:
+    student = _student(
+        plain_paper=True,
+        review_status="missing",
+        review_state=None,
+        minimum_status=None,
+    )
+
+    assert _category(student)[:2] == (
+        "minimum_requirements_pending",
+        "minimum_requirement_outcome_not_checked",
+    )
+
+
+def test_duplicate_display_names_preserve_exact_student_identity() -> None:
+    first = classify_review_work_queue_item(
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        _student(student_id="00100", display_name="Alex Lee"),
+        configured_requirement_count=1,
+    )
+    second = classify_review_work_queue_item(
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        _student(student_id="00200", display_name="Alex Lee"),
+        configured_requirement_count=1,
+    )
+
+    assert first.display_name == second.display_name == "Alex Lee"
+    assert first.student_id == "00100"
+    assert second.student_id == "00200"
+    assert first.student_id != second.student_id
+
+
+def test_markdown_only_current_export_satisfies_export_gate() -> None:
+    student = _student(
+        review_state="exported",
+        minimum_status="met",
+        pdf_status="missing",
+        markdown_status="present",
+    )
+
+    assert _category(student)[:2] == (
+        "complete",
+        "current_feedback_export_present",
+    )
+
+
+def test_current_supported_export_is_complete_even_if_companion_is_stale() -> None:
+    student = _student(
+        review_state="exported",
+        minimum_status="met",
+        pdf_status="present",
+        markdown_status="stale",
+        warnings=("feedback_markdown_stale",),
+    )
+
+    category, reason, warnings = _category(student)
+
+    assert category == "complete"
+    assert reason == "current_feedback_export_present"
+    assert warnings == ("feedback_markdown_stale",)
+
+
+@pytest.mark.parametrize(
+    ("pdf_status", "markdown_status", "reason"),
+    (
+        ("stale", "missing", "feedback_export_stale"),
+        ("unknown", "missing", "feedback_export_metadata_unknown"),
+        ("missing", "missing", "feedback_export_missing"),
+    ),
+)
+def test_export_pending_reason_uses_existing_freshness_state(
+    pdf_status: str,
+    markdown_status: str,
+    reason: str,
+) -> None:
+    student = _student(
+        review_state="exported",
+        minimum_status="met",
+        pdf_status=pdf_status,
+        markdown_status=markdown_status,
+    )
+
+    assert _category(student)[:2] == ("export_pending", reason)
+
+
+def test_returned_without_full_review_bypasses_non_applicable_review_stages() -> None:
+    returned = _student(
+        review_state="returned_without_full_review",
+        minimum_status="returned_without_full_review",
+        returned=True,
+    )
+    returned_exported = _student(
+        review_state="returned_without_full_review",
+        minimum_status="returned_without_full_review",
+        returned=True,
+        pdf_status="present",
+    )
+
+    assert _category(returned)[:2] == (
+        "export_pending",
+        "feedback_export_missing",
+    )
+    assert _category(returned_exported)[:2] == (
+        "complete",
+        "current_feedback_export_present",
+    )
+
+
+def test_inconsistent_returned_state_fails_closed() -> None:
+    student = _student(
+        review_state="returned_without_full_review",
+        minimum_status="met",
+        returned=False,
+    )
+
+    assert _category(student)[:2] == (
+        "attention_required",
+        "returned_state_inconsistent",
+    )
+
+
+@pytest.mark.parametrize(
+    ("student", "reason"),
+    (
+        (_student(submission_status="invalid"), "invalid_submission"),
+        (
+            _student(submission_status="identity_mismatch"),
+            "record_identity_mismatch",
+        ),
+        (_student(review_status="invalid"), "invalid_review"),
+        (_student(review_status="orphaned"), "orphan_review"),
+        (
+            _student(review_status="identity_mismatch"),
+            "record_identity_mismatch",
+        ),
+    ),
+)
+def test_invalid_or_unsafe_record_state_requires_attention(
+    student: DashboardStudentStatus,
+    reason: str,
+) -> None:
+    assert _category(student)[:2] == ("attention_required", reason)
+
+
+def test_real_queue_uses_roster_order_fixed_counts_and_writes_nothing(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path)
+    _write_roster(tmp_path)
+    before = _snapshot(tmp_path)
+
+    queue = build_assignment_review_work_queue(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    document = cast(dict[str, Any], assignment_review_work_queue_to_dict(queue))
+    text = format_assignment_review_work_queue(queue)
+
+    assert [item.student_id for item in queue.items] == ["00100", "00200", "00900"]
+    assert [item.category for item in queue.items] == [
+        "no_submission",
+        "no_submission",
+        "no_submission",
+    ]
+    counts = cast(dict[str, int], document["counts"])
+    assert list(counts) == list(WORK_QUEUE_CATEGORIES)
+    assert sum(counts.values()) == 3
+    assert counts["no_submission"] == 3
+    assert queue.complete_count == 0
+    assert queue.needs_work_count == 3
+    assert "Review Work Queue" in text
+    assert "Avery Rivera (00100)" in text
+    assert _snapshot(tmp_path) == before
+
+
+def test_unrostered_records_are_excluded_from_roster_queue(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_roster(tmp_path)
+    _write_records(tmp_path, "00300")
+
+    queue = build_assignment_review_work_queue(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+    assert [item.student_id for item in queue.items] == ["00100", "00200", "00900"]
+    assert queue.unrostered_student_ids == ("00300",)
+    assert "unrostered_records_excluded" in queue.warnings
+    assert sum(dict(queue.counts).values()) == 3
+
+
+def test_roster_unavailable_fails_instead_of_using_directory_order(
+    tmp_path: Path,
+) -> None:
+    _write_assignment(tmp_path)
+    _write_records(tmp_path, "00300")
+
+    with pytest.raises(ReviewWorkQueueError, match="roster is unavailable"):
+        build_assignment_review_work_queue(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+
+
+def test_repeated_queue_serialization_is_deterministic(tmp_path: Path) -> None:
+    _write_assignment(tmp_path)
+    _write_roster(tmp_path)
+
+    first = assignment_review_work_queue_to_dict(
+        build_assignment_review_work_queue(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    )
+    second = assignment_review_work_queue_to_dict(
+        build_assignment_review_work_queue(tmp_path, CLASS_ID, ASSIGNMENT_ID)
+    )
+
+    assert first == second


### PR DESCRIPTION
## Summary

Implements the deterministic, read-only review work queue for Quillan Phase 1.

This gives teachers one canonical, roster-ordered view of where each student stands in the review workflow and the earliest mechanically identifiable reason additional work is needed.

The queue derives entirely from existing canonical Core/Quillan state. It does not persist queue state, infer teacher judgment, rank students, mutate reviews, assemble submissions, generate feedback, or export artifacts.

## What this adds

- a reusable immutable `AssignmentReviewWorkQueue` / `ReviewWorkQueueItem` model;
- deterministic classification of every roster student into exactly one work state;
- fixed category counts and stable roster ordering;
- bounded fail-closed `attention_required` handling for unsafe or invalid canonical state;
- deterministic text and JSON representations;
- a new read-only direct CLI command:
  - `quillan review-queue <class_id> <assignment_id> [--format text|json]`;
- teacher-menu access through `Assignment Review Actions`;
- the same canonical work-state labels in student/submission selection;
- active-context integration with the class/assignment session context introduced by #382;
- documentation for queue semantics, precedence, privacy, and side-effect boundaries.

## Queue categories

Normal states are:

- `no_submission`
- `needs_assembly`
- `minimum_requirements_pending`
- `observations_pending`
- `ratings_pending`
- `feedback_pending`
- `export_pending`
- `complete`

Canonical integrity failures that prevent safe classification use:

- `attention_required`

Classification is deterministic and follows explicit precedence rather than inferred educational priority.

## Classification behavior

The queue:

- uses the canonical Core roster as the population and ordering source;
- keeps exact `student_id` authoritative even when display names are duplicated;
- distinguishes missing submissions from routed evidence awaiting assembly;
- respects explicit minimum-requirement outcomes without judging student work;
- treats `returned_without_full_review` as its explicit terminal review path;
- uses persisted workflow state for observation, rating, and feedback completion;
- requires a current canonical supported feedback export before classifying work as complete;
- accepts either a current PDF or Markdown feedback export under the existing export contract;
- treats stale, missing, or unverifiable exports as `export_pending`;
- handles explicit plain-paper submissions as valid submissions;
- excludes unrostered diagnostic discoveries from the normal roster queue;
- never infers completion from counts of observations, ratings, comments, or files.

## Teacher workflow

`Assignment Review Actions` now includes:

```text
7. View review work queue
```

The queue view:

- shows the exact active class and assignment;
- displays completion/work counts;
- lists students in canonical roster order;
- shows exact student identity and queue state;
- can be refreshed from current canonical state;
- preserves existing Back/Main Menu/Quit behavior.

Student selection also reuses the same queue classifier so Quillan does not maintain a second interpretation of review progress.

This PR intentionally does **not** add:

- next/previous student navigation;
- next-student-needing-review behavior;
- automatic student opening;
- `Continue Review` routing;
- automatic assembly;
- automatic review decisions;
- automatic feedback/export.

Those remain later Phase 1 work.

## CLI

Adds:

```text
quillan review-queue <class_id> <assignment_id> [--format text|json]
```

The command is direct, deterministic, non-interactive, and strictly read-only.

The CLI contract and authoritative argparse inventory are updated accordingly.

## Read-only and privacy boundaries

Building, formatting, serializing, viewing, or refreshing the queue performs no workspace writes.

Queue output is limited to operational identity/status information such as:

- class/assignment identity;
- student identity/display name;
- mechanical queue category;
- bounded reason codes/labels;
- category counts;
- bounded integrity warnings.

It does not expose student writing, teacher notes, feedback bodies, rating values, rationales, or other review content.

No new Core API, shared schema, suite dependency, or persisted queue record is introduced.

## Tests

Adds dedicated coverage for:

- roster ordering and deterministic classification;
- category precedence and fixed counts;
- missing submission vs. assembly-needed state;
- minimum-requirement gates;
- returned-without-full-review behavior;
- observation/rating/feedback stages;
- current, stale, missing, and Markdown-only exports;
- plain-paper submissions;
- duplicate display names with distinct exact identities;
- malformed, mismatched, and orphaned records;
- unrostered records;
- no-write behavior;
- deterministic CLI text/JSON;
- CLI failure/help behavior;
- menu queue rendering and refresh;
- student-picker classifier reuse;
- #382 active-context preservation;
- explicit exclusion of #384/#385 navigation behavior.

## Validation

Final local validation on Windows / Python 3.14.1:

- #383 acceptance set: **139 passed**
- full repository suite: **2548 passed, 21 skipped**
- `python -m ruff check .` — passed
- `python -m mypy .` — passed with no issues in 307 source files
- `git diff --check` — clean

## Scope

This PR implements only issue #383's deterministic review work queue.

It preserves the existing teacher-workflow audit baseline and leaves next/previous navigation, `Continue Review`, batch export, broader completion views, and shared suite attention/readiness providers to their later tickets.

Closes #383