### PR TITLE
feat: add class-set student review navigation

### DIFF
--- a/docs/cli_contract.md
+++ b/docs/cli_contract.md
@@ -1277,7 +1277,8 @@ fuller context restored. Prior menu options, parent dashboard blocks, and
 debug-style details should not remain on screen merely because the terminal
 transcript stacked them there.
 
-The selected-student review menu provides:
+The selected-student review menu provides the existing numbered review actions plus
+#384's local class-set navigation controls:
 
 ```text
 1. Open submission evidence
@@ -1291,8 +1292,21 @@ The selected-student review menu provides:
 9. Update review workflow state
 10. Export student feedback
 11. Refresh summary
-12. Back
+P. Previous student — <previous roster identity or boundary>
+N. Next student — <next roster identity or boundary>
+W. Next student needing review — <first later non-complete identity or none>
+B. Back
+M. Main Menu
+Q. Quit
 ```
+
+The selected-student root rebuilds #384 navigation from the current #383 queue on
+every redraw. Position and remaining-work counts therefore reflect explicit durable
+state after a completed child action. `P` and `N` use immediate canonical roster
+neighbors; `W` searches strictly forward for the first queue category other than
+`complete`. None of these actions wraps, persists current-student state, or enters a
+review stage automatically. The commands are intentionally available at the clean
+selected-student root rather than inside judgment-bearing child input prompts.
 
 Opening submission evidence delegates to the same existing safe selected
 evidence-opening path as:

--- a/docs/review_student_navigation.md
+++ b/docs/review_student_navigation.md
@@ -1,0 +1,137 @@
+# Deterministic review student navigation
+
+Issue: #384 — class-set student navigation
+
+## Boundary
+
+Quillan class-set review navigation is a read-only derived view over the exact
+`AssignmentReviewWorkQueue` introduced by #383. It does not define roster order,
+review-work categories, teacher priority, or review-stage guidance independently.
+
+Core remains authoritative for the canonical class roster and roster order. #383
+remains authoritative for Quillan's assignment-local work classification. #384 only
+answers where the selected roster student sits in that queue and which bounded roster
+targets are available.
+
+Navigation state is not persisted in the workspace.
+
+## Canonical order and identity
+
+Normal navigation uses `AssignmentReviewWorkQueue.items` exactly as ordered by #383.
+Exact `student_id` is authoritative; display names are labels only. Duplicate display
+names do not affect navigation identity.
+
+An unrostered diagnostic record is not a queue member and therefore has no canonical
+roster position. If a selected student is absent from the queue, normal class-set
+navigation fails closed rather than inventing a position.
+
+## Previous and next
+
+For a selected queue item at zero-based index `i`:
+
+```text
+previous = items[i - 1] when i > 0
+next     = items[i + 1] when i + 1 < len(items)
+```
+
+There is no wraparound. The first student has no previous target and the final student
+has no next target.
+
+Adjacent navigation does not skip students because of submission state, integrity
+state, or completion state.
+
+## Next student needing review
+
+A student needs work for #384 exactly when the existing #383 category is not:
+
+```text
+complete
+```
+
+Starting strictly after the current position, the target is the first later queue item
+whose category is not `complete`.
+
+This includes every #383 non-complete category:
+
+```text
+no_submission
+needs_assembly
+minimum_requirements_pending
+observations_pending
+ratings_pending
+feedback_pending
+export_pending
+attention_required
+```
+
+No category is ranked above another. Search is forward-only and never wraps to an
+earlier roster student.
+
+## Counts
+
+The navigation projection exposes:
+
+```text
+position
+roster_count
+needs_work_count
+needs_work_after_current_count
+```
+
+`position` is one-based for teacher-facing display. `needs_work_count` counts every
+queue item whose category is not `complete`. `needs_work_after_current_count` applies
+the same predicate only to subsequent roster items.
+
+These are operational workflow counts, not estimates of difficulty, severity,
+performance, or time.
+
+## Freshness and writes
+
+The workspace-facing builder obtains a fresh #383 work queue each time it is invoked.
+The pure resolver performs no filesystem access and no writes.
+
+Later menu integration should rebuild navigation after returning from student actions
+so explicitly persisted review/export changes can alter the next-needing-review target
+before the teacher navigates.
+
+## Later issue boundary
+
+#384 decides **which student** is before, after, or the next later non-complete roster
+student. It deliberately does not decide **which review stage** should be opened for a
+student. That stage-routing concern belongs to #385 `Continue Review`.
+
+Likewise, #384 does not redesign the selected-student action surface; #386 may later
+consume this navigation model while creating the compact routine review screen.
+
+## Teacher menu integration
+
+The root `Selected Student Review` screen rebuilds this navigation from current
+canonical #383 state on every redraw. It shows the selected student's display name
+with exact `student_id`, exact roster position, the current queue work category, total
+students needing work, and forward remaining-work count.
+It also exposes local class-set controls without renumbering the existing review
+actions:
+
+```text
+P. Previous student — <exact target or first-roster boundary>
+N. Next student — <exact target or final-roster boundary>
+W. Next student needing review — <first later non-complete target or none>
+```
+
+Targets include exact `student_id` when a display name exists. `P` and `N` move only
+to the immediately adjacent canonical roster item. `W` searches strictly forward
+for the first #383 item whose category is not `complete`. None of these commands
+wraps around the roster.
+
+Navigation is available from the clean selected-student root for missing-submission,
+routed-evidence, plain-paper, and review-ready states. It is not injected into child
+teacher-input workflows, so pending requirement, observation, rating, feedback,
+note, page-management, workflow-state, or export input must first save, cancel, or
+return to the root screen. A successful child write is reflected when the root
+rebuilds; a canceled child operation is not converted into a navigation write.
+
+If the selected identity is outside the canonical roster queue, or the queue cannot
+be built safely, class-set navigation is unavailable rather than inferred. Existing
+`B`, `M`, and `Q` behavior remains owned by the shared menu-navigation layer. #385
+will add stage routing for one already-selected student and must not be folded into
+these student-to-student controls.

--- a/quillan/review_menu.py
+++ b/quillan/review_menu.py
@@ -110,10 +110,16 @@ from quillan.review_status_display import (
     review_progress_status,
     review_status_label,
 )
+from quillan.review_student_navigation import (
+    ReviewStudentNavigation,
+    ReviewStudentNavigationError,
+    build_review_student_navigation,
+)
 from quillan.review_work_queue import (
     CATEGORY_LABELS,
     AssignmentReviewWorkQueue,
     ReviewWorkQueueError,
+    ReviewWorkQueueItem,
     build_assignment_review_work_queue,
 )
 from quillan.review_snapshot import current_review_details_text
@@ -538,6 +544,106 @@ def _student_status_label(
     )
 
 
+def _load_review_student_navigation(
+    workspace_root: Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> ReviewStudentNavigation | None:
+    try:
+        return build_review_student_navigation(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+    except (ReviewStudentNavigationError, OSError) as error:
+        print(f"Class-set navigation unavailable: {error}")
+        return None
+
+
+def _review_student_navigation_item_label(
+    item: ReviewWorkQueueItem | None,
+    *,
+    none_label: str,
+) -> str:
+    if item is None:
+        return none_label
+    if item.display_name == item.student_id:
+        return item.student_id
+    return f"{item.display_name} ({item.student_id})"
+
+
+def _print_review_student_navigation(
+    navigation: ReviewStudentNavigation | None,
+) -> None:
+    if navigation is None:
+        print("Class-set navigation: unavailable")
+        return
+
+    print(f"Position: {navigation.position} of {navigation.roster_count}")
+    print(f"Work state: {CATEGORY_LABELS[navigation.current.category]}")
+    print(f"Students needing work: {navigation.needs_work_count}")
+    print(
+        "Students needing work after this position: "
+        f"{navigation.needs_work_after_current_count}"
+    )
+    print()
+    print(
+        "P. Previous student — "
+        + _review_student_navigation_item_label(
+            navigation.previous,
+            none_label="none (first roster student)",
+        )
+    )
+    print(
+        "N. Next student — "
+        + _review_student_navigation_item_label(
+            navigation.next,
+            none_label="none (final roster student)",
+        )
+    )
+    print(
+        "W. Next student needing review — "
+        + _review_student_navigation_item_label(
+            navigation.next_needing_review,
+            none_label="none later in roster",
+        )
+    )
+
+
+def _review_student_navigation_choice(
+    choice: str,
+    navigation: ReviewStudentNavigation | None,
+) -> tuple[bool, str | None]:
+    normalized = choice.strip().casefold()
+    if normalized not in {"p", "n", "w"}:
+        return False, None
+    if navigation is None:
+        return True, None
+
+    target = {
+        "p": navigation.previous,
+        "n": navigation.next,
+        "w": navigation.next_needing_review,
+    }[normalized]
+    return True, None if target is None else target.student_id
+
+
+def _review_student_navigation_unavailable_message(
+    choice: str,
+    navigation: ReviewStudentNavigation | None,
+) -> str:
+    if navigation is None:
+        return "Class-set navigation is unavailable for this selected student."
+    normalized = choice.strip().casefold()
+    if normalized == "p":
+        return "No previous roster student; this is the first roster student."
+    if normalized == "n":
+        return "No next roster student; this is the final roster student."
+    return "No later roster student currently needs review work."
+
+
 def _launch_selected_student_review(
     workspace_root: Path,
     class_id: str,
@@ -546,6 +652,7 @@ def _launch_selected_student_review(
 ) -> int:
     from quillan.menu import clear_screen, print_menu_header
 
+    current_student_id = student_id
     while True:
         clear_screen()
         print_menu_header("Selected Student Review")
@@ -554,17 +661,26 @@ def _launch_selected_student_review(
             workspace_root,
             class_id,
             assignment_id,
-            student_id,
+            current_student_id,
         )
         print()
+        class_set_navigation = _load_review_student_navigation(
+            workspace_root,
+            class_id,
+            assignment_id,
+            current_student_id,
+        )
+        _print_review_student_navigation(class_set_navigation)
+        print()
+
         status = _load_submission_status(workspace_root, class_id, assignment_id)
-        student_status = _student_submission_status(status, student_id)
+        student_status = _student_submission_status(status, current_student_id)
         if student_status is None:
             print("No digital submission evidence has been found for this student.")
             print()
             try:
                 plan_plain_paper_submission(
-                    workspace_root, class_id, assignment_id, student_id
+                    workspace_root, class_id, assignment_id, current_student_id
                 )
             except (PlainPaperSubmissionError, OSError, ValueError) as error:
                 plain_paper_available = False
@@ -585,9 +701,23 @@ def _launch_selected_student_review(
             print()
             if choice == "" or navigation is NavigationChoice.BACK:
                 return 0
+            handled, target_student_id = _review_student_navigation_choice(
+                choice, class_set_navigation
+            )
+            if handled:
+                if target_student_id is None:
+                    print(
+                        _review_student_navigation_unavailable_message(
+                            choice, class_set_navigation
+                        )
+                    )
+                    input("Press Enter to continue...")
+                else:
+                    current_student_id = target_student_id
+                continue
             if choice == "1" and plain_paper_available:
                 _create_plain_paper_submission_menu(
-                    workspace_root, class_id, assignment_id, student_id
+                    workspace_root, class_id, assignment_id, current_student_id
                 )
                 input("Press Enter to continue...")
                 continue
@@ -601,9 +731,7 @@ def _launch_selected_student_review(
                 "This student has routed evidence, but the review-ready "
                 "submission record has not been assembled yet."
             )
-            print(
-                "Assemble submissions before reviewing, rating, or exporting."
-            )
+            print("Assemble submissions before reviewing, rating, or exporting.")
             print()
             print("1. Assemble this assignment now")
             print("2. View routed evidence status")
@@ -615,13 +743,27 @@ def _launch_selected_student_review(
             print()
             if choice == "" or navigation is NavigationChoice.BACK:
                 return 0
+            handled, target_student_id = _review_student_navigation_choice(
+                choice, class_set_navigation
+            )
+            if handled:
+                if target_student_id is None:
+                    print(
+                        _review_student_navigation_unavailable_message(
+                            choice, class_set_navigation
+                        )
+                    )
+                    input("Press Enter to continue...")
+                else:
+                    current_student_id = target_student_id
+                continue
             if choice == "1":
                 _assemble_assignment(workspace_root, class_id, assignment_id)
                 input("Press Enter to continue...")
             elif choice in {"2", "3"}:
                 continue
             else:
-                print("Invalid selection. Please enter a number from 1 to 4.")
+                print("Invalid selection. Please choose a listed action.")
                 input("Press Enter to continue...")
             continue
         print("1. Open submission evidence")
@@ -644,12 +786,26 @@ def _launch_selected_student_review(
 
         if choice == "" or navigation is NavigationChoice.BACK:
             return 0
+        handled, target_student_id = _review_student_navigation_choice(
+            choice, class_set_navigation
+        )
+        if handled:
+            if target_student_id is None:
+                print(
+                    _review_student_navigation_unavailable_message(
+                        choice, class_set_navigation
+                    )
+                )
+                input("Press Enter to continue...")
+            else:
+                current_student_id = target_student_id
+            continue
         if choice == "1":
             _open_submission_evidence(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
             input("Press Enter to continue...")
         elif choice == "2":
@@ -657,7 +813,7 @@ def _launch_selected_student_review(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
             input("Press Enter to continue...")
         elif choice == "3":
@@ -665,35 +821,35 @@ def _launch_selected_student_review(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
         elif choice == "4":
             _menu_review_unit_observations(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
         elif choice == "5":
             _menu_overall_focus_standard_ratings(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
         elif choice == "6":
             _menu_compose_focus_standard_feedback(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
         elif choice == "7":
             _menu_manage_submission_pages(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
             input("Press Enter to continue...")
         elif choice == "8":
@@ -701,7 +857,7 @@ def _launch_selected_student_review(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
             input("Press Enter to continue...")
         elif choice == "9":
@@ -709,7 +865,7 @@ def _launch_selected_student_review(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
             input("Press Enter to continue...")
         elif choice == "10":
@@ -717,16 +873,14 @@ def _launch_selected_student_review(
                 workspace_root,
                 class_id,
                 assignment_id,
-                student_id,
+                current_student_id,
             )
             input("Press Enter to continue...")
         elif choice == "11":
             continue
         else:
-            print("Invalid selection. Please enter a number from 1 to 12.")
+            print("Invalid selection. Please choose a listed action.")
             input("Press Enter to continue...")
-
-
 def _student_submission_status(
     status: AssignmentSubmissionStatus | None, student_id: str
 ) -> StudentSubmissionStatus | None:
@@ -1231,7 +1385,6 @@ def _print_review_summary(
         print(f"Status unavailable: {error}")
         return
     data = student_review_status_to_dict(status)
-    student = cast(dict[str, Any], data["student"])
     routed = cast(dict[str, Any], data["routed_evidence"])
     submission = cast(dict[str, Any], data["submission"])
     review = cast(dict[str, Any], data["review"])
@@ -1240,7 +1393,9 @@ def _print_review_summary(
     export_summary = cast(dict[str, Any], exports["summary"])
     print(f"Class: {class_id}")
     print(f"Assignment: {assignment_id}")
-    print(f"Student: {student['display_name']}")
+    print(
+        f"Student: {student_review_label(workspace_root, class_id, student_id)}"
+    )
     print(f"Submission: {submission['status']}")
     print(f"Routed evidence files: {routed['file_count']}")
     print(f"Needs assembly: {_format_yes_no(routed['needs_assembly'] is True)}")

--- a/quillan/review_student_navigation.py
+++ b/quillan/review_student_navigation.py
@@ -1,0 +1,125 @@
+"""Deterministic class-set student navigation over the review work queue."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from quillan.review_work_queue import (
+    WORK_QUEUE_CATEGORIES,
+    AssignmentReviewWorkQueue,
+    ReviewWorkQueueError,
+    ReviewWorkQueueItem,
+    build_assignment_review_work_queue,
+)
+
+
+class ReviewStudentNavigationError(ValueError):
+    """Raised when safe deterministic student navigation cannot be derived."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewStudentNavigation:
+    """Immutable roster-position navigation for one selected review student."""
+
+    class_id: str
+    assignment_id: str
+    current: ReviewWorkQueueItem
+    position: int
+    roster_count: int
+    previous: ReviewWorkQueueItem | None
+    next: ReviewWorkQueueItem | None
+    next_needing_review: ReviewWorkQueueItem | None
+    needs_work_count: int
+    needs_work_after_current_count: int
+
+
+def build_review_student_navigation(
+    workspace_root: str | Path,
+    class_id: str,
+    assignment_id: str,
+    student_id: str,
+) -> ReviewStudentNavigation:
+    """Build fresh navigation from the current canonical #383 work queue."""
+    try:
+        queue = build_assignment_review_work_queue(
+            workspace_root,
+            class_id,
+            assignment_id,
+        )
+    except ReviewWorkQueueError as error:
+        raise ReviewStudentNavigationError(
+            f"Could not build review student navigation: {error}"
+        ) from error
+    return derive_review_student_navigation(queue, student_id)
+
+
+def derive_review_student_navigation(
+    queue: AssignmentReviewWorkQueue,
+    student_id: str,
+) -> ReviewStudentNavigation:
+    """Resolve bounded roster navigation without writing or wrapping."""
+    if not isinstance(student_id, str) or not student_id:
+        raise ReviewStudentNavigationError("student_id must be a non-empty string")
+
+    _validate_queue_identity(queue)
+
+    current_index = next(
+        (
+            index
+            for index, item in enumerate(queue.items)
+            if item.student_id == student_id
+        ),
+        None,
+    )
+    if current_index is None:
+        raise ReviewStudentNavigationError(
+            f"Student {student_id!r} is not in the canonical review queue for "
+            f"class {queue.class_id!r}, assignment {queue.assignment_id!r}."
+        )
+
+    previous = queue.items[current_index - 1] if current_index > 0 else None
+    next_index = current_index + 1
+    next_student = (
+        queue.items[next_index] if next_index < len(queue.items) else None
+    )
+    later_items = queue.items[next_index:]
+    next_needing_review = next(
+        (item for item in later_items if item.category != "complete"),
+        None,
+    )
+    needs_work_count = sum(item.category != "complete" for item in queue.items)
+    needs_work_after_current_count = sum(
+        item.category != "complete" for item in later_items
+    )
+
+    return ReviewStudentNavigation(
+        class_id=queue.class_id,
+        assignment_id=queue.assignment_id,
+        current=queue.items[current_index],
+        position=current_index + 1,
+        roster_count=len(queue.items),
+        previous=previous,
+        next=next_student,
+        next_needing_review=next_needing_review,
+        needs_work_count=needs_work_count,
+        needs_work_after_current_count=needs_work_after_current_count,
+    )
+
+
+def _validate_queue_identity(queue: AssignmentReviewWorkQueue) -> None:
+    seen: set[str] = set()
+    for item in queue.items:
+        if item.class_id != queue.class_id or item.assignment_id != queue.assignment_id:
+            raise ReviewStudentNavigationError(
+                "Review queue item identity does not match its class/assignment."
+            )
+        if item.student_id in seen:
+            raise ReviewStudentNavigationError(
+                f"Review queue contains duplicate student_id {item.student_id!r}."
+            )
+        if item.category not in WORK_QUEUE_CATEGORIES:
+            raise ReviewStudentNavigationError(
+                f"Review queue contains unknown category {item.category!r}."
+            )
+        seen.add(item.student_id)

--- a/tests/test_menu_review_student_navigation_issue384.py
+++ b/tests/test_menu_review_student_navigation_issue384.py
@@ -1,0 +1,438 @@
+"""Issue #384 menu integration tests for class-set student navigation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+import pytest
+
+import quillan.review_menu as review_menu
+from quillan.plain_paper_submission import create_plain_paper_submission
+from quillan.review_record_paths import review_record_path
+from quillan.review_student_navigation import (
+    ReviewStudentNavigation,
+    build_review_student_navigation,
+)
+from tests.test_menu_review_student_work import (
+    ASSIGNMENT_ID,
+    CLASS_ID,
+    SECOND_STUDENT_ID,
+    STUDENT_ID,
+    TIMESTAMP,
+    _review_record,
+    _write_workspace,
+)
+
+
+def _inputs(monkeypatch: pytest.MonkeyPatch, responses: tuple[str, ...]) -> None:
+    iterator = iter(responses)
+
+    def fake_input(_prompt: str = "") -> str:
+        try:
+            return next(iterator)
+        except StopIteration as error:
+            raise AssertionError("Menu requested more input than supplied.") from error
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+def _snapshot(root: Path) -> dict[str, bytes | None]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes() if path.is_file() else None
+        for path in root.rglob("*")
+    }
+
+
+def _prepare(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_workspace(tmp_path)
+    monkeypatch.setattr("quillan.menu.clear_screen", lambda: None)
+    monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
+
+
+def test_next_student_moves_directly_without_picker_and_writes_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    before = _snapshot(tmp_path)
+    _inputs(monkeypatch, ("n", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert f"Student: Avery Rivera ({STUDENT_ID})" in output
+    assert f"Student: Mina Patel ({SECOND_STUDENT_ID})" in output
+    assert "Position: 1 of 2" in output
+    assert f"N. Next student — Mina Patel ({SECOND_STUDENT_ID})" in output
+    assert "Position: 2 of 2" in output
+    assert f"P. Previous student — Avery Rivera ({STUDENT_ID})" in output
+    assert "Select Student/Submission" not in output
+    assert _snapshot(tmp_path) == before
+
+
+def test_previous_student_moves_directly_in_roster_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    _inputs(monkeypatch, ("p", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, SECOND_STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Position: 2 of 2" in output
+    assert f"P. Previous student — Avery Rivera ({STUDENT_ID})" in output
+    assert "Position: 1 of 2" in output
+    assert f"N. Next student — Mina Patel ({SECOND_STUDENT_ID})" in output
+
+
+def test_next_needing_review_uses_same_forward_queue_semantics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    _inputs(monkeypatch, ("w", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert (
+        f"W. Next student needing review — Mina Patel ({SECOND_STUDENT_ID})"
+        in output
+    )
+    assert "Position: 2 of 2" in output
+    assert "W. Next student needing review — none later in roster" in output
+
+
+def test_final_student_boundaries_are_visible_and_do_not_wrap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    _inputs(monkeypatch, ("b",))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, SECOND_STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "N. Next student — none (final roster student)" in output
+    assert "W. Next student needing review — none later in roster" in output
+    assert "Position: 2 of 2" in output
+
+
+def test_navigation_rebuilds_from_current_queue_on_every_root_redraw(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    calls: list[str] = []
+
+    def recording_builder(
+        workspace_root: str | Path,
+        class_id: str,
+        assignment_id: str,
+        student_id: str,
+    ) -> ReviewStudentNavigation:
+        calls.append(student_id)
+        return build_review_student_navigation(
+            workspace_root, class_id, assignment_id, student_id
+        )
+
+    monkeypatch.setattr(
+        review_menu,
+        "build_review_student_navigation",
+        recording_builder,
+    )
+    _inputs(monkeypatch, ("n", "p", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ) == 0
+
+    assert calls == [STUDENT_ID, SECOND_STUDENT_ID, STUDENT_ID]
+
+
+def test_existing_review_actions_keep_their_numbers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    _inputs(monkeypatch, ("b",))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    for expected in (
+        "1. Open submission evidence",
+        "2. View current review details",
+        "3. Review minimum requirements",
+        "4. Review units and Focus Standard observations",
+        "5. Overall Focus Standard ratings",
+        "6. Compose Focus Standard feedback",
+        "7. Manage submission pages",
+        "8. Add teacher note",
+        "9. Update review workflow state",
+        "10. Export student feedback",
+        "11. Refresh summary",
+    ):
+        assert expected in output
+
+
+def test_canceled_teacher_note_is_not_written_or_carried_to_next_student(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    before = _snapshot(tmp_path)
+    _inputs(monkeypatch, ("8", "b", "", "n", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Add note canceled." in output
+    assert "Position: 2 of 2" in output
+    assert f"P. Previous student — Avery Rivera ({STUDENT_ID})" in output
+    assert _snapshot(tmp_path) == before
+
+
+def test_routed_evidence_awaiting_assembly_root_keeps_navigation_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from types import SimpleNamespace
+
+    _prepare(tmp_path, monkeypatch)
+    before = _snapshot(tmp_path)
+    synthetic_status = SimpleNamespace(
+        student_statuses=(
+            SimpleNamespace(
+                student_id=SECOND_STUDENT_ID,
+                manifest_path=None,
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        review_menu,
+        "_load_submission_status",
+        lambda *_args, **_kwargs: synthetic_status,
+    )
+    _inputs(monkeypatch, ("p", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, SECOND_STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert (
+        "This student has routed evidence, but the review-ready submission record "
+        "has not been assembled yet."
+    ) in output
+    assert f"P. Previous student — Avery Rivera ({STUDENT_ID})" in output
+    assert "Position: 1 of 2" in output
+    assert _snapshot(tmp_path) == before
+
+
+def test_unrostered_selected_student_fails_closed_for_class_set_navigation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from quillan.review_student_navigation import ReviewStudentNavigationError
+
+    _prepare(tmp_path, monkeypatch)
+    diagnostic_student_id = "stu_unrostered_diagnostic"
+    monkeypatch.setattr(
+        review_menu,
+        "_print_review_summary",
+        lambda *_args, **_kwargs: print(f"Student: {diagnostic_student_id}"),
+    )
+    monkeypatch.setattr(
+        review_menu,
+        "build_review_student_navigation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ReviewStudentNavigationError("student is outside the canonical roster")
+        ),
+    )
+    monkeypatch.setattr(
+        review_menu,
+        "_load_submission_status",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        review_menu,
+        "plan_plain_paper_submission",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ValueError("student is not rostered")
+        ),
+    )
+    _inputs(monkeypatch, ("n", "", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, diagnostic_student_id
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Class-set navigation unavailable:" in output
+    assert "Class-set navigation: unavailable" in output
+    assert "Class-set navigation is unavailable for this selected student." in output
+    assert "Position: 1 of 2" not in output
+    assert "Position: 2 of 2" not in output
+
+
+def test_completed_child_write_is_reflected_by_fresh_navigation_redraw(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from dataclasses import replace
+
+    _prepare(tmp_path, monkeypatch)
+    marker = tmp_path / "synthetic-explicit-child-write"
+    real_builder = build_review_student_navigation
+    calls: list[bool] = []
+
+    def state_sensitive_builder(
+        workspace_root: str | Path,
+        class_id: str,
+        assignment_id: str,
+        student_id: str,
+    ) -> ReviewStudentNavigation:
+        navigation = real_builder(
+            workspace_root,
+            class_id,
+            assignment_id,
+            student_id,
+        )
+        changed = marker.exists()
+        calls.append(changed)
+        if not changed:
+            return navigation
+        return replace(
+            navigation,
+            current=replace(
+                navigation.current,
+                category="complete",
+                reason_code="current_feedback_export_present",
+            ),
+            needs_work_count=max(0, navigation.needs_work_count - 1),
+        )
+
+    def explicit_child_write(*_args: object, **_kwargs: object) -> None:
+        marker.write_text("saved", encoding="utf-8")
+
+    monkeypatch.setattr(
+        review_menu,
+        "build_review_student_navigation",
+        state_sensitive_builder,
+    )
+    monkeypatch.setattr(review_menu, "_menu_add_review_note", explicit_child_write)
+    _inputs(monkeypatch, ("8", "", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert calls == [False, True]
+    assert "Work state: minimum requirements pending" in output
+    assert "Work state: complete" in output
+    assert marker.read_text(encoding="utf-8") == "saved"
+
+
+def test_unavailable_final_next_action_does_not_wrap_to_first_student(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    _inputs(monkeypatch, ("n", "", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, SECOND_STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "No next roster student; this is the final roster student." in output
+    assert output.count("Position: 2 of 2") == 2
+    assert "Position: 1 of 2" not in output
+
+
+def test_plain_paper_student_participates_in_adjacent_navigation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    created = create_plain_paper_submission(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        SECOND_STUDENT_ID,
+        created_at=TIMESTAMP,
+    )
+    manifest = json.loads(created.submission_manifest_path.read_text(encoding="utf-8"))
+    assert manifest["module_details"]["submission_entry_method"] == "plain_paper_manual"
+    before = _snapshot(tmp_path)
+    _inputs(monkeypatch, ("p", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, SECOND_STUDENT_ID
+    ) == 0
+
+    output = capsys.readouterr().out
+    assert "Position: 2 of 2" in output
+    assert f"P. Previous student — Avery Rivera ({STUDENT_ID})" in output
+    assert "Position: 1 of 2" in output
+    assert _snapshot(tmp_path) == before
+
+
+def test_completed_teacher_note_save_is_retained_once_when_navigation_follows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _prepare(tmp_path, monkeypatch)
+    first_review_path = review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    )
+    second_review_path = review_record_path(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, SECOND_STUDENT_ID
+    )
+    record = _review_record()
+    record["private_notes"] = []
+    first_review_path.parent.mkdir(parents=True, exist_ok=True)
+    first_review_path.write_text(json.dumps(record), encoding="utf-8")
+    assert not second_review_path.exists()
+    _inputs(monkeypatch, ("8", "Saved exactly once.", "", "n", "b"))
+
+    assert review_menu._launch_selected_student_review(
+        tmp_path, CLASS_ID, ASSIGNMENT_ID, STUDENT_ID
+    ) == 0
+
+    persisted = json.loads(first_review_path.read_text(encoding="utf-8"))
+    assert [note["text"] for note in persisted["private_notes"]] == [
+        "Saved exactly once."
+    ]
+    assert not second_review_path.exists()
+    output = capsys.readouterr().out
+    assert "Position: 2 of 2" in output
+    assert f"P. Previous student — Avery Rivera ({STUDENT_ID})" in output

--- a/tests/test_review_student_navigation_issue384.py
+++ b/tests/test_review_student_navigation_issue384.py
@@ -1,0 +1,254 @@
+"""Issue #384 tests for deterministic class-set student navigation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quillan.review_student_navigation import (
+    ReviewStudentNavigationError,
+    build_review_student_navigation,
+    derive_review_student_navigation,
+)
+from quillan.review_work_queue import (
+    WORK_QUEUE_CATEGORIES,
+    AssignmentReviewWorkQueue,
+    ReviewWorkQueueItem,
+)
+import quillan.review_student_navigation as navigation_module
+
+CLASS_ID = "english12_p3_synthetic"
+ASSIGNMENT_ID = "essay_01_synthetic"
+
+
+def _item(
+    student_id: str,
+    category: str,
+    *,
+    display_name: str | None = None,
+    class_id: str = CLASS_ID,
+    assignment_id: str = ASSIGNMENT_ID,
+) -> ReviewWorkQueueItem:
+    return ReviewWorkQueueItem(
+        class_id=class_id,
+        assignment_id=assignment_id,
+        student_id=student_id,
+        display_name=display_name or f"Student {student_id}",
+        category=category,
+        reason_code=f"reason_{category}",
+        warnings=(),
+    )
+
+
+def _queue(*items: ReviewWorkQueueItem) -> AssignmentReviewWorkQueue:
+    counts = tuple(
+        (
+            category,
+            sum(item.category == category for item in items),
+        )
+        for category in WORK_QUEUE_CATEGORIES
+    )
+    return AssignmentReviewWorkQueue(
+        class_id=CLASS_ID,
+        assignment_id=ASSIGNMENT_ID,
+        assignment_title="Synthetic Essay",
+        items=items,
+        counts=counts,
+        unrostered_student_ids=(),
+        warnings=(),
+    )
+
+
+def test_middle_student_resolves_previous_next_and_first_later_work() -> None:
+    queue = _queue(
+        _item("001", "observations_pending"),
+        _item("002", "ratings_pending"),
+        _item("003", "complete"),
+        _item("004", "feedback_pending"),
+        _item("005", "complete"),
+    )
+
+    result = derive_review_student_navigation(queue, "002")
+
+    assert result.position == 2
+    assert result.roster_count == 5
+    assert result.current.student_id == "002"
+    assert result.previous is not None
+    assert result.previous.student_id == "001"
+    assert result.next is not None
+    assert result.next.student_id == "003"
+    assert result.next_needing_review is not None
+    assert result.next_needing_review.student_id == "004"
+    assert result.needs_work_count == 3
+    assert result.needs_work_after_current_count == 1
+
+
+def test_first_student_has_no_previous_and_never_wraps() -> None:
+    queue = _queue(
+        _item("001", "complete"),
+        _item("002", "ratings_pending"),
+    )
+
+    result = derive_review_student_navigation(queue, "001")
+
+    assert result.position == 1
+    assert result.previous is None
+    assert result.next is not None
+    assert result.next.student_id == "002"
+    assert result.next_needing_review is not None
+    assert result.next_needing_review.student_id == "002"
+
+
+def test_last_student_has_no_forward_target_and_never_wraps() -> None:
+    queue = _queue(
+        _item("001", "ratings_pending"),
+        _item("002", "complete"),
+        _item("003", "complete"),
+    )
+
+    result = derive_review_student_navigation(queue, "003")
+
+    assert result.position == 3
+    assert result.previous is not None
+    assert result.previous.student_id == "002"
+    assert result.next is None
+    assert result.next_needing_review is None
+    assert result.needs_work_count == 1
+    assert result.needs_work_after_current_count == 0
+
+
+def test_all_complete_has_no_next_needing_review() -> None:
+    queue = _queue(
+        _item("001", "complete"),
+        _item("002", "complete"),
+        _item("003", "complete"),
+    )
+
+    for student_id in ("001", "002", "003"):
+        result = derive_review_student_navigation(queue, student_id)
+        assert result.next_needing_review is None
+        assert result.needs_work_count == 0
+
+
+@pytest.mark.parametrize(
+    "category",
+    tuple(category for category in WORK_QUEUE_CATEGORIES if category != "complete"),
+)
+def test_every_non_complete_queue_category_is_eligible_for_next_work(
+    category: str,
+) -> None:
+    queue = _queue(
+        _item("001", "complete"),
+        _item("002", "complete"),
+        _item("003", category),
+        _item("004", "observations_pending"),
+    )
+
+    result = derive_review_student_navigation(queue, "001")
+
+    assert result.next_needing_review is not None
+    assert result.next_needing_review.student_id == "003"
+    assert result.next_needing_review.category == category
+
+
+def test_duplicate_display_names_remain_distinct_by_exact_student_id() -> None:
+    queue = _queue(
+        _item("001", "complete", display_name="Alex Lee"),
+        _item("017", "ratings_pending", display_name="Alex Lee"),
+    )
+
+    first = derive_review_student_navigation(queue, "001")
+    second = derive_review_student_navigation(queue, "017")
+
+    assert first.current.display_name == second.current.display_name == "Alex Lee"
+    assert first.current.student_id == "001"
+    assert second.current.student_id == "017"
+    assert first.next is not None
+    assert first.next.student_id == "017"
+    assert second.previous is not None
+    assert second.previous.student_id == "001"
+
+
+def test_current_student_outside_roster_queue_fails_closed() -> None:
+    queue = _queue(_item("001", "complete"), _item("002", "ratings_pending"))
+
+    with pytest.raises(ReviewStudentNavigationError, match="not in the canonical"):
+        derive_review_student_navigation(queue, "unrostered_003")
+
+
+def test_duplicate_student_identity_in_queue_fails_closed() -> None:
+    queue = _queue(
+        _item("001", "complete"),
+        _item("001", "ratings_pending", display_name="Duplicate"),
+    )
+
+    with pytest.raises(ReviewStudentNavigationError, match="duplicate student_id"):
+        derive_review_student_navigation(queue, "001")
+
+
+def test_mismatched_queue_item_identity_fails_closed() -> None:
+    queue = _queue(
+        _item("001", "complete"),
+        _item("002", "ratings_pending", class_id="other_class"),
+    )
+
+    with pytest.raises(ReviewStudentNavigationError, match="identity does not match"):
+        derive_review_student_navigation(queue, "001")
+
+
+def test_empty_student_id_is_rejected() -> None:
+    queue = _queue(_item("001", "complete"))
+
+    with pytest.raises(ReviewStudentNavigationError, match="non-empty string"):
+        derive_review_student_navigation(queue, "")
+
+
+def test_repeated_derivation_is_deterministic() -> None:
+    queue = _queue(
+        _item("001", "complete"),
+        _item("002", "ratings_pending"),
+        _item("003", "feedback_pending"),
+    )
+
+    first = derive_review_student_navigation(queue, "002")
+    second = derive_review_student_navigation(queue, "002")
+
+    assert first == second
+
+
+def test_workspace_builder_reuses_exact_383_queue_service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue = _queue(
+        _item("001", "complete"),
+        _item("002", "ratings_pending"),
+    )
+    calls: list[tuple[str | Path, str, str]] = []
+
+    def fake_build_queue(
+        workspace_root: str | Path,
+        class_id: str,
+        assignment_id: str,
+    ) -> AssignmentReviewWorkQueue:
+        calls.append((workspace_root, class_id, assignment_id))
+        return queue
+
+    monkeypatch.setattr(
+        navigation_module,
+        "build_assignment_review_work_queue",
+        fake_build_queue,
+    )
+
+    result = build_review_student_navigation(
+        tmp_path,
+        CLASS_ID,
+        ASSIGNMENT_ID,
+        "001",
+    )
+
+    assert calls == [(tmp_path, CLASS_ID, ASSIGNMENT_ID)]
+    assert result.current.student_id == "001"
+    assert result.next is not None
+    assert result.next.student_id == "002"

--- a/tests/test_teacher_workflow_audit_issue379.py
+++ b/tests/test_teacher_workflow_audit_issue379.py
@@ -118,7 +118,7 @@ def test_class_set_student_handoff_audit_uses_real_workflow(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Measure the current parent-menu round trip required between students."""
+    """Verify the improved direct handoff removes the parent/picker round trip."""
     _write_workspace(tmp_path)
     monkeypatch.setattr(review_menu, "resolve_workspace_root", lambda: tmp_path)
     original_files = {
@@ -134,10 +134,8 @@ def test_class_set_student_handoff_audit_uses_real_workflow(
             "1",  # Assignment selection.
             "1",  # Assignment Review Actions -> Select student/submission.
             "1",  # First roster student.
-            "b",  # Back from first student's review.
-            "1",  # Re-enter Select student/submission from assignment dashboard.
-            "2",  # Second roster student, which currently has no digital submission.
-            "b",  # Back from second student's review.
+            "n",  # Directly navigate to the next roster student.
+            "b",  # Back from the selected-student review.
             "b",  # Back from Assignment Review Actions.
             "",  # Pause before redrawing Review Student Work.
             "b",  # Back to Quillan main menu.
@@ -163,11 +161,14 @@ def test_class_set_student_handoff_audit_uses_real_workflow(
         unrelated_previous_text="Assembly needed:",
     )
 
-    assert output.count("Select Student/Submission") >= 2
+    assert output.count("Select Student/Submission") == 1
     assert f"Assignment: {ASSIGNMENT_ID}" in output
     assert f"Class: {CLASS_ID}" in output
     assert "Student: Avery Rivera" in output
     assert "Student: Mina Patel" in output
+    assert f"N. Next student — Mina Patel ({SECOND_STUDENT_ID})" in output
+    assert "Position: 1 of 2" in output
+    assert "Position: 2 of 2" in output
     assert "No digital submission evidence has been found for this student." in output
     assert {
         path.relative_to(tmp_path).as_posix(): path.read_bytes()


### PR DESCRIPTION
## Summary

Completes Quillan issue #384 by adding deterministic class-set navigation to the selected-student review workflow.

## What this adds

- `P. Previous student`
- `N. Next student`
- `W. Next student needing review`
- exact roster position and student identity
- current #383 work category
- total and forward remaining-work counts
- fresh navigation state on every selected-student root redraw
- navigation across missing-submission, routed-evidence, plain-paper, and review-ready states
- fail-closed handling for unrostered or otherwise non-canonical selected students
- direct student-to-student handoff without returning through the assignment dashboard or student picker

## Behavioral boundaries

- canonical roster order remains owned by Core
- work classification remains owned by #383
- navigation never wraps
- `W` selects the first strictly later roster student whose #383 category is not `complete`
- no category prioritization or teacher-judgment inference
- navigation performs no writes
- navigation state is not persisted
- child review inputs must save, cancel, or return before student navigation
- #384 does not implement #385 review-stage routing
- #384 does not implement #386 compact review-screen redesign

## Validation

Local validation on Windows / Python 3.14.1:

- `2580 passed, 21 skipped`
- `python -m ruff check .` — clean
- `python -m mypy .` — clean
- `git diff --check` — clean
- complete menu-density acceptance matrix — clean

Closes #384